### PR TITLE
Add workbook for VM Connections - Azure Monitor for VMs 

### DIFF
--- a/Workbooks/Log Analytics - VM Dependencies/VM Network Dependencies/VM Network Dependencies.workbook
+++ b/Workbooks/Log Analytics - VM Dependencies/VM Network Dependencies/VM Network Dependencies.workbook
@@ -1,0 +1,462 @@
+{
+  "version": "Notebook/1.0",
+  "isLocked": true,
+  "items": [
+    {
+      "type": 1,
+      "content": {
+        "json": "# VM Connection Analysis\n\n"
+      },
+      "conditionalVisibility": null
+    },
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "query": "",
+        "crossComponentResources": [],
+        "parameters": [
+          {
+            "id": "e41c2177-932a-4c58-ba24-03ef070eb197",
+            "version": "KqlParameterItem/1.0",
+            "name": "Workspaces",
+            "type": 5,
+            "isRequired": true,
+            "multiSelect": true,
+            "quote": "'",
+            "delimiter": ",",
+            "query": "where type =~ \"Microsoft.OperationalInsights/workspaces\"\r\n| project id",
+            "crossComponentResources": [
+              "value::selected"
+            ],
+            "value": [
+              "/subscriptions/f9cf50ed-d814-4b95-b76c-c709845f84c9/resourceGroups/mms-eus/providers/Microsoft.OperationalInsights/workspaces/AdmDemo"
+            ],
+            "isHiddenWhenLocked": false,
+            "typeSettings": {
+              "resourceTypeFilter": {
+                "microsoft.operationalinsights/workspaces": true
+              },
+              "additionalResourceOptions": []
+            },
+            "timeContextFromParameter": null,
+            "resourceType": "microsoft.resourcestopology/resources"
+          },
+          {
+            "id": "5f8cce4b-9c4c-47da-8683-7e5ccc9faed3",
+            "version": "KqlParameterItem/1.0",
+            "name": "TimeRange",
+            "type": 4,
+            "isRequired": false,
+            "value": {
+              "durationMs": 86400000,
+              "createdTime": "2018-10-04T22:01:18.374Z",
+              "isInitialTime": false,
+              "grain": 1,
+              "useDashboardTimeRange": false
+            },
+            "isHiddenWhenLocked": false,
+            "typeSettings": {
+              "selectableValues": [
+                {
+                  "durationMs": 300000,
+                  "createdTime": "2018-10-04T22:01:18.372Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 900000,
+                  "createdTime": "2018-10-04T22:01:18.372Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 1800000,
+                  "createdTime": "2018-10-04T22:01:18.372Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 3600000,
+                  "createdTime": "2018-10-04T22:01:18.372Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 14400000,
+                  "createdTime": "2018-10-04T22:01:18.374Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 43200000,
+                  "createdTime": "2018-10-04T22:01:18.374Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 86400000,
+                  "createdTime": "2018-10-04T22:01:18.374Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 172800000,
+                  "createdTime": "2018-10-04T22:01:18.374Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 259200000,
+                  "createdTime": "2018-10-04T22:01:18.375Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 604800000,
+                  "createdTime": "2018-10-04T22:01:18.375Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 1209600000,
+                  "createdTime": "2018-10-04T22:01:18.375Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 2592000000,
+                  "createdTime": "2018-10-04T22:01:18.375Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 5184000000,
+                  "createdTime": "2018-10-04T22:01:18.375Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 7776000000,
+                  "createdTime": "2018-10-04T22:01:18.375Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                }
+              ],
+              "allowCustom": true
+            }
+          },
+          {
+            "id": "aa2368fc-ad30-4608-b96a-72abf7b1e1af",
+            "version": "KqlParameterItem/1.0",
+            "name": "Metric",
+            "type": 2,
+            "isRequired": false,
+            "value": "sum(Responses)",
+            "isHiddenWhenLocked": false,
+            "jsonData": "[\r\n    { \"value\":\"sum(Responses)\", \"label\":\"Responses\" },\r\n    { \"value\":\"sum(LinksFailed)\", \"label\":\"Sum of Links Failed\" },\r\n    { \"value\":\"max(LinksLive)\", \"label\":\"Max Links Live\" },\r\n    { \"value\":\"sum(BytesSent)\", \"label\":\"Bytes Sent\" },\r\n    { \"value\":\"sum(BytesReceived)\", \"label\":\"Bytes Received\" },\r\n    { \"value\":\"sum(ResponseTimeSum)\", \"label\":\"Sum of Response Times\" },\r\n    { \"value\":\"1.0 * sum(ResponseTimeSum) / sum(Responses)\", \"label\":\"Average Response Time\" }\r\n]",
+            "timeContextFromParameter": null
+          },
+          {
+            "id": "ba25d2e0-8692-492c-b9fd-53845fca6b0e",
+            "version": "KqlParameterItem/1.0",
+            "name": "Direction",
+            "type": 2,
+            "isRequired": false,
+            "value": "outbound",
+            "isHiddenWhenLocked": false,
+            "jsonData": "[\r\n    { \"value\":\"inbound\", \"label\":\"Inbound\" },\r\n    { \"value\":\"outbound\", \"label\":\"Outbound\" }\r\n]"
+          }
+        ],
+        "resourceType": "microsoft.insights/components"
+      },
+      "conditionalVisibility": null
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "## VM Connections\n\n"
+      },
+      "conditionalVisibility": null
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "let maxChildNodes = 8;\nlet computers = ServiceMapComputer_CL\n| where TimeGenerated {TimeRange}\n| summarize (TimeGenerated, Properties) = arg_max(TimeGenerated, pack_all()) by Computer;\nlet ipComputerMapping = computers \n| project Computer, Ipv4 = todynamic(tostring(Properties.Ipv4Addresses_s))\n| mvexpand Ipv4 to typeof(string);\nlet connectionData = VMConnection\n| where TimeGenerated {TimeRange}\n| extend RemoteComputer = iff(Direction == 'outbound', DestinationIp, SourceIp)\n| where Direction == '{Direction}'\n| summarize Metric = {Metric} by Computer, RemoteComputer\n| join kind = leftouter (ipComputerMapping) on $left.RemoteComputer == $right.Ipv4\n| extend RemoteComputer = iff(Computer1 == '', strcat('External (', RemoteComputer, ')'), Computer1)\n| project-away Computer1, Ipv4;\nlet computerData = connectionData\n| summarize Metric = sum(Metric) by Name = Computer\n| order by Metric desc, Name asc\n| serialize Id = row_number()\n| extend ParentId = -1, Kind = 'Computer';\nlet remoteData = connectionData\n| top-nested 200 of Computer by ComputerMetric = sum(Metric) desc, top-nested maxChildNodes of RemoteComputer with others = 'Others' by Metric = sum(Metric) desc\n| extend rank = iff(RemoteComputer == 'Others', 2, 1)\n| extend Kind = iff(RemoteComputer == 'Others', 'Remote Computer Group', 'Remote Computer');\nremoteData\n| serialize Id = row_number(1000000)\n| order by ComputerMetric desc, Computer asc, rank asc, Metric desc, RemoteComputer asc\n| join kind = inner (computerData) on $left.Computer == $right.Name\n| order by ComputerMetric desc, Computer asc, rank asc, Metric desc, RemoteComputer asc\n| project Name = RemoteComputer, Kind, Metric, Id, ParentId = Id1, ComputerMetric, rank, ParentComputer = Name\n| union (computerData)\n| project Computer = case(Kind == 'Computer', strcat('🖥️ ', Name), Kind == 'Remote Computer Group', strcat('🔹 ', Name), Name !startswith 'External (', strcat('🔸 ', Name), strcat('🔹 ', Name)), Kind, Metric, Id, ParentId, Name, ParentComputer\n\n",
+        "showQuery": false,
+        "size": 0,
+        "aggregation": 0,
+        "showAnnotations": false,
+        "exportParameterName": "ConnectionGrid",
+        "showAnalytics": false,
+        "timeContextFromParameter": null,
+        "resourceType": "microsoft.operationalinsights/workspaces",
+        "crossComponentResources": [
+          "{Workspaces}"
+        ],
+        "gridSettings": {
+          "formatters": [
+            {
+              "columnMatch": "Metric",
+              "formatter": 4,
+              "formatOptions": {
+                "min": 0,
+                "max": null,
+                "palette": "green"
+              }
+            },
+            {
+              "columnMatch": "Id",
+              "formatter": 5,
+              "formatOptions": {}
+            },
+            {
+              "columnMatch": "ParentId",
+              "formatter": 5,
+              "formatOptions": {}
+            },
+            {
+              "columnMatch": "Name",
+              "formatter": 5,
+              "formatOptions": {}
+            },
+            {
+              "columnMatch": "ParentComputer",
+              "formatter": 5,
+              "formatOptions": {}
+            }
+          ],
+          "hierarchySettings": {
+            "idColumn": "Id",
+            "parentColumn": "ParentId",
+            "expanderColumn": "Computer"
+          }
+        }
+      },
+      "conditionalVisibility": null
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "💡 *Click on the rows of the table above to see details for other operations*"
+      },
+      "conditionalVisibility": null
+    },
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "query": "",
+        "crossComponentResources": [],
+        "parameters": [
+          {
+            "id": "09218117-f5f1-434b-90ec-22280c7ea9bb",
+            "version": "KqlParameterItem/1.0",
+            "name": "SourceComputer",
+            "type": 1,
+            "isRequired": true,
+            "query": "let row = dynamic({ConnectionGrid});\r\nlet computer = tostring(row.Computer);\r\nlet parentComputer = tostring(row.ParentComputer);\r\nlet parentId = row.ParentId;\r\nlet length = strlen(computer);\r\nrange i from 1 to 1 step 1\r\n| project computer = iff(parentId == -1, computer, strcat(\"🖥️ \", parentComputer))",
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "resourceType": "microsoft.insights/components"
+          },
+          {
+            "id": "9baa3eeb-99e1-4f1a-b6dc-9dba013bde52",
+            "version": "KqlParameterItem/1.0",
+            "name": "DirectionText",
+            "type": 1,
+            "isRequired": true,
+            "query": "range i from 1 to 1 step 1\r\n| project direction = iff('{Direction}' == \"outbound\", \"-->\", \"<--\")",
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "resourceType": "microsoft.insights/components"
+          },
+          {
+            "id": "e2312722-4f36-49b9-b1b9-27e45f9b1921",
+            "version": "KqlParameterItem/1.0",
+            "name": "ChildComputer",
+            "type": 1,
+            "isRequired": true,
+            "query": "let row = dynamic({ConnectionGrid});\r\nlet computer = tostring(row.Computer);\r\nlet parentComputer = tostring(row.ParentComputer);\r\nlet parentId = row.ParentId;\r\nrange i from 1 to 1 step 1\r\n| project computer = iff(parentId == -1, \"any\", computer)",
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "resourceType": "microsoft.insights/components"
+          }
+        ],
+        "resourceType": "microsoft.insights/components"
+      },
+      "conditionalVisibility": null
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "## Details: {SourceComputer} {DirectionText} {ChildComputer}"
+      },
+      "conditionalVisibility": {
+        "parameterName": "SourceComputer",
+        "comparison": "isNotEqualTo",
+        "value": null
+      }
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "### Responses"
+      },
+      "conditionalVisibility": {
+        "parameterName": "SourceComputer",
+        "comparison": "isNotEqualTo",
+        "value": null
+      },
+      "customWidth": "25"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "### Latency"
+      },
+      "conditionalVisibility": {
+        "parameterName": "SourceComputer",
+        "comparison": "isNotEqualTo",
+        "value": null
+      },
+      "customWidth": "25"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "### Network"
+      },
+      "conditionalVisibility": {
+        "parameterName": "SourceComputer",
+        "comparison": "isNotEqualTo",
+        "value": null
+      },
+      "customWidth": "25"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "### Links"
+      },
+      "conditionalVisibility": {
+        "parameterName": "SourceComputer",
+        "comparison": "isNotEqualTo",
+        "value": null
+      },
+      "customWidth": "25"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "let length = strlen('{ChildComputer}');\r\nlet SourceMachine = iff('{SourceComputer}' contains '🖥️', substring('{SourceComputer}', 3), '{SourceComputer}');\r\nlet ChildMachine = iff('{ChildComputer}' contains '🖥️', substring('{ChildComputer}', 3), \r\n                        iff('{ChildComputer}' contains '🔸',  substring('{ChildComputer}', 2), \r\n                        iff('{ChildComputer}' contains \"External\", substring('{ChildComputer}', 12, length - 13), '{ChildComputer}')));\r\nlet SouceMachineData = VMConnection\r\n| where TimeGenerated {TimeRange}\r\n| where Computer == SourceMachine\r\n| where ChildMachine == \"any\"\r\n| where Direction == '{Direction}'\r\n| summarize Computer = sum(Responses) by bin(TimeGenerated, time('{TimeRange:grain}')), Type = SourceMachine;\r\nlet computers = ServiceMapComputer_CL\r\n| where TimeGenerated {TimeRange}\r\n| summarize (TimeGenerated, Properties) = arg_max(TimeGenerated, pack_all()) by Computer;\r\nlet ipComputerMapping = computers \r\n| project Computer, Ipv4 = todynamic(tostring(Properties.Ipv4Addresses_s))\r\n| mvexpand Ipv4 to typeof(string);\r\nlet remoteMachineIps = ipComputerMapping\r\n| where Computer == ChildMachine\r\n| project Ipv4;\r\nlet ConnectionData = VMConnection\r\n| where TimeGenerated {TimeRange}\r\n| where Computer == SourceMachine\r\n| where RemoteIp in (remoteMachineIps) or RemoteIp == ChildMachine\r\n| where Direction == '{Direction}'\r\n| summarize Computer = sum(Responses) by bin(TimeGenerated, time('{TimeRange:grain}')), Type = ChildMachine;\r\nSouceMachineData\r\n| union ConnectionData\r\n\r\n\r\n",
+        "showQuery": false,
+        "size": 1,
+        "aggregation": 0,
+        "showAnnotations": false,
+        "showAnalytics": false,
+        "timeContextFromParameter": null,
+        "resourceType": "microsoft.operationalinsights/workspaces",
+        "crossComponentResources": [
+          "{Workspaces}"
+        ],
+        "visualization": "areachart"
+      },
+      "conditionalVisibility": {
+        "parameterName": "SourceComputer",
+        "comparison": "isNotEqualTo",
+        "value": null
+      },
+      "customWidth": "25"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "let length = strlen('{ChildComputer}');\r\nlet SourceMachine = iff('{SourceComputer}' contains '🖥️', substring('{SourceComputer}', 3), '{SourceComputer}');\r\nlet ChildMachine = iff('{ChildComputer}' contains '🖥️', substring('{ChildComputer}', 3), \r\n                        iff('{ChildComputer}' contains '🔸',  substring('{ChildComputer}', 2), \r\n                        iff('{ChildComputer}' contains \"External\", substring('{ChildComputer}', 12, length - 13), '{ChildComputer}')));\r\nlet SouceMachineData = VMConnection\r\n| where TimeGenerated {TimeRange}\r\n| where Computer == SourceMachine\r\n| where ChildMachine == \"any\"\r\n| where Direction == '{Direction}'\r\n| summarize P50 = percentiles(ResponseTimeSum, 50), P90 = percentiles(ResponseTimeSum, 90), P95 = percentiles(ResponseTimeSum, 95) by bin(TimeGenerated, time('{TimeRange:grain}'));\r\nlet computers = ServiceMapComputer_CL\r\n| where TimeGenerated {TimeRange}\r\n| summarize (TimeGenerated, Properties) = arg_max(TimeGenerated, pack_all()) by Computer;\r\nlet ipComputerMapping = computers \r\n| project Computer, Ipv4 = todynamic(tostring(Properties.Ipv4Addresses_s))\r\n| mvexpand Ipv4 to typeof(string);\r\nlet remoteMachineIps = ipComputerMapping\r\n| where Computer == ChildMachine\r\n| project Ipv4;\r\nlet ConnectionData = VMConnection\r\n| where TimeGenerated {TimeRange}\r\n| where Computer == SourceMachine\r\n| where RemoteIp in (remoteMachineIps) or RemoteIp == ChildMachine\r\n| where Direction == '{Direction}'\r\n| summarize P50 = percentiles(ResponseTimeSum, 50), P90 = percentiles(ResponseTimeSum, 90), P95 = percentiles(ResponseTimeSum, 95) by bin(TimeGenerated, time('{TimeRange:grain}'));\r\nSouceMachineData\r\n| union ConnectionData\r\n\r\n\r\n",
+        "showQuery": false,
+        "size": 1,
+        "aggregation": 3,
+        "showAnnotations": false,
+        "showAnalytics": false,
+        "timeContextFromParameter": null,
+        "resourceType": "microsoft.operationalinsights/workspaces",
+        "crossComponentResources": [
+          "{Workspaces}"
+        ],
+        "visualization": "linechart"
+      },
+      "conditionalVisibility": {
+        "parameterName": "SourceComputer",
+        "comparison": "isNotEqualTo",
+        "value": null
+      },
+      "customWidth": "25"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "let length = strlen('{ChildComputer}');\r\nlet SourceMachine = iff('{SourceComputer}' contains '🖥️', substring('{SourceComputer}', 3), '{SourceComputer}');\r\nlet ChildMachine = iff('{ChildComputer}' contains '🖥️', substring('{ChildComputer}', 3), \r\n                        iff('{ChildComputer}' contains '🔸',  substring('{ChildComputer}', 2), \r\n                        iff('{ChildComputer}' contains \"External\", substring('{ChildComputer}', 12, length - 13), '{ChildComputer}')));\r\nlet SouceMachineData = VMConnection\r\n| where TimeGenerated {TimeRange}\r\n| where Computer == SourceMachine\r\n| where ChildMachine == \"any\"\r\n| where Direction == '{Direction}'\r\n| summarize Sent = sum(BytesSent), Received = sum(BytesReceived) by bin(TimeGenerated, time('{TimeRange:grain}')), Type = SourceMachine;\r\nlet computers = ServiceMapComputer_CL\r\n| where TimeGenerated {TimeRange}\r\n| summarize (TimeGenerated, Properties) = arg_max(TimeGenerated, pack_all()) by Computer;\r\nlet ipComputerMapping = computers \r\n| project Computer, Ipv4 = todynamic(tostring(Properties.Ipv4Addresses_s))\r\n| mvexpand Ipv4 to typeof(string);\r\nlet remoteMachineIps = ipComputerMapping\r\n| where Computer == ChildMachine\r\n| project Ipv4;\r\nlet ConnectionData = VMConnection\r\n| where TimeGenerated {TimeRange}\r\n| where Computer == SourceMachine\r\n| where RemoteIp in (remoteMachineIps) or RemoteIp == ChildMachine\r\n| where Direction == '{Direction}'\r\n| summarize Sent = sum(BytesSent), Received = sum(BytesReceived) by bin(TimeGenerated, time('{TimeRange:grain}')), Type = ChildMachine;\r\nSouceMachineData\r\n| union ConnectionData\r\n\r\n\r\n",
+        "showQuery": false,
+        "size": 1,
+        "aggregation": 0,
+        "showAnnotations": false,
+        "showAnalytics": false,
+        "timeContextFromParameter": null,
+        "resourceType": "microsoft.operationalinsights/workspaces",
+        "crossComponentResources": [
+          "{Workspaces}"
+        ],
+        "visualization": "areachart"
+      },
+      "conditionalVisibility": {
+        "parameterName": "SourceComputer",
+        "comparison": "isNotEqualTo",
+        "value": null
+      },
+      "customWidth": "25"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "let length = strlen('{ChildComputer}');\r\nlet SourceMachine = iff('{SourceComputer}' contains '🖥️', substring('{SourceComputer}', 3), '{SourceComputer}');\r\nlet ChildMachine = iff('{ChildComputer}' contains '🖥️', substring('{ChildComputer}', 3), \r\n                        iff('{ChildComputer}' contains '🔸',  substring('{ChildComputer}', 2), \r\n                        iff('{ChildComputer}' contains \"External\", substring('{ChildComputer}', 12, length - 13), '{ChildComputer}')));\r\nlet SouceMachineData = VMConnection\r\n| where TimeGenerated {TimeRange}\r\n| where Computer == SourceMachine\r\n| where ChildMachine == \"any\"\r\n| where Direction == '{Direction}'\r\n| summarize MaxOpenPorts = max(LinksLive), SumFailed = sum(LinksFailed) by bin(TimeGenerated, time('{TimeRange:grain}')), Type = SourceMachine;\r\nlet computers = ServiceMapComputer_CL\r\n| where TimeGenerated {TimeRange}\r\n| summarize (TimeGenerated, Properties) = arg_max(TimeGenerated, pack_all()) by Computer;\r\nlet ipComputerMapping = computers \r\n| project Computer, Ipv4 = todynamic(tostring(Properties.Ipv4Addresses_s))\r\n| mvexpand Ipv4 to typeof(string);\r\nlet remoteMachineIps = ipComputerMapping\r\n| where Computer == ChildMachine\r\n| project Ipv4;\r\nlet ConnectionData = VMConnection\r\n| where TimeGenerated {TimeRange}\r\n| where Computer == SourceMachine\r\n| where RemoteIp in (remoteMachineIps) or RemoteIp == ChildMachine\r\n| where Direction == '{Direction}'\r\n| summarize MaxOpenPorts = max(LinksLive), SumFailed = sum(LinksFailed) by bin(TimeGenerated, time('{TimeRange:grain}')), Type = ChildMachine;\r\nSouceMachineData\r\n| union ConnectionData\r\n\r\n\r\n",
+        "showQuery": false,
+        "size": 1,
+        "aggregation": 3,
+        "showAnnotations": false,
+        "showAnalytics": false,
+        "timeContextFromParameter": null,
+        "resourceType": "microsoft.operationalinsights/workspaces",
+        "crossComponentResources": [
+          "{Workspaces}"
+        ],
+        "visualization": "areachart"
+      },
+      "conditionalVisibility": {
+        "parameterName": "SourceComputer",
+        "comparison": "isNotEqualTo",
+        "value": null
+      },
+      "customWidth": "25"
+    }
+  ],
+  "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
+}

