### PR TITLE
Update Single VM workbook

### DIFF
--- a/Workbooks/Virtual Machines - Performance Analysis/Performance Analysis for a Single VM/Performance Analysis for a Single VM.workbook
+++ b/Workbooks/Virtual Machines - Performance Analysis/Performance Analysis for a Single VM/Performance Analysis for a Single VM.workbook
@@ -3,9 +3,40 @@
   "isLocked": true,
   "items": [
     {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "query": "",
+        "crossComponentResources": [],
+        "parameters": [
+          {
+            "id": "4f883c2c-8e3d-4d52-8f71-30fd86a0f827",
+            "version": "KqlParameterItem/1.0",
+            "name": "Computer",
+            "type": 5,
+            "isRequired": true,
+            "value": "value::1",
+            "isHiddenWhenLocked": true,
+            "typeSettings": {
+              "resourceTypeFilter": {
+                "microsoft.compute/virtualmachines": true
+              },
+              "additionalResourceOptions": [
+                "value::1"
+              ]
+            },
+            "timeContextFromParameter": null
+          }
+        ],
+        "style": "above",
+        "resourceType": "microsoft.compute/virtualmachines"
+      },
+      "conditionalVisibility": null
+    },
+    {
       "type": 1,
       "content": {
-        "json": "# Performance Analysis\nAnalyze the performance counters (processor, memory, disk, etc.) of a single VM. You can also customize this workbook by clicking on the `Edit` button in the toolbar.\n\n💡 In the graph below a default counter (`Counter`) has been selected, select the pill to choose a different counter."
+        "json": "# Performance Analysis\nAnalyze the performance counters (processor, memory, disk, etc.) of `{Computer:label}`. You can also customize this workbook by clicking on the `Edit` button in the toolbar.\n\n<hr style=\"height: 3px;\" />\n\n## Trend\n\n💡 In the graph below a default counter (`Counter`) has been selected, select the pill to choose a different counter."
       },
       "conditionalVisibility": null
     },
@@ -136,35 +167,19 @@
             "timeContextFromParameter": null
           },
           {
-            "id": "0f7b5485-e076-4a5d-ac13-57ed4141fe05",
-            "version": "KqlParameterItem/1.0",
-            "name": "Computer",
-            "type": 5,
-            "description": null,
-            "isRequired": true,
-            "multiSelect": false,
-            "isHiddenWhenLocked": true,
-            "typeSettings": {
-              "resourceTypeFilter": {
-                "microsoft.compute/virtualmachines": true
-              },
-              "additionalResourceOptions": [
-                "value::1"
-              ]
-            },
-            "value": "value::1"
-          },
-          {
             "id": "d495f8c1-c6b2-490e-8eb6-43d151bc20c0",
             "version": "KqlParameterItem/1.0",
             "name": "Counter",
             "type": 2,
-            "isRequired": false,
+            "isRequired": true,
             "query": "Perf\r\n| where TimeGenerated {TimeRange}\r\n| summarize by CounterName, ObjectName, CounterText = strcat(ObjectName, ' > ', CounterName)\r\n| order by ObjectName asc, CounterText asc\r\n| project Counter = pack('counter', CounterName, 'object', ObjectName), CounterText",
+            "value": "{\"counter\":\"% Used Inodes\",\"object\":\"Logical Disk\"}",
             "isHiddenWhenLocked": false,
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
             "timeContextFromParameter": null,
-            "resourceType": "microsoft.compute/virtualmachines",
-            "value": "{\"counter\":\"% Used Inodes\",\"object\":\"Logical Disk\"}"
+            "resourceType": "microsoft.compute/virtualmachines"
           },
           {
             "id": "31b68fb4-3740-406d-b8eb-ac29cb461c3f",
@@ -191,21 +206,21 @@
           {
             "id": "dff91367-8a90-4d46-8a43-8595972eacc8",
             "version": "KqlParameterItem/1.0",
-            "name": "ChartMetrics",
+            "name": "Percentiles",
             "type": 2,
             "isRequired": true,
             "multiSelect": true,
             "quote": "",
             "delimiter": ",",
-            "value": [
-              "Average = round(avg(CounterValue), 2)"
-            ],
             "isHiddenWhenLocked": false,
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
             "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\", \"selected\":true },\r\n    { \"value\":\"P1st = round(percentile(CounterValue, 1), 2)\", \"label\":\"P1st\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\", \"selected\":false},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\", \"selected\":false},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\", \"selected\":false},\r\n    { \"value\":\"P99th = round(percentile(CounterValue, 99), 2)\", \"label\":\"P99th\", \"selected\":false},\r\n    { \"value\":\"Min = round(min(CounterValue), 2)\", \"label\":\"Min\", \"selected\":false},\r\n    { \"value\":\"Max = round(max(CounterValue), 2)\", \"label\":\"Max\", \"selected\":false}    \r\n]",
             "timeContextFromParameter": null
           }
         ],
