### PR TITLE
Update VM Group Perf Analysis Workbook

### DIFF
--- a/Workbooks/Virtual Machines - Performance Analysis/Performance Analysis for a Group of VMs/Performance Analysis for a Group of VMs.workbook
+++ b/Workbooks/Virtual Machines - Performance Analysis/Performance Analysis for a Group of VMs/Performance Analysis for a Group of VMs.workbook
@@ -5,7 +5,7 @@
     {
       "type": 1,
       "content": {
-        "json": "# VM Performance Analysis\n\n"
+        "json": "# Performance Analysis\n"
       },
       "conditionalVisibility": null
     },
@@ -28,7 +28,7 @@
             "value": [
               "value::1"
             ],
-            "isHiddenWhenLocked": false,
+            "isHiddenWhenLocked": true,
             "typeSettings": {
               "resourceTypeFilter": {
                 "microsoft.operationalinsights/workspaces": true
@@ -187,63 +187,6 @@
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
           {
-            "id": "9ad8858d-8ef3-4144-94b1-66a8bf9fa9c9",
-            "version": "KqlParameterItem/1.0",
-            "name": "Aggregators",
-            "type": 2,
-            "isRequired": true,
-            "multiSelect": true,
-            "quote": "",
-            "delimiter": ",",
-            "value": [
-              "P95th",
-              "Average",
-              "P10th",
-              "P50th"
-            ],
-            "isHiddenWhenLocked": false,
-            "jsonData": "[\r\n    { \"value\":\"Average\", \"label\":\"Average\", \"selected\":true },\r\n    { \"value\":\"P5th\", \"label\":\"P5th\", \"selected\":false},\r\n    { \"value\":\"P10th\", \"label\":\"P10th\", \"selected\":false},\r\n    { \"value\":\"P50th\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P80th\", \"label\":\"P80th\", \"selected\":false},\r\n    { \"value\":\"P90th\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th\", \"label\":\"P95th\", \"selected\":true},\r\n    { \"value\":\"Min\", \"label\":\"Min\", \"selected\":false},\r\n    { \"value\":\"Max\", \"label\":\"Max\", \"selected\":true}    \r\n]",
-            "timeContextFromParameter": null
-          },
-          {
-            "id": "6a7306ea-247f-46ca-abca-501911f9e9d3",
-            "version": "KqlParameterItem/1.0",
-            "name": "TrendAggregator",
-            "type": 2,
-            "isRequired": true,
-            "isHiddenWhenLocked": false,
-            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\", \"selected\":false},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\", \"selected\":false},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P80th = round(percentile(CounterValue, 80), 2)\", \"label\":\"P80th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\", \"selected\":true}    \r\n]",
-            "timeContextFromParameter": null
-          },
-          {
-            "id": "0327f26e-cdde-4b48-b512-6c35f06ad1d0",
-            "version": "KqlParameterItem/1.0",
-            "name": "TrendAggregatorOrder",
-            "type": 1,
-            "isRequired": false,
-            "query": "range Steps from 1 to 1 step 1\r\n| project value = iff('{TrendAggregator}' contains 'P5th'  or '{TrendAggregator}' contains 'P10th', 'asc', 'desc')",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
-            "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
-            "resourceType": "microsoft.operationalinsights/workspaces"
-          },
-          {
-            "id": "c2f05b6d-970d-4fde-88b0-868387c02250",
-            "version": "KqlParameterItem/1.0",
-            "name": "MergedAggregators",
-            "type": 1,
-            "isRequired": false,
-            "query": "let aggregators = iff('{Aggregators}' contains '{TrendAggregator:label}', '{Aggregators}', '{Aggregators},{TrendAggregator:label}');\r\nrange Steps from 1 to 1 step 1\r\n| project aggregators",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
-            "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
-            "resourceType": "microsoft.operationalinsights/workspaces"
-          },
-          {
             "id": "ce228deb-88eb-4438-9dce-6c6d1972ff09",
             "version": "KqlParameterItem/1.0",
             "name": "IsNetworkCounter",
@@ -266,6 +209,7 @@
             "resourceType": "microsoft.operationalinsights/workspaces"
           }
         ],
+        "style": "above",
         "resourceType": "microsoft.operationalinsights/workspaces"
       },
       "conditionalVisibility": null
@@ -284,7 +228,14 @@
     {
       "type": 1,
       "content": {
-        "json": "## Top 100 Machines based on ({CounterText}) ({TrendAggregator:label} {TrendAggregatorOrder})"
+        "json": "---"
+      },
+      "conditionalVisibility": null
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "## Top 100 Machines\r\n#### <span style=\"color: #444;\">{CounterText}</span>"
       },
       "conditionalVisibility": null,
       "customWidth": "50"