--- a/Workbooks/Log Analytics - VM Dependencies/VM Network Dependencies/settings.json
+++ b/Workbooks/Log Analytics - VM Dependencies/VM Network Dependencies/settings.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/settings.json",
+    "name":"VM Network Dependencies",
+    "author": "Microsoft",
+    "galleries": [
+        { "type": "workbook", "resourceType": "microsoft.operationalinsights/workspaces", "order": 200 },
+        { "type": "performance-vm", "resourceType": "microsoft.compute/virtualmachines", "order": 200 }
+    ]
+}

--- a/Workbooks/Log Analytics - VM Dependencies/categoryResources.json
+++ b/Workbooks/Log Analytics - VM Dependencies/categoryResources.json
@@ -1,0 +1,3 @@
+{
+    "en-us": {"name":"Virtual Machine Dependencies", "description": "Look for network dependencies of your Virtual Machines.", "order": 200}
+}


### PR DESCRIPTION
This is an initial attempt to provide a workbook for at-scale network dependencies view of Azure Monitor for VMs.
This contains
1. A Tree view of VMs to the <server | clients> this VM is talking with.
2. User can click a particular VM or a connection to view more details.

![image](https://user-images.githubusercontent.com/45012871/48569494-c1540100-e8b6-11e8-81a8-3a251a30067b.png)
