### PR TITLE
Add usage pattern templates (calendar, hours of day) to AI workbooks

### DIFF
--- a/Workbooks/Usage/Retention - N Period/settings.json
+++ b/Workbooks/Usage/Retention - N Period/settings.json
@@ -1,6 +1,5 @@
 {
     "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/settings.json",
     "name":"N-Period Retention",
-    "author": "Microsoft",
-    "galleries": [{ "type": "workbook", "resourceType": "microsoft.insights/components", "order": 1200 }]
+    "author": "Microsoft"
 }

--- a/Workbooks/Usage/Retention - N Period/settings.json
+++ b/Workbooks/Usage/Retention - N Period/settings.json
@@ -1,5 +1,6 @@
 {
     "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/settings.json",
     "name":"N-Period Retention",
-    "author": "Microsoft"
+    "author": "Microsoft",
+    "galleries": [{ "type": "workbook", "resourceType": "microsoft.insights/components", "order": 1200 }]
 }

--- a/Workbooks/Usage/Usage Calendar/Usage Calendar.workbook
+++ b/Workbooks/Usage/Usage Calendar/Usage Calendar.workbook
@@ -1,0 +1,168 @@
+{
+  "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json",
+  "version": "Notebook/1.0",
+  "isLocked": false,
+  "items": [
+    {
+      "type": 1,
+      "content": {
+        "json": "# Usage Calendar\nThis report helps you understand the usage patterns of your application through the days of the week. It should help you identify patterns like:\n* My app is primarly used on weekdays and has almost no activity over the weekend, or\n* Overall activity has increased week over week, and especially on Mondays.\n\nUse the parameters below to select the app activities you are interested in, the analysis time window, and the metric you wish to analyze (count of users, sessions, events)."
+      },
+      "conditionalVisibility": null
+    },
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "query": "",
+        "crossComponentResources": [],
+        "parameters": [
+          {
+            "id": "0a333341-3965-4d73-abec-85d9af5d30cf",
+            "version": "KqlParameterItem/1.0",
+            "name": "Activities",
+            "type": 2,
+            "isRequired": true,
+            "multiSelect": true,
+            "quote": "'",
+            "delimiter": ",",
+            "query": "union customEvents, pageViews\n| where timestamp >= ago(1d)\n| summarize Count = count() by name\n| order by Count desc\n| project name, label = name, selected = false\n| union (datatable(name:string, label:string, selected:boolean)[\n'*', 'All Events and Page Views', true,\n'#', 'All Page Views', false,\n'&', 'All Events', false\n])",
+            "isHiddenWhenLocked": false,
+            "resourceType": "microsoft.insights/components"
+          },
+          {
+            "id": "abed64a1-3333-40ed-ad17-34dd66e33895",
+            "version": "KqlParameterItem/1.0",
+            "name": "TimeRange",
+            "type": 4,
+            "isRequired": true,
+            "isHiddenWhenLocked": false,
+            "typeSettings": {
+              "selectableValues": [
+                {
+                  "durationMs": 2592000000,
+                  "createdTime": "2018-08-22T03:49:07.015Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 5184000000,
+                  "createdTime": "2018-08-22T03:49:07.015Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 7776000000,
+                  "createdTime": "2018-08-22T03:49:07.015Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                }
+              ],
+              "allowCustom": true
+            },
+            "value": {
+              "durationMs": 2592000000,
+              "createdTime": "2018-08-22T03:49:07.015Z",
+              "isInitialTime": false,
+              "grain": 1,
+              "useDashboardTimeRange": false
+            }
+          },
+          {
+            "id": "e42f01af-de79-45f1-a30a-8d41894a6ac7",
+            "version": "KqlParameterItem/1.0",
+            "name": "Metric",
+            "type": 2,
+            "isRequired": true,
+            "multiSelect": null,
+            "query": "datatable(value:string, label:string, selected:boolean)[\n'Metric = dcount(user_Id)', 'Unique Users', true,\n'Metric = dcount(session_Id)', 'Unique Sessions', false,\n'Metric = count()', 'Event Count', false\n]",
+            "isHiddenWhenLocked": false,
+            "resourceType": "microsoft.insights/components"
+          },
+          {
+            "id": "ce93f5c0-cb7c-4d3a-9361-c0ba735b40f6",
+            "version": "KqlParameterItem/1.0",
+            "name": "ExcludeWeekends",
+            "type": 2,
+            "isRequired": true,
+            "multiSelect": null,
+            "isHiddenWhenLocked": false,
+            "jsonData": "[\"Yes\", \"No\"]",
+            "value": "No"
+          }
+        ],
+        "resourceType": "microsoft.insights/components"
+      },
+      "conditionalVisibility": null
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": ""
+      },
+      "conditionalVisibility": null
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "##  Usage\nShows your app usage measured by the `Metric` parameter chosen above."
+      },
+      "conditionalVisibility": null,
+      "customWidth": "65"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "##  Calendar\nA basic calendar to use as reference in your analysis."
+      },
+      "conditionalVisibility": null,
+      "customWidth": "35"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "let start = startofweek({TimeRange:start});\nunion customEvents, pageViews\n| where timestamp >= start\n| where name in ({Activities}) or ('*' in ({Activities})) or ('#' in ({Activities}) and itemType == 'pageView') or ('&' in ({Activities}) and itemType == 'customEvent')\n| make-series {Metric} default=0 on timestamp in range(start, endofweek({TimeRange:end}), 1d)\n| mvexpand timestamp to typeof(datetime), Metric to typeof(long)\n| extend WeekDay = dayofweek(timestamp), Week = toint((timestamp - start) / 7d) \n| where '{ExcludeWeekends}' == 'No' or (WeekDay != 0d and WeekDay != 6d)\n| extend WeekDay = case(WeekDay == 0d, 'Sun', WeekDay == 1d, 'Mon', WeekDay == 2d, 'Tue', WeekDay == 3d, 'Wed', WeekDay == 4d, 'Thu', WeekDay == 5d, 'Fri', 'Sat')\n| order by timestamp asc\n| project-away timestamp\n| evaluate pivot(WeekDay, sum(Metric))\n| project-away Week ",
+        "showQuery": false,
+        "size": 0,
+        "aggregation": 0,
+        "showAnnotations": false,
+        "showAnalytics": false,
+        "resourceType": "microsoft.insights/components",
+        "gridSettings": {
+          "formatters": [
+            {
+              "columnMatch": ".*",
+              "formatter": 8,
+              "formatOptions": {
+                "min": 0,
+                "max": null,
+                "palette": "green"
+              }
+            }
+          ]
+        }
+      },
+      "conditionalVisibility": null,
+      "customWidth": "65"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "let start = startofweek({TimeRange:start});\nrange i from 0d to 366d step 1d\n| extend timestamp = startofday(now() - i)\n| make-series Max = max(1) default=0 on timestamp in range(start, endofweek({TimeRange:end}), 1d)\n| mvexpand timestamp to typeof(datetime), Max\n| extend WeekDay = dayofweek(timestamp), Week = toint((timestamp - start) / 7d), Day = dayofmonth(timestamp)\n| where '{ExcludeWeekends}' == 'No' or (WeekDay != 0d and WeekDay != 6d)\n| extend WeekDay = case(WeekDay == 0d, 'Sun', WeekDay == 1d, 'Mon', WeekDay == 2d, 'Tue', WeekDay == 3d, 'Wed', WeekDay == 4d, 'Thu', WeekDay == 5d, 'Fri', 'Sat')\n| order by timestamp asc\n| project-away timestamp, Max\n| evaluate pivot(WeekDay, sum(Day))\n| project-away Week ",
+        "showQuery": false,
+        "size": 0,
+        "aggregation": 0,
+        "showAnnotations": false,
+        "showAnalytics": false,
+        "resourceType": "microsoft.insights/components"
+      },
+      "conditionalVisibility": null,
+      "customWidth": "35"
+    }
+  ]
+}

