### PR TITLE
Add custom query field

### DIFF
--- a/Workbooks/Virtual Machines - Performance Analysis/Performance Analysis for a Single VM/Performance Analysis for a Single VM.workbook
+++ b/Workbooks/Virtual Machines - Performance Analysis/Performance Analysis for a Single VM/Performance Analysis for a Single VM.workbook
@@ -16,6 +16,122 @@
         "crossComponentResources": [],
         "parameters": [
           {
+            "id": "481dad1d-44e6-40f8-acc6-8e96ad00c8eb",
+            "version": "KqlParameterItem/1.0",
+            "name": "TimeRange",
+            "type": 4,
+            "isRequired": true,
+            "value": {
+              "durationMs": 86400000,
+              "isInitialTime": false,
+              "grain": 1,
+              "useDashboardTimeRange": false
+            },
+            "isHiddenWhenLocked": false,
+            "typeSettings": {
+              "selectableValues": [
+                {
+                  "durationMs": 300000,
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 900000,
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 1800000,
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 3600000,
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 14400000,
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 43200000,
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 86400000,
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 172800000,
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 259200000,
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 604800000,
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 1209600000,
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 2592000000,
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 5184000000,
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 7776000000,
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                }
+              ],
+              "allowCustom": true
+            },
+            "timeContextFromParameter": null
+          }
+        ],
+        "resourceType": "microsoft.compute/virtualmachines"
+      },
+      "conditionalVisibility": null
+    },
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "query": "",
+        "crossComponentResources": [],
+        "parameters": [
+          {
             "id": "0f7b5485-e076-4a5d-ac13-57ed4141fe05",
             "version": "KqlParameterItem/1.0",
             "name": "Computer",
@@ -35,132 +151,12 @@
             "value": "value::1"
           },
           {
-            "id": "764356de-cf43-4be7-a9f2-f582e5f2ffc2",
-            "version": "KqlParameterItem/1.0",
-            "name": "TimeRange",
-            "type": 4,
-            "isRequired": true,
-            "value": {
-              "durationMs": 86400000,
-              "createdTime": "2018-11-14T21:26:35.440Z",
-              "isInitialTime": false,
-              "grain": 1,
-              "useDashboardTimeRange": false
-            },
-            "isHiddenWhenLocked": false,
-            "typeSettings": {
-              "selectableValues": [
-                {
-                  "durationMs": 300000,
-                  "createdTime": "2018-11-14T21:26:35.438Z",
-                  "isInitialTime": false,
-                  "grain": 1,
-                  "useDashboardTimeRange": false
-                },
-                {
-                  "durationMs": 900000,
-                  "createdTime": "2018-11-14T21:26:35.438Z",
-                  "isInitialTime": false,
-                  "grain": 1,
-                  "useDashboardTimeRange": false
-                },
-                {
-                  "durationMs": 1800000,
-                  "createdTime": "2018-11-14T21:26:35.439Z",
-                  "isInitialTime": false,
-                  "grain": 1,
-                  "useDashboardTimeRange": false
-                },
-                {
-                  "durationMs": 3600000,
-                  "createdTime": "2018-11-14T21:26:35.440Z",
-                  "isInitialTime": false,
-                  "grain": 1,
-                  "useDashboardTimeRange": false
-                },
-                {
-                  "durationMs": 14400000,
-                  "createdTime": "2018-11-14T21:26:35.440Z",
-                  "isInitialTime": false,
-                  "grain": 1,
-                  "useDashboardTimeRange": false
-                },
-                {
-                  "durationMs": 43200000,
-                  "createdTime": "2018-11-14T21:26:35.440Z",
-                  "isInitialTime": false,
-                  "grain": 1,
-                  "useDashboardTimeRange": false
-                },
-                {
-                  "durationMs": 86400000,
-                  "createdTime": "2018-11-14T21:26:35.440Z",
-                  "isInitialTime": false,
-                  "grain": 1,
-                  "useDashboardTimeRange": false
-                },
-                {
-                  "durationMs": 172800000,
-                  "createdTime": "2018-11-14T21:26:35.440Z",
-                  "isInitialTime": false,
-                  "grain": 1,
-                  "useDashboardTimeRange": false
-                },
-                {
-                  "durationMs": 259200000,
-                  "createdTime": "2018-11-14T21:26:35.440Z",
-                  "isInitialTime": false,
-                  "grain": 1,
-                  "useDashboardTimeRange": false
-                },
-                {
-                  "durationMs": 604800000,
-                  "createdTime": "2018-11-14T21:26:35.440Z",
-                  "isInitialTime": false,
-                  "grain": 1,
-                  "useDashboardTimeRange": false
-                },
-                {
-                  "durationMs": 1209600000,
-                  "createdTime": "2018-11-14T21:26:35.440Z",
-                  "isInitialTime": false,
-                  "grain": 1,
-                  "useDashboardTimeRange": false
-                },
-                {
-                  "durationMs": 2592000000,
-                  "createdTime": "2018-11-14T21:26:35.441Z",
-                  "isInitialTime": false,
-                  "grain": 1,
-                  "useDashboardTimeRange": false
-                },
-                {
-                  "durationMs": 5184000000,
-                  "createdTime": "2018-11-14T21:26:35.441Z",
-                  "isInitialTime": false,
-                  "grain": 1,
-                  "useDashboardTimeRange": false
-                },
-                {
-                  "durationMs": 7776000000,
-                  "createdTime": "2018-11-14T21:26:35.442Z",
-                  "isInitialTime": false,
-                  "grain": 1,
-                  "useDashboardTimeRange": false
-                }
-              ],
-              "allowCustom": true
-            },
-            "timeContextFromParameter": null
-          },
-          {
             "id": "d495f8c1-c6b2-490e-8eb6-43d151bc20c0",
             "version": "KqlParameterItem/1.0",
             "name": "Counter",
             "type": 2,
-            "isRequired": true,
+            "isRequired": false,
             "query": "Perf\r\n| where TimeGenerated {TimeRange}\r\n| summarize by CounterName, ObjectName, CounterText = strcat(ObjectName, ' > ', CounterName)\r\n| order by ObjectName asc, CounterText asc\r\n| project Counter = pack('counter', CounterName, 'object', ObjectName), CounterText",
-            "value": "{\"counter\":\"% Processor Time\",\"object\":\"Processor\"}",
             "isHiddenWhenLocked": false,
             "timeContextFromParameter": null,
             "resourceType": "microsoft.compute/virtualmachines"
@@ -177,7 +173,47 @@
             "resourceType": "microsoft.compute/virtualmachines"
           },
           {
-            "id": "28991f51-2685-417c-8737-afb1d6e8d166",
+            "id": "4bf4bd96-531d-4d30-b1ba-1aef067fbc6e",
+            "version": "KqlParameterItem/1.0",
+            "name": "grain",
+            "type": 1,
+            "isRequired": true,
+            "query": "print ({TimeRange:end} - {TimeRange:start})/100",
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "resourceType": "microsoft.compute/virtualmachines"
+          },
+          {
+            "id": "bbf25e25-6f57-44ee-a26a-045f33538cc9",
+            "version": "KqlParameterItem/1.0",
+            "name": "CustomQuery",
+            "type": 1,
+            "isRequired": false,
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null
+          },
+          {
+            "id": "f3b88dab-9ea9-4cae-a6d7-a2104d6c9125",
+            "version": "KqlParameterItem/1.0",
+            "name": "CustomCounterText",
+            "type": 1,
+            "isRequired": false,
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null
+          }
+        ],
+        "resourceType": "microsoft.operationalinsights/resources"
+      }
+    },
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "query": "",
+        "crossComponentResources": [],
+        "parameters": [
+          {
+            "id": "dff91367-8a90-4d46-8a43-8595972eacc8",
             "version": "KqlParameterItem/1.0",
             "name": "ChartMetrics",
             "type": 2,
@@ -189,27 +225,38 @@
               "Average = round(avg(CounterValue), 2)"
             ],
             "isHiddenWhenLocked": false,
-            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\", \"selected\":true },\r\n    { \"value\":\"P1st = round(percentile(CounterValue, 1), 2)\", \"label\":\"P1st\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\", \"selected\":false},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\", \"selected\":false},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\", \"selected\":true},\r\n    { \"value\":\"P99th = round(percentile(CounterValue, 99), 2)\", \"label\":\"P99th\", \"selected\":false},\r\n    { \"value\":\"Min = round(min(CounterValue), 2)\", \"label\":\"Min\", \"selected\":false},\r\n    { \"value\":\"Max = round(max(CounterValue), 2)\", \"label\":\"Max\", \"selected\":false}    \r\n]"
-          },
-          {
-            "id": "4bf4bd96-531d-4d30-b1ba-1aef067fbc6e",
-            "version": "KqlParameterItem/1.0",
-            "name": "grain",
-            "type": 1,
-            "isRequired": true,
-            "query": "print ({TimeRange:end} - {TimeRange:start})/100",
-            "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
-            "resourceType": "microsoft.compute/virtualmachines"
+            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\", \"selected\":true },\r\n    { \"value\":\"P1st = round(percentile(CounterValue, 1), 2)\", \"label\":\"P1st\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\", \"selected\":false},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\", \"selected\":false},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\", \"selected\":false},\r\n    { \"value\":\"P99th = round(percentile(CounterValue, 99), 2)\", \"label\":\"P99th\", \"selected\":false},\r\n    { \"value\":\"Min = round(min(CounterValue), 2)\", \"label\":\"Min\", \"selected\":false},\r\n    { \"value\":\"Max = round(max(CounterValue), 2)\", \"label\":\"Max\", \"selected\":false}    \r\n]",
+            "timeContextFromParameter": null
           }
         ],