@@ -292,7 +243,144 @@
     {
       "type": 1,
       "content": {
-        "json": "## Top 5 Machines based on ({CounterText}) ({TrendAggregator:label} {TrendAggregatorOrder})"
+        "json": "## Top 5 Machines\r\n#### <span style=\"color: #444;\">{CounterText}</span>"
+      },
+      "conditionalVisibility": null,
+      "customWidth": "50"
+    },
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "query": "",
+        "crossComponentResources": [],
+        "parameters": [
+          {
+            "id": "9ad8858d-8ef3-4144-94b1-66a8bf9fa9c9",
+            "version": "KqlParameterItem/1.0",
+            "name": "Aggregators",
+            "type": 2,
+            "isRequired": true,
+            "multiSelect": true,
+            "quote": "",
+            "delimiter": ",",
+            "value": [
+              "Average",
+              "P95th",
+              "Max"
+            ],
+            "isHiddenWhenLocked": false,
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "jsonData": "[\r\n    { \"value\":\"Average\", \"label\":\"Average\" },\r\n    { \"value\":\"P5th\", \"label\":\"P5th\"},\r\n    { \"value\":\"P10th\", \"label\":\"P10th\"},\r\n    { \"value\":\"P50th\", \"label\":\"P50th\"},\r\n    { \"value\":\"P80th\", \"label\":\"P80th\"},\r\n    { \"value\":\"P90th\", \"label\":\"P90th\"},\r\n    { \"value\":\"P95th\", \"label\":\"P95th\"},\r\n    { \"value\":\"Min\", \"label\":\"Min\"},\r\n    { \"value\":\"Max\", \"label\":\"Max\"}    \r\n]",
+            "timeContextFromParameter": null
+          },
+          {
+            "id": "6a7306ea-247f-46ca-abca-501911f9e9d3",
+            "version": "KqlParameterItem/1.0",
+            "name": "TableTrend",
+            "type": 2,
+            "isRequired": true,
+            "value": "Average = round(avg(CounterValue), 2)",
+            "isHiddenWhenLocked": false,
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\"},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\"},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\"},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\"},\r\n    { \"value\":\"P80th = round(percentile(CounterValue, 80), 2)\", \"label\":\"P80th\"},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\"},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\"}\r\n]",
+            "timeContextFromParameter": null
+          },
+          {
+            "id": "0327f26e-cdde-4b48-b512-6c35f06ad1d0",
+            "version": "KqlParameterItem/1.0",
+            "name": "tableTrendOrder",
+            "type": 1,
+            "isRequired": false,
+            "query": "range Steps from 1 to 1 step 1\r\n| project value = iff('{TableTrend}' contains 'P5th'  or '{TableTrend}' contains 'P10th', 'asc', 'desc')",
+            "crossComponentResources": [
+              "{Workspaces}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          },
+          {
+            "id": "c2f05b6d-970d-4fde-88b0-868387c02250",
+            "version": "KqlParameterItem/1.0",
+            "name": "mergedAggregators",
+            "type": 1,
+            "isRequired": false,
+            "query": "let aggregators = iff('{Aggregators}' contains '{TableTrend:label}', '{Aggregators}', '{Aggregators},{TableTrend:label}');\r\nrange Steps from 1 to 1 step 1\r\n| project aggregators",
+            "crossComponentResources": [
+              "{Workspaces}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          }
+        ],
+        "style": "above",
+        "resourceType": "microsoft.operationalinsights/workspaces"
+      },
+      "conditionalVisibility": null,
+      "customWidth": "50"
+    },
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "query": "",
+        "crossComponentResources": [
+          "{Workspaces}"
+        ],
+        "parameters": [
+          {
+            "id": "6a7306ea-247f-46ca-abca-501911f9e9d3",
+            "version": "KqlParameterItem/1.0",
+            "name": "Percentile",
+            "type": 2,
+            "isRequired": true,
+            "value": "Average = round(avg(CounterValue), 2)",
+            "isHiddenWhenLocked": false,
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\"},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\"},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\"},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\"},\r\n    { \"value\":\"P80th = round(percentile(CounterValue, 80), 2)\", \"label\":\"P80th\"},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\"},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\"}\r\n]",
+            "timeContextFromParameter": null
+          },
+          {
+            "id": "541f295c-8426-410a-be40-5a858a0261c1",
+            "version": "KqlParameterItem/1.0",
+            "name": "percentileOrder",
+            "type": 1,
+            "isRequired": false,
+            "query": "range Steps from 1 to 1 step 1\r\n| project value = iff('{Percentile}' contains 'P5th'  or '{Percentile}' contains 'P10th', 'asc', 'desc')",
+            "crossComponentResources": [
+              "{Workspaces}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          }
+        ],
+        "style": "above",
+        "resourceType": "microsoft.operationalinsights/workspaces"
+      },
+      "conditionalVisibility": null,
+      "customWidth": "50"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "<p><strong style=\"color:#333;\">Aggregators</strong> Select one or more different percentiles to display in the table below</p>\r\n<p><strong style=\"color:#333;\">TableTrend</strong> Select a percentile to display in the Trend column in the table below</p>"
+      },
+      "conditionalVisibility": null,
+      "customWidth": "50"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "<p><strong style=\"color:#333;\">Percentile</strong> Select a percentile for the chart below</span></p>"
       },
       "conditionalVisibility": null,
       "customWidth": "50"
@@ -301,7 +389,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let maxResultCount = 100;  \r\nlet metric = dynamic({Counter});\r\nlet summaryPerComputer = totable(Perf \r\n    | where TimeGenerated {TimeRange}  \r\n    | where ObjectName == metric.object and CounterName == metric.counter\r\n    | summarize hint.shufflekey = Computer Average = avg(CounterValue), Max = max(CounterValue), Min = min(CounterValue), percentiles(CounterValue, 5, 10, 50, 80, 90, 95) by Computer \r\n    | project Computer, Average, Max, Min, P5th = percentile_CounterValue_5, P10th = percentile_CounterValue_10, P50th = percentile_CounterValue_50, P80th = percentile_CounterValue_80, P90th = percentile_CounterValue_90, P95th = percentile_CounterValue_95 \r\n    | order by {TrendAggregator:label} {TrendAggregatorOrder}, Computer \r\n    | limit maxResultCount); \r\nlet computerList = summaryPerComputer \r\n    | project Computer; \r\nlet MachineSummary = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | project Computer, MachineSummary = pack(\"Fully Qualified Domain Name\", Computer, \"OS Type\", OperatingSystemFamily_s, \"Operating System\", OperatingSystemFullName_s, \"Ipv4 Addresses\", Ipv4Addresses_s,\r\n        \"Ipv6 Addresses\", Ipv6Addresses_s, \"Mac Addresses\", MacAddresses_s, \"DNS Names\", DnsNames_s, \"CPUs\", strcat(Cpus_d, \" @ \", CpuSpeed_d, \" MHz\"), \"Bitness\", Bitness_s,\r\n        \"Physcial Memory\", strcat(PhysicalMemory_d, \" MB\"), \"Virtualization State\", VirtualizationState_s, \"VM Type\", VirtualMachineType_s, \"OMS Agent\", split(ResourceName_s, \"m-\")[1]);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Type = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", strcat(NodeProps.vmScaleSetName, \" | \", NodeProps.scaleSetInstanceId), \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", strcat(NodeProps.cloudServiceRoleName, \" | \", NodeProps.cloudServiceInstanceId), Computer))\r\n    | project Computer, Type, ResourceId, ResourceName;\r\nlet trend = Perf     \r\n    | where TimeGenerated {TimeRange}    \r\n    | where Computer in (computerList)     \r\n    | where ObjectName == metric.object and CounterName == metric.counter   \r\n    | make-series {TrendAggregator} default = 0 on TimeGenerated in range({TimeRange:start}, {TimeRange:end}, {TimeRange:grain}) by Computer\r\n    | project Computer, ['Trend ({TrendAggregator:label})'] = {TrendAggregator:label};\r\nsummaryPerComputer\r\n    | join kind=leftouter (trend) on Computer\r\n    | join kind=leftouter (NodeIdentityAndProps) on Computer\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | join kind=leftouter (MachineSummary) on Computer\r\n    | project ResourceName, Type, {MergedAggregators}, ['Trend ({TrendAggregator:label})'], Properties = MachineSummary\r\n    | sort by {TrendAggregator:label} {TrendAggregatorOrder}",
+        "query": "let maxResultCount = 100;  \r\nlet metric = dynamic({Counter});\r\nlet summaryPerComputer = totable(Perf \r\n    | where TimeGenerated {TimeRange}  \r\n    | where ObjectName == metric.object and CounterName == metric.counter\r\n    | summarize hint.shufflekey = Computer Average = avg(CounterValue), Max = max(CounterValue), Min = min(CounterValue), percentiles(CounterValue, 5, 10, 50, 80, 90, 95) by Computer \r\n    | project Computer, Average, Max, Min, P5th = percentile_CounterValue_5, P10th = percentile_CounterValue_10, P50th = percentile_CounterValue_50, P80th = percentile_CounterValue_80, P90th = percentile_CounterValue_90, P95th = percentile_CounterValue_95 \r\n    | order by {TableTrend:label} {tableTrendOrder}, Computer \r\n    | limit maxResultCount); \r\nlet computerList = summaryPerComputer \r\n    | project Computer; \r\nlet MachineSummary = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | project Computer, MachineSummary = pack(\"Fully Qualified Domain Name\", Computer, \"OS Type\", OperatingSystemFamily_s, \"Operating System\", OperatingSystemFullName_s, \"Ipv4 Addresses\", Ipv4Addresses_s,\r\n        \"Ipv6 Addresses\", Ipv6Addresses_s, \"Mac Addresses\", MacAddresses_s, \"DNS Names\", DnsNames_s, \"CPUs\", strcat(Cpus_d, \" @ \", CpuSpeed_d, \" MHz\"), \"Bitness\", Bitness_s,\r\n        \"Physcial Memory\", strcat(PhysicalMemory_d, \" MB\"), \"Virtualization State\", VirtualizationState_s, \"VM Type\", VirtualMachineType_s, \"OMS Agent\", split(ResourceName_s, \"m-\")[1]);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Type = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", strcat(NodeProps.vmScaleSetName, \" | \", NodeProps.scaleSetInstanceId), \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", strcat(NodeProps.cloudServiceRoleName, \" | \", NodeProps.cloudServiceInstanceId), Computer))\r\n    | project Computer, Type, ResourceId, ResourceName;\r\nlet trend = Perf     \r\n    | where TimeGenerated {TimeRange}    \r\n    | where Computer in (computerList)     \r\n    | where ObjectName == metric.object and CounterName == metric.counter   \r\n    | make-series {TableTrend} default = 0 on TimeGenerated in range({TimeRange:start}, {TimeRange:end}, {TimeRange:grain}) by Computer\r\n    | project Computer, ['Trend ({TableTrend:label})'] = {TableTrend:label};\r\nsummaryPerComputer\r\n    | join kind=leftouter (trend) on Computer\r\n    | join kind=leftouter (NodeIdentityAndProps) on Computer\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | join kind=leftouter (MachineSummary) on Computer\r\n    | project ResourceName, Type, {mergedAggregators}, ['Trend ({TableTrend:label})'], Properties = MachineSummary\r\n    | sort by {TableTrend:label} {tableTrendOrder}",
         "showQuery": false,
         "size": 0,
         "aggregation": 0,
@@ -322,15 +410,43 @@
             },
             {
               "columnMatch": "Average",
-              "formatter": 1,
+              "formatter": 8,
               "formatOptions": {
-                "palette": "greenRed"
+                "palette": "blue"
               },
               "numberFormat": {
                 "unit": 0,
                 "options": {
                   "style": "decimal"
                 }
+              }
+            },
+            {
+              "columnMatch": "P50th",
+              "formatter": 8,
+              "formatOptions": {
+                "palette": "blue"
+              },
+              "numberFormat": {
+                "unit": 0,
+                "options": {
+                  "style": "decimal"
+                }
+              }
+            },
+            {
+              "columnMatch": "Trend (Average)",
+              "formatter": 10,
+              "formatOptions": {
+                "palette": "blue"
+              }
+            },
+            {
+              "columnMatch": "Properties",
+              "formatter": 7,
+              "formatOptions": {
+                "linkTarget": "CellDetails",
+                "linkLabel": "ℹ️ Info"
               }
             },
             {
@@ -361,20 +477,9 @@
             },
             {
               "columnMatch": "P10th",
-              "formatter": 1,
-              "formatOptions": {},
-              "numberFormat": {
-                "unit": 0,
-                "options": {
-                  "style": "decimal"
-                }
-              }
-            },
-            {
-              "columnMatch": "P50th",
-              "formatter": 1,
+              "formatter": 8,
               "formatOptions": {
-                "palette": "greenRed"
+                "palette": "blue"
               },
               "numberFormat": {
                 "unit": 0,
@@ -385,9 +490,9 @@
             },
             {
               "columnMatch": "P80th",
-              "formatter": 1,
+              "formatter": 8,
               "formatOptions": {
-                "palette": "greenRed"
+                "palette": "blue"
               },
               "numberFormat": {
                 "unit": 0,
@@ -398,9 +503,9 @@
             },
             {
               "columnMatch": "P90th",
-              "formatter": 1,
+              "formatter": 8,
               "formatOptions": {
-                "palette": "greenRed"
+                "palette": "blue"
               },
               "numberFormat": {
                 "unit": 0,
@@ -411,8 +516,10 @@
             },
             {
               "columnMatch": "Min",
-              "formatter": 1,
-              "formatOptions": {},
+              "formatter": 8,
+              "formatOptions": {
+                "palette": "blue"
+              },
               "numberFormat": {
                 "unit": 0,
                 "options": {
@@ -422,9 +529,9 @@
             },
             {
               "columnMatch": "Max",
-              "formatter": 1,
+              "formatter": 8,
               "formatOptions": {
-                "palette": "greenRed"
+                "palette": "blue"
               },
               "numberFormat": {
                 "unit": 0,
@@ -438,14 +545,6 @@
               "formatter": 10,
               "formatOptions": {
                 "palette": "blue"
-              }
-            },
-            {
-              "columnMatch": "Properties",
-              "formatter": 7,
-              "formatOptions": {
-                "linkTarget": "CellDetails",
-                "linkLabel": "ℹ️ Info"
               }
             },
             {
@@ -482,13 +581,6 @@
               "formatOptions": {
                 "palette": "blue"
               }
-            },
-            {
-              "columnMatch": "Trend (Average)",
-              "formatter": 10,
-              "formatOptions": {
-                "palette": "blue"
-              }
             }
           ]
         }
@@ -504,7 +596,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let metric = dynamic({Counter});\r\nlet linux = iff(metric.counter == 'Bytes Received/sec', dynamic({'object': 'Network', 'counter': 'Total Bytes Received'}), dynamic({'object': 'Network', 'counter': 'Total Bytes Transmitted'}));\r\nlet maxResultCount = 100;\r\nlet windowsNetworkRaw = Perf\r\n| where TimeGenerated {TimeRange}\r\n| where ObjectName == metric.object and CounterName == metric.couter;\r\nlet windowsNetworkSum = windowsNetworkRaw\r\n| summarize hint.shufflekey=Computer CounterValue=sum(CounterValue) by Computer, TimeGenerated;\r\nlet windowsNetworkPctl = windowsNetworkRaw\r\n| summarize hint.shufflekey=Computer Average = avg(CounterValue), Max = max(CounterValue), Min = min(CounterValue), percentiles(CounterValue, 5, 10, 50, 80, 90, 95) by Computer, TimeGenerated\r\n| project TimeGenerated, Computer, Average, Max, Min, P5th = percentile_CounterValue_5, P10th = percentile_CounterValue_10, P50th = percentile_CounterValue_50, P80th = percentile_CounterValue_80, P90th = percentile_CounterValue_90, P95th = percentile_CounterValue_95;\r\nlet linuxNetworkRaw = Perf\r\n| where TimeGenerated {TimeRange}\r\n| where ObjectName == linux.object and CounterName == linux.counter\r\n| order by InstanceName, TimeGenerated asc\r\n| extend prev_Value = prev(CounterValue), prev_t = prev(TimeGenerated), prev_instance = prev(InstanceName)\r\n| project TimeGenerated, Computer, CounterValue = iff(prev_instance == InstanceName and CounterValue >= prev_Value and TimeGenerated > prev_t, (CounterValue - prev_Value) / ((TimeGenerated - prev_t) / 1s), real(0));\r\nlet linuxNetworkSum = linuxNetworkRaw\r\n| summarize hint.shufflekey=Computer CounterValue=sum(CounterValue) by Computer, TimeGenerated;\r\nlet linuxNetworkPctl = linuxNetworkRaw\r\n| summarize hint.shufflekey=Computer Average = avg(CounterValue), Max = max(CounterValue), Min = min(CounterValue), percentiles(CounterValue, 5, 10, 50, 80, 90, 95) by Computer, TimeGenerated\r\n| project TimeGenerated, Computer, Average, Max, Min, P5th = percentile_CounterValue_5, P10th = percentile_CounterValue_10, P50th = percentile_CounterValue_50, P80th = percentile_CounterValue_80, P90th = percentile_CounterValue_90, P95th = percentile_CounterValue_95;\r\nlet networkDataSum = union windowsNetworkSum, linuxNetworkSum;\r\nlet networkDataPctl = union windowsNetworkPctl, linuxNetworkPctl;\r\nlet computerList = Perf \r\n| project Computer;\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n| extend NodeId = Computer\r\n| extend Priority = 1\r\n| extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n| where TimeGenerated {TimeRange}\r\n| where Computer in (computerList)\r\n| summarize hint.shufflekey=Computer arg_max(TimeGenerated, *) by Computer\r\n| extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|', columnifexists('AzureCloudServiceDeployment_g', '')), ''), AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')), strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|', columnifexists('AzureVmScaleSetDeployment_g', '')), ''), ComputerProps = pack('type', 'StandAloneNode', 'name', ComputerName_s, 'mappingResourceId', ResourceId, 'subscriptionId', AzureSubscriptionId_g, 'resourceGroup', AzureResourceGroup_s, 'azureResourceId', columnifexists('AzureResourceId_s', '')), AzureCloudServiceNodeProps = pack('type', 'AzureCloudServiceNode', 'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''), 'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''), 'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''), 'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''), 'mappingResourceId', ResourceId), AzureScaleSetNodeProps = pack('type', 'AzureScaleSetNode', 'scaleSetInstanceId', columnifexists('AzureName_s', ''), 'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''), 'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''), 'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''), 'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''), 'resourceGroupName', columnifexists('AzureResourceGroup_s', ''), 'subscriptionId', columnifexists('AzureSubscriptionId_g', ''), 'mappingResourceId', ResourceId)| project   Computer, NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity, isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer), NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps, isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps), Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps\r\n| summarize hint.shufflekey=Computer arg_max(Priority, *) by Computer;\r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n| extend Type = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)), ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", strcat(NodeProps.vmScaleSetName, \" | \", NodeProps.scaleSetInstanceId), iff(NodeProps.type == \"AzureCloudServiceNode\", strcat(NodeProps.cloudServiceRoleName, \" | \", NodeProps.cloudServiceInstanceId), Computer))\r\n| project Computer, Type, ResourceId, ResourceName;\r\nlet MachineSummary = ServiceMapComputer_CL\r\n| where TimeGenerated {TimeRange}\r\n| where Computer in (computerList)\r\n| summarize hint.shufflekey=Computer arg_max(TimeGenerated, *) by Computer\r\n| project Computer, MachineSummary = pack(\"Fully Qualified Domain Name\", Computer, \"OS Type\", OperatingSystemFamily_s, \"Operating System\", OperatingSystemFullName_s, \"Ipv4 Addresses\", Ipv4Addresses_s, \"Ipv6 Addresses\", Ipv6Addresses_s, \"Mac Addresses\", MacAddresses_s, \"DNS Names\", DnsNames_s, \"CPUs\", strcat(Cpus_d, \" @ \", CpuSpeed_d, \" MHz\"), \"Bitness\", Bitness_s, \"Physcial Memory\", strcat(PhysicalMemory_d, \" MB\"), \"Virtualization State\", VirtualizationState_s, \"VM Type\", VirtualMachineType_s, \"OMS Agent\", split(ResourceName_s, \"m-\")[1]);\r\nlet trend = networkDataSum\r\n| make-series {TrendAggregator} default=0 on TimeGenerated in range({TimeRange:start}, {TimeRange:end}, {TimeRange:grain}) by Computer\r\n| project Computer, ['Trend ({TrendAggregator:label})'] = {TrendAggregator:label};\r\nnetworkDataPctl\r\n| join kind=leftouter hint.shufflekey=Computer (trend) on Computer\r\n| join kind=leftouter hint.shufflekey=Computer (NodeIdentityAndPropsMin) on Computer\r\n| join kind=leftouter hint.shufflekey=Computer (MachineSummary) on Computer\r\n| project ResourceName, Type, {MergedAggregators}, ['Trend ({TrendAggregator:label})'], Properties = MachineSummary\r\n| sort by {TrendAggregator:label} {TrendAggregatorOrder}\r\n| limit maxResultCount",
+        "query": "let metric = dynamic({Counter});\r\nlet linux = iff(metric.counter == 'Bytes Received/sec', dynamic({'object': 'Network', 'counter': 'Total Bytes Received'}), dynamic({'object': 'Network', 'counter': 'Total Bytes Transmitted'}));\r\nlet maxResultCount = 100;\r\nlet windowsNetworkRaw = Perf\r\n| where TimeGenerated {TimeRange}\r\n| where ObjectName == metric.object and CounterName == metric.couter;\r\nlet windowsNetworkSum = windowsNetworkRaw\r\n| summarize hint.shufflekey=Computer CounterValue=sum(CounterValue) by Computer, TimeGenerated;\r\nlet windowsNetworkPctl = windowsNetworkRaw\r\n| summarize hint.shufflekey=Computer Average = avg(CounterValue), Max = max(CounterValue), Min = min(CounterValue), percentiles(CounterValue, 5, 10, 50, 80, 90, 95) by Computer, TimeGenerated\r\n| project TimeGenerated, Computer, Average, Max, Min, P5th = percentile_CounterValue_5, P10th = percentile_CounterValue_10, P50th = percentile_CounterValue_50, P80th = percentile_CounterValue_80, P90th = percentile_CounterValue_90, P95th = percentile_CounterValue_95;\r\nlet linuxNetworkRaw = Perf\r\n| where TimeGenerated {TimeRange}\r\n| where ObjectName == linux.object and CounterName == linux.counter\r\n| order by InstanceName, TimeGenerated asc\r\n| extend prev_Value = prev(CounterValue), prev_t = prev(TimeGenerated), prev_instance = prev(InstanceName)\r\n| project TimeGenerated, Computer, CounterValue = iff(prev_instance == InstanceName and CounterValue >= prev_Value and TimeGenerated > prev_t, (CounterValue - prev_Value) / ((TimeGenerated - prev_t) / 1s), real(0));\r\nlet linuxNetworkSum = linuxNetworkRaw\r\n| summarize hint.shufflekey=Computer CounterValue=sum(CounterValue) by Computer, TimeGenerated;\r\nlet linuxNetworkPctl = linuxNetworkRaw\r\n| summarize hint.shufflekey=Computer Average = avg(CounterValue), Max = max(CounterValue), Min = min(CounterValue), percentiles(CounterValue, 5, 10, 50, 80, 90, 95) by Computer, TimeGenerated\r\n| project TimeGenerated, Computer, Average, Max, Min, P5th = percentile_CounterValue_5, P10th = percentile_CounterValue_10, P50th = percentile_CounterValue_50, P80th = percentile_CounterValue_80, P90th = percentile_CounterValue_90, P95th = percentile_CounterValue_95;\r\nlet networkDataSum = union windowsNetworkSum, linuxNetworkSum;\r\nlet networkDataPctl = union windowsNetworkPctl, linuxNetworkPctl;\r\nlet computerList = Perf \r\n| project Computer;\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n| extend NodeId = Computer\r\n| extend Priority = 1\r\n| extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n| where TimeGenerated {TimeRange}\r\n| where Computer in (computerList)\r\n| summarize hint.shufflekey=Computer arg_max(TimeGenerated, *) by Computer\r\n| extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|', columnifexists('AzureCloudServiceDeployment_g', '')), ''), AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')), strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|', columnifexists('AzureVmScaleSetDeployment_g', '')), ''), ComputerProps = pack('type', 'StandAloneNode', 'name', ComputerName_s, 'mappingResourceId', ResourceId, 'subscriptionId', AzureSubscriptionId_g, 'resourceGroup', AzureResourceGroup_s, 'azureResourceId', columnifexists('AzureResourceId_s', '')), AzureCloudServiceNodeProps = pack('type', 'AzureCloudServiceNode', 'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''), 'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''), 'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''), 'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''), 'mappingResourceId', ResourceId), AzureScaleSetNodeProps = pack('type', 'AzureScaleSetNode', 'scaleSetInstanceId', columnifexists('AzureName_s', ''), 'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''), 'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''), 'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''), 'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''), 'resourceGroupName', columnifexists('AzureResourceGroup_s', ''), 'subscriptionId', columnifexists('AzureSubscriptionId_g', ''), 'mappingResourceId', ResourceId)| project   Computer, NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity, isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer), NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps, isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps), Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps\r\n| summarize hint.shufflekey=Computer arg_max(Priority, *) by Computer;\r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n| extend Type = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)), ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", strcat(NodeProps.vmScaleSetName, \" | \", NodeProps.scaleSetInstanceId), iff(NodeProps.type == \"AzureCloudServiceNode\", strcat(NodeProps.cloudServiceRoleName, \" | \", NodeProps.cloudServiceInstanceId), Computer))\r\n| project Computer, Type, ResourceId, ResourceName;\r\nlet MachineSummary = ServiceMapComputer_CL\r\n| where TimeGenerated {TimeRange}\r\n| where Computer in (computerList)\r\n| summarize hint.shufflekey=Computer arg_max(TimeGenerated, *) by Computer\r\n| project Computer, MachineSummary = pack(\"Fully Qualified Domain Name\", Computer, \"OS Type\", OperatingSystemFamily_s, \"Operating System\", OperatingSystemFullName_s, \"Ipv4 Addresses\", Ipv4Addresses_s, \"Ipv6 Addresses\", Ipv6Addresses_s, \"Mac Addresses\", MacAddresses_s, \"DNS Names\", DnsNames_s, \"CPUs\", strcat(Cpus_d, \" @ \", CpuSpeed_d, \" MHz\"), \"Bitness\", Bitness_s, \"Physcial Memory\", strcat(PhysicalMemory_d, \" MB\"), \"Virtualization State\", VirtualizationState_s, \"VM Type\", VirtualMachineType_s, \"OMS Agent\", split(ResourceName_s, \"m-\")[1]);\r\nlet trend = networkDataSum\r\n| make-series {TableTrend} default=0 on TimeGenerated in range({TimeRange:start}, {TimeRange:end}, {TimeRange:grain}) by Computer\r\n| project Computer, ['Trend ({TableTrend:label})'] = {TableTrend:label};\r\nnetworkDataPctl\r\n| join kind=leftouter hint.shufflekey=Computer (trend) on Computer\r\n| join kind=leftouter hint.shufflekey=Computer (NodeIdentityAndPropsMin) on Computer\r\n| join kind=leftouter hint.shufflekey=Computer (MachineSummary) on Computer\r\n| project ResourceName, Type, {mergedAggregators}, ['Trend ({TableTrend:label})'], Properties = MachineSummary\r\n| sort by {TableTrend:label} {tableTrendOrder}\r\n| limit maxResultCount",
         "showQuery": false,
         "size": 0,
         "aggregation": 0,
@@ -704,7 +796,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let metric = dynamic({Counter});\r\nlet cpuSummary=totable(Perf\r\n    | where TimeGenerated {TimeRange} \r\n    | where ObjectName == metric.object and CounterName == metric.counter\r\n    | summarize hint.shufflekey=Computer {TrendAggregator} by Computer, CounterName\r\n    | top 5 by {TrendAggregator:label} {TrendAggregatorOrder});\r\nlet computerList=(cpuSummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nPerf\r\n    | where TimeGenerated {TimeRange}\r\n    | where ObjectName == metric.object and CounterName == metric.counter\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {TrendAggregator} by bin(TimeGenerated, ({TimeRange:end} - {TimeRange:start})/100), ResourceName",
+        "query": "let metric = dynamic({Counter});\r\nlet cpuSummary=totable(Perf\r\n    | where TimeGenerated {TimeRange} \r\n    | where ObjectName == metric.object and CounterName == metric.counter\r\n    | summarize hint.shufflekey=Computer {Percentile} by Computer, CounterName\r\n    | top 5 by {Percentile:label} {percentileOrder});\r\nlet computerList=(cpuSummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nPerf\r\n    | where TimeGenerated {TimeRange}\r\n    | where ObjectName == metric.object and CounterName == metric.counter\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {Percentile} by bin(TimeGenerated, ({TimeRange:end} - {TimeRange:start})/100), ResourceName",
         "showQuery": false,
         "size": 0,
         "aggregation": 3,
@@ -749,7 +841,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let metric = dynamic({Counter});\r\nlet linux = iff(metric.counter == 'Bytes Received/sec', dynamic({'object': 'Network', 'counter': 'Total Bytes Received'}), dynamic({'object': 'Network', 'counter': 'Total Bytes Transmitted'}));\r\nlet windowsNetworkRaw = Perf\r\n| where TimeGenerated {TimeRange}\r\n| where ObjectName == metric.object and CounterName == metric.counter;\r\nlet windowsNetworkPctl = windowsNetworkRaw\r\n| summarize hint.shufflekey=Computer Average = avg(CounterValue), Max = max(CounterValue), Min = min(CounterValue), percentiles(CounterValue, 5, 10, 50, 80, 90, 95) by bin(TimeGenerated, ({TimeRange:end} - {TimeRange:start})/100), Computer\r\n| project TimeGenerated, Computer, Average, Max, Min, P5th = percentile_CounterValue_5, P10th = percentile_CounterValue_10, P50th = percentile_CounterValue_50, P80th = percentile_CounterValue_80, P90th = percentile_CounterValue_90, P95th = percentile_CounterValue_95;\r\nlet linuxNetworkRaw = Perf\r\n| where TimeGenerated {TimeRange}\r\n| where ObjectName == linux.object and CounterName == linux.counter\r\n| order by InstanceName, TimeGenerated asc\r\n| extend prev_Value = prev(CounterValue), prev_t = prev(TimeGenerated), prev_instance = prev(InstanceName)\r\n| project TimeGenerated, Computer, CounterValue = iff(prev_instance == InstanceName and CounterValue >= prev_Value and TimeGenerated > prev_t, (CounterValue - prev_Value) / ((TimeGenerated - prev_t) / 1s), real(0));\r\nlet linuxNetworkPctl = linuxNetworkRaw\r\n| summarize hint.shufflekey=Computer Average = avg(CounterValue), Max = max(CounterValue), Min = min(CounterValue), percentiles(CounterValue, 5, 10, 50, 80, 90, 95) by bin(TimeGenerated, ({TimeRange:end} - {TimeRange:start})/100), Computer\r\n| project TimeGenerated, Computer, Average, Max, Min, P5th = percentile_CounterValue_5, P10th = percentile_CounterValue_10, P50th = percentile_CounterValue_50, P80th = percentile_CounterValue_80, P90th = percentile_CounterValue_90, P95th = percentile_CounterValue_95;\r\nlet networkDataPctl = union windowsNetworkPctl, linuxNetworkPctl;\r\nlet networkDataPctlTopComputers = networkDataPctl\r\n| summarize CounterValue=sum({TrendAggregator:label}) by Computer\r\n| top 5 by CounterValue desc\r\n| project Computer;\r\nlet computerList=(Perf\r\n| project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n| extend NodeId = Computer\r\n| extend Priority = 1\r\n| extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n| where TimeGenerated {TimeRange}\r\n| where Computer in (computerList)\r\n| summarize hint.shufflekey=Computer arg_max(TimeGenerated, *) by Computer\r\n| extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|', columnifexists('AzureCloudServiceDeployment_g', '')), ''), AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')), strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|', columnifexists('AzureVmScaleSetDeployment_g', '')), ''), ComputerProps = pack('type', 'StandAloneNode', 'name', ComputerName_s, 'mappingResourceId', ResourceId, 'subscriptionId', AzureSubscriptionId_g, 'resourceGroup', AzureResourceGroup_s, 'azureResourceId', columnifexists('AzureResourceId_s', '')), AzureCloudServiceNodeProps = pack('type', 'AzureCloudServiceNode', 'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''), 'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''), 'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''), 'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''), 'mappingResourceId', ResourceId), AzureScaleSetNodeProps = pack('type', 'AzureScaleSetNode', 'scaleSetInstanceId', columnifexists('AzureName_s', ''), 'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''), 'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''), 'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''), 'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''), 'resourceGroupName', columnifexists('AzureResourceGroup_s', ''), 'subscriptionId', columnifexists('AzureSubscriptionId_g', ''), 'mappingResourceId', ResourceId)| project   Computer, NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity, isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer), NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps, isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps), Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps\r\n| summarize hint.shufflekey=Computer arg_max(Priority, *) by Computer;\r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n| extend Type = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)), ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", strcat(NodeProps.vmScaleSetName, \" | \", NodeProps.scaleSetInstanceId), iff(NodeProps.type == \"AzureCloudServiceNode\", strcat(NodeProps.cloudServiceRoleName, \" | \", NodeProps.cloudServiceInstanceId), Computer))\r\n| project Computer, Type, ResourceId, ResourceName;\r\nnetworkDataPctl\r\n| where TimeGenerated {TimeRange}\r\n| where Computer in (networkDataPctlTopComputers)\r\n| join kind=leftouter hint.shufflekey=Computer (NodeIdentityAndPropsMin) on Computer\r\n| project TimeGenerated, ResourceName, {TrendAggregator:label}",
+        "query": "let metric = dynamic({Counter});\r\nlet linux = iff(metric.counter == 'Bytes Received/sec', dynamic({'object': 'Network', 'counter': 'Total Bytes Received'}), dynamic({'object': 'Network', 'counter': 'Total Bytes Transmitted'}));\r\nlet windowsNetworkRaw = Perf\r\n| where TimeGenerated {TimeRange}\r\n| where ObjectName == metric.object and CounterName == metric.counter;\r\nlet windowsNetworkPctl = windowsNetworkRaw\r\n| summarize hint.shufflekey=Computer Average = avg(CounterValue), Max = max(CounterValue), Min = min(CounterValue), percentiles(CounterValue, 5, 10, 50, 80, 90, 95) by bin(TimeGenerated, ({TimeRange:end} - {TimeRange:start})/100), Computer\r\n| project TimeGenerated, Computer, Average, Max, Min, P5th = percentile_CounterValue_5, P10th = percentile_CounterValue_10, P50th = percentile_CounterValue_50, P80th = percentile_CounterValue_80, P90th = percentile_CounterValue_90, P95th = percentile_CounterValue_95;\r\nlet linuxNetworkRaw = Perf\r\n| where TimeGenerated {TimeRange}\r\n| where ObjectName == linux.object and CounterName == linux.counter\r\n| order by InstanceName, TimeGenerated asc\r\n| extend prev_Value = prev(CounterValue), prev_t = prev(TimeGenerated), prev_instance = prev(InstanceName)\r\n| project TimeGenerated, Computer, CounterValue = iff(prev_instance == InstanceName and CounterValue >= prev_Value and TimeGenerated > prev_t, (CounterValue - prev_Value) / ((TimeGenerated - prev_t) / 1s), real(0));\r\nlet linuxNetworkPctl = linuxNetworkRaw\r\n| summarize hint.shufflekey=Computer Average = avg(CounterValue), Max = max(CounterValue), Min = min(CounterValue), percentiles(CounterValue, 5, 10, 50, 80, 90, 95) by bin(TimeGenerated, ({TimeRange:end} - {TimeRange:start})/100), Computer\r\n| project TimeGenerated, Computer, Average, Max, Min, P5th = percentile_CounterValue_5, P10th = percentile_CounterValue_10, P50th = percentile_CounterValue_50, P80th = percentile_CounterValue_80, P90th = percentile_CounterValue_90, P95th = percentile_CounterValue_95;\r\nlet networkDataPctl = union windowsNetworkPctl, linuxNetworkPctl;\r\nlet networkDataPctlTopComputers = networkDataPctl\r\n| summarize CounterValue=sum({Percentile:label}) by Computer\r\n| top 5 by CounterValue desc\r\n| project Computer;\r\nlet computerList=(Perf\r\n| project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n| extend NodeId = Computer\r\n| extend Priority = 1\r\n| extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n| where TimeGenerated {TimeRange}\r\n| where Computer in (computerList)\r\n| summarize hint.shufflekey=Computer arg_max(TimeGenerated, *) by Computer\r\n| extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|', columnifexists('AzureCloudServiceDeployment_g', '')), ''), AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')), strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|', columnifexists('AzureVmScaleSetDeployment_g', '')), ''), ComputerProps = pack('type', 'StandAloneNode', 'name', ComputerName_s, 'mappingResourceId', ResourceId, 'subscriptionId', AzureSubscriptionId_g, 'resourceGroup', AzureResourceGroup_s, 'azureResourceId', columnifexists('AzureResourceId_s', '')), AzureCloudServiceNodeProps = pack('type', 'AzureCloudServiceNode', 'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''), 'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''), 'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''), 'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''), 'mappingResourceId', ResourceId), AzureScaleSetNodeProps = pack('type', 'AzureScaleSetNode', 'scaleSetInstanceId', columnifexists('AzureName_s', ''), 'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''), 'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''), 'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''), 'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''), 'resourceGroupName', columnifexists('AzureResourceGroup_s', ''), 'subscriptionId', columnifexists('AzureSubscriptionId_g', ''), 'mappingResourceId', ResourceId)| project   Computer, NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity, isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer), NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps, isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps), Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps\r\n| summarize hint.shufflekey=Computer arg_max(Priority, *) by Computer;\r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n| extend Type = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)), ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", strcat(NodeProps.vmScaleSetName, \" | \", NodeProps.scaleSetInstanceId), iff(NodeProps.type == \"AzureCloudServiceNode\", strcat(NodeProps.cloudServiceRoleName, \" | \", NodeProps.cloudServiceInstanceId), Computer))\r\n| project Computer, Type, ResourceId, ResourceName;\r\nnetworkDataPctl\r\n| where TimeGenerated {TimeRange}\r\n| where Computer in (networkDataPctlTopComputers)\r\n| join kind=leftouter hint.shufflekey=Computer (NodeIdentityAndPropsMin) on Computer\r\n| project TimeGenerated, ResourceName, {Percentile:label}",
         "showQuery": false,
         "size": 0,
         "aggregation": 3,
@@ -793,14 +885,52 @@
     {
       "type": 1,
       "content": {
-        "json": "## Top 10 Machines"
+        "json": "---\r\n## Top 10 Machines\r\n<p><strong>Percentile</strong> for each chart below, select a percentile to display for that particular chart</p>"
+      },
+      "conditionalVisibility": null
+    },
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "query": "",
+        "crossComponentResources": [],
+        "parameters": [
+          {
+            "id": "92358ae0-d5e1-494b-b65b-6d904f1325c5",
+            "version": "KqlParameterItem/1.0",
+            "name": "Percentile",
+            "type": 2,
+            "isRequired": true,
+            "value": "P95th = round(percentile(CounterValue, 95), 2)",
+            "isHiddenWhenLocked": false,
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\"},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\"},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\"},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\"},\r\n    { \"value\":\"P80th = round(percentile(CounterValue, 80), 2)\", \"label\":\"P80th\"},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\"},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\"}\r\n]",
+            "timeContextFromParameter": null
+          },
+          {
+            "id": "27345375-4376-4e2f-8ac4-59d4eab9d235",
+            "version": "KqlParameterItem/1.0",
+            "name": "percentileOrder",
+            "type": 1,
+            "isRequired": false,
+            "query": "range Steps from 1 to 1 step 1\r\n| project value = iff('{Percentile}' contains 'P5th'  or '{Percentile}' contains 'P10th', 'asc', 'desc')",
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          }
+        ],
+        "style": "above",
+        "resourceType": "microsoft.operationalinsights/workspaces"
       },
       "conditionalVisibility": null
     },
     {
       "type": 1,
       "content": {
-        "json": "### CPU Utilization % (P95th)"
+        "json": "### CPU Utilization % ({Percentile:label})"
       },
       "conditionalVisibility": null
     },
