### PR TITLE
Fix Single VM chart workbook

### DIFF
--- a/Workbooks/Virtual Machines/Virtual Machine Performance/Single Virtual Machine Performance.workbook
+++ b/Workbooks/Virtual Machines/Virtual Machine Performance/Single Virtual Machine Performance.workbook
@@ -220,10 +220,9 @@
           {
             "id": "6e1380f6-5694-4457-8958-7a4a6dcb7d56",
             "version": "KqlParameterItem/1.0",
-            "name": "computer",
+            "name": "Computer",
             "type": 1,
             "isRequired": false,
-            "value": "",
             "isHiddenWhenLocked": true,
             "timeContextFromParameter": null
           },
@@ -291,7 +290,7 @@
         "aggregation": 0,
         "showAnnotations": false,
         "exportFieldName": "Computer",
-        "exportParameterName": "computer",
+        "exportParameterName": "Computer",
         "showAnalytics": false,
         "timeContextFromParameter": null,
         "resourceType": "microsoft.operationalinsights/workspaces",
@@ -337,7 +336,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let metric = dynamic({Counter});\r\nPerf\r\n| where TimeGenerated {TimeRange}\r\n| where Computer in ({VirtualMachines}) or '*' in ({VirtualMachines})\r\n| where Computer == '{computer}' or 'All' == '{computer}'\r\n| where ObjectName == metric.object and CounterName == metric.counter\r\n| summarize {Metrics} by bin(TimeGenerated, totimespan('{grain}'))",
+        "query": "let metric = dynamic({Counter});\r\nPerf\r\n| where TimeGenerated {TimeRange}\r\n| where Computer in ({VirtualMachines}) or '*' in ({VirtualMachines})\r\n| where Computer == '{Computer}'\r\n| where ObjectName == metric.object and CounterName == metric.counter\r\n| summarize {Metrics} by bin(TimeGenerated, totimespan('{grain}'))",
         "showQuery": false,
         "size": 0,
         "aggregation": 3,
