### PR TITLE
Add crossComponentResources to Single VM workbook

### DIFF
--- a/Workbooks/Virtual Machines - Performance Analysis/Performance Analysis for a Single VM/Performance Analysis for a Single VM.workbook
+++ b/Workbooks/Virtual Machines - Performance Analysis/Performance Analysis for a Single VM/Performance Analysis for a Single VM.workbook
@@ -13,7 +13,9 @@
       "content": {
         "version": "KqlParameterItem/1.0",
         "query": "",
-        "crossComponentResources": [],
+        "crossComponentResources": [
+          "{Computer}"
+        ],
         "parameters": [
           {
             "id": "0f7b5485-e076-4a5d-ac13-57ed4141fe05",
@@ -255,7 +257,9 @@
       "content": {
         "version": "KqlParameterItem/1.0",
         "query": "",
-        "crossComponentResources": [],
+        "crossComponentResources": [
+          "{Computer}"
+        ],
         "parameters": [
           {
             "id": "f4ab7159-2f3a-4720-96b2-2365a3e93617",
@@ -289,7 +293,9 @@
       "content": {
         "version": "KqlParameterItem/1.0",
         "query": "",
-        "crossComponentResources": [],
+        "crossComponentResources": [
+          "{Computer}"
+        ],
         "parameters": [
           {
             "id": "a1d2a8b9-9c5b-4d1f-b709-49dbd0fe94bd",
@@ -375,7 +381,9 @@
       "content": {
         "version": "KqlParameterItem/1.0",
         "query": "",
-        "crossComponentResources": [],
+        "crossComponentResources": [
+          "{Computer}"
+        ],
         "parameters": [
           {
             "id": "547dae05-22bf-47a5-ad44-043a23995759",
@@ -409,7 +417,9 @@
       "content": {
         "version": "KqlParameterItem/1.0",
         "query": "",
-        "crossComponentResources": [],
+        "crossComponentResources": [
+          "{Computer}"
+        ],
         "parameters": [
           {
             "id": "8aaa181d-7182-4d9d-b74e-22f37e3acbce",
@@ -495,7 +505,9 @@
       "content": {
         "version": "KqlParameterItem/1.0",
         "query": "",
-        "crossComponentResources": [],
+        "crossComponentResources": [
+          "{Computer}"
+        ],
         "parameters": []
       },
       "customWidth": "50"
@@ -505,7 +517,9 @@
       "content": {
         "version": "KqlParameterItem/1.0",
         "query": "",
-        "crossComponentResources": [],
+        "crossComponentResources": [
+          "{Computer}"
+        ],
         "parameters": [
           {
             "id": "f963e52a-2099-4cd3-a3ad-0fdf78f38238",
@@ -580,16 +594,13 @@
       "customWidth": "50"
     },
     {
-      "type": 1,
-      "content": {},
-      "customWidth": "50"
-    },
-    {
       "type": 9,
       "content": {
         "version": "KqlParameterItem/1.0",
         "query": "",
-        "crossComponentResources": [],
+        "crossComponentResources": [
+          "{Computer}"
+        ],
         "parameters": [
           {
             "id": "c0592d9a-edd4-4a69-86c0-098ac0c72cf2",
@@ -619,11 +630,6 @@
       "customWidth": "50"
     },
     {
-      "type": 9,
-      "content": {},
-      "customWidth": "50"
-    },
-    {
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
@@ -640,11 +646,6 @@
         ],
         "visualization": "timechart"
       },
-      "customWidth": "50"
-    },
-    {
-      "type": 3,
-      "content": {},
       "customWidth": "50"
     }
   ],


### PR DESCRIPTION
I added `crossComponentResources` or the workbook will not correctly read in the passed in resources (workspace and computer ID). Also removed blank items.