@@ -808,7 +938,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let cpuSummary=totable(Perf\r\n    | where TimeGenerated {TimeRange} \r\n    | where (ObjectName == 'Processor' and InstanceName == '_Total' and CounterName == '% Processor Time')\r\n    | summarize hint.shufflekey=Computer score=percentile(CounterValue, 95) by Computer, CounterName\r\n    | top 10 by score);\r\nlet computerList=(cpuSummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nPerf\r\n    | where TimeGenerated {TimeRange}\r\n    | where (ObjectName == 'Processor' and InstanceName == '_Total' and CounterName == '% Processor Time')\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize value = percentile(CounterValue, 95) by bin(TimeGenerated, ({TimeRange:end} - {TimeRange:start})/100), ResourceName",
+        "query": "let cpuSummary=totable(Perf\r\n    | where TimeGenerated {TimeRange} \r\n    | where (ObjectName == 'Processor' and InstanceName == '_Total' and CounterName == '% Processor Time')\r\n    | summarize hint.shufflekey=Computer {Percentile} by Computer, CounterName\r\n    | top 10 by {Percentile:label} {percentileOrder});\r\nlet computerList=(cpuSummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nPerf\r\n    | where TimeGenerated {TimeRange}\r\n    | where (ObjectName == 'Processor' and InstanceName == '_Total' and CounterName == '% Processor Time')\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {Percentile} by bin(TimeGenerated, ({TimeRange:end} - {TimeRange:start})/100), ResourceName",
         "showQuery": false,
         "size": 0,
         "aggregation": 3,
@@ -845,9 +975,47 @@
       "conditionalVisibility": null
     },
     {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "query": "",
+        "crossComponentResources": [],
+        "parameters": [
+          {
+            "id": "333837c2-d5a4-4173-9aad-3db1dca17e2a",
+            "version": "KqlParameterItem/1.0",
+            "name": "Percentile",
+            "type": 2,
+            "isRequired": true,
+            "value": "P5th = round(percentile(CounterValue, 5), 2)",
+            "isHiddenWhenLocked": false,
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\"},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\"},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\"},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\"},\r\n    { \"value\":\"P80th = round(percentile(CounterValue, 80), 2)\", \"label\":\"P80th\"},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\"},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\"}\r\n]",
+            "timeContextFromParameter": null
+          },
+          {
+            "id": "a23b29a5-5e4a-4d8e-ba73-bfdf27b2980e",
+            "version": "KqlParameterItem/1.0",
+            "name": "percentileOrder",
+            "type": 1,
+            "isRequired": false,
+            "query": "range Steps from 1 to 1 step 1\r\n| project value = iff('{Percentile}' contains 'P5th'  or '{Percentile}' contains 'P10th', 'asc', 'desc')",
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          }
+        ],
+        "style": "above",
+        "resourceType": "microsoft.operationalinsights/workspaces"
+      },
+      "conditionalVisibility": null
+    },
+    {
       "type": 1,
       "content": {
-        "json": "### Available Memory (P5th)"
+        "json": "### Available Memory ({Percentile:label})"
       },
       "conditionalVisibility": null
     },