-        "resourceType": "microsoft.operationalinsights/resources"
+        "resourceType": "microsoft.compute/virtualmachines"
+      },
+      "conditionalVisibility": {
+        "parameterName": "Counter",
+        "comparison": "isNotEqualTo",
+        "value": ""
+      }
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "💡 *Custom query is being used to display this chart, individual metric selection is currently disabled. Select a Counter to enable metric selection.*"
+      },
+      "conditionalVisibility": {
+        "parameterName": "Counter",
+        "comparison": "isEqualTo",
+        "value": null
       }
     },
     {
       "type": 1,
       "content": {
         "json": "## Trend ({CounterText})"
+      },
+      "conditionalVisibility": {
+        "parameterName": "Counter",
+        "comparison": "isNotEqualTo",
+        "value": null
       }
     },
     {
@@ -228,6 +275,41 @@
           "{Computer}"
         ],
         "visualization": "timechart"
+      },
+      "conditionalVisibility": {
+        "parameterName": "Counter",
+        "comparison": "isNotEqualTo",
+        "value": null
+      }
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "## Trend ({CustomCounterText})"
+      },
+      "conditionalVisibility": {
+        "parameterName": "Counter",
+        "comparison": "isEqualTo",
+        "value": null
+      }
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "{CustomQuery}\r\n| render timechart",
+        "showQuery": false,
+        "size": 0,
+        "aggregation": 0,
+        "showAnnotations": false,
+        "showAnalytics": false,
+        "timeContextFromParameter": null,
+        "resourceType": "microsoft.compute/virtualmachines"
+      },
+      "conditionalVisibility": {
+        "parameterName": "Counter",
+        "comparison": "isEqualTo",
+        "value": null
       }
     },
     {
@@ -580,6 +662,13 @@
       "customWidth": "50"
     },
     {
+      "type": 1,
+      "content": {
+        "json": ""
+      },
+      "customWidth": "50"
+    },
+    {
       "type": 9,
       "content": {
         "version": "KqlParameterItem/1.0",
@@ -610,6 +699,16 @@
             "resourceType": "microsoft.compute/virtualmachines"
           }
         ]
+      },
+      "customWidth": "50"
+    },
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "query": "",
+        "crossComponentResources": [],
+        "parameters": []
       },
       "customWidth": "50"
     },


### PR DESCRIPTION
Single VM workbooks supports custom query for charts such as network and
max logical disk used that cannot be generalized. Also rearranged the
parameters so they appear in a column due to conditional visibility.
Removed "createdTime" from TimeRange parameter as that is not deemed
necessary.

Custom Query:
![image](https://user-images.githubusercontent.com/43890980/49767570-d3467b00-fc8d-11e8-857e-bd08d01e232c.png)

Regular (Non-Custom Query):
![image](https://user-images.githubusercontent.com/43890980/49767624-13a5f900-fc8e-11e8-9ba9-ecdcedccb0a6.png)