-        "style": "pills",
+        "style": "above",
         "resourceType": "microsoft.compute/virtualmachines"
       },
       "conditionalVisibility": null
@@ -213,7 +228,14 @@
     {
       "type": 1,
       "content": {
-        "json": "## Trend ({CounterText})"
+        "json": "<p><strong>TimeRange</strong> Select a range of time in which to display data</p>\r\n\r\n<p><strong>Counter</strong> Select a virtual machine performance counter to display in the chart below</p>\r\n\r\n<p><strong>Percentiles</strong> Select one or more percentiles for the performance counter to display in the chart below</p>\r\n\r\n<hr style=\"height: 2px;\" />"
+      },
+      "conditionalVisibility": null
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "### {CounterText}"
       },
       "conditionalVisibility": {
         "parameterName": "Counter",
@@ -225,7 +247,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let metric = dynamic({Counter});\r\nPerf\r\n| where TimeGenerated {TimeRange}\r\n| where ObjectName == metric.object and CounterName == metric.counter\r\n| summarize {ChartMetrics} by bin(TimeGenerated, totimespan('{grain}'))",
+        "query": "let metric = dynamic({Counter});\r\nPerf\r\n| where TimeGenerated {TimeRange}\r\n| where ObjectName == metric.object and CounterName == metric.counter\r\n| summarize {Percentiles} by bin(TimeGenerated, totimespan('{grain}'))",
         "showQuery": false,
         "size": 0,
         "aggregation": 3,
@@ -244,7 +266,7 @@
     {
       "type": 1,
       "content": {
-        "json": "💡 *Customize or add your own charts below in edit mode or by using the advanced editor*\n## Single VM Performance Charts"
+        "json": "<hr style=\"height: 3px;\" />\n\n## Performance Charts\n💡 *Customize or add your own charts below in edit mode or by using the advanced editor*\n\n<hr style=\"height: 2px;\" />"
       },
       "conditionalVisibility": null
     },
@@ -274,28 +296,32 @@
           {
             "id": "f4ab7159-2f3a-4720-96b2-2365a3e93617",
             "version": "KqlParameterItem/1.0",
-            "name": "Metrics",
+            "name": "Percentiles",
             "type": 2,
             "isRequired": false,
             "multiSelect": true,
             "quote": "",
             "delimiter": ",",
             "isHiddenWhenLocked": false,
-            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\", \"selected\":true },\r\n    { \"value\":\"P1st = round(percentile(CounterValue, 1), 2)\", \"label\":\"P1st\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\", \"selected\":false},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\", \"selected\":false},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\", \"selected\":true},\r\n    { \"value\":\"P99th = round(percentile(CounterValue, 99), 2)\", \"label\":\"P99th\", \"selected\":false},\r\n    { \"value\":\"Min = round(min(CounterValue), 2)\", \"label\":\"Min\", \"selected\":false},\r\n    { \"value\":\"Max = round(max(CounterValue), 2)\", \"label\":\"Max\", \"selected\":false}    \r\n]"
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\", \"selected\":true },\r\n    { \"value\":\"P1st = round(percentile(CounterValue, 1), 2)\", \"label\":\"P1st\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\", \"selected\":false},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\", \"selected\":false},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\", \"selected\":true},\r\n    { \"value\":\"P99th = round(percentile(CounterValue, 99), 2)\", \"label\":\"P99th\", \"selected\":false},\r\n    { \"value\":\"Min = round(min(CounterValue), 2)\", \"label\":\"Min\", \"selected\":false},\r\n    { \"value\":\"Max = round(max(CounterValue), 2)\", \"label\":\"Max\", \"selected\":false}    \r\n]",
+            "timeContextFromParameter": null
           },
           {
             "id": "069034ca-ed62-48e7-b6ae-d90d1d6d7aaf",
             "version": "KqlParameterItem/1.0",
-            "name": "MetricsLeft",
+            "name": "PercentilesLeft",
             "type": 1,
             "isRequired": false,
-            "query": "print \"{Metrics}\"",
+            "query": "print \"{Percentiles}\"",
             "isHiddenWhenLocked": true,
             "timeContextFromParameter": null,
             "resourceType": "microsoft.compute/virtualmachines"
           }
         ],