@@ -855,7 +1023,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let memorySummary=totable(Perf\r\n    | where TimeGenerated {TimeRange} \r\n    | where ObjectName == 'Memory' and CounterName in ('Available MBytes', 'Available MBytes Memory')\r\n    | summarize hint.shufflekey=Computer score=percentile(CounterValue, 5) by Computer, CounterName\r\n    | top 10 by score asc);\r\nlet computerList=(memorySummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nPerf\r\n    | where TimeGenerated {TimeRange}\r\n    | where ObjectName == 'Memory' and CounterName in ('Available MBytes', 'Available MBytes Memory')\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize value = percentile(CounterValue, 5) by bin(TimeGenerated, ({TimeRange:end} - {TimeRange:start})/100), ResourceName",
+        "query": "let memorySummary=totable(Perf\r\n    | where TimeGenerated {TimeRange} \r\n    | where ObjectName == 'Memory' and CounterName in ('Available MBytes', 'Available MBytes Memory')\r\n    | summarize hint.shufflekey=Computer {Percentile} by Computer, CounterName\r\n    | top 10 by {Percentile:label} {percentileOrder});\r\nlet computerList=(memorySummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nPerf\r\n    | where TimeGenerated {TimeRange}\r\n    | where ObjectName == 'Memory' and CounterName in ('Available MBytes', 'Available MBytes Memory')\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {Percentile} by bin(TimeGenerated, ({TimeRange:end} - {TimeRange:start})/100), ResourceName",
         "showQuery": false,
         "size": 0,
         "aggregation": 3,
@@ -892,9 +1060,47 @@
       "conditionalVisibility": null
     },
     {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "query": "",
+        "crossComponentResources": [],
+        "parameters": [
+          {
+            "id": "360da4c1-97fa-4b15-a008-33a6110d0acd",
+            "version": "KqlParameterItem/1.0",
+            "name": "Percentile",
+            "type": 2,
+            "isRequired": true,
+            "value": "P95th = round(percentile(CounterValue, 95), 2)",
+            "isHiddenWhenLocked": false,
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\"},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\"},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\"},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\"},\r\n    { \"value\":\"P80th = round(percentile(CounterValue, 80), 2)\", \"label\":\"P80th\"},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\"},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\"}\r\n]",
+            "timeContextFromParameter": null
+          },
+          {
+            "id": "31ccd4a1-d626-44bb-a5de-1780a33b37a5",
+            "version": "KqlParameterItem/1.0",
+            "name": "percentileOrder",
+            "type": 1,
+            "isRequired": false,
+            "query": "range Steps from 1 to 1 step 1\r\n| project value = iff('{Percentile}' contains 'P5th'  or '{Percentile}' contains 'P10th', 'asc', 'desc')",
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          }
+        ],
+        "style": "above",
+        "resourceType": "microsoft.operationalinsights/workspaces"
+      },
+      "conditionalVisibility": null
+    },
+    {
       "type": 1,
       "content": {
-        "json": "### Bytes Sent Rate (P95th)"
+        "json": "### Bytes Sent Rate ({Percentile:label})"
       },
       "conditionalVisibility": null
     },