@@ -371,10 +370,10 @@
     {
       "type": 1,
       "content": {
-        "json": "### CPU Utilization % ({computer})"
+        "json": "### CPU Utilization % ({Computer})"
       },
       "conditionalVisibility": {
-        "parameterName": "computer",
+        "parameterName": "Computer",
         "comparison": "isNotEqualTo",
         "value": null
       }
@@ -383,7 +382,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let metric = dynamic({\"counter\": \"% Processor Time\", \"object\": \"Processor\"});\nPerf\n| where TimeGenerated {TimeRange}\n| where Computer in ({VirtualMachines}) or '*' in ({VirtualMachines})\n| where Computer == '{computer}' or 'All' == '{computer}'\n| where (ObjectName == 'Processor' and InstanceName == '_Total' and CounterName == '% Processor Time')\n| where InstanceName == '_Total'\n| summarize AVERAGE = round(avg(CounterValue), 2), 95TH = round(percentile(CounterValue, 95), 2) by bin(TimeGenerated, totimespan('{grain}'))",
+        "query": "let metric = dynamic({\"counter\": \"% Processor Time\", \"object\": \"Processor\"});\nPerf\n| where TimeGenerated {TimeRange}\n| where Computer in ({VirtualMachines}) or '*' in ({VirtualMachines})\n| where Computer == '{Computer}'\n| where (ObjectName == 'Processor' and InstanceName == '_Total' and CounterName == '% Processor Time')\n| where InstanceName == '_Total'\n| summarize AVERAGE = round(avg(CounterValue), 2), 95TH = round(percentile(CounterValue, 95), 2) by bin(TimeGenerated, totimespan('{grain}'))",
         "showQuery": false,
         "size": 0,
         "aggregation": 3,
@@ -397,7 +396,7 @@
         "visualization": "timechart"
       },
       "conditionalVisibility": {
-        "parameterName": "computer",
+        "parameterName": "Computer",
         "comparison": "isNotEqualTo",
         "value": null
       }
@@ -405,10 +404,10 @@
     {
       "type": 1,
       "content": {
-        "json": "### Available Memory MB ({computer})"
+        "json": "### Available Memory MB ({Computer})"
       },
       "conditionalVisibility": {
-        "parameterName": "computer",
+        "parameterName": "Computer",
         "comparison": "isNotEqualTo",
         "value": null
       }
@@ -417,7 +416,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "Perf\r\n| where TimeGenerated {TimeRange}\r\n| where Computer in ({VirtualMachines}) or '*' in ({VirtualMachines})\r\n| where Computer == '{computer}' or 'All' == '{computer}'\r\n| where (ObjectName == 'Memory' and CounterName in ('Available MBytes', 'Available MBytes Memory'))\r\n| summarize AVERAGE = round(avg(CounterValue), 2), 5TH = round(percentile(CounterValue, 5), 2), 10TH = round(percentile(CounterValue, 10), 2) by bin(TimeGenerated, totimespan('{grain}'))",
+        "query": "Perf\r\n| where TimeGenerated {TimeRange}\r\n| where Computer in ({VirtualMachines}) or '*' in ({VirtualMachines})\r\n| where Computer == '{Computer}'\r\n| where (ObjectName == 'Memory' and CounterName in ('Available MBytes', 'Available MBytes Memory'))\r\n| summarize AVERAGE = round(avg(CounterValue), 2), 5TH = round(percentile(CounterValue, 5), 2), 10TH = round(percentile(CounterValue, 10), 2) by bin(TimeGenerated, totimespan('{grain}'))",
         "showQuery": false,
         "size": 0,
         "aggregation": 3,
@@ -431,7 +430,7 @@
         "visualization": "linechart"
       },
       "conditionalVisibility": {
-        "parameterName": "computer",
+        "parameterName": "Computer",
         "comparison": "isNotEqualTo",
         "value": null
       }
@@ -439,10 +438,10 @@
     {
       "type": 1,
       "content": {
-        "json": "### Logical Disk IOPS ({computer})"
+        "json": "### Logical Disk IOPS ({Computer})"
       },
       "conditionalVisibility": {
-        "parameterName": "computer",
+        "parameterName": "Computer",
         "comparison": "isNotEqualTo",
         "value": null
       }
@@ -451,7 +450,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "Perf\r\n| where TimeGenerated {TimeRange}\r\n| where Computer in ({VirtualMachines}) or '*' in ({VirtualMachines})\r\n| where Computer == '{computer}' or 'All' == '{computer}'\r\n| where (ObjectName == 'Logical Disk' and InstanceName != '_Total' and CounterName == 'Disk Transfers/sec')\r\n| summarize AVERAGE = round(avg(CounterValue), 2), 95TH = round(percentile(CounterValue, 95), 2) by bin(TimeGenerated, totimespan('{grain}'))",
+        "query": "Perf\r\n| where TimeGenerated {TimeRange}\r\n| where Computer in ({VirtualMachines}) or '*' in ({VirtualMachines})\r\n| where Computer == '{Computer}'\r\n| where (ObjectName == 'Logical Disk' and InstanceName != '_Total' and CounterName == 'Disk Transfers/sec')\r\n| summarize AVERAGE = round(avg(CounterValue), 2), 95TH = round(percentile(CounterValue, 95), 2) by bin(TimeGenerated, totimespan('{grain}'))",
         "showQuery": false,
         "size": 0,
         "aggregation": 3,
@@ -465,7 +464,7 @@
         "visualization": "timechart"
       },
       "conditionalVisibility": {
-        "parameterName": "computer",
+        "parameterName": "Computer",
         "comparison": "isNotEqualTo",
         "value": null
       }
@@ -473,10 +472,10 @@
     {
       "type": 1,
       "content": {
-        "json": "### Logical Disk MB/s ({computer})"
+        "json": "### Logical Disk MB/s ({Computer})"
       },
       "conditionalVisibility": {
-        "parameterName": "computer",
+        "parameterName": "Computer",
         "comparison": "isNotEqualTo",
         "value": null
       }
@@ -485,7 +484,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "Perf\r\n| where TimeGenerated {TimeRange}\r\n| where Computer in ({VirtualMachines}) or '*' in ({VirtualMachines})\r\n| where Computer == '{computer}' or 'All' == '{computer}'\r\n| where (ObjectName == 'Logical Disk' and InstanceName != '_Total' and CounterName == 'Logical Disk Bytes/sec')\r\n| summarize AVERAGE = round(avg(CounterValue), 2), 95TH = round(percentile(CounterValue, 95), 2) by bin(TimeGenerated, totimespan('{grain}'))",
+        "query": "Perf\r\n| where TimeGenerated {TimeRange}\r\n| where Computer in ({VirtualMachines}) or '*' in ({VirtualMachines})\r\n| where Computer == '{Computer}'\r\n| where (ObjectName == 'Logical Disk' and InstanceName != '_Total' and CounterName == 'Logical Disk Bytes/sec')\r\n| summarize AVERAGE = round(avg(CounterValue), 2), 95TH = round(percentile(CounterValue, 95), 2) by bin(TimeGenerated, totimespan('{grain}'))",
         "showQuery": false,
         "size": 0,
         "aggregation": 3,
@@ -499,7 +498,7 @@
         "visualization": "linechart"
       },
       "conditionalVisibility": {
-        "parameterName": "computer",
+        "parameterName": "Computer",
         "comparison": "isNotEqualTo",
         "value": null
       }
@@ -507,10 +506,10 @@
     {
       "type": 1,
       "content": {
-        "json": "### Max Logical Disk Used % ({computer})"
+        "json": "### Max Logical Disk Used % ({Computer})"
       },
       "conditionalVisibility": {
-        "parameterName": "computer",
+        "parameterName": "Computer",
         "comparison": "isNotEqualTo",
         "value": null
       }
@@ -519,7 +518,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let computerName = '{computer}';\r\nlet trendBinSize = totimespan('{grain}');\r\nlet MaxListSize = 1000;\r\nlet rawDataCached = materialize(Perf\r\n\t| where TimeGenerated {TimeRange}\r\n    | where Computer == computerName\r\n    | where\r\n\t\t(ObjectName == 'Logical Disk' and InstanceName != '_Total' and CounterName == '% Used Space') or\r\n        (ObjectName == 'LogicalDisk'  and InstanceName != '_Total' and CounterName == '% Free Space')\r\n\t| project TimeGenerated,\r\n\t\tInstanceName,\r\n\t\tcValue = case(CounterName == '% Free Space', 100 - CounterValue, CounterValue < 0, real(0), CounterValue));\r\n\t\trawDataCached\r\n\t\t\t| summarize max(cValue) by InstanceName\r\n\t\t\t| top 8 by max_cValue\r\n\t\t\t| join (rawDataCached) on InstanceName\r\n\t\t\t| summarize max(cValue), global_Max=any(max_cValue) by bin(TimeGenerated, trendBinSize), InstanceName\r\n\t\t\t| sort by TimeGenerated asc\r\n\t\t\t| summarize makelist(TimeGenerated, MaxListSize), list_max_cValue=makelist(max_cValue, MaxListSize), max_cValue=any(global_Max) by InstanceName",
+        "query": "let computerName = '{Computer}';\r\nlet trendBinSize = totimespan('{grain}');\r\nlet MaxListSize = 1000;\r\nlet rawDataCached = materialize(Perf\r\n\t| where TimeGenerated {TimeRange}\r\n    | where Computer == computerName\r\n    | where\r\n\t\t(ObjectName == 'Logical Disk' and InstanceName != '_Total' and CounterName == '% Used Space') or\r\n        (ObjectName == 'LogicalDisk'  and InstanceName != '_Total' and CounterName == '% Free Space')\r\n\t| project TimeGenerated,\r\n\t\tInstanceName,\r\n\t\tcValue = case(CounterName == '% Free Space', 100 - CounterValue, CounterValue < 0, real(0), CounterValue));\r\n\t\trawDataCached\r\n\t\t\t| summarize max(cValue) by InstanceName\r\n\t\t\t| top 8 by max_cValue\r\n\t\t\t| join (rawDataCached) on InstanceName\r\n\t\t\t| summarize max(cValue), global_Max=any(max_cValue) by bin(TimeGenerated, trendBinSize), InstanceName\r\n\t\t\t| sort by TimeGenerated asc\r\n\t\t\t| summarize makelist(TimeGenerated, MaxListSize), list_max_cValue=makelist(max_cValue, MaxListSize), max_cValue=any(global_Max) by InstanceName",
         "showQuery": false,
         "size": 0,
         "aggregation": 2,
@@ -533,7 +532,7 @@
         "visualization": "timechart"
       },
       "conditionalVisibility": {
-        "parameterName": "computer",
+        "parameterName": "Computer",
         "comparison": "isNotEqualTo",
         "value": null
       }
@@ -541,10 +540,10 @@
     {
       "type": 1,
       "content": {
-        "json": "### Bytes Sent Rate B/s ({computer})"
+        "json": "### Bytes Sent Rate B/s ({Computer})"
       },
       "conditionalVisibility": {
-        "parameterName": "computer",
+        "parameterName": "Computer",
         "comparison": "isNotEqualTo",
         "value": null
       }
@@ -553,7 +552,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let grain = totimespan('{grain}');\r\nlet windowsNetwork=Perf\r\n| where TimeGenerated {TimeRange}\r\n| where Computer == '{computer}'\r\n| where ObjectName == 'Network Adapter' and CounterName == 'Bytes Sent/sec'\r\n| summarize CounterValue = sum(CounterValue) by bin(TimeGenerated, 2s);\r\nlet linuxNetwork=Perf\r\n| where TimeGenerated {TimeRange}\r\n| where Computer == '{computer}'\r\n| where ObjectName == 'Network' and CounterName == 'Total Bytes Transmitted'\r\n| order by InstanceName, TimeGenerated asc\r\n| extend prev_Value=prev(CounterValue), prev_t=prev(TimeGenerated), prev_instance=prev(InstanceName)\r\n| project TimeGenerated, CounterValue=iff(prev_instance == InstanceName and CounterValue >= prev_Value and TimeGenerated > prev_t, (CounterValue - prev_Value) / ((TimeGenerated - prev_t) / 1s), real(0))\r\n| summarize CounterValue = sum(CounterValue) by bin(TimeGenerated, 2s);\r\nlet networkDataSend = union windowsNetwork, linuxNetwork;\r\nnetworkDataSend\r\n| summarize AVERAGE = round(avg(CounterValue), 2) by bin(TimeGenerated, grain)",
+        "query": "let grain = totimespan('{grain}');\r\nlet windowsNetwork=Perf\r\n| where TimeGenerated {TimeRange}\r\n| where Computer == '{Computer}'\r\n| where ObjectName == 'Network Adapter' and CounterName == 'Bytes Sent/sec'\r\n| summarize CounterValue = sum(CounterValue) by bin(TimeGenerated, 2s);\r\nlet linuxNetwork=Perf\r\n| where TimeGenerated {TimeRange}\r\n| where Computer == '{Computer}'\r\n| where ObjectName == 'Network' and CounterName == 'Total Bytes Transmitted'\r\n| order by InstanceName, TimeGenerated asc\r\n| extend prev_Value=prev(CounterValue), prev_t=prev(TimeGenerated), prev_instance=prev(InstanceName)\r\n| project TimeGenerated, CounterValue=iff(prev_instance == InstanceName and CounterValue >= prev_Value and TimeGenerated > prev_t, (CounterValue - prev_Value) / ((TimeGenerated - prev_t) / 1s), real(0))\r\n| summarize CounterValue = sum(CounterValue) by bin(TimeGenerated, 2s);\r\nlet networkDataSend = union windowsNetwork, linuxNetwork;\r\nnetworkDataSend\r\n| summarize AVERAGE = round(avg(CounterValue), 2) by bin(TimeGenerated, grain)",
         "showQuery": false,
         "size": 0,
         "aggregation": 3,
@@ -567,7 +566,7 @@
         "visualization": "timechart"
       },
       "conditionalVisibility": {
-        "parameterName": "computer",
+        "parameterName": "Computer",
         "comparison": "isNotEqualTo",
         "value": null
       }
@@ -575,10 +574,10 @@
     {
       "type": 1,
       "content": {
-        "json": "### Bytes Received Rate B/s ({computer})"
+        "json": "### Bytes Received Rate B/s ({Computer})"
       },
       "conditionalVisibility": {
-        "parameterName": "computer",
+        "parameterName": "Computer",
         "comparison": "isNotEqualTo",
         "value": null
       }
@@ -587,7 +586,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let grain = totimespan('{grain}');\r\nlet windowsNetwork=Perf\r\n| where TimeGenerated {TimeRange}\r\n| where Computer == '{computer}'\r\n| where ObjectName == 'Network Adapter' and CounterName == 'Bytes Received/sec'\r\n| summarize CounterValue = sum(CounterValue) by bin(TimeGenerated, 2s);\r\nlet linuxNetwork=Perf\r\n| where TimeGenerated {TimeRange}\r\n| where Computer == '{computer}'\r\n| where ObjectName == 'Network' and CounterName == 'Total Bytes Received'\r\n| order by InstanceName, TimeGenerated asc\r\n| extend prev_Value = prev(CounterValue), prev_t = prev(TimeGenerated), prev_instance = prev(InstanceName)\r\n| project TimeGenerated, CounterValue = iff(prev_instance == InstanceName and CounterValue >= prev_Value and TimeGenerated > prev_t, (CounterValue - prev_Value) / ((TimeGenerated - prev_t) / 1s), real(0))\r\n| summarize CounterValue = sum(CounterValue) by bin(TimeGenerated, 2s);\r\nlet networkDataReceive = union windowsNetwork, linuxNetwork;\r\nnetworkDataReceive\r\n| summarize AVERAGE = round(avg(CounterValue), 2) by bin(TimeGenerated, grain)",
+        "query": "let grain = totimespan('{grain}');\r\nlet windowsNetwork=Perf\r\n| where TimeGenerated {TimeRange}\r\n| where Computer == '{Computer}'\r\n| where ObjectName == 'Network Adapter' and CounterName == 'Bytes Received/sec'\r\n| summarize CounterValue = sum(CounterValue) by bin(TimeGenerated, 2s);\r\nlet linuxNetwork=Perf\r\n| where TimeGenerated {TimeRange}\r\n| where Computer == '{Computer}'\r\n| where ObjectName == 'Network' and CounterName == 'Total Bytes Received'\r\n| order by InstanceName, TimeGenerated asc\r\n| extend prev_Value = prev(CounterValue), prev_t = prev(TimeGenerated), prev_instance = prev(InstanceName)\r\n| project TimeGenerated, CounterValue = iff(prev_instance == InstanceName and CounterValue >= prev_Value and TimeGenerated > prev_t, (CounterValue - prev_Value) / ((TimeGenerated - prev_t) / 1s), real(0))\r\n| summarize CounterValue = sum(CounterValue) by bin(TimeGenerated, 2s);\r\nlet networkDataReceive = union windowsNetwork, linuxNetwork;\r\nnetworkDataReceive\r\n| summarize AVERAGE = round(avg(CounterValue), 2) by bin(TimeGenerated, grain)",
         "showQuery": false,
         "size": 0,
         "aggregation": 3,
@@ -601,7 +600,7 @@
         "visualization": "timechart"
       },
       "conditionalVisibility": {
-        "parameterName": "computer",
+        "parameterName": "Computer",
         "comparison": "isNotEqualTo",
         "value": null
       }


### PR DESCRIPTION
Change the `computer` parameter to sentence case (i.e. `Computer`) so it
will correctly receive the current computer name when the user navigates
to this workbook from a single VM chart.

- Change `computer` hidden parameter to `Computer`

- Adjust kusto query to remove unused clause

![image](https://user-images.githubusercontent.com/43890980/48744313-9ac9f900-ec1b-11e8-8a3d-6ed57fa68b94.png)