### PR TITLE
Change Metrics name to ChartMetrics

### DIFF
--- a/Workbooks/Virtual Machines - Performance Analysis/Performance Analysis for a Single VM/Performance Analysis for a Single VM.workbook
+++ b/Workbooks/Virtual Machines - Performance Analysis/Performance Analysis for a Single VM/Performance Analysis for a Single VM.workbook
@@ -179,7 +179,7 @@
           {
             "id": "28991f51-2685-417c-8737-afb1d6e8d166",
             "version": "KqlParameterItem/1.0",
-            "name": "Metrics",
+            "name": "ChartMetrics",
             "type": 2,
             "isRequired": true,
             "multiSelect": true,
@@ -216,7 +216,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let metric = dynamic({Counter});\r\nPerf\r\n| where TimeGenerated {TimeRange}\r\n| where Computer == Computer\r\n| where ObjectName == metric.object and CounterName == metric.counter\r\n| summarize {Metrics} by bin(TimeGenerated, totimespan('{grain}'))",
+        "query": "let metric = dynamic({Counter});\r\nPerf\r\n| where TimeGenerated {TimeRange}\r\n| where Computer == Computer\r\n| where ObjectName == metric.object and CounterName == metric.counter\r\n| summarize {ChartMetrics} by bin(TimeGenerated, totimespan('{grain}'))",
         "showQuery": false,
         "size": 0,
         "aggregation": 3,
@@ -580,11 +580,6 @@
       "customWidth": "50"
     },
     {
-      "type": 1,
-      "content": {},
-      "customWidth": "50"
-    },
-    {
       "type": 9,
       "content": {
         "version": "KqlParameterItem/1.0",
@@ -619,11 +614,6 @@
       "customWidth": "50"
     },
     {
-      "type": 9,
-      "content": {},
-      "customWidth": "50"
-    },
-    {
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
@@ -640,11 +630,6 @@
         ],
         "visualization": "timechart"
       },
-      "customWidth": "50"
-    },
-    {
-      "type": 3,
-      "content": {},
       "customWidth": "50"
     }
   ],


### PR DESCRIPTION
The Metrics notebook parameter was colliding with the other charts in
the latter half of the workbook. Changing the top-most Metrics to
ChartMetrtics to prevent overriding the defaults of the other charts.

![image](https://user-images.githubusercontent.com/43890980/49616813-f0660b80-f966-11e8-8f56-022b2e622da3.png)