@@ -902,7 +1108,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let linuxNetworkSend=Perf \r\n    | where TimeGenerated {TimeRange} \r\n    | where ObjectName == 'Network' and CounterName == 'Total Bytes Transmitted'\r\n    | order by CounterName asc, InstanceName, Computer asc, TimeGenerated asc\r\n    | extend prev_Computer=prev(Computer), prev_Value=prev(CounterValue), prev_t=prev(TimeGenerated), prev_counter=prev(CounterName), prev_instance=prev(InstanceName)\r\n    | project   TimeGenerated,            Computer,            CounterValue = iff(prev_Computer == Computer and prev_instance == InstanceName and prev_counter == CounterName and CounterValue >= prev_Value and TimeGenerated > prev_t, (CounterValue-prev_Value)/((TimeGenerated-prev_t)/1s), real(0))\r\n    | summarize hint.shufflekey=Computer CounterValue = sum(CounterValue) by Computer, bin(TimeGenerated, 2s);\r\nlet windowsNetworkSend = Perf \r\n    | where TimeGenerated {TimeRange} \r\n    | where ObjectName == 'Network Adapter' and CounterName == 'Bytes Sent/sec'\r\n    | summarize hint.shufflekey=Computer CounterValue = sum(CounterValue) by Computer, bin(TimeGenerated, 2s);\r\nlet networkDataSend = union linuxNetworkSend, windowsNetworkSend;\r\nlet networkSendSummary = totable(networkDataSend\r\n    | where TimeGenerated {TimeRange}\r\n    | summarize hint.shufflekey=Computer score=percentile(CounterValue, 95) by Computer\r\n    | top 10 by score);\r\nlet computerList=(networkSendSummary | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nnetworkDataSend\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize value = percentile(CounterValue, 95) by bin(TimeGenerated, ({TimeRange:end} - {TimeRange:start})/100), ResourceName",
+        "query": "let linuxNetworkSend=Perf \r\n    | where TimeGenerated {TimeRange} \r\n    | where ObjectName == 'Network' and CounterName == 'Total Bytes Transmitted'\r\n    | order by CounterName asc, InstanceName, Computer asc, TimeGenerated asc\r\n    | extend prev_Computer=prev(Computer), prev_Value=prev(CounterValue), prev_t=prev(TimeGenerated), prev_counter=prev(CounterName), prev_instance=prev(InstanceName)\r\n    | project   TimeGenerated,            Computer,            CounterValue = iff(prev_Computer == Computer and prev_instance == InstanceName and prev_counter == CounterName and CounterValue >= prev_Value and TimeGenerated > prev_t, (CounterValue-prev_Value)/((TimeGenerated-prev_t)/1s), real(0))\r\n    | summarize hint.shufflekey=Computer CounterValue = sum(CounterValue) by Computer, bin(TimeGenerated, 2s);\r\nlet windowsNetworkSend = Perf \r\n    | where TimeGenerated {TimeRange} \r\n    | where ObjectName == 'Network Adapter' and CounterName == 'Bytes Sent/sec'\r\n    | summarize hint.shufflekey=Computer CounterValue = sum(CounterValue) by Computer, bin(TimeGenerated, 2s);\r\nlet networkDataSend = union linuxNetworkSend, windowsNetworkSend;\r\nlet networkSendSummary = totable(networkDataSend\r\n    | where TimeGenerated {TimeRange}\r\n    | summarize hint.shufflekey=Computer {Percentile} by Computer\r\n    | top 10 by {Percentile:label} {percentileOrder});\r\nlet computerList=(networkSendSummary | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nnetworkDataSend\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {Percentile} by bin(TimeGenerated, ({TimeRange:end} - {TimeRange:start})/100), ResourceName",
         "showQuery": false,
         "size": 0,
         "aggregation": 0,
@@ -939,9 +1145,47 @@
       "conditionalVisibility": null
     },
     {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "query": "",
+        "crossComponentResources": [],
+        "parameters": [
+          {
+            "id": "6772b281-d17d-4293-a227-1b2ed67f399e",
+            "version": "KqlParameterItem/1.0",
+            "name": "Percentile",
+            "type": 2,
+            "isRequired": true,
+            "value": "P95th = round(percentile(CounterValue, 95), 2)",
+            "isHiddenWhenLocked": false,
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\"},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\"},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\"},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\"},\r\n    { \"value\":\"P80th = round(percentile(CounterValue, 80), 2)\", \"label\":\"P80th\"},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\"},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\"}\r\n]",
+            "timeContextFromParameter": null
+          },
+          {
+            "id": "5e2eef28-0528-406f-86b5-ceae535455f9",
+            "version": "KqlParameterItem/1.0",
+            "name": "percentileOrder",
+            "type": 1,
+            "isRequired": false,
+            "query": "range Steps from 1 to 1 step 1\r\n| project value = iff('{Percentile}' contains 'P5th'  or '{Percentile}' contains 'P10th', 'asc', 'desc')",
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          }
+        ],
+        "style": "above",
+        "resourceType": "microsoft.operationalinsights/workspaces"
+      },
+      "conditionalVisibility": null
+    },
+    {
       "type": 1,
       "content": {
-        "json": "### Bytes Received Rate (P95th)"
+        "json": "### Bytes Received Rate ({Percentile:label})"
       },
       "conditionalVisibility": null
     },