--- a/Workbooks/Usage/Usage Calendar/settings.json
+++ b/Workbooks/Usage/Usage Calendar/settings.json
@@ -1,0 +1,6 @@
+{
+    "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/settings.json",
+    "name":"Usage Calendar",
+    "author": "Microsoft",
+    "galleries": [{ "type": "workbook", "resourceType": "microsoft.insights/components", "order": 600 }]
+}

--- a/Workbooks/Usage/Usage by hours of the day/Usage by hours of the day.workbook
+++ b/Workbooks/Usage/Usage by hours of the day/Usage by hours of the day.workbook
@@ -1,0 +1,143 @@
+{
+  "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json",
+  "version": "Notebook/1.0",
+  "isLocked": true,
+  "items": [
+    {
+      "type": 1,
+      "content": {
+        "json": "# Usage through the day\nThis report helps you understand the usage patterns of your application through the hours of a day. It should help you identify patterns like:\n\n* My app is primarly on weekdays in the evenings between 6pm and 11pm\n* On weekends, usage is spread evenly through the day.\n\nUse the parameters below to select the app activities you are interested in, the analysis time window, and the metric you wish to analyze (count of users, sessions, events)."
+      },
+      "conditionalVisibility": null
+    },
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "query": "",
+        "crossComponentResources": [],
+        "parameters": [
+          {
+            "id": "0a333341-3965-4d73-abec-85d9af5d30cf",
+            "version": "KqlParameterItem/1.0",
+            "name": "Activities",
+            "type": 2,
+            "isRequired": true,
+            "multiSelect": true,
+            "quote": "'",
+            "delimiter": ",",
+            "query": "union customEvents, pageViews\n| where timestamp >= ago(1d)\n| summarize Count = count() by name\n| order by Count desc\n| project name, label = name, selected = false\n| union (datatable(name:string, label:string, selected:boolean)[\n'*', 'All Events and Page Views', true,\n'#', 'All Page Views', false,\n'&', 'All Events', false\n])",
+            "isHiddenWhenLocked": false,
+            "resourceType": "microsoft.insights/components"
+          },
+          {
+            "id": "abed64a1-3333-40ed-ad17-34dd66e33895",
+            "version": "KqlParameterItem/1.0",
+            "name": "TimeRange",
+            "type": 4,
+            "isRequired": true,
+            "isHiddenWhenLocked": false,
+            "typeSettings": {
+              "selectableValues": [
+                {
+                  "durationMs": 604800000,
+                  "createdTime": "2018-08-22T04:57:17.254Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 1209600000,
+                  "createdTime": "2018-08-22T04:57:17.254Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 2592000000,
+                  "createdTime": "2018-08-22T04:57:17.254Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 5184000000,
+                  "createdTime": "2018-08-22T04:57:17.254Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                }
+              ],
+              "allowCustom": false
+            },
+            "value": {
+              "durationMs": 1209600000,
+              "createdTime": "2018-08-22T04:57:17.254Z",
+              "isInitialTime": false,
+              "grain": 1,
+              "useDashboardTimeRange": false
+            }
+          },
+          {
+            "id": "e42f01af-de79-45f1-a30a-8d41894a6ac7",
+            "version": "KqlParameterItem/1.0",
+            "name": "Metric",
+            "type": 2,
+            "isRequired": true,
+            "multiSelect": null,
+            "query": "datatable(value:string, label:string, selected:boolean)[\n'Metric = dcount(user_Id)', 'Unique Users', true,\n'Metric = dcount(session_Id)', 'Unique Sessions', false,\n'Metric = count()', 'Event Count', false\n]",
+            "isHiddenWhenLocked": false,
+            "resourceType": "microsoft.insights/components"
+          },
+          {
+            "id": "5cddc86e-909f-412e-b122-91347c02235e",
+            "version": "KqlParameterItem/1.0",
+            "name": "ExcludeWeekends",
+            "type": 2,
+            "isRequired": true,
+            "multiSelect": null,
+            "isHiddenWhenLocked": false,
+            "jsonData": "[\"Yes\", \"No\"]",
+            "value": "No"
+          }
+        ],
+        "resourceType": "microsoft.insights/components"
+      },
+      "conditionalVisibility": null
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": ""
+      },
+      "conditionalVisibility": null
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "let start = startofday({TimeRange:start});\nunion customEvents, pageViews\n| where timestamp >= start\n| where name in ({Activities}) or ('*' in ({Activities})) or ('#' in ({Activities}) and itemType == 'pageView') or ('&' in ({Activities}) and itemType == 'customEvent')\n| summarize {Metric} by bin(timestamp, 2h)\n| extend Hour = hourofday(timestamp), WeekDay = dayofweek(timestamp)\n| where '{ExcludeWeekends}' == 'No' or (WeekDay != 0d and WeekDay != 6d)\n| extend HourDisplay = case(Hour == 0, '12am', Hour < 12, strcat(Hour, 'am'), Hour == 12, '12pm', strcat(Hour - 12, 'pm'))\n| extend Day = strcat(monthofyear(timestamp), '/', dayofmonth(timestamp), ' - ', case(WeekDay == 0d, 'Sun', WeekDay == 1d, 'Mon', WeekDay == 2d, 'Tue', WeekDay == 3d, 'Wed', WeekDay == 4d, 'Thu', WeekDay == 5d, 'Fri', 'Sat'))\n| order by Hour asc\n| extend Day1 = bin(timestamp, 1d)\n| project-away timestamp, WeekDay, Hour\n| serialize\n| evaluate pivot(HourDisplay, sum(Metric))\n| order by Day1 asc\n| project-away Day1\n",
+        "showQuery": false,
+        "size": 2,
+        "aggregation": 0,
+        "showAnnotations": false,
+        "showAnalytics": false,
+        "resourceType": "microsoft.insights/components",
+        "gridSettings": {
+          "formatters": [
+            {
+              "columnMatch": "m",
+              "formatter": 8,
+              "formatOptions": {
+                "min": 0,
+                "max": null,
+                "palette": "green"
+              }
+            }
+          ]
+        }
+      },
+      "conditionalVisibility": null
+    }
+  ]
+}

--- a/Workbooks/Usage/Usage by hours of the day/settings.json
+++ b/Workbooks/Usage/Usage by hours of the day/settings.json
@@ -1,0 +1,6 @@
+{
+    "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/settings.json",
+    "name":"Usage by hours of the day",
+    "author": "Microsoft",
+    "galleries": [{ "type": "workbook", "resourceType": "microsoft.insights/components", "order": 700 }]
+}


### PR DESCRIPTION
Also include a chance to hide the N-period retention template from the Usage group of AI workbooks. Eric, you should confirm that not having a gallery entry will be fine with the template service.