### PR TITLE
Add Workbook for Single VM Performance - Azure Monitor for VMs

### DIFF
--- a/Workbooks/Virtual Machines/Virtual Machine Performance/Single Virtual Machine Performance.txt
+++ b/Workbooks/Virtual Machines/Virtual Machine Performance/Single Virtual Machine Performance.txt
@@ -1,0 +1,515 @@
+{
+  "version": "Notebook/1.0",
+  "isLocked": false,
+  "items": [
+    {
+      "type": 1,
+      "content": {
+        "json": "# Single Virtual Machine Performance\n\n*Click on a row to see trends for only that machine*\n---"
+      },
+      "conditionalVisibility": null
+    },
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "query": "",
+        "crossComponentResources": [
+          "{Workspace}"
+        ],
+        "parameters": [
+          {
+            "id": "8f72709f-725a-41e6-82a2-8d067e38a261",
+            "version": "KqlParameterItem/1.0",
+            "name": "Workspace",
+            "type": 5,
+            "isRequired": true,
+            "isHiddenWhenLocked": false,
+            "typeSettings": {
+              "resourceTypeFilter": {
+                "microsoft.operationalinsights/workspaces": true
+              },
+              "additionalResourceOptions": []
+            },
+            "value": "/subscriptions/f9cf50ed-d814-4b95-b76c-c709845f84c9/resourceGroups/mms-eus/providers/Microsoft.OperationalInsights/workspaces/admdemo"
+          },
+          {
+            "id": "24eb29a6-309b-4b55-aebd-87d3a2057b3f",
+            "version": "KqlParameterItem/1.0",
+            "name": "VirtualMachines",
+            "type": 2,
+            "isRequired": true,
+            "multiSelect": true,
+            "quote": "'",
+            "delimiter": ",",
+            "query": "Perf\r\n| summarize by Computer\r\n| order by Computer asc\r\n| serialize rank = row_number()\r\n| project Computer, Label = Computer, Selected = iff(rank == 1, true, false)\r\n| union (datatable(Computer:string, Label:string, Selected:boolean)['*', 'All Machines', false])",
+            "crossComponentResources": [
+              "{Workspace}"
+            ],
+            "isHiddenWhenLocked": false,
+            "resourceType": "microsoft.operationalinsights/workspaces",
+            "value": [
+              "admdemo-appsvr",
+              "RHEL75"
+            ]
+          },
+          {
+            "id": "d495f8c1-c6b2-490e-8eb6-43d151bc20c0",
+            "version": "KqlParameterItem/1.0",
+            "name": "Counter",
+            "type": 2,
+            "isRequired": true,
+            "query": "Perf\r\n| where TimeGenerated {TimeRange}\r\n| summarize by CounterName, ObjectName, CounterText = strcat(ObjectName, ' > ', CounterName)\r\n| order by ObjectName asc, CounterText asc\r\n| project Counter = pack('counter', CounterName, 'object', ObjectName), CounterText",
+            "crossComponentResources": [
+              "{Workspace}"
+            ],
+            "value": "{\"counter\":\"% Used Memory\",\"object\":\"Memory\"}",
+            "isHiddenWhenLocked": false,
+            "timeContextFromParameter": null,
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          },
+          {
+            "id": "764356de-cf43-4be7-a9f2-f582e5f2ffc2",
+            "version": "KqlParameterItem/1.0",
+            "name": "TimeRange",
+            "type": 4,
+            "isRequired": true,
+            "value": {
+              "durationMs": 86400000,
+              "createdTime": "2018-10-25T18:51:46.918Z",
+              "isInitialTime": false,
+              "grain": 1,
+              "useDashboardTimeRange": false
+            },
+            "isHiddenWhenLocked": false,
+            "typeSettings": {
+              "selectableValues": [
+                {
+                  "durationMs": 300000,
+                  "createdTime": "2018-10-25T18:51:46.917Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 900000,
+                  "createdTime": "2018-10-25T18:51:46.917Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 1800000,
+                  "createdTime": "2018-10-25T18:51:46.917Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 3600000,
+                  "createdTime": "2018-10-25T18:51:46.917Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 14400000,
+                  "createdTime": "2018-10-25T18:51:46.918Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 43200000,
+                  "createdTime": "2018-10-25T18:51:46.918Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 86400000,
+                  "createdTime": "2018-10-25T18:51:46.918Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 172800000,
+                  "createdTime": "2018-10-25T18:51:46.918Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 259200000,
+                  "createdTime": "2018-10-25T18:51:46.918Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 604800000,
+                  "createdTime": "2018-10-25T18:51:46.918Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 1209600000,
+                  "createdTime": "2018-10-25T18:51:46.918Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 2592000000,
+                  "createdTime": "2018-10-25T18:51:46.919Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 5184000000,
+                  "createdTime": "2018-10-25T18:51:46.919Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 7776000000,
+                  "createdTime": "2018-10-25T18:51:46.919Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                }
+              ],
+              "allowCustom": true
+            }
+          },
+          {
+            "id": "31b68fb4-3740-406d-b8eb-ac29cb461c3f",
+            "version": "KqlParameterItem/1.0",
+            "name": "CounterText",
+            "type": 1,
+            "isRequired": false,
+            "query": "let metric = dynamic({Counter});\r\nrange Steps from 1 to 1 step 1\r\n| project strcat(metric.object, \" > \", metric.counter)",
+            "crossComponentResources": [
+              "{Workspace}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          },
+          {
+            "id": "28991f51-2685-417c-8737-afb1d6e8d166",
+            "version": "KqlParameterItem/1.0",
+            "name": "Metrics",
+            "type": 2,
+            "isRequired": true,
+            "multiSelect": true,
+            "quote": "",
+            "delimiter": ",",
+            "value": [
+              "Average = round(avg(CounterValue), 2)"
+            ],
+            "isHiddenWhenLocked": false,
+            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\", \"selected\":true },\r\n    { \"value\":\"p1 = round(percentile(CounterValue, 1), 2)\", \"label\":\"p1\", \"selected\":false},\r\n    { \"value\":\"p5 = round(percentile(CounterValue, 5), 2)\", \"label\":\"p5\", \"selected\":false},\r\n    { \"value\":\"p10 = round(percentile(CounterValue, 10), 2)\", \"label\":\"p10\", \"selected\":false},\r\n    { \"value\":\"p50 = round(percentile(CounterValue, 50), 2)\", \"label\":\"p50\", \"selected\":false},\r\n    { \"value\":\"p90 = round(percentile(CounterValue, 90), 2)\", \"label\":\"p90\", \"selected\":false},\r\n    { \"value\":\"p95 = round(percentile(CounterValue, 95), 2)\", \"label\":\"p95\", \"selected\":true},\r\n    { \"value\":\"p99 = round(percentile(CounterValue, 99), 2)\", \"label\":\"p99\", \"selected\":false},\r\n    { \"value\":\"Min = round(min(CounterValue), 2)\", \"label\":\"Min\", \"selected\":false},\r\n    { \"value\":\"Max = round(max(CounterValue), 2)\", \"label\":\"Max\", \"selected\":false}    \r\n]"
+          },
+          {
+            "id": "6e1380f6-5694-4457-8958-7a4a6dcb7d56",
+            "version": "KqlParameterItem/1.0",
+            "name": "computer",
+            "type": 1,
+            "isRequired": false,
+            "value": "",
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null
+          },
+          {
+            "id": "4bf4bd96-531d-4d30-b1ba-1aef067fbc6e",
+            "version": "KqlParameterItem/1.0",
+            "name": "grain",
+            "type": 1,
+            "isRequired": true,
+            "query": "print ({TimeRange:end} - {TimeRange:start})/100",
+            "crossComponentResources": [
+              "{Workspace}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          }
+        ],
+        "resourceType": "microsoft.operationalinsights/workspaces"
+      },
+      "conditionalVisibility": null
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "## Machines"
+      },
+      "conditionalVisibility": null,
+      "customWidth": "50"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "## {CounterText} (Grain: {grain}) (HH:mm:ss)"
+      },
+      "conditionalVisibility": null,
+      "customWidth": "50"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "let metric = dynamic({Counter});\nlet data = Perf\n| where TimeGenerated {TimeRange}\n| where Computer in ({VirtualMachines}) or '*' in ({VirtualMachines})\n| where ObjectName == metric.object and CounterName == metric.counter\n| summarize {Metrics} by Computer;\nPerf\n| where TimeGenerated {TimeRange}\n| where Computer in ({VirtualMachines}) or '*' in ({VirtualMachines})\n| where ObjectName == metric.object and CounterName == metric.counter\n| make-series Trend = round(avg(CounterValue), 2) default = 0 on TimeGenerated in range({TimeRange:start}, {TimeRange:end}, {TimeRange:grain}) by Computer\n| project Computer, ['Trend (avg)'] = Trend\n| join kind=inner (data) on Computer\n| project-away Computer1\n| order by tolower(Computer) asc",
+        "showQuery": false,
+        "size": 3,
+        "aggregation": 0,
+        "showAnnotations": false,
+        "exportFieldName": "Computer",
+        "exportParameterName": "computer",
+        "showAnalytics": false,
+        "timeContextFromParameter": null,
+        "resourceType": "microsoft.operationalinsights/workspaces",
+        "crossComponentResources": [
+          "{Workspace}"
+        ],
+        "gridSettings": {
+          "formatters": [
+            {
+              "columnMatch": "Computer",
+              "formatter": 1,
+              "formatOptions": {}
+            },
+            {
+              "columnMatch": "Trend (avg)",
+              "formatter": 10,
+              "formatOptions": {
+                "min": null,
+                "max": null,
+                "palette": "green"
+              }
+            },
+            {
+              "columnMatch": ".*",
+              "formatter": 8,
+              "formatOptions": {
+                "min": 0,
+                "max": null,
+                "palette": "red"
+              }
+            }
+          ]
+        }
+      },
+      "conditionalVisibility": null,
+      "customWidth": "50"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "let metric = dynamic({Counter});\r\nPerf\r\n| where TimeGenerated {TimeRange}\r\n| where Computer in ({VirtualMachines}) or '*' in ({VirtualMachines})\r\n| where Computer == '{computer}' or 'All' == '{computer}'\r\n| where ObjectName == metric.object and CounterName == metric.counter\r\n| summarize {Metrics} by bin(TimeGenerated, totimespan('{grain}'))",
+        "showQuery": false,
+        "size": 0,
+        "aggregation": 3,
+        "showAnnotations": false,
+        "showAnalytics": false,
+        "timeContextFromParameter": null,
+        "resourceType": "microsoft.operationalinsights/workspaces",
+        "crossComponentResources": [
+          "{Workspace}"
+        ],
+        "visualization": "timechart"
+      },
+      "conditionalVisibility": null,
+      "customWidth": "50"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "### CPU Utilization % ({computer})"
+      },
+      "conditionalVisibility": null
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "let metric = dynamic({\"counter\": \"% Processor Time\", \"object\": \"Processor\"});\nPerf\n| where TimeGenerated {TimeRange}\n| where Computer in ({VirtualMachines}) or '*' in ({VirtualMachines})\n| where Computer == '{computer}' or 'All' == '{computer}'\n| where (ObjectName == 'Processor' and InstanceName == '_Total' and CounterName == '% Processor Time')\n| where InstanceName == '_Total'\n| summarize AVERAGE = round(avg(CounterValue), 2), 95TH = round(percentile(CounterValue, 95), 2) by bin(TimeGenerated, totimespan('{grain}'))",
+        "showQuery": false,
+        "size": 0,
+        "aggregation": 3,
+        "showAnnotations": true,
+        "showAnalytics": false,
+        "timeContextFromParameter": null,
+        "resourceType": "microsoft.operationalinsights/workspaces",
+        "crossComponentResources": [
+          "{Workspace}"
+        ],
+        "visualization": "timechart"
+      },
+      "conditionalVisibility": null
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "### Available Memory MB ({computer})"
+      },
+      "conditionalVisibility": null
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "Perf\r\n| where TimeGenerated {TimeRange}\r\n| where Computer in ({VirtualMachines}) or '*' in ({VirtualMachines})\r\n| where Computer == '{computer}' or 'All' == '{computer}'\r\n| where (ObjectName == 'Memory' and CounterName in ('Available MBytes', 'Available MBytes Memory'))\r\n| summarize AVERAGE = round(avg(CounterValue), 2), 5TH = round(percentile(CounterValue, 5), 2), 10TH = round(percentile(CounterValue, 10), 2) by bin(TimeGenerated, totimespan('{grain}'))",
+        "showQuery": false,
+        "size": 0,
+        "aggregation": 3,
+        "showAnnotations": true,
+        "showAnalytics": false,
+        "timeContextFromParameter": null,
+        "resourceType": "microsoft.operationalinsights/workspaces",
+        "crossComponentResources": [
+          "{Workspace}"
+        ],
+        "visualization": "linechart"
+      },
+      "conditionalVisibility": null
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "### Logical Disk IOPS ({computer})"
+      },
+      "conditionalVisibility": null
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "Perf\r\n| where TimeGenerated {TimeRange}\r\n| where Computer in ({VirtualMachines}) or '*' in ({VirtualMachines})\r\n| where Computer == '{computer}' or 'All' == '{computer}'\r\n| where (ObjectName == 'Logical Disk' and InstanceName != '_Total' and CounterName == 'Disk Transfers/sec')\r\n| summarize AVERAGE = round(avg(CounterValue), 2), 95TH = round(percentile(CounterValue, 95), 2) by bin(TimeGenerated, totimespan('{grain}'))",
+        "showQuery": false,
+        "size": 0,
+        "aggregation": 3,
+        "showAnnotations": true,
+        "showAnalytics": false,
+        "timeContextFromParameter": null,
+        "resourceType": "microsoft.operationalinsights/workspaces",
+        "crossComponentResources": [
+          "{Workspace}"
+        ],
+        "visualization": "timechart"
+      },
+      "conditionalVisibility": null
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "### Logical Disk MB/s ({computer})"
+      },
+      "conditionalVisibility": null
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "Perf\r\n| where TimeGenerated {TimeRange}\r\n| where Computer in ({VirtualMachines}) or '*' in ({VirtualMachines})\r\n| where Computer == '{computer}' or 'All' == '{computer}'\r\n| where (ObjectName == 'Logical Disk' and InstanceName != '_Total' and CounterName == 'Logical Disk Bytes/sec')\r\n| summarize AVERAGE = round(avg(CounterValue), 2), 95TH = round(percentile(CounterValue, 95), 2) by bin(TimeGenerated, totimespan('{grain}'))",
+        "showQuery": false,
+        "size": 0,
+        "aggregation": 3,
+        "showAnnotations": true,
+        "showAnalytics": false,
+        "timeContextFromParameter": null,
+        "resourceType": "microsoft.operationalinsights/workspaces",
+        "crossComponentResources": [
+          "{Workspace}"
+        ],
+        "visualization": "linechart"
+      },
+      "conditionalVisibility": null
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "### Max Logical Disk Used % ({computer})"
+      },
+      "conditionalVisibility": null
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "let computerName = '{computer}';\r\nlet trendBinSize = totimespan('{grain}');\r\nlet MaxListSize = 1000;\r\nlet rawDataCached = materialize(Perf\r\n\t| where TimeGenerated {TimeRange}\r\n    | where Computer == computerName\r\n    | where\r\n\t\t(ObjectName == 'Logical Disk' and InstanceName != '_Total' and CounterName == '% Used Space') or\r\n        (ObjectName == 'LogicalDisk'  and InstanceName != '_Total' and CounterName == '% Free Space')\r\n\t| project TimeGenerated,\r\n\t\tInstanceName,\r\n\t\tcValue = case(CounterName == '% Free Space', 100 - CounterValue, CounterValue < 0, real(0), CounterValue));\r\n\t\trawDataCached\r\n\t\t\t| summarize max(cValue) by InstanceName\r\n\t\t\t| top 8 by max_cValue\r\n\t\t\t| join (rawDataCached) on InstanceName\r\n\t\t\t| summarize max(cValue), global_Max=any(max_cValue) by bin(TimeGenerated, trendBinSize), InstanceName\r\n\t\t\t| sort by TimeGenerated asc\r\n\t\t\t| summarize makelist(TimeGenerated, MaxListSize), list_max_cValue=makelist(max_cValue, MaxListSize), max_cValue=any(global_Max) by InstanceName",
+        "showQuery": false,
+        "size": 0,
+        "aggregation": 2,
+        "showAnnotations": true,
+        "showAnalytics": false,
+        "timeContextFromParameter": null,
+        "resourceType": "microsoft.operationalinsights/workspaces",
+        "crossComponentResources": [
+          "{Workspace}"
+        ],
+        "visualization": "timechart"
+      },
+      "conditionalVisibility": null
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "### Bytes Sent Rate B/s ({computer})"
+      },
+      "conditionalVisibility": null
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "let grain = totimespan('{grain}');\r\nlet windowsNetwork=Perf\r\n| where TimeGenerated {TimeRange}\r\n| where Computer == '{computer}'\r\n| where ObjectName == 'Network Adapter' and CounterName == 'Bytes Sent/sec'\r\n| summarize CounterValue = sum(CounterValue) by bin(TimeGenerated, 2s);\r\nlet linuxNetwork=Perf\r\n| where TimeGenerated {TimeRange}\r\n| where Computer == '{computer}'\r\n| where ObjectName == 'Network' and CounterName == 'Total Bytes Transmitted'\r\n| order by InstanceName, TimeGenerated asc\r\n| extend prev_Value=prev(CounterValue), prev_t=prev(TimeGenerated), prev_instance=prev(InstanceName)\r\n| project TimeGenerated, CounterValue=iff(prev_instance == InstanceName and CounterValue >= prev_Value and TimeGenerated > prev_t, (CounterValue - prev_Value) / ((TimeGenerated - prev_t) / 1s), real(0))\r\n| summarize CounterValue = sum(CounterValue) by bin(TimeGenerated, 2s);\r\nlet networkDataSend = union windowsNetwork, linuxNetwork;\r\nnetworkDataSend\r\n| summarize AVERAGE = round(avg(CounterValue), 2) by bin(TimeGenerated, grain)",
+        "showQuery": false,
+        "size": 0,
+        "aggregation": 3,
+        "showAnnotations": true,
+        "showAnalytics": false,
+        "timeContextFromParameter": null,
+        "resourceType": "microsoft.operationalinsights/workspaces",
+        "crossComponentResources": [
+          "{Workspace}"
+        ],
+        "visualization": "timechart"
+      },
+      "conditionalVisibility": null
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "### Bytes Received Rate B/s ({computer})"
+      },
+      "conditionalVisibility": null
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "let grain = totimespan('{grain}');\r\nlet windowsNetwork=Perf\r\n| where TimeGenerated {TimeRange}\r\n| where Computer == '{computer}'\r\n| where ObjectName == 'Network Adapter' and CounterName == 'Bytes Received/sec'\r\n| summarize CounterValue = sum(CounterValue) by bin(TimeGenerated, 2s);\r\nlet linuxNetwork=Perf\r\n| where TimeGenerated {TimeRange}\r\n| where Computer == '{computer}'\r\n| where ObjectName == 'Network' and CounterName == 'Total Bytes Received'\r\n| order by InstanceName, TimeGenerated asc\r\n| extend prev_Value = prev(CounterValue), prev_t = prev(TimeGenerated), prev_instance = prev(InstanceName)\r\n| project TimeGenerated, CounterValue = iff(prev_instance == InstanceName and CounterValue >= prev_Value and TimeGenerated > prev_t, (CounterValue - prev_Value) / ((TimeGenerated - prev_t) / 1s), real(0))\r\n| summarize CounterValue = sum(CounterValue) by bin(TimeGenerated, 2s);\r\nlet networkDataReceive = union windowsNetwork, linuxNetwork;\r\nnetworkDataReceive\r\n| summarize AVERAGE = round(avg(CounterValue), 2) by bin(TimeGenerated, grain)",
+        "showQuery": false,
+        "size": 0,
+        "aggregation": 3,
+        "showAnnotations": true,
+        "showAnalytics": false,
+        "timeContextFromParameter": null,
+        "resourceType": "microsoft.operationalinsights/workspaces",
+        "crossComponentResources": [
+          "{Workspace}"
+        ],
+        "visualization": "timechart"
+      },
+      "conditionalVisibility": null
+    }
+  ],
+  "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
+}


### PR DESCRIPTION
Initial attempt for Single VM performance view of Azure Monitor for VMs. Contains the following:

* Seven performance charts mirrored from Single VM Insights page
* Grid where users can select a particular VM
* Chart showing user-selected counter for a particular VM

![image](https://user-images.githubusercontent.com/43890980/48449405-3c9ea100-e757-11e8-90ff-c3ca4c2cca05.png)