-        "style": "pills",
+        "style": "above",
         "resourceType": "microsoft.compute/virtualmachines"
       },
       "conditionalVisibility": null,
@@ -311,28 +337,32 @@
           {
             "id": "a1d2a8b9-9c5b-4d1f-b709-49dbd0fe94bd",
             "version": "KqlParameterItem/1.0",
-            "name": "Metrics",
+            "name": "Percentiles",
             "type": 2,
             "isRequired": false,
             "multiSelect": true,
             "quote": "",
             "delimiter": ",",
             "isHiddenWhenLocked": false,
-            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\", \"selected\":true },\r\n    { \"value\":\"P1st = round(percentile(CounterValue, 1), 2)\", \"label\":\"P1st\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\", \"selected\":true},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\", \"selected\":true},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\", \"selected\":false},\r\n    { \"value\":\"P99th = round(percentile(CounterValue, 99), 2)\", \"label\":\"P99th\", \"selected\":false},\r\n    { \"value\":\"Min = round(min(CounterValue), 2)\", \"label\":\"Min\", \"selected\":false},\r\n    { \"value\":\"Max = round(max(CounterValue), 2)\", \"label\":\"Max\", \"selected\":false}    \r\n]"
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\", \"selected\":true },\r\n    { \"value\":\"P1st = round(percentile(CounterValue, 1), 2)\", \"label\":\"P1st\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\", \"selected\":true},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\", \"selected\":true},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\", \"selected\":false},\r\n    { \"value\":\"P99th = round(percentile(CounterValue, 99), 2)\", \"label\":\"P99th\", \"selected\":false},\r\n    { \"value\":\"Min = round(min(CounterValue), 2)\", \"label\":\"Min\", \"selected\":false},\r\n    { \"value\":\"Max = round(max(CounterValue), 2)\", \"label\":\"Max\", \"selected\":false}    \r\n]",
+            "timeContextFromParameter": null
           },
           {
             "id": "1f360103-df10-41c7-8f82-13edd11461aa",
             "version": "KqlParameterItem/1.0",
-            "name": "MetricsRight",
+            "name": "PercentilesRight",
             "type": 1,
             "isRequired": false,
-            "query": "print \"{Metrics}\"",
+            "query": "print \"{Percentiles}\"",
             "isHiddenWhenLocked": true,
             "timeContextFromParameter": null,
             "resourceType": "microsoft.compute/virtualmachines"
           }
         ],
-        "style": "pills",
+        "style": "above",
         "resourceType": "microsoft.compute/virtualmachines"
       },
       "conditionalVisibility": null,
