### PR TITLE
remove export of userId in the sessions grid, it is breaking this step

### DIFF
--- a/Workbooks/Usage/Authenticated User Timelines/Authenticated User Timelines.workbook
+++ b/Workbooks/Usage/Authenticated User Timelines/Authenticated User Timelines.workbook
@@ -195,8 +195,6 @@
         "size": 0,
         "aggregation": 0,
         "showAnnotations": false,
-        "exportFieldName": "User",
-        "exportParameterName": "UserId",
         "showAnalytics": false,
         "resourceType": "microsoft.insights/components",
         "gridSettings": {


### PR DESCRIPTION
The sessions grid at the bottom is "broken" once there's a selection there, so after you select a row in the bottom, changing users at the top won't do anything.

The sessions query step both “consumes” UserId, and it also says it “exports” UserId as well.  So once a row is selected in that bottom grid, it is ignoring any incoming change to UserId since it has its own value now “locked” by the selection in the grid.

This step just shouldn’t have that checkbox set.  That step was probably cloned from the previous query and then the query changed, leaving this field intact.

This removes that exported selection parameter in that step.