@@ -949,7 +1193,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let linuxNetworkReceive=Perf \r\n    | where TimeGenerated {TimeRange} \r\n    | where ObjectName == 'Network' and CounterName == 'Total Bytes Received'\r\n    | order by CounterName asc, InstanceName, Computer asc, TimeGenerated asc\r\n    | extend prev_Computer=prev(Computer), prev_Value=prev(CounterValue), prev_t=prev(TimeGenerated), prev_counter=prev(CounterName), prev_instance=prev(InstanceName)\r\n    | project   TimeGenerated,            Computer,            CounterValue = iff(prev_Computer == Computer and prev_instance == InstanceName and prev_counter == CounterName and CounterValue >= prev_Value and TimeGenerated > prev_t, (CounterValue-prev_Value)/((TimeGenerated-prev_t)/1s), real(0))\r\n    | summarize hint.shufflekey=Computer CounterValue = sum(CounterValue) by Computer, bin(TimeGenerated, 2s);\r\nlet windowsNetworkReceive = Perf \r\n    | where TimeGenerated {TimeRange} \r\n    | where ObjectName == 'Network Adapter' and CounterName == 'Bytes Received/sec'\r\n    | summarize hint.shufflekey=Computer CounterValue = sum(CounterValue) by Computer, bin(TimeGenerated, 2s);\r\nlet networkDataReceive = union linuxNetworkReceive, windowsNetworkReceive;\r\nlet networkReceiveSummary = totable(networkDataReceive\r\n    | where TimeGenerated {TimeRange}\r\n    | summarize hint.shufflekey=Computer score=percentile(CounterValue, 95) by Computer\r\n    | top 10 by score);\r\nlet computerList=(networkReceiveSummary | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nnetworkDataReceive\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize value = percentile(CounterValue, 95) by bin(TimeGenerated, ({TimeRange:end} - {TimeRange:start})/100), ResourceName",
+        "query": "let linuxNetworkReceive=Perf \r\n    | where TimeGenerated {TimeRange} \r\n    | where ObjectName == 'Network' and CounterName == 'Total Bytes Received'\r\n    | order by CounterName asc, InstanceName, Computer asc, TimeGenerated asc\r\n    | extend prev_Computer=prev(Computer), prev_Value=prev(CounterValue), prev_t=prev(TimeGenerated), prev_counter=prev(CounterName), prev_instance=prev(InstanceName)\r\n    | project   TimeGenerated,            Computer,            CounterValue = iff(prev_Computer == Computer and prev_instance == InstanceName and prev_counter == CounterName and CounterValue >= prev_Value and TimeGenerated > prev_t, (CounterValue-prev_Value)/((TimeGenerated-prev_t)/1s), real(0))\r\n    | summarize hint.shufflekey=Computer CounterValue = sum(CounterValue) by Computer, bin(TimeGenerated, 2s);\r\nlet windowsNetworkReceive = Perf \r\n    | where TimeGenerated {TimeRange} \r\n    | where ObjectName == 'Network Adapter' and CounterName == 'Bytes Received/sec'\r\n    | summarize hint.shufflekey=Computer CounterValue = sum(CounterValue) by Computer, bin(TimeGenerated, 2s);\r\nlet networkDataReceive = union linuxNetworkReceive, windowsNetworkReceive;\r\nlet networkReceiveSummary = totable(networkDataReceive\r\n    | where TimeGenerated {TimeRange}\r\n    | summarize hint.shufflekey=Computer {Percentile} by Computer\r\n    | top 10 by {Percentile:label} {percentileOrder});\r\nlet computerList=(networkReceiveSummary | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nnetworkDataReceive\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {Percentile} by bin(TimeGenerated, ({TimeRange:end} - {TimeRange:start})/100), ResourceName",
         "showQuery": false,
         "size": 0,
         "aggregation": 0,
@@ -986,9 +1230,47 @@
       "conditionalVisibility": null
     },
     {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "query": "",
+        "crossComponentResources": [],
+        "parameters": [
+          {
+            "id": "5d6afbec-79f6-4cd1-b3a1-361503478304",
+            "version": "KqlParameterItem/1.0",
+            "name": "Percentile",
+            "type": 2,
+            "isRequired": true,
+            "value": "P95th = round(percentile(CounterValue, 95), 2)",
+            "isHiddenWhenLocked": false,
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\"},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\"},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\"},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\"},\r\n    { \"value\":\"P80th = round(percentile(CounterValue, 80), 2)\", \"label\":\"P80th\"},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\"},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\"}\r\n]",
+            "timeContextFromParameter": null
+          },
+          {
+            "id": "1d5a805c-acce-4afe-a38b-c2740fb3ff26",
+            "version": "KqlParameterItem/1.0",
+            "name": "percentileOrder",
+            "type": 1,
+            "isRequired": false,
+            "query": "range Steps from 1 to 1 step 1\r\n| project value = iff('{Percentile}' contains 'P5th'  or '{Percentile}' contains 'P10th', 'asc', 'desc')",
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          }
+        ],
+        "style": "above",
+        "resourceType": "microsoft.operationalinsights/workspaces"
+      },
+      "conditionalVisibility": null
+    },
+    {
       "type": 1,
       "content": {
-        "json": "### Logical Disk Space Used % (P95th)"
+        "json": "### Logical Disk Space Used % ({Percentile:label})"
       },
       "conditionalVisibility": null
     },