@@ -342,7 +372,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let metric = dynamic({\"counter\": \"% Processor Time\", \"object\": \"Processor\"});\nPerf\n| where TimeGenerated {TimeRange}\n| where (ObjectName == 'Processor' and InstanceName == '_Total' and CounterName == '% Processor Time')\n| where InstanceName == '_Total'\n| summarize {MetricsLeft} by bin(TimeGenerated, totimespan('{grain}'))",
+        "query": "let metric = dynamic({\"counter\": \"% Processor Time\", \"object\": \"Processor\"});\nPerf\n| where TimeGenerated {TimeRange}\n| where (ObjectName == 'Processor' and InstanceName == '_Total' and CounterName == '% Processor Time')\n| where InstanceName == '_Total'\n| summarize {PercentilesLeft} by bin(TimeGenerated, totimespan('{grain}'))",
         "showQuery": false,
         "size": 0,
         "aggregation": 3,
@@ -363,7 +393,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "Perf\r\n| where TimeGenerated {TimeRange}\r\n| where (ObjectName == 'Memory' and CounterName in ('Available MBytes', 'Available MBytes Memory'))\r\n| summarize {MetricsRight} by bin(TimeGenerated, totimespan('{grain}'))",
+        "query": "Perf\r\n| where TimeGenerated {TimeRange}\r\n| where (ObjectName == 'Memory' and CounterName in ('Available MBytes', 'Available MBytes Memory'))\r\n| summarize {PercentilesRight} by bin(TimeGenerated, totimespan('{grain}'))",
         "showQuery": false,
         "size": 0,
         "aggregation": 3,
@@ -406,28 +436,32 @@
           {
             "id": "547dae05-22bf-47a5-ad44-043a23995759",
             "version": "KqlParameterItem/1.0",
-            "name": "Metrics",
+            "name": "Percentiles",
             "type": 2,
             "isRequired": false,
             "multiSelect": true,
             "quote": "",
             "delimiter": ",",
             "isHiddenWhenLocked": false,
-            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\", \"selected\":true },\r\n    { \"value\":\"P1st = round(percentile(CounterValue, 1), 2)\", \"label\":\"P1st\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\", \"selected\":false},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\", \"selected\":false},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\", \"selected\":true},\r\n    { \"value\":\"P99th = round(percentile(CounterValue, 99), 2)\", \"label\":\"P99th\", \"selected\":false},\r\n    { \"value\":\"Min = round(min(CounterValue), 2)\", \"label\":\"Min\", \"selected\":false},\r\n    { \"value\":\"Max = round(max(CounterValue), 2)\", \"label\":\"Max\", \"selected\":false}    \r\n]"
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\", \"selected\":true },\r\n    { \"value\":\"P1st = round(percentile(CounterValue, 1), 2)\", \"label\":\"P1st\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\", \"selected\":false},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\", \"selected\":false},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\", \"selected\":true},\r\n    { \"value\":\"P99th = round(percentile(CounterValue, 99), 2)\", \"label\":\"P99th\", \"selected\":false},\r\n    { \"value\":\"Min = round(min(CounterValue), 2)\", \"label\":\"Min\", \"selected\":false},\r\n    { \"value\":\"Max = round(max(CounterValue), 2)\", \"label\":\"Max\", \"selected\":false}    \r\n]",
+            "timeContextFromParameter": null
           },
           {
             "id": "1af979b2-3131-4771-bf02-30193138c565",
             "version": "KqlParameterItem/1.0",
-            "name": "MetricsLeft",
+            "name": "PercentilesLeft",
             "type": 1,
             "isRequired": false,
-            "query": "print \"{Metrics}\"",
+            "query": "print \"{Percentiles}\"",
             "isHiddenWhenLocked": true,
             "timeContextFromParameter": null,
             "resourceType": "microsoft.compute/virtualmachines"
           }
         ],
-        "style": "pills",
+        "style": "above",
         "resourceType": "microsoft.compute/virtualmachines"
       },
       "conditionalVisibility": null,
