### PR TITLE
Fix vm perf workbook from single vm gallery

### DIFF
--- a/Workbooks/Virtual Machines/Virtual Machine Performance/Virtual Machine Performance.workbook
+++ b/Workbooks/Virtual Machines/Virtual Machine Performance/Virtual Machine Performance.workbook
@@ -139,6 +139,9 @@
             "id": "8f72709f-725a-41e6-82a2-8d067e38a261",
             "version": "KqlParameterItem/1.0",
             "name": "Workspace",
+            "value": [
+              "value::1"
+            ],
             "type": 5,
             "isRequired": true,
             "isHiddenWhenLocked": false,
@@ -146,7 +149,9 @@
               "resourceTypeFilter": {
                 "microsoft.operationalinsights/workspaces": true
               },
-              "additionalResourceOptions": []
+              "additionalResourceOptions": [
+                "value::1"
+              ]
             }
           },
           {


### PR DESCRIPTION
Opening this workbook from Single VM gallery will automatically select a default workspace

![image](https://user-images.githubusercontent.com/43890980/51158536-92bcbd00-184a-11e9-942c-4f065dd41d18.png)