@@ -996,7 +1278,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let diskSummary=totable(Perf\r\n    | where TimeGenerated {TimeRange} \r\n    | where (ObjectName == 'LogicalDisk' and InstanceName != '_Total' and CounterName in ('% Free Space')) or        (ObjectName == 'Logical Disk' and InstanceName != '_Total' and CounterName in ('% Used Space'))\r\n    | project TimeGenerated, Computer,    CounterName = '% Used Space',    CounterValue = case(ObjectName == 'LogicalDisk' and CounterName == '% Free Space', 100 - CounterValue,                CounterValue < 0, real(0),                CounterValue)\r\n    | summarize hint.shufflekey=Computer score=percentile(CounterValue, 95) by Computer, CounterName\r\n    | top 10 by score);\r\nlet computerList=(diskSummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nPerf\r\n    | where TimeGenerated {TimeRange}\r\n    | where (ObjectName == 'LogicalDisk' and InstanceName != '_Total' and CounterName in ('% Free Space')) or        (ObjectName == 'Logical Disk' and InstanceName != '_Total' and CounterName in ('% Used Space'))\r\n    | where Computer in (computerList)\r\n    | project TimeGenerated, Computer,    CounterName = '% Used Space',    CounterValue = case(ObjectName == 'LogicalDisk' and CounterName == '% Free Space', 100 - CounterValue,                CounterValue < 0, real(0),                CounterValue)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize value = percentile(CounterValue, 95) by bin(TimeGenerated, ({TimeRange:end} - {TimeRange:start})/100), ResourceName",
+        "query": "let diskSummary=totable(Perf\r\n    | where TimeGenerated {TimeRange} \r\n    | where (ObjectName == 'LogicalDisk' and InstanceName != '_Total' and CounterName in ('% Free Space')) or        (ObjectName == 'Logical Disk' and InstanceName != '_Total' and CounterName in ('% Used Space'))\r\n    | project TimeGenerated, Computer,    CounterName = '% Used Space',    CounterValue = case(ObjectName == 'LogicalDisk' and CounterName == '% Free Space', 100 - CounterValue,                CounterValue < 0, real(0),                CounterValue)\r\n    | summarize hint.shufflekey=Computer {Percentile} by Computer, CounterName\r\n    | top 10 by {Percentile:label} {percentileOrder});\r\nlet computerList=(diskSummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nPerf\r\n    | where TimeGenerated {TimeRange}\r\n    | where (ObjectName == 'LogicalDisk' and InstanceName != '_Total' and CounterName in ('% Free Space')) or        (ObjectName == 'Logical Disk' and InstanceName != '_Total' and CounterName in ('% Used Space'))\r\n    | where Computer in (computerList)\r\n    | project TimeGenerated, Computer,    CounterName = '% Used Space',    CounterValue = case(ObjectName == 'LogicalDisk' and CounterName == '% Free Space', 100 - CounterValue,                CounterValue < 0, real(0),                CounterValue)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {Percentile} by bin(TimeGenerated, ({TimeRange:end} - {TimeRange:start})/100), ResourceName",
         "showQuery": false,
         "size": 0,
         "aggregation": 3,

--- a/Workbooks/Virtual Machines - Performance Analysis/Performance Analysis for a Group of VMs/settings.json
+++ b/Workbooks/Virtual Machines - Performance Analysis/Performance Analysis for a Group of VMs/settings.json
@@ -1,9 +1,8 @@
 {
     "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/settings.json",
-    "name":"Performance Analysis for a Group of VMs",
+    "name":"Performance",
     "author": "Microsoft",
     "galleries": [
         { "type": "workbook", "resourceType": "microsoft.operationalinsights/workspaces", "order": 200 },
-        { "type": "performance-vm", "resourceType": "microsoft.compute/virtualmachines", "order": 200 }
     ]
 }

--- a/Workbooks/Virtual Machines - Performance Analysis/Performance Analysis for a Group of VMs/settings.json
+++ b/Workbooks/Virtual Machines - Performance Analysis/Performance Analysis for a Group of VMs/settings.json
@@ -3,6 +3,6 @@
     "name":"Performance",
     "author": "Microsoft",
     "galleries": [
-        { "type": "workbook", "resourceType": "microsoft.operationalinsights/workspaces", "order": 200 },
+        { "type": "workbook", "resourceType": "microsoft.operationalinsights/workspaces", "order": 200 }
     ]
 }


### PR DESCRIPTION
Improve UX of group perf workbook and have it only shown when accessed from AtScale Monitor

- Rename workbook to `Performance`
- Minor cosmetic fixes
- Hide workbook dropdown
- Add helper text
- Add missing heatmap to table
- Split parameters for all the charts
- Fix erroneous dropdown

Example:
![image](https://user-images.githubusercontent.com/43890980/51708237-3a1eba00-1fd8-11e9-8a09-33217fb79799.png)