@@ -443,28 +477,32 @@
           {
             "id": "8aaa181d-7182-4d9d-b74e-22f37e3acbce",
             "version": "KqlParameterItem/1.0",
-            "name": "Metrics",
+            "name": "Percentiles",
             "type": 2,
             "isRequired": false,
             "multiSelect": true,
             "quote": "",
             "delimiter": ",",
             "isHiddenWhenLocked": false,
-            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\", \"selected\":true },\r\n    { \"value\":\"P1st = round(percentile(CounterValue, 1), 2)\", \"label\":\"P1st\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\", \"selected\":false},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\", \"selected\":false},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\", \"selected\":true},\r\n    { \"value\":\"P99th = round(percentile(CounterValue, 99), 2)\", \"label\":\"P99th\", \"selected\":false},\r\n    { \"value\":\"Min = round(min(CounterValue), 2)\", \"label\":\"Min\", \"selected\":false},\r\n    { \"value\":\"Max = round(max(CounterValue), 2)\", \"label\":\"Max\", \"selected\":false}    \r\n]"
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\", \"selected\":true },\r\n    { \"value\":\"P1st = round(percentile(CounterValue, 1), 2)\", \"label\":\"P1st\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\", \"selected\":false},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\", \"selected\":false},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\", \"selected\":true},\r\n    { \"value\":\"P99th = round(percentile(CounterValue, 99), 2)\", \"label\":\"P99th\", \"selected\":false},\r\n    { \"value\":\"Min = round(min(CounterValue), 2)\", \"label\":\"Min\", \"selected\":false},\r\n    { \"value\":\"Max = round(max(CounterValue), 2)\", \"label\":\"Max\", \"selected\":false}    \r\n]",
+            "timeContextFromParameter": null
           },
           {
             "id": "c021b342-6bc8-4870-a88b-8ddf0b8b9cfa",
             "version": "KqlParameterItem/1.0",
-            "name": "MetricsRight",
+            "name": "PercentilesRight",
             "type": 1,
             "isRequired": false,
-            "query": "print \"{Metrics}\"",
+            "query": "print \"{Percentiles}\"",
             "isHiddenWhenLocked": true,
             "timeContextFromParameter": null,
             "resourceType": "microsoft.compute/virtualmachines"
           }
         ],
-        "style": "pills",
+        "style": "above",
         "resourceType": "microsoft.compute/virtualmachines"
       },
       "conditionalVisibility": null,
@@ -474,7 +512,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "Perf\r\n| where TimeGenerated {TimeRange}\r\n| where (ObjectName == 'Logical Disk' and InstanceName != '_Total' and CounterName == 'Disk Transfers/sec')\r\n| summarize {MetricsLeft} by bin(TimeGenerated, totimespan('{grain}'))",
+        "query": "Perf\r\n| where TimeGenerated {TimeRange}\r\n| where (ObjectName == 'Logical Disk' and InstanceName != '_Total' and CounterName == 'Disk Transfers/sec')\r\n| summarize {PercentilesLeft} by bin(TimeGenerated, totimespan('{grain}'))",
         "showQuery": false,
         "size": 0,
         "aggregation": 3,
@@ -495,7 +533,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "Perf\r\n| where TimeGenerated {TimeRange}\r\n| where (ObjectName == 'Logical Disk' and InstanceName != '_Total' and CounterName == 'Logical Disk Bytes/sec')\r\n| summarize {MetricsRight} by bin(TimeGenerated, totimespan('{grain}'))",
+        "query": "Perf\r\n| where TimeGenerated {TimeRange}\r\n| where (ObjectName == 'Logical Disk' and InstanceName != '_Total' and CounterName == 'Logical Disk Bytes/sec')\r\n| summarize {PercentilesRight} by bin(TimeGenerated, totimespan('{grain}'))",
         "showQuery": false,
         "size": 0,
         "aggregation": 3,
@@ -551,28 +589,32 @@
           {
             "id": "f963e52a-2099-4cd3-a3ad-0fdf78f38238",
             "version": "KqlParameterItem/1.0",
-            "name": "Metrics",
+            "name": "Percentiles",
             "type": 2,
             "isRequired": false,
             "multiSelect": true,
             "quote": "",
             "delimiter": ",",
             "isHiddenWhenLocked": false,
-            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\", \"selected\":true },\r\n    { \"value\":\"P1st = round(percentile(CounterValue, 1), 2)\", \"label\":\"P1st\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\", \"selected\":false},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\", \"selected\":false},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\", \"selected\":false},\r\n    { \"value\":\"P99th = round(percentile(CounterValue, 99), 2)\", \"label\":\"P99th\", \"selected\":false},\r\n    { \"value\":\"Min = round(min(CounterValue), 2)\", \"label\":\"Min\", \"selected\":false},\r\n    { \"value\":\"Max = round(max(CounterValue), 2)\", \"label\":\"Max\", \"selected\":false}    \r\n]"
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\", \"selected\":true },\r\n    { \"value\":\"P1st = round(percentile(CounterValue, 1), 2)\", \"label\":\"P1st\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\", \"selected\":false},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\", \"selected\":false},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\", \"selected\":false},\r\n    { \"value\":\"P99th = round(percentile(CounterValue, 99), 2)\", \"label\":\"P99th\", \"selected\":false},\r\n    { \"value\":\"Min = round(min(CounterValue), 2)\", \"label\":\"Min\", \"selected\":false},\r\n    { \"value\":\"Max = round(max(CounterValue), 2)\", \"label\":\"Max\", \"selected\":false}    \r\n]",
+            "timeContextFromParameter": null
           },
           {
             "id": "6c5d9373-5403-44e5-b496-7155c338f958",
             "version": "KqlParameterItem/1.0",
-            "name": "MetricsRight",
+            "name": "PercentilesRight",
             "type": 1,
             "isRequired": false,
-            "query": "print \"{Metrics}\"",
+            "query": "print \"{Percentiles}\"",
             "isHiddenWhenLocked": true,
             "timeContextFromParameter": null,
             "resourceType": "microsoft.compute/virtualmachines"
           }
         ],
-        "style": "pills",
+        "style": "above",
         "resourceType": "microsoft.compute/virtualmachines"
       },
       "conditionalVisibility": null,
@@ -603,7 +645,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let grain = totimespan('{grain}');\r\nlet windowsNetwork=Perf\r\n| where TimeGenerated {TimeRange}\r\n| where ObjectName == 'Network Adapter' and CounterName == 'Bytes Sent/sec'\r\n| summarize CounterValue = sum(CounterValue) by bin(TimeGenerated, 2s);\r\nlet linuxNetwork=Perf\r\n| where TimeGenerated {TimeRange}\r\n| where ObjectName == 'Network' and CounterName == 'Total Bytes Transmitted'\r\n| order by InstanceName, TimeGenerated asc\r\n| extend prev_Value=prev(CounterValue), prev_t=prev(TimeGenerated), prev_instance=prev(InstanceName)\r\n| project TimeGenerated, CounterValue=iff(prev_instance == InstanceName and CounterValue >= prev_Value and TimeGenerated > prev_t, (CounterValue - prev_Value) / ((TimeGenerated - prev_t) / 1s), real(0))\r\n| summarize CounterValue = sum(CounterValue) by bin(TimeGenerated, 2s);\r\nlet networkDataSend = union windowsNetwork, linuxNetwork;\r\nnetworkDataSend\r\n| summarize {MetricsRight} by bin(TimeGenerated, grain)",
+        "query": "let grain = totimespan('{grain}');\r\nlet windowsNetwork=Perf\r\n| where TimeGenerated {TimeRange}\r\n| where ObjectName == 'Network Adapter' and CounterName == 'Bytes Sent/sec'\r\n| summarize CounterValue = sum(CounterValue) by bin(TimeGenerated, 2s);\r\nlet linuxNetwork=Perf\r\n| where TimeGenerated {TimeRange}\r\n| where ObjectName == 'Network' and CounterName == 'Total Bytes Transmitted'\r\n| order by InstanceName, TimeGenerated asc\r\n| extend prev_Value=prev(CounterValue), prev_t=prev(TimeGenerated), prev_instance=prev(InstanceName)\r\n| project TimeGenerated, CounterValue=iff(prev_instance == InstanceName and CounterValue >= prev_Value and TimeGenerated > prev_t, (CounterValue - prev_Value) / ((TimeGenerated - prev_t) / 1s), real(0))\r\n| summarize CounterValue = sum(CounterValue) by bin(TimeGenerated, 2s);\r\nlet networkDataSend = union windowsNetwork, linuxNetwork;\r\nnetworkDataSend\r\n| summarize {PercentilesRight} by bin(TimeGenerated, grain)",
         "showQuery": false,
         "size": 0,
         "aggregation": 3,
@@ -646,28 +688,32 @@
           {
             "id": "c0592d9a-edd4-4a69-86c0-098ac0c72cf2",
             "version": "KqlParameterItem/1.0",
-            "name": "Metrics",
+            "name": "Percentiles",
             "type": 2,
             "isRequired": false,
             "multiSelect": true,
             "quote": "",
             "delimiter": ",",
             "isHiddenWhenLocked": false,
-            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\", \"selected\":true },\r\n    { \"value\":\"P1st = round(percentile(CounterValue, 1), 2)\", \"label\":\"P1st\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\", \"selected\":false},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\", \"selected\":false},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\", \"selected\":false},\r\n    { \"value\":\"P99th = round(percentile(CounterValue, 99), 2)\", \"label\":\"P99th\", \"selected\":false},\r\n    { \"value\":\"Min = round(min(CounterValue), 2)\", \"label\":\"Min\", \"selected\":false},\r\n    { \"value\":\"Max = round(max(CounterValue), 2)\", \"label\":\"Max\", \"selected\":false}    \r\n]"
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\", \"selected\":true },\r\n    { \"value\":\"P1st = round(percentile(CounterValue, 1), 2)\", \"label\":\"P1st\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\", \"selected\":false},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\", \"selected\":false},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\", \"selected\":false},\r\n    { \"value\":\"P99th = round(percentile(CounterValue, 99), 2)\", \"label\":\"P99th\", \"selected\":false},\r\n    { \"value\":\"Min = round(min(CounterValue), 2)\", \"label\":\"Min\", \"selected\":false},\r\n    { \"value\":\"Max = round(max(CounterValue), 2)\", \"label\":\"Max\", \"selected\":false}    \r\n]",
+            "timeContextFromParameter": null
           },
           {
             "id": "d4795fc0-c995-4975-8bc6-e515dbad00be",
             "version": "KqlParameterItem/1.0",
-            "name": "MetricsLeft",
+            "name": "PercentilesLeft",
             "type": 1,
             "isRequired": false,
-            "query": "print \"{Metrics}\"",
+            "query": "print \"{Percentiles}\"",
             "isHiddenWhenLocked": true,
             "timeContextFromParameter": null,
             "resourceType": "microsoft.compute/virtualmachines"
           }
         ],
-        "style": "pills",
+        "style": "above",
         "resourceType": "microsoft.compute/virtualmachines"
       },
       "conditionalVisibility": null,
@@ -690,7 +736,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let grain = totimespan('{grain}');\r\nlet windowsNetwork=Perf\r\n| where TimeGenerated {TimeRange}\r\n| where ObjectName == 'Network Adapter' and CounterName == 'Bytes Received/sec'\r\n| summarize CounterValue = sum(CounterValue) by bin(TimeGenerated, 2s);\r\nlet linuxNetwork=Perf\r\n| where TimeGenerated {TimeRange}\r\n| where ObjectName == 'Network' and CounterName == 'Total Bytes Received'\r\n| order by InstanceName, TimeGenerated asc\r\n| extend prev_Value = prev(CounterValue), prev_t = prev(TimeGenerated), prev_instance = prev(InstanceName)\r\n| project TimeGenerated, CounterValue = iff(prev_instance == InstanceName and CounterValue >= prev_Value and TimeGenerated > prev_t, (CounterValue - prev_Value) / ((TimeGenerated - prev_t) / 1s), real(0))\r\n| summarize CounterValue = sum(CounterValue) by bin(TimeGenerated, 2s);\r\nlet networkDataReceive = union windowsNetwork, linuxNetwork;\r\nnetworkDataReceive\r\n| summarize {Metrics} by bin(TimeGenerated, grain)",
+        "query": "let grain = totimespan('{grain}');\r\nlet windowsNetwork=Perf\r\n| where TimeGenerated {TimeRange}\r\n| where ObjectName == 'Network Adapter' and CounterName == 'Bytes Received/sec'\r\n| summarize CounterValue = sum(CounterValue) by bin(TimeGenerated, 2s);\r\nlet linuxNetwork=Perf\r\n| where TimeGenerated {TimeRange}\r\n| where ObjectName == 'Network' and CounterName == 'Total Bytes Received'\r\n| order by InstanceName, TimeGenerated asc\r\n| extend prev_Value = prev(CounterValue), prev_t = prev(TimeGenerated), prev_instance = prev(InstanceName)\r\n| project TimeGenerated, CounterValue = iff(prev_instance == InstanceName and CounterValue >= prev_Value and TimeGenerated > prev_t, (CounterValue - prev_Value) / ((TimeGenerated - prev_t) / 1s), real(0))\r\n| summarize CounterValue = sum(CounterValue) by bin(TimeGenerated, 2s);\r\nlet networkDataReceive = union windowsNetwork, linuxNetwork;\r\nnetworkDataReceive\r\n| summarize {PercentilesLeft} by bin(TimeGenerated, grain)",
         "showQuery": false,
         "size": 0,
         "aggregation": 3,

--- a/Workbooks/Virtual Machines - Performance Analysis/Performance Analysis for a Single VM/settings.json
+++ b/Workbooks/Virtual Machines - Performance Analysis/Performance Analysis for a Single VM/settings.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/settings.json",
-    "name":"Performance Analysis for a Single VM",
+    "name":"Performance",
     "author": "Microsoft",
     "galleries": [
         { "type": "performance-vm", "resourceType": "microsoft.compute/virtualmachines", "order": 200 }

--- a/Workbooks/Virtual Machines/Virtual Machine Performance/settings.json
+++ b/Workbooks/Virtual Machines/Virtual Machine Performance/settings.json
@@ -3,6 +3,5 @@
     "name":"Virtual Machine Performance",
     "author": "Microsoft",
     "galleries": [
-        { "type": "performance-vm", "resourceType": "microsoft.compute/virtualmachines", "order": 200 }
     ]
 }


### PR DESCRIPTION
Further polish Single VM performance analysis workbook to bring it more
in line with its AtScale counterpart. Also delist a duplicate workbook
since that has been incorporated into this workbook. Update cosmetic
look-and-feel and add helper text to aid end-user in navigating around
this workbook.

- Rename workbook to "Performance" in Single VM gallery

- Delist "Virtual Machine Performance" workbook from Single VM gallery

- Add and update helper text

- Cosmetic changes for easier readability

- Align parameter names with AtScale Performance workbook

- Minor fix in last chart to use correct parameter

![image](https://user-images.githubusercontent.com/43890980/51857070-28922680-22e6-11e9-9dfe-c8c1df4420e4.png)