### PR TITLE
Add Single VM support in Connections Overview

### DIFF
--- a/Workbooks/Virtual Machines - Network Dependencies/Connections Overview/Connections Overview.workbook
+++ b/Workbooks/Virtual Machines - Network Dependencies/Connections Overview/Connections Overview.workbook
@@ -150,7 +150,7 @@
     {
       "type": 1,
       "content": {
-        "json": "---\r\n\r\n## Connection Statistics\r\n\r\nThe following table presents the connection statistics for computers in your workspace (max `10,000` rows).\r\n\r\nUse the <em>Hierarchy</em> dropdown for more detailed information for each computer but fewer computers will be shown.\r\n\r\n<hr style=\"border: none;height: 2px;color: grey;\" />"
+        "json": "---\r\n\r\n## Connection Statistics\r\n\r\nThe following table presents the connection statistics for computers in your workspace (max `10,000` rows).\r\n\r\nUse the <em>Hierarchy</em> dropdown for more detailed information for each computer but fewer computers will be shown if the total number of rows rendered exceeds `10,000`.\r\n\r\n<hr style=\"border: none;height: 2px;color: grey;\" />"
       },
       "conditionalVisibility": null
     },

--- a/Workbooks/Virtual Machines - Network Dependencies/Connections Overview/Connections Overview.workbook
+++ b/Workbooks/Virtual Machines - Network Dependencies/Connections Overview/Connections Overview.workbook
@@ -150,265 +150,6 @@
     {
       "type": 1,
       "content": {
-        "json": "---\n\n## Connection Records\n\nEach <strong>record</strong> from [VMConnections](https://docs.microsoft.com/en-us/azure/azure-monitor/insights/service-map) represents a connection from one machine to another over a 1-minute interval.\n\nEach <strong>record</strong> aggregates the following properties over a 1-minute interval: the total number of bytes sent and received, the number of links (port connections) that are established, currently active, and terminated, and the number of responses received.\n\n<hr style=\"height: 2px;\" />"
-      },
-      "conditionalVisibility": null
-    },
-    {
-      "type": 9,
-      "content": {
-        "version": "KqlParameterItem/1.0",
-        "query": "",
-        "crossComponentResources": [
-          "{Workspace}"
-        ],
-        "parameters": [
-          {
-            "id": "5f8cce4b-9c4c-47da-8683-7e5ccc9faed3",
-            "version": "KqlParameterItem/1.0",
-            "name": "TimeRange",
-            "type": 4,
-            "isRequired": false,
-            "value": {
-              "durationMs": 3600000,
-              "createdTime": "2018-10-04T22:01:18.372Z",
-              "isInitialTime": false,
-              "grain": 1,
-              "useDashboardTimeRange": false
-            },
-            "isHiddenWhenLocked": false,
-            "typeSettings": {
-              "selectableValues": [
-                {
-                  "durationMs": 300000,
-                  "createdTime": "2018-10-04T22:01:18.372Z",
-                  "isInitialTime": false,
-                  "grain": 1,
-                  "useDashboardTimeRange": false
-                },
-                {
-                  "durationMs": 900000,
-                  "createdTime": "2018-10-04T22:01:18.372Z",
-                  "isInitialTime": false,
-                  "grain": 1,
-                  "useDashboardTimeRange": false
-                },
-                {
-                  "durationMs": 1800000,
-                  "createdTime": "2018-10-04T22:01:18.372Z",
-                  "isInitialTime": false,
-                  "grain": 1,
-                  "useDashboardTimeRange": false
-                },
-                {
-                  "durationMs": 3600000,
-                  "createdTime": "2018-10-04T22:01:18.372Z",
-                  "isInitialTime": false,
-                  "grain": 1,
-                  "useDashboardTimeRange": false
-                },
-                {
-                  "durationMs": 14400000,
-                  "createdTime": "2018-10-04T22:01:18.374Z",
-                  "isInitialTime": false,
-                  "grain": 1,
-                  "useDashboardTimeRange": false
-                },
-                {
-                  "durationMs": 43200000,
-                  "createdTime": "2018-10-04T22:01:18.374Z",
-                  "isInitialTime": false,
-                  "grain": 1,
-                  "useDashboardTimeRange": false
-                },
-                {
-                  "durationMs": 86400000,
-                  "createdTime": "2018-10-04T22:01:18.374Z",
-                  "isInitialTime": false,
-                  "grain": 1,
-                  "useDashboardTimeRange": false
-                },
-                {
-                  "durationMs": 172800000,
-                  "createdTime": "2018-10-04T22:01:18.374Z",
-                  "isInitialTime": false,
-                  "grain": 1,
-                  "useDashboardTimeRange": false
-                },
-                {
-                  "durationMs": 259200000,
-                  "createdTime": "2018-10-04T22:01:18.375Z",
-                  "isInitialTime": false,
-                  "grain": 1,
-                  "useDashboardTimeRange": false
-                },
-                {
-                  "durationMs": 604800000,
-                  "createdTime": "2018-10-04T22:01:18.375Z",
-                  "isInitialTime": false,
-                  "grain": 1,
-                  "useDashboardTimeRange": false
-                },
-                {
-                  "durationMs": 1209600000,
-                  "createdTime": "2018-10-04T22:01:18.375Z",
-                  "isInitialTime": false,
-                  "grain": 1,
-                  "useDashboardTimeRange": false
-                },
-                {
-                  "durationMs": 2592000000,
-                  "createdTime": "2018-10-04T22:01:18.375Z",
-                  "isInitialTime": false,
-                  "grain": 1,
-                  "useDashboardTimeRange": false
-                },
-                {
-                  "durationMs": 5184000000,
-                  "createdTime": "2018-10-04T22:01:18.375Z",
-                  "isInitialTime": false,
-                  "grain": 1,
-                  "useDashboardTimeRange": false
-                },
-                {
-                  "durationMs": 7776000000,
-                  "createdTime": "2018-10-04T22:01:18.375Z",
-                  "isInitialTime": false,
-                  "grain": 1,
-                  "useDashboardTimeRange": false
-                }
-              ],
-              "allowCustom": true
-            }
-          }
-        ],
-        "style": "above",
-        "resourceType": "microsoft.operationalinsights/workspaces"
-      },
-      "conditionalVisibility": null
-    },
-    {
-      "type": 1,
-      "content": {
-        "json": "<p><strong>TimeRange</strong> specifies how far back in time to gather connection records from <em>VMConnections</em>. Selecting a large time range will result in a long query processing time.</p>\r\n\r\n<hr style=\"height: 1px;\" />"
-      },
-      "conditionalVisibility": null
-    },
-    {
-      "type": 1,
-      "content": {
-        "json": "### Aggregate Connection Records\n\n"
-      },
-      "conditionalVisibility": null,
-      "customWidth": "25"
-    },
-    {
-      "type": 1,
-      "content": {
-        "json": "### Connection Records by Country"
-      },
-      "conditionalVisibility": null,
-      "customWidth": "75"
-    },
-    {
-      "type": 3,
-      "content": {
-        "version": "KqlItem/1.0",
-        "query": "VMConnection\r\n| where TimeGenerated {TimeRange}\r\n| summarize Count = count() by Direction",
-        "showQuery": false,
-        "size": 0,
-        "aggregation": 0,
-        "showAnnotations": false,
-        "showAnalytics": false,
-        "timeContextFromParameter": null,
-        "resourceType": "microsoft.operationalinsights/workspaces",
-        "crossComponentResources": [
-          "{Workspace}"
-        ],
-        "visualization": "piechart"
-      },
-      "conditionalVisibility": {
-        "parameterName": "ComputerName",
-        "comparison": "isEqualTo",
-        "value": "undefined"
-      },
-      "customWidth": "25"
-    },
-    {
-      "type": 3,
-      "content": {
-        "version": "KqlItem/1.0",
-        "query": "VMConnection\r\n| where TimeGenerated {TimeRange}\r\n| summarize Count = count() by RemoteCountry, bin(TimeGenerated, {TimeRange:grain})",
-        "showQuery": false,
-        "size": 1,
-        "aggregation": 0,
-        "showAnnotations": true,
-        "showAnalytics": false,
-        "timeContextFromParameter": null,
-        "resourceType": "microsoft.operationalinsights/workspaces",
-        "crossComponentResources": [
-          "{Workspace}"
-        ],
-        "visualization": "areachart"
-      },
-      "conditionalVisibility": {
-        "parameterName": "ComputerName",
-        "comparison": "isEqualTo",
-        "value": "undefined"
-      },
-      "customWidth": "75"
-    },
-    {
-      "type": 3,
-      "content": {
-        "version": "KqlItem/1.0",
-        "query": "VMConnection\r\n| where TimeGenerated {TimeRange}\r\n| summarize Count = count() by Direction",
-        "showQuery": false,
-        "size": 0,
-        "aggregation": 0,
-        "showAnnotations": false,
-        "showAnalytics": false,
-        "timeContextFromParameter": null,
-        "resourceType": "microsoft.compute/virtualmachines",
-        "crossComponentResources": [
-          "{Computer}"
-        ],
-        "visualization": "piechart"
-      },
-      "conditionalVisibility": {
-        "parameterName": "ComputerName",
-        "comparison": "isNotEqualTo",
-        "value": "undefined"
-      },
-      "customWidth": "25"
-    },
-    {
-      "type": 3,
-      "content": {
-        "version": "KqlItem/1.0",
-        "query": "VMConnection\r\n| where TimeGenerated {TimeRange}\r\n| summarize Count = count() by RemoteCountry, bin(TimeGenerated, {TimeRange:grain})",
-        "showQuery": false,
-        "size": 1,
-        "aggregation": 0,
-        "showAnnotations": false,
-        "showAnalytics": false,
-        "timeContextFromParameter": null,
-        "resourceType": "microsoft.compute/virtualmachines",
-        "crossComponentResources": [
-          "{Computer}"
-        ],
-        "visualization": "areachart"
-      },
-      "conditionalVisibility": {
-        "parameterName": "ComputerName",
-        "comparison": "isNotEqualTo",
-        "value": "undefined"
-      },
-      "customWidth": "75"
-    },
-    {
-      "type": 1,
-      "content": {
         "json": "---\r\n\r\n## Connection Statistics\r\n\r\nThe following table presents the connection statistics for computers in your workspace (max `10,000` rows).\r\n\r\nUse the <em>Hierarchy</em> dropdown for more detailed information for each computer but fewer computers will be shown.\r\n\r\n<hr style=\"border: none;height: 2px;color: grey;\" />"
       },
       "conditionalVisibility": null
@@ -617,9 +358,12 @@
             "multiSelect": true,
             "quote": "'",
             "delimiter": ",",
-            "query": "VMConnection\r\n| where TimeGenerated {TimeRange}\r\n| where Computer contains '{ComputerNameContains}'\r\n| summarize by Computer\r\n| project Value = Computer, Display = Computer, IsDefault = false\r\n| order by Display asc\r\n| union (datatable(Value:string, Display:string, IsDefault:boolean)['*', 'All', true])",
+            "query": "VMConnection\r\n| where TimeGenerated {TimeRange}\r\n| where Computer contains '{ComputerNameContains}'\r\n| summarize by Computer\r\n| project Value = Computer, Display = Computer\r\n| order by Display asc\r\n| union (datatable(Value:string, Display:string)['*', 'All'])",
             "crossComponentResources": [
               "{Workspace}"
+            ],
+            "value": [
+              "*"
             ],
             "isHiddenWhenLocked": false,
             "typeSettings": {
@@ -675,7 +419,7 @@
           {
             "id": "5e335a1b-7f99-4647-854a-d7b5cb489bb2",
             "version": "KqlParameterItem/1.0",
-            "name": "QC",
+            "name": "ServiceMapComputers",
             "type": 1,
             "isRequired": true,
             "query": "print(strcat(\"let computers = ServiceMapComputer_CL \", iff(\"{ComputerName}\" == \"undefined\", \"\", \" | where Computer == '{ComputerName}'\"), \"| where 'run' == 'run' | where TimeGenerated > ago(1h) | summarize (TimeGenerated, Properties) = arg_max(TimeGenerated, pack_all()) by Computer;\"));",
@@ -686,7 +430,7 @@
           {
             "id": "c69fbaae-4fd2-4527-acdd-a2c358eebffa",
             "version": "KqlParameterItem/1.0",
-            "name": "MD",
+            "name": "MaliciousIpData",
             "type": 1,
             "isRequired": false,
             "query": "print(strcat(\"let maliciousIpData = VMConnection\", iff(\"{ComputerName}\" == \"undefined\", \"\", \" | where Computer == '{ComputerName}'\"),\" | where '{GridRefresh}' == 'run' | where TimeGenerated {TimeRange} | where Direction == '{Direction}' {ComputerFilter} | where MaliciousIp != '' | summarize argmax(TimeGenerated, *) by MaliciousIp | project MaliciousIp = strcat(max_TimeGenerated_Computer, '-', max_TimeGenerated_ProcessName, '-', MaliciousIp), Computer = max_TimeGenerated_Computer, Process = strcat(max_TimeGenerated_Computer, '-', max_TimeGenerated_ProcessName), MaliciousIpInfo = pack('Malicious IP', MaliciousIp, 'Is Active', max_TimeGenerated_IsActive, 'Indicator Threat Type', max_TimeGenerated_IndicatorThreatType, 'Remote Country', max_TimeGenerated_RemoteCountry, 'Longitude', max_TimeGenerated_RemoteLongitude, 'Latitude', max_TimeGenerated_RemoteLatitude, 'Confidence', max_TimeGenerated_Confidence, 'Severity', max_TimeGenerated_Severity, 'First Reported DateTime', max_TimeGenerated_FirstReportedDateTime, 'Last Reported DateTime', max_TimeGenerated_LastReportedDateTime, 'Report Reference Link', max_TimeGenerated_ReportReferenceLink);\"));\r\n",
@@ -700,7 +444,7 @@
           {
             "id": "dd933ac8-1273-48fe-8d09-bd65d857ce83",
             "version": "KqlParameterItem/1.0",
-            "name": "CD",
+            "name": "ComputerData",
             "type": 1,
             "isRequired": false,
             "query": "print(strcat(\"let computerData = VMConnection\", iff(\"{ComputerName}\" == \"undefined\", \"\", \" | where Computer == '{ComputerName}'\"), \" | where '{GridRefresh}' == 'run' | where TimeGenerated {TimeRange} | where Direction == '{Direction}' {ComputerFilter} | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) by  Name = strcat('🖥️ ', Computer), Type = 'Computer', TypeKey = 1, Key = Computer, ParentKey = '---' | join kind=leftouter (maliciousIpData | summarize MaliciousIpInfo = tostring(count()) by Computer) on $left.Key == $right.Computer | project-away Computer | order by Name asc;\"));",
@@ -714,10 +458,10 @@
           {
             "id": "9789ead5-eae5-4f52-86c2-ac197da62f30",
             "version": "KqlParameterItem/1.0",
-            "name": "CPIP",
+            "name": "Computer_Process_IP_Port",
             "type": 1,
             "isRequired": false,
-            "query": "print(strcat(\"{QC}\", \" let ipComputerMapping = computers | project Computer, Ipv4 = todynamic(tostring(Properties.Ipv4Addresses_s)) | mvexpand Ipv4 to typeof(string); \", \"{MD}\", \" let totalMaliciousConnectionsCount = maliciousIpData | summarize MaliciousIpInfo = count() | extend Type = 'Overall'; \", \"{CD}\", \" let processData = VMConnection | where '{GridRefresh}' == 'run' | where TimeGenerated {TimeRange} | where Direction == '{Direction}' {ComputerFilter} | where ProcessName != '' | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) by  Computer, Name = strcat('🎫 ', ProcessName), Type = 'Process', TypeKey = 2, Key = strcat(Computer, '-', ProcessName), ParentKey = Computer | join kind=inner computerData on $left.ParentKey == $right.Key | project-away Name1, Responses1, LinksFailed1, MaxLinksLive1, TotalBytesSent1, TotalBytesReceived1, AverageResponseTime1, Type1, Key1, ParentKey1 | join kind=leftouter (maliciousIpData | summarize MaliciousIpInfo = tostring(count()) by Process) on $left.Key == $right.Process | project-away Process, MaliciousIpInfo | extend MaliciousIpInfo = tostring(MaliciousIpInfo1) | project-away MaliciousIpInfo1\t\t\t\t\t\t\t   | order by Name asc; let remoteIpData = VMConnection | where '{GridRefresh}' == 'run' | where TimeGenerated {TimeRange} | where '{Direction}' == 'outbound' | where Direction == '{Direction}' {ComputerFilter} | extend RemoteIp = iff(Direction == 'outbound', DestinationIp, SourceIp) | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) by Computer, ProcessName, RemoteIp, Type = 'Remote Computer', TypeKey = 3, Key = strcat(Computer, '-', ProcessName, '-', RemoteIp), ParentKey = strcat(Computer, '-', ProcessName) | join kind=inner processData on $left.ParentKey == $right.Key | project-away Name, Responses1, LinksFailed1, MaxLinksLive1, TotalBytesSent1, TotalBytesReceived1, AverageResponseTime1, Type1, Key1, ParentKey1 | join kind=leftouter maliciousIpData on $left.Key == $right.MaliciousIp | project-away MaliciousIp, Computer, Process, Computer1, Computer2, MaliciousIpInfo | extend MaliciousIpInfo = tostring(MaliciousIpInfo1) | project-away MaliciousIpInfo1 | join kind = leftouter (ipComputerMapping) on $left.RemoteIp == $right.Ipv4 | extend Name = iff(Computer == '', iff(RemoteIp == '127.0.0.1', '🌐 Localhost',  strcat('🌐 External (', RemoteIp, ')')), strcat('🖥️ ', Computer)) | project-away Computer, Ipv4 | order by Name desc; let destinationPortData = VMConnection | where '{GridRefresh}' == 'run' | where TimeGenerated {TimeRange} | where Direction == '{Direction}' | where '{Direction}' == 'outbound' {ComputerFilter} | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) by Computer, ProcessName, DestinationIp, DestinationPort, Name = strcat('🔶 ', DestinationPort), Type = 'Remote Port', TypeKey = 4, Key = strcat(Computer, '-', ProcessName, '-', DestinationIp, '-', tostring(DestinationPort)), ParentKey = strcat(Computer, '-', ProcessName, '-', DestinationIp) | join kind=inner remoteIpData on $left.ParentKey == $right.Key | project-away Name1, Responses1, Type1, Key1, ParentKey1 | order by Name asc; let sourcePortData = VMConnection | where '{GridRefresh}' == 'run' | where TimeGenerated > ago(1h) | where Direction == '{Direction}' | where '{Direction}' == 'inbound' | where Computer contains '' | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) by Computer, ProcessName, DestinationIp, DestinationPort, Name = strcat('🔶 ', DestinationPort), Type = 'Remote Port', TypeKey = 4, Key = strcat(Computer, '-', ProcessName, '-', tostring(DestinationPort)), ParentKey = strcat(Computer, '-', ProcessName) | join kind=inner     processData on $left.ParentKey == $right.Key | project-away Name1, AverageResponseTime1, Computer1, Key1, LinksFailed1, MaxLinksLive1, ParentKey1, Responses1, TotalBytesReceived1, TotalBytesSent1, Type1, TypeKey1, TypeKey2; let remoteIpDataInbound = VMConnection | where '{GridRefresh}' == 'run' | where TimeGenerated > ago(1h) | where Direction == '{Direction}' | where '{Direction}' == 'inbound' | where Computer contains '' | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) by Computer, ProcessName, RemoteIp, Type = 'Remote Computer', TypeKey = 3, Key = strcat(Computer, '-', ProcessName, '-', tostring(DestinationPort), '-', RemoteIp), ParentKey = strcat(Computer, '-', ProcessName, '-', tostring(DestinationPort)), Id = strcat(Computer, '-', ProcessName, '-', RemoteIp) | join kind=inner     sourcePortData on $left.ParentKey == $right.Key | project-away AverageResponseTime1, Computer1, Key1, LinksFailed1, MaxLinksLive1, ParentKey1, ProcessName1, Responses1, TotalBytesReceived1, TotalBytesSent1, Type1, TypeKey1 | order by Name asc | join kind=leftouter     ipComputerMapping on $left.RemoteIp == $right.Ipv4 | extend Name = iff(RemoteIp == '', 'Unknown',  strcat('🌐 External (', RemoteIp, ')')) | project-away Computer, Ipv4 | order by Name desc | join kind=leftouter     maliciousIpData on $left.Id == $right.MaliciousIp | project-away MaliciousIp, Computer, Process, Computer1, MaliciousIpInfo, Id | extend MaliciousIpInfo = tostring(MaliciousIpInfo1) | project-away MaliciousIpInfo1; let overalldata = VMConnection | where '{GridRefresh}' == 'run' | where TimeGenerated {TimeRange} | where Direction == '{Direction}' {ComputerFilter} | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) | extend Name = '🔵 Overall', Type = 'Overall', TypeKey = 0, Key = '--Overall--', ParentKey = '----' | join kind=leftouter totalMaliciousConnectionsCount on Type | extend MaliciousIpInfo = iff(MaliciousIpInfo == '0', '', tostring(MaliciousIpInfo)) | project-away Type1; computerData | union processData | union remoteIpData | union destinationPortData | union remoteIpDataInbound | union sourcePortData | union overalldata\t\t\t\t\t\t\t | extend MaliciousConnectionsCount = iff(MaliciousIpInfo == '', 0, iff(Type == 'Computer' or Type == 'Process' or Type == 'Overall', tolong(MaliciousIpInfo), 1)) | project Name, Type, MaliciousConnections = iff(MaliciousIpInfo == '', '✅ No Malicious Connections', iff(Type == 'Computer' or Type == 'Process' or Type == 'Overall', iff(MaliciousConnectionsCount > 1, strcat('❌ ', MaliciousIpInfo, ' Malicious Connections'), strcat('❌ ', MaliciousIpInfo, ' Malicious Connection')), '❌ Malicious Connection')), Responses, MaxLinksLive, LinksFailed, AverageResponseTime, TotalBytesSent, TotalBytesReceived, Info = iff(MaliciousIpInfo != '', MaliciousIpInfo, ''), Key, ParentKey, TypeKey, MaliciousConnectionsCount | order by TypeKey asc, MaliciousConnectionsCount desc, LinksFailed desc, AverageResponseTime desc, Responses desc, MaxLinksLive desc, Name asc | project-away TypeKey\"));\r\n",
+            "query": "print(strcat(\"{ServiceMapComputers}\", \" let ipComputerMapping = computers | project Computer, Ipv4 = todynamic(tostring(Properties.Ipv4Addresses_s)) | mvexpand Ipv4 to typeof(string); \", \"{MaliciousIpData}\", \" let totalMaliciousConnectionsCount = maliciousIpData | summarize MaliciousIpInfo = count() | extend Type = 'Overall'; \", \"{ComputerData}\", \" let processData = VMConnection | where '{GridRefresh}' == 'run' | where TimeGenerated {TimeRange} | where Direction == '{Direction}' {ComputerFilter} | where ProcessName != '' | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) by  Computer, Name = strcat('🎫 ', ProcessName), Type = 'Process', TypeKey = 2, Key = strcat(Computer, '-', ProcessName), ParentKey = Computer | join kind=inner computerData on $left.ParentKey == $right.Key | project-away Name1, Responses1, LinksFailed1, MaxLinksLive1, TotalBytesSent1, TotalBytesReceived1, AverageResponseTime1, Type1, Key1, ParentKey1 | join kind=leftouter (maliciousIpData | summarize MaliciousIpInfo = tostring(count()) by Process) on $left.Key == $right.Process | project-away Process, MaliciousIpInfo | extend MaliciousIpInfo = tostring(MaliciousIpInfo1) | project-away MaliciousIpInfo1\t\t\t\t\t\t\t   | order by Name asc; let remoteIpData = VMConnection | where '{GridRefresh}' == 'run' | where TimeGenerated {TimeRange} | where '{Direction}' == 'outbound' | where Direction == '{Direction}' {ComputerFilter} | extend RemoteIp = iff(Direction == 'outbound', DestinationIp, SourceIp) | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) by Computer, ProcessName, RemoteIp, Type = 'Remote Computer', TypeKey = 3, Key = strcat(Computer, '-', ProcessName, '-', RemoteIp), ParentKey = strcat(Computer, '-', ProcessName) | join kind=inner processData on $left.ParentKey == $right.Key | project-away Name, Responses1, LinksFailed1, MaxLinksLive1, TotalBytesSent1, TotalBytesReceived1, AverageResponseTime1, Type1, Key1, ParentKey1 | join kind=leftouter maliciousIpData on $left.Key == $right.MaliciousIp | project-away MaliciousIp, Computer, Process, Computer1, Computer2, MaliciousIpInfo | extend MaliciousIpInfo = tostring(MaliciousIpInfo1) | project-away MaliciousIpInfo1 | join kind = leftouter (ipComputerMapping) on $left.RemoteIp == $right.Ipv4 | extend Name = iff(Computer == '', iff(RemoteIp == '127.0.0.1', '🌐 Localhost',  strcat('🌐 External (', RemoteIp, ')')), strcat('🖥️ ', Computer)) | project-away Computer, Ipv4 | order by Name desc; let destinationPortData = VMConnection | where '{GridRefresh}' == 'run' | where TimeGenerated {TimeRange} | where Direction == '{Direction}' | where '{Direction}' == 'outbound' {ComputerFilter} | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) by Computer, ProcessName, DestinationIp, DestinationPort, Name = strcat('🔶 ', DestinationPort), Type = 'Remote Port', TypeKey = 4, Key = strcat(Computer, '-', ProcessName, '-', DestinationIp, '-', tostring(DestinationPort)), ParentKey = strcat(Computer, '-', ProcessName, '-', DestinationIp) | join kind=inner remoteIpData on $left.ParentKey == $right.Key | project-away Name1, Responses1, Type1, Key1, ParentKey1 | order by Name asc; let sourcePortData = VMConnection | where '{GridRefresh}' == 'run' | where TimeGenerated > ago(1h) | where Direction == '{Direction}' | where '{Direction}' == 'inbound' | where Computer contains '' | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) by Computer, ProcessName, DestinationIp, DestinationPort, Name = strcat('🔶 ', DestinationPort), Type = 'Remote Port', TypeKey = 4, Key = strcat(Computer, '-', ProcessName, '-', tostring(DestinationPort)), ParentKey = strcat(Computer, '-', ProcessName) | join kind=inner     processData on $left.ParentKey == $right.Key | project-away Name1, AverageResponseTime1, Computer1, Key1, LinksFailed1, MaxLinksLive1, ParentKey1, Responses1, TotalBytesReceived1, TotalBytesSent1, Type1, TypeKey1, TypeKey2; let remoteIpDataInbound = VMConnection | where '{GridRefresh}' == 'run' | where TimeGenerated > ago(1h) | where Direction == '{Direction}' | where '{Direction}' == 'inbound' | where Computer contains '' | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) by Computer, ProcessName, RemoteIp, Type = 'Remote Computer', TypeKey = 3, Key = strcat(Computer, '-', ProcessName, '-', tostring(DestinationPort), '-', RemoteIp), ParentKey = strcat(Computer, '-', ProcessName, '-', tostring(DestinationPort)), Id = strcat(Computer, '-', ProcessName, '-', RemoteIp) | join kind=inner     sourcePortData on $left.ParentKey == $right.Key | project-away AverageResponseTime1, Computer1, Key1, LinksFailed1, MaxLinksLive1, ParentKey1, ProcessName1, Responses1, TotalBytesReceived1, TotalBytesSent1, Type1, TypeKey1 | order by Name asc | join kind=leftouter     ipComputerMapping on $left.RemoteIp == $right.Ipv4 | extend Name = iff(RemoteIp == '', 'Unknown',  strcat('🌐 External (', RemoteIp, ')')) | project-away Computer, Ipv4 | order by Name desc | join kind=leftouter     maliciousIpData on $left.Id == $right.MaliciousIp | project-away MaliciousIp, Computer, Process, Computer1, MaliciousIpInfo, Id | extend MaliciousIpInfo = tostring(MaliciousIpInfo1) | project-away MaliciousIpInfo1; let overalldata = VMConnection | where '{GridRefresh}' == 'run' | where TimeGenerated {TimeRange} | where Direction == '{Direction}' {ComputerFilter} | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) | extend Name = '🔵 Overall', Type = 'Overall', TypeKey = 0, Key = '--Overall--', ParentKey = '----' | join kind=leftouter totalMaliciousConnectionsCount on Type | extend MaliciousIpInfo = iff(MaliciousIpInfo == '0', '', tostring(MaliciousIpInfo)) | project-away Type1; computerData | union processData | union remoteIpData | union destinationPortData | union remoteIpDataInbound | union sourcePortData | union overalldata\t\t\t\t\t\t\t | extend MaliciousConnectionsCount = iff(MaliciousIpInfo == '', 0, iff(Type == 'Computer' or Type == 'Process' or Type == 'Overall', tolong(MaliciousIpInfo), 1)) | project Name, Type, MaliciousConnections = iff(MaliciousIpInfo == '', '✅ No Malicious Connections', iff(Type == 'Computer' or Type == 'Process' or Type == 'Overall', iff(MaliciousConnectionsCount > 1, strcat('❌ ', MaliciousIpInfo, ' Malicious Connections'), strcat('❌ ', MaliciousIpInfo, ' Malicious Connection')), '❌ Malicious Connection')), Responses, MaxLinksLive, LinksFailed, AverageResponseTime, TotalBytesSent, TotalBytesReceived, Info = iff(MaliciousIpInfo != '', MaliciousIpInfo, ''), Key, ParentKey, TypeKey, MaliciousConnectionsCount | order by TypeKey asc, MaliciousConnectionsCount desc, LinksFailed desc, AverageResponseTime desc, Responses desc, MaxLinksLive desc, Name asc | project-away TypeKey\"));\r\n",
             "crossComponentResources": [
               "{Workspace}"
             ],
@@ -728,10 +472,10 @@
           {
             "id": "0d6a320e-2cef-44fd-ac0b-ad833f8d0c03",
             "version": "KqlParameterItem/1.0",
-            "name": "CPI",
+            "name": "Computer_Process_IP",
             "type": 1,
             "isRequired": false,
-            "query": "print(strcat(\"{QC}\", \" let ipComputerMapping = computers | project Computer, Ipv4 = todynamic(tostring(Properties.Ipv4Addresses_s)) | mvexpand Ipv4 to typeof(string); \", \"{MD}\", \" let totalMaliciousConnectionsCount = maliciousIpData | summarize MaliciousIpInfo = count() | extend Type = 'Overall'; \", \"{CD}\", \" let processData = VMConnection | where '{GridRefresh}' == 'run' | where TimeGenerated {TimeRange} | where Direction == '{Direction}' {ComputerFilter} | where ProcessName != '' | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) by  Computer, Name = strcat('🎫 ', ProcessName), Type = 'Process', TypeKey = 2, Key = strcat(Computer, '-', ProcessName), ParentKey = Computer | join kind=inner computerData on $left.ParentKey == $right.Key | project-away Name1, Responses1, LinksFailed1, MaxLinksLive1, TotalBytesSent1, TotalBytesReceived1, AverageResponseTime1, Type1, Key1, ParentKey1 | join kind=leftouter (maliciousIpData | summarize MaliciousIpInfo = tostring(count()) by Process) on $left.Key == $right.Process | project-away Process, MaliciousIpInfo | extend MaliciousIpInfo = tostring(MaliciousIpInfo1) | project-away MaliciousIpInfo1\t\t\t\t\t\t\t   | order by Name asc; let remoteIpData = VMConnection | where '{GridRefresh}' == 'run' | where TimeGenerated {TimeRange} | where Direction == '{Direction}' {ComputerFilter} | extend RemoteIp = iff(Direction == 'outbound', DestinationIp, SourceIp) | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) by Computer, ProcessName, RemoteIp, Type = 'Remote Computer', TypeKey = 3, Key = strcat(Computer, '-', ProcessName, '-', RemoteIp), ParentKey = strcat(Computer, '-', ProcessName) | join kind=inner processData on $left.ParentKey == $right.Key | project-away Name, Responses1, LinksFailed1, MaxLinksLive1, TotalBytesSent1, TotalBytesReceived1, AverageResponseTime1, Type1, Key1, ParentKey1 | join kind=leftouter maliciousIpData on $left.Key == $right.MaliciousIp | project-away MaliciousIp, Computer, Process, Computer1, Computer2, MaliciousIpInfo | extend MaliciousIpInfo = tostring(MaliciousIpInfo1) | project-away MaliciousIpInfo1 | join kind = leftouter (ipComputerMapping) on $left.RemoteIp == $right.Ipv4 | extend Name = iff(Computer == '', iff(RemoteIp == '127.0.0.1', '🌐 Localhost',  strcat('🌐 External (', RemoteIp, ')')), strcat('🖥️ ', Computer)) | project-away Computer, Ipv4 | order by Name desc; let overalldata = VMConnection | where '{GridRefresh}' == 'run' | where TimeGenerated {TimeRange} | where Direction == '{Direction}' {ComputerFilter} | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) | extend Name = '🔵 Overall', Type = 'Overall', TypeKey = 0, Key = '--Overall--', ParentKey = '----' | join kind=leftouter totalMaliciousConnectionsCount on Type | extend MaliciousIpInfo = iff(MaliciousIpInfo == '0', '', tostring(MaliciousIpInfo)) | project-away Type1; computerData | union processData | union remoteIpData | union overalldata\t\t\t\t\t\t\t | extend MaliciousConnectionsCount = iff(MaliciousIpInfo == '', 0, iff(Type == 'Computer' or Type == 'Process' or Type == 'Overall', tolong(MaliciousIpInfo), 1)) | project Name, Type, MaliciousConnections = iff(MaliciousIpInfo == '', '✅ No Malicious Connections', iff(Type == 'Computer' or Type == 'Process' or Type == 'Overall', iff(MaliciousConnectionsCount > 1, strcat('❌ ', MaliciousIpInfo, ' Malicious Connections'), strcat('❌ ', MaliciousIpInfo, ' Malicious Connection')), '❌ Malicious Connection')), Responses, MaxLinksLive, LinksFailed, AverageResponseTime, TotalBytesSent, TotalBytesReceived, Info = iff(MaliciousIpInfo != '', MaliciousIpInfo, ''), Key, ParentKey, TypeKey, MaliciousConnectionsCount | order by TypeKey asc, MaliciousConnectionsCount desc, LinksFailed desc, AverageResponseTime desc, Responses desc, MaxLinksLive desc, Name asc | project-away TypeKey\"));\r\n",
+            "query": "print(strcat(\"{ServiceMapComputers}\", \" let ipComputerMapping = computers | project Computer, Ipv4 = todynamic(tostring(Properties.Ipv4Addresses_s)) | mvexpand Ipv4 to typeof(string); \", \"{MaliciousIpData}\", \" let totalMaliciousConnectionsCount = maliciousIpData | summarize MaliciousIpInfo = count() | extend Type = 'Overall'; \", \"{ComputerData}\", \" let processData = VMConnection | where '{GridRefresh}' == 'run' | where TimeGenerated {TimeRange} | where Direction == '{Direction}' {ComputerFilter} | where ProcessName != '' | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) by  Computer, Name = strcat('🎫 ', ProcessName), Type = 'Process', TypeKey = 2, Key = strcat(Computer, '-', ProcessName), ParentKey = Computer | join kind=inner computerData on $left.ParentKey == $right.Key | project-away Name1, Responses1, LinksFailed1, MaxLinksLive1, TotalBytesSent1, TotalBytesReceived1, AverageResponseTime1, Type1, Key1, ParentKey1 | join kind=leftouter (maliciousIpData | summarize MaliciousIpInfo = tostring(count()) by Process) on $left.Key == $right.Process | project-away Process, MaliciousIpInfo | extend MaliciousIpInfo = tostring(MaliciousIpInfo1) | project-away MaliciousIpInfo1\t\t\t\t\t\t\t   | order by Name asc; let remoteIpData = VMConnection | where '{GridRefresh}' == 'run' | where TimeGenerated {TimeRange} | where Direction == '{Direction}' {ComputerFilter} | extend RemoteIp = iff(Direction == 'outbound', DestinationIp, SourceIp) | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) by Computer, ProcessName, RemoteIp, Type = 'Remote Computer', TypeKey = 3, Key = strcat(Computer, '-', ProcessName, '-', RemoteIp), ParentKey = strcat(Computer, '-', ProcessName) | join kind=inner processData on $left.ParentKey == $right.Key | project-away Name, Responses1, LinksFailed1, MaxLinksLive1, TotalBytesSent1, TotalBytesReceived1, AverageResponseTime1, Type1, Key1, ParentKey1 | join kind=leftouter maliciousIpData on $left.Key == $right.MaliciousIp | project-away MaliciousIp, Computer, Process, Computer1, Computer2, MaliciousIpInfo | extend MaliciousIpInfo = tostring(MaliciousIpInfo1) | project-away MaliciousIpInfo1 | join kind = leftouter (ipComputerMapping) on $left.RemoteIp == $right.Ipv4 | extend Name = iff(Computer == '', iff(RemoteIp == '127.0.0.1', '🌐 Localhost',  strcat('🌐 External (', RemoteIp, ')')), strcat('🖥️ ', Computer)) | project-away Computer, Ipv4 | order by Name desc; let overalldata = VMConnection | where '{GridRefresh}' == 'run' | where TimeGenerated {TimeRange} | where Direction == '{Direction}' {ComputerFilter} | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) | extend Name = '🔵 Overall', Type = 'Overall', TypeKey = 0, Key = '--Overall--', ParentKey = '----' | join kind=leftouter totalMaliciousConnectionsCount on Type | extend MaliciousIpInfo = iff(MaliciousIpInfo == '0', '', tostring(MaliciousIpInfo)) | project-away Type1; computerData | union processData | union remoteIpData | union overalldata\t\t\t\t\t\t\t | extend MaliciousConnectionsCount = iff(MaliciousIpInfo == '', 0, iff(Type == 'Computer' or Type == 'Process' or Type == 'Overall', tolong(MaliciousIpInfo), 1)) | project Name, Type, MaliciousConnections = iff(MaliciousIpInfo == '', '✅ No Malicious Connections', iff(Type == 'Computer' or Type == 'Process' or Type == 'Overall', iff(MaliciousConnectionsCount > 1, strcat('❌ ', MaliciousIpInfo, ' Malicious Connections'), strcat('❌ ', MaliciousIpInfo, ' Malicious Connection')), '❌ Malicious Connection')), Responses, MaxLinksLive, LinksFailed, AverageResponseTime, TotalBytesSent, TotalBytesReceived, Info = iff(MaliciousIpInfo != '', MaliciousIpInfo, ''), Key, ParentKey, TypeKey, MaliciousConnectionsCount | order by TypeKey asc, MaliciousConnectionsCount desc, LinksFailed desc, AverageResponseTime desc, Responses desc, MaxLinksLive desc, Name asc | project-away TypeKey\"));\r\n",
             "crossComponentResources": [
               "{Workspace}"
             ],
@@ -742,10 +486,10 @@
           {
             "id": "e8f2c394-18e8-4d6d-8f5e-8453cb67128c",
             "version": "KqlParameterItem/1.0",
-            "name": "CP",
+            "name": "Computer_Process",
             "type": 1,
             "isRequired": false,
-            "query": "print(strcat(\"{QC}\", \" let ipComputerMapping = computers | project Computer, Ipv4 = todynamic(tostring(Properties.Ipv4Addresses_s)) | mvexpand Ipv4 to typeof(string); \", \"{MD}\", \" let totalMaliciousConnectionsCount = maliciousIpData | summarize MaliciousIpInfo = count() | extend Type = 'Overall'; \", \"{CD}\", \" let processData = VMConnection | where '{GridRefresh}' == 'run' | where TimeGenerated {TimeRange} | where Direction == '{Direction}' {ComputerFilter} | where ProcessName != '' | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) by  Computer, Name = strcat('🎫 ', ProcessName), Type = 'Process', TypeKey = 2, Key = strcat(Computer, '-', ProcessName), ParentKey = Computer | join kind=inner computerData on $left.ParentKey == $right.Key | project-away Name1, Responses1, LinksFailed1, MaxLinksLive1, TotalBytesSent1, TotalBytesReceived1, AverageResponseTime1, Type1, Key1, ParentKey1 | join kind=leftouter (maliciousIpData | summarize MaliciousIpInfo = tostring(count()) by Process) on $left.Key == $right.Process | project-away Process, MaliciousIpInfo | extend MaliciousIpInfo = tostring(MaliciousIpInfo1) | project-away MaliciousIpInfo1\t\t\t\t\t\t\t   | order by Name asc; let overalldata = VMConnection | where '{GridRefresh}' == 'run' | where TimeGenerated {TimeRange} | where Direction == '{Direction}' {ComputerFilter} | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) | extend Name = '🔵 Overall', Type = 'Overall', TypeKey = 0, Key = '--Overall--', ParentKey = '----' | join kind=leftouter totalMaliciousConnectionsCount on Type | extend MaliciousIpInfo = iff(MaliciousIpInfo == '0', '', tostring(MaliciousIpInfo)) | project-away Type1; computerData | union processData | union overalldata\t\t\t\t\t\t\t | extend MaliciousConnectionsCount = iff(MaliciousIpInfo == '', 0, iff(Type == 'Computer' or Type == 'Process' or Type == 'Overall', tolong(MaliciousIpInfo), 1)) | project Name, Type, MaliciousConnections = iff(MaliciousIpInfo == '', '✅ No Malicious Connections', iff(Type == 'Computer' or Type == 'Process' or Type == 'Overall', iff(MaliciousConnectionsCount > 1, strcat('❌ ', MaliciousIpInfo, ' Malicious Connections'), strcat('❌ ', MaliciousIpInfo, ' Malicious Connection')), '❌ Malicious Connection')), Responses, MaxLinksLive, LinksFailed, AverageResponseTime, TotalBytesSent, TotalBytesReceived, Info = iff(MaliciousIpInfo != '', MaliciousIpInfo, ''), Key, ParentKey, TypeKey, MaliciousConnectionsCount | order by TypeKey asc, MaliciousConnectionsCount desc, LinksFailed desc, AverageResponseTime desc, Responses desc, MaxLinksLive desc, Name asc | project-away TypeKey\"));\r\n",
+            "query": "print(strcat(\"{ServiceMapComputers}\", \" let ipComputerMapping = computers | project Computer, Ipv4 = todynamic(tostring(Properties.Ipv4Addresses_s)) | mvexpand Ipv4 to typeof(string); \", \"{MaliciousIpData}\", \" let totalMaliciousConnectionsCount = maliciousIpData | summarize MaliciousIpInfo = count() | extend Type = 'Overall'; \", \"{ComputerData}\", \" let processData = VMConnection | where '{GridRefresh}' == 'run' | where TimeGenerated {TimeRange} | where Direction == '{Direction}' {ComputerFilter} | where ProcessName != '' | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) by  Computer, Name = strcat('🎫 ', ProcessName), Type = 'Process', TypeKey = 2, Key = strcat(Computer, '-', ProcessName), ParentKey = Computer | join kind=inner computerData on $left.ParentKey == $right.Key | project-away Name1, Responses1, LinksFailed1, MaxLinksLive1, TotalBytesSent1, TotalBytesReceived1, AverageResponseTime1, Type1, Key1, ParentKey1 | join kind=leftouter (maliciousIpData | summarize MaliciousIpInfo = tostring(count()) by Process) on $left.Key == $right.Process | project-away Process, MaliciousIpInfo | extend MaliciousIpInfo = tostring(MaliciousIpInfo1) | project-away MaliciousIpInfo1\t\t\t\t\t\t\t   | order by Name asc; let overalldata = VMConnection | where '{GridRefresh}' == 'run' | where TimeGenerated {TimeRange} | where Direction == '{Direction}' {ComputerFilter} | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) | extend Name = '🔵 Overall', Type = 'Overall', TypeKey = 0, Key = '--Overall--', ParentKey = '----' | join kind=leftouter totalMaliciousConnectionsCount on Type | extend MaliciousIpInfo = iff(MaliciousIpInfo == '0', '', tostring(MaliciousIpInfo)) | project-away Type1; computerData | union processData | union overalldata\t\t\t\t\t\t\t | extend MaliciousConnectionsCount = iff(MaliciousIpInfo == '', 0, iff(Type == 'Computer' or Type == 'Process' or Type == 'Overall', tolong(MaliciousIpInfo), 1)) | project Name, Type, MaliciousConnections = iff(MaliciousIpInfo == '', '✅ No Malicious Connections', iff(Type == 'Computer' or Type == 'Process' or Type == 'Overall', iff(MaliciousConnectionsCount > 1, strcat('❌ ', MaliciousIpInfo, ' Malicious Connections'), strcat('❌ ', MaliciousIpInfo, ' Malicious Connection')), '❌ Malicious Connection')), Responses, MaxLinksLive, LinksFailed, AverageResponseTime, TotalBytesSent, TotalBytesReceived, Info = iff(MaliciousIpInfo != '', MaliciousIpInfo, ''), Key, ParentKey, TypeKey, MaliciousConnectionsCount | order by TypeKey asc, MaliciousConnectionsCount desc, LinksFailed desc, AverageResponseTime desc, Responses desc, MaxLinksLive desc, Name asc | project-away TypeKey\"));\r\n",
             "crossComponentResources": [
               "{Workspace}"
             ],
@@ -756,10 +500,10 @@
           {
             "id": "a4b0e146-7c89-40bb-ade2-ed2e392e9311",
             "version": "KqlParameterItem/1.0",
-            "name": "C",
+            "name": "Computer",
             "type": 1,
             "isRequired": false,
-            "query": "print(strcat(\"{QC}\", \" let ipComputerMapping = computers | project Computer, Ipv4 = todynamic(tostring(Properties.Ipv4Addresses_s)) | mvexpand Ipv4 to typeof(string); \", \"{MD}\", \" let totalMaliciousConnectionsCount = maliciousIpData | summarize MaliciousIpInfo = count() | extend Type = 'Overall'; \", \"{CD}\", \" let overalldata = VMConnection | where '{GridRefresh}' == 'run' | where TimeGenerated {TimeRange} | where Direction == '{Direction}' {ComputerFilter} | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) | extend Name = '🔵 Overall', Type = 'Overall', TypeKey = 0, Key = '--Overall--', ParentKey = '----' | join kind=leftouter totalMaliciousConnectionsCount on Type | extend MaliciousIpInfo = iff(MaliciousIpInfo == '0', '', tostring(MaliciousIpInfo)) | project-away Type1; computerData | union overalldata\t\t\t\t\t\t\t | extend MaliciousConnectionsCount = iff(MaliciousIpInfo == '', 0, iff(Type == 'Computer' or Type == 'Process' or Type == 'Overall', tolong(MaliciousIpInfo), 1)) | project Name, Type, MaliciousConnections = iff(MaliciousIpInfo == '', '✅ No Malicious Connections', iff(Type == 'Computer' or Type == 'Process' or Type == 'Overall', iff(MaliciousConnectionsCount > 1, strcat('❌ ', MaliciousIpInfo, ' Malicious Connections'), strcat('❌ ', MaliciousIpInfo, ' Malicious Connection')), '❌ Malicious Connection')), Responses, MaxLinksLive, LinksFailed, AverageResponseTime, TotalBytesSent, TotalBytesReceived, Info = iff(MaliciousIpInfo != '', MaliciousIpInfo, ''), Key, ParentKey, TypeKey, MaliciousConnectionsCount | order by TypeKey asc, MaliciousConnectionsCount desc, LinksFailed desc, AverageResponseTime desc, Responses desc, MaxLinksLive desc, Name asc | project-away TypeKey\"));\r\n",
+            "query": "print(strcat(\"{ServiceMapComputers}\", \" let ipComputerMapping = computers | project Computer, Ipv4 = todynamic(tostring(Properties.Ipv4Addresses_s)) | mvexpand Ipv4 to typeof(string); \", \"{MaliciousIpData}\", \" let totalMaliciousConnectionsCount = maliciousIpData | summarize MaliciousIpInfo = count() | extend Type = 'Overall'; \", \"{ComputerData}\", \" let overalldata = VMConnection | where '{GridRefresh}' == 'run' | where TimeGenerated {TimeRange} | where Direction == '{Direction}' {ComputerFilter} | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) | extend Name = '🔵 Overall', Type = 'Overall', TypeKey = 0, Key = '--Overall--', ParentKey = '----' | join kind=leftouter totalMaliciousConnectionsCount on Type | extend MaliciousIpInfo = iff(MaliciousIpInfo == '0', '', tostring(MaliciousIpInfo)) | project-away Type1; computerData | union overalldata\t\t\t\t\t\t\t | extend MaliciousConnectionsCount = iff(MaliciousIpInfo == '', 0, iff(Type == 'Computer' or Type == 'Process' or Type == 'Overall', tolong(MaliciousIpInfo), 1)) | project Name, Type, MaliciousConnections = iff(MaliciousIpInfo == '', '✅ No Malicious Connections', iff(Type == 'Computer' or Type == 'Process' or Type == 'Overall', iff(MaliciousConnectionsCount > 1, strcat('❌ ', MaliciousIpInfo, ' Malicious Connections'), strcat('❌ ', MaliciousIpInfo, ' Malicious Connection')), '❌ Malicious Connection')), Responses, MaxLinksLive, LinksFailed, AverageResponseTime, TotalBytesSent, TotalBytesReceived, Info = iff(MaliciousIpInfo != '', MaliciousIpInfo, ''), Key, ParentKey, TypeKey, MaliciousConnectionsCount | order by TypeKey asc, MaliciousConnectionsCount desc, LinksFailed desc, AverageResponseTime desc, Responses desc, MaxLinksLive desc, Name asc | project-away TypeKey\"));\r\n",
             "crossComponentResources": [
               "{Workspace}"
             ],
@@ -773,7 +517,7 @@
             "name": "FinalQuery",
             "type": 1,
             "isRequired": false,
-            "query": "print(\r\niff({Hierarchy} == 0, \"{CPIP}\", \r\niff({Hierarchy} == 1, \"{CPI}\",\r\niff({Hierarchy} == 2, \"{CP}\",\r\niff({Hierarchy} == 3, \"{C}\", \"{C}\")))));",
+            "query": "print(\r\niff({Hierarchy} == 0, \"{Computer_Process_IP_Port}\", \r\niff({Hierarchy} == 1, \"{Computer_Process_IP}\",\r\niff({Hierarchy} == 2, \"{Computer_Process}\",\r\niff({Hierarchy} == 3, \"{Computer}\", \"{Computer}\")))));",
             "crossComponentResources": [
               "{Workspace}"
             ],
@@ -794,6 +538,13 @@
         ],
         "style": "above",
         "resourceType": "microsoft.operationalinsights/workspaces"
+      },
+      "conditionalVisibility": null
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "💡 <em>Select a computer from the table below to view connection details for that machine.</em>"
       },
       "conditionalVisibility": null
     },
@@ -821,7 +572,7 @@
               "columnMatch": "Responses",
               "formatter": 4,
               "formatOptions": {
-                "palette": "yellow"
+                "palette": "blueDark"
               },
               "numberFormat": {
                 "unit": 17,
@@ -834,7 +585,7 @@
               "columnMatch": "MaxLinksLive",
               "formatter": 4,
               "formatOptions": {
-                "palette": "green"
+                "palette": "lightBlue"
               },
               "numberFormat": {
                 "unit": 17,
@@ -873,7 +624,7 @@
               "columnMatch": "TotalBytesSent",
               "formatter": 4,
               "formatOptions": {
-                "palette": "blueDark"
+                "palette": "orange"
               },
               "numberFormat": {
                 "unit": 2,
@@ -886,7 +637,7 @@
               "columnMatch": "TotalBytesReceived",
               "formatter": 4,
               "formatOptions": {
-                "palette": "lightBlue"
+                "palette": "green"
               },
               "numberFormat": {
                 "unit": 2,
@@ -1023,17 +774,6 @@
       "conditionalVisibility": {
         "parameterName": "IsComputer",
         "comparison": "isEqualTo",
-        "value": "True"
-      }
-    },
-    {
-      "type": 1,
-      "content": {
-        "json": "💡 <em>Select a computer from the table above to view connection details for that machine.</em>"
-      },
-      "conditionalVisibility": {
-        "parameterName": "IsComputer",
-        "comparison": "isNotEqualTo",
         "value": "True"
       }
     },

--- a/Workbooks/Virtual Machines - Network Dependencies/Connections Overview/Connections Overview.workbook
+++ b/Workbooks/Virtual Machines - Network Dependencies/Connections Overview/Connections Overview.workbook
@@ -3,13 +3,6 @@
   "isLocked": true,
   "items": [
     {
-      "type": 1,
-      "content": {
-        "json": "# Connection Overview\nThis workbook requires [Azure Monitor for VMs (preview)](https://docs.microsoft.com/en-us/azure/azure-monitor/insights/vminsights-overview) enabled in your workspace\n\n---\n\n## Connection Records\n\nEach <strong>record</strong> from [VMConnections](https://docs.microsoft.com/en-us/azure/azure-monitor/insights/service-map) represents a connection from one machine to another over a 1-minute interval.\n\nEach <strong>record</strong> aggregates the following properties over a 1-minute interval: the total number of bytes sent and received, the number of links (port connections) that are established, currently active, and terminated, and the number of responses received.\n\n<hr style=\"height: 2px;\" />"
-      },
-      "conditionalVisibility": null
-    },
-    {
       "type": 9,
       "content": {
         "version": "KqlParameterItem/1.0",
@@ -19,15 +12,10 @@
           {
             "id": "e41c2177-932a-4c58-ba24-03ef070eb197",
             "version": "KqlParameterItem/1.0",
-            "name": "Workspaces",
+            "name": "Workspace",
             "type": 5,
             "isRequired": true,
-            "multiSelect": true,
-            "quote": "'",
-            "delimiter": ",",
-            "value": [
-              "value::1"
-            ],
+            "value": "value::1",
             "isHiddenWhenLocked": true,
             "typeSettings": {
               "resourceTypeFilter": {
@@ -39,6 +27,142 @@
             },
             "timeContextFromParameter": null
           },
+          {
+            "id": "67b8a28c-f7f9-4903-883d-4a308a6ffe71",
+            "version": "KqlParameterItem/1.0",
+            "name": "Computer",
+            "type": 5,
+            "isRequired": true,
+            "value": "value::1",
+            "isHiddenWhenLocked": true,
+            "typeSettings": {
+              "resourceTypeFilter": {
+                "microsoft.compute/virtualmachines": true
+              },
+              "additionalResourceOptions": [
+                "value::1"
+              ]
+            },
+            "timeContextFromParameter": null
+          },
+          {
+            "id": "68692e38-3c2c-4fd2-8e03-2357f2275142",
+            "version": "KqlParameterItem/1.0",
+            "name": "ComputerName",
+            "type": 1,
+            "isRequired": true,
+            "query": "print '{Computer:label}'",
+            "crossComponentResources": [
+              "{Workspace}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          }
+        ],
+        "style": "above",
+        "resourceType": "microsoft.compute/virtualmachines"
+      },
+      "conditionalVisibility": {
+        "parameterName": "_",
+        "comparison": "isNotEqualTo",
+        "value": null
+      }
+    },
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "query": "",
+        "crossComponentResources": [
+          "{Workspace}"
+        ],
+        "parameters": [
+          {
+            "id": "2debcfba-e410-4300-9886-78069cef42e0",
+            "version": "KqlParameterItem/1.0",
+            "name": "_A_ComputerName",
+            "type": 1,
+            "isRequired": false,
+            "query": "print(iff(\"{ComputerName}\" == \"undefined\", \"\", \"<h2 style='color:#777;font-weight:normal;margin-top:0;padding-top:0;font-size:1rem;'>{ComputerName}</h2>\"));",
+            "crossComponentResources": [
+              "{Workspace}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          },
+          {
+            "id": "648ac90d-4be5-4c08-ac13-bcff7f8ddbf9",
+            "version": "KqlParameterItem/1.0",
+            "name": "_A_HeaderTextPrefix",
+            "type": 1,
+            "isRequired": false,
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "value": "This workbook requires [Azure Monitor for VMs (preview)](https://docs.microsoft.com/en-us/azure/azure-monitor/insights/vminsights-overview) enabled"
+          },
+          {
+            "id": "b902566a-20d1-4137-9944-24fcd5f2fe1b",
+            "version": "KqlParameterItem/1.0",
+            "name": "_A_HeaderTextSuffix",
+            "type": 1,
+            "isRequired": false,
+            "query": "print(iff(\"{ComputerName}\" == \"undefined\", \"in your workspace\", \"for your machine `{ComputerName}`\"));",
+            "crossComponentResources": [
+              "{Workspace}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          },
+          {
+            "id": "fccd76d3-382b-4c2b-a39b-2653503c504b",
+            "version": "KqlParameterItem/1.0",
+            "name": "_A_HeaderStyle",
+            "type": 1,
+            "isRequired": false,
+            "query": "print(iff(\"{ComputerName}\" == \"undefined\", \"\", \"margin:0;padding:0;\"));",
+            "crossComponentResources": [
+              "{Workspace}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          }
+        ],
+        "style": "above",
+        "resourceType": "microsoft.operationalinsights/workspaces"
+      },
+      "conditionalVisibility": {
+        "parameterName": "_",
+        "comparison": "isNotEqualTo",
+        "value": null
+      }
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "<h1 style=\"{_A_HeaderStyle}\">Connections Overview</h1>{_A_ComputerName}\r\n{_A_HeaderTextPrefix} {_A_HeaderTextSuffix}"
+      },
+      "conditionalVisibility": null
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "---\n\n## Connection Records\n\nEach <strong>record</strong> from [VMConnections](https://docs.microsoft.com/en-us/azure/azure-monitor/insights/service-map) represents a connection from one machine to another over a 1-minute interval.\n\nEach <strong>record</strong> aggregates the following properties over a 1-minute interval: the total number of bytes sent and received, the number of links (port connections) that are established, currently active, and terminated, and the number of responses received.\n\n<hr style=\"height: 2px;\" />"
+      },
+      "conditionalVisibility": null
+    },
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "query": "",
+        "crossComponentResources": [
+          "{Workspace}"
+        ],
+        "parameters": [
           {
             "id": "5f8cce4b-9c4c-47da-8683-7e5ccc9faed3",
             "version": "KqlParameterItem/1.0",
@@ -199,11 +323,15 @@
         "timeContextFromParameter": null,
         "resourceType": "microsoft.operationalinsights/workspaces",
         "crossComponentResources": [
-          "{Workspaces}"
+          "{Workspace}"
         ],
         "visualization": "piechart"
       },
-      "conditionalVisibility": null,
+      "conditionalVisibility": {
+        "parameterName": "ComputerName",
+        "comparison": "isEqualTo",
+        "value": "undefined"
+      },
       "customWidth": "25"
     },
     {
@@ -219,17 +347,69 @@
         "timeContextFromParameter": null,
         "resourceType": "microsoft.operationalinsights/workspaces",
         "crossComponentResources": [
-          "{Workspaces}"
+          "{Workspace}"
         ],
         "visualization": "areachart"
       },
-      "conditionalVisibility": null,
+      "conditionalVisibility": {
+        "parameterName": "ComputerName",
+        "comparison": "isEqualTo",
+        "value": "undefined"
+      },
+      "customWidth": "75"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "VMConnection\r\n| where TimeGenerated {TimeRange}\r\n| summarize Count = count() by Direction",
+        "showQuery": false,
+        "size": 0,
+        "aggregation": 0,
+        "showAnnotations": false,
+        "showAnalytics": false,
+        "timeContextFromParameter": null,
+        "resourceType": "microsoft.compute/virtualmachines",
+        "crossComponentResources": [
+          "{Computer}"
+        ],
+        "visualization": "piechart"
+      },
+      "conditionalVisibility": {
+        "parameterName": "ComputerName",
+        "comparison": "isNotEqualTo",
+        "value": "undefined"
+      },
+      "customWidth": "25"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "VMConnection\r\n| where TimeGenerated {TimeRange}\r\n| summarize Count = count() by RemoteCountry, bin(TimeGenerated, {TimeRange:grain})",
+        "showQuery": false,
+        "size": 1,
+        "aggregation": 0,
+        "showAnnotations": false,
+        "showAnalytics": false,
+        "timeContextFromParameter": null,
+        "resourceType": "microsoft.compute/virtualmachines",
+        "crossComponentResources": [
+          "{Computer}"
+        ],
+        "visualization": "areachart"
+      },
+      "conditionalVisibility": {
+        "parameterName": "ComputerName",
+        "comparison": "isNotEqualTo",
+        "value": "undefined"
+      },
       "customWidth": "75"
     },
     {
       "type": 1,
       "content": {
-        "json": "---\r\n\r\n## Connection Stats\r\n\r\nThe following table presents the connection statistics for every computer in your workspace (max `10,000` rows).\r\n\r\nYou can drill down using the <em>Hierarchy</em> dropdown for more detailed information for each computer, but fewer computers will be shown.\r\n\r\n<hr style=\"border: none;height: 2px;color: grey;\" />"
+        "json": "---\r\n\r\n## Connection Statistics\r\n\r\nThe following table presents the connection statistics for computers in your workspace (max `10,000` rows).\r\n\r\nUse the <em>Hierarchy</em> dropdown for more detailed information for each computer but fewer computers will be shown.\r\n\r\n<hr style=\"border: none;height: 2px;color: grey;\" />"
       },
       "conditionalVisibility": null
     },
@@ -238,9 +418,7 @@
       "content": {
         "version": "KqlParameterItem/1.0",
         "query": "",
-        "crossComponentResources": [
-          "{Workspaces}"
-        ],
+        "crossComponentResources": [],
         "parameters": [
           {
             "id": "306614b4-14f2-4777-a044-8c1121f04d6d",
@@ -264,7 +442,7 @@
             "isRequired": true,
             "value": {
               "durationMs": 3600000,
-              "createdTime": "2019-01-25T00:48:38.343Z",
+              "createdTime": "2019-01-28T23:37:45.024Z",
               "isInitialTime": false,
               "grain": 1,
               "useDashboardTimeRange": false
@@ -274,98 +452,98 @@
               "selectableValues": [
                 {
                   "durationMs": 300000,
-                  "createdTime": "2019-01-25T00:48:38.343Z",
+                  "createdTime": "2019-01-28T23:37:45.024Z",
                   "isInitialTime": false,
                   "grain": 1,
                   "useDashboardTimeRange": false
                 },
                 {
                   "durationMs": 900000,
-                  "createdTime": "2019-01-25T00:48:38.343Z",
+                  "createdTime": "2019-01-28T23:37:45.024Z",
                   "isInitialTime": false,
                   "grain": 1,
                   "useDashboardTimeRange": false
                 },
                 {
                   "durationMs": 1800000,
-                  "createdTime": "2019-01-25T00:48:38.343Z",
+                  "createdTime": "2019-01-28T23:37:45.024Z",
                   "isInitialTime": false,
                   "grain": 1,
                   "useDashboardTimeRange": false
                 },
                 {
                   "durationMs": 3600000,
-                  "createdTime": "2019-01-25T00:48:38.343Z",
+                  "createdTime": "2019-01-28T23:37:45.024Z",
                   "isInitialTime": false,
                   "grain": 1,
                   "useDashboardTimeRange": false
                 },
                 {
                   "durationMs": 14400000,
-                  "createdTime": "2019-01-25T00:48:38.343Z",
+                  "createdTime": "2019-01-28T23:37:45.024Z",
                   "isInitialTime": false,
                   "grain": 1,
                   "useDashboardTimeRange": false
                 },
                 {
                   "durationMs": 43200000,
-                  "createdTime": "2019-01-25T00:48:38.343Z",
+                  "createdTime": "2019-01-28T23:37:45.024Z",
                   "isInitialTime": false,
                   "grain": 1,
                   "useDashboardTimeRange": false
                 },
                 {
                   "durationMs": 86400000,
-                  "createdTime": "2019-01-25T00:48:38.343Z",
+                  "createdTime": "2019-01-28T23:37:45.025Z",
                   "isInitialTime": false,
                   "grain": 1,
                   "useDashboardTimeRange": false
                 },
                 {
                   "durationMs": 172800000,
-                  "createdTime": "2019-01-25T00:48:38.343Z",
+                  "createdTime": "2019-01-28T23:37:45.025Z",
                   "isInitialTime": false,
                   "grain": 1,
                   "useDashboardTimeRange": false
                 },
                 {
                   "durationMs": 259200000,
-                  "createdTime": "2019-01-25T00:48:38.343Z",
+                  "createdTime": "2019-01-28T23:37:45.025Z",
                   "isInitialTime": false,
                   "grain": 1,
                   "useDashboardTimeRange": false
                 },
                 {
                   "durationMs": 604800000,
-                  "createdTime": "2019-01-25T00:48:38.343Z",
+                  "createdTime": "2019-01-28T23:37:45.025Z",
                   "isInitialTime": false,
                   "grain": 1,
                   "useDashboardTimeRange": false
                 },
                 {
                   "durationMs": 1209600000,
-                  "createdTime": "2019-01-25T00:48:38.343Z",
+                  "createdTime": "2019-01-28T23:37:45.025Z",
                   "isInitialTime": false,
                   "grain": 1,
                   "useDashboardTimeRange": false
                 },
                 {
                   "durationMs": 2592000000,
-                  "createdTime": "2019-01-25T00:48:38.343Z",
+                  "createdTime": "2019-01-28T23:37:45.026Z",
                   "isInitialTime": false,
                   "grain": 1,
                   "useDashboardTimeRange": false
                 },
                 {
                   "durationMs": 5184000000,
-                  "createdTime": "2019-01-25T00:48:38.343Z",
+                  "createdTime": "2019-01-28T23:37:45.026Z",
                   "isInitialTime": false,
                   "grain": 1,
                   "useDashboardTimeRange": false
                 },
                 {
                   "durationMs": 7776000000,
-                  "createdTime": "2019-01-25T00:48:38.344Z",
+                  "createdTime": "2019-01-28T23:37:45.026Z",
                   "isInitialTime": false,
                   "grain": 1,
                   "useDashboardTimeRange": false
@@ -387,12 +565,46 @@
             "timeContextFromParameter": null
           },
           {
+            "id": "56ab6626-c12d-4de1-8a3d-8a6099db3cd3",
+            "version": "KqlParameterItem/1.0",
+            "name": "Hierarchy",
+            "type": 2,
+            "isRequired": true,
+            "query": "datatable (value:string, Display:string)\r\n    [\"0\", \"Computer -> Process -> IP -> Port\",\r\n     \"1\", \"Computer -> Process -> IP\",\r\n     \"2\", \"Computer -> Process\",\r\n     \"3\", \"Computer\"]",
+            "crossComponentResources": [],
+            "value": "2",
+            "isHiddenWhenLocked": false,
+            "timeContextFromParameter": null,
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          }
+        ],
+        "style": "above",
+        "resourceType": "microsoft.operationalinsights/workspaces"
+      },
+      "conditionalVisibility": null
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "<p><strong>TimeRange</strong> specifies how far back in time to gather connection statistics. Selecting a large time range will result in a long query processing time.</p>\r\n<p><strong>Direction</strong> either shows <em>Inbound</em> or <em>Outbound</em> network connections.</p>\r\n<p><strong>Hierarchy</strong> specifies the level of detail for each computer. Selecting a larger hierarchy will cause fewer computers to be displayed but more information for each computer in the table below.</p>\r\n\r\n<hr style=\"height: 1px;\" />"
+      },
+      "conditionalVisibility": null
+    },
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "query": "",
+        "crossComponentResources": [
+          "{Workspace}"
+        ],
+        "parameters": [
+          {
             "id": "8744c427-f060-4725-95af-850af2fa08b1",
             "version": "KqlParameterItem/1.0",
             "name": "ComputerNameContains",
             "type": 1,
             "isRequired": false,
-            "value": "",
             "isHiddenWhenLocked": false,
             "timeContextFromParameter": null
           },
@@ -407,12 +619,12 @@
             "delimiter": ",",
             "query": "VMConnection\r\n| where TimeGenerated {TimeRange}\r\n| where Computer contains '{ComputerNameContains}'\r\n| summarize by Computer\r\n| project Value = Computer, Display = Computer, IsDefault = false\r\n| order by Display asc\r\n| union (datatable(Value:string, Display:string, IsDefault:boolean)['*', 'All', true])",
             "crossComponentResources": [
-              "{Workspaces}"
-            ],
-            "value": [
-              "*"
+              "{Workspace}"
             ],
             "isHiddenWhenLocked": false,
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
             "timeContextFromParameter": null,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
@@ -424,24 +636,9 @@
             "isRequired": true,
             "query": "let computerFilter = iff('*' in ({Computers}), \"| where Computer contains '{ComputerNameContains}'\", \"| where Computer in ({Computers})\");\r\nprint(computerFilter)",
             "crossComponentResources": [
-              "{Workspaces}"
+              "{Workspace}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
-            "resourceType": "microsoft.operationalinsights/workspaces"
-          },
-          {
-            "id": "56ab6626-c12d-4de1-8a3d-8a6099db3cd3",
-            "version": "KqlParameterItem/1.0",
-            "name": "Hierarchy",
-            "type": 2,
-            "isRequired": true,
-            "query": "datatable (value:string, Display:string)\r\n    [\"0\", \"Computer -> Process -> IP -> Port\",\r\n     \"1\", \"Computer -> Process -> IP\",\r\n     \"2\", \"Computer -> Process\",\r\n     \"3\", \"Computer\"]",
-            "value": "2",
-            "isHiddenWhenLocked": false,
-            "typeSettings": {
-              "additionalResourceOptions": []
-            },
             "timeContextFromParameter": null,
             "resourceType": "microsoft.operationalinsights/workspaces"
           }
@@ -449,7 +646,22 @@
         "style": "above",
         "resourceType": "microsoft.operationalinsights/workspaces"
       },
-      "conditionalVisibility": null
+      "conditionalVisibility": {
+        "parameterName": "ComputerName",
+        "comparison": "isEqualTo",
+        "value": "undefined"
+      }
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "<p><strong>ComputerNameContains</strong> by default will show <em>any</em> computers. Specify a string to narrow down the computers you are interested in so more data can be shown in the table below.</p>\r\n<p><strong>Computers</strong> by default all computers in the current workspace will be selected. Select one or more computers to further narrow down the table below.</p>\r\n\r\n<hr style=\"height: 1px;\" />"
+      },
+      "conditionalVisibility": {
+        "parameterName": "ComputerName",
+        "comparison": "isEqualTo",
+        "value": "undefined"
+      }
     },
     {
       "type": 9,
@@ -457,18 +669,57 @@
         "version": "KqlParameterItem/1.0",
         "query": "",
         "crossComponentResources": [
-          "{Workspaces}"
+          "{Workspace}"
         ],
         "parameters": [
+          {
+            "id": "5e335a1b-7f99-4647-854a-d7b5cb489bb2",
+            "version": "KqlParameterItem/1.0",
+            "name": "QC",
+            "type": 1,
+            "isRequired": true,
+            "query": "print(strcat(\"let computers = ServiceMapComputer_CL \", iff(\"{ComputerName}\" == \"undefined\", \"\", \" | where Computer == '{ComputerName}'\"), \"| where 'run' == 'run' | where TimeGenerated > ago(1h) | summarize (TimeGenerated, Properties) = arg_max(TimeGenerated, pack_all()) by Computer;\"));",
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          },
+          {
+            "id": "c69fbaae-4fd2-4527-acdd-a2c358eebffa",
+            "version": "KqlParameterItem/1.0",
+            "name": "MD",
+            "type": 1,
+            "isRequired": false,
+            "query": "print(strcat(\"let maliciousIpData = VMConnection\", iff(\"{ComputerName}\" == \"undefined\", \"\", \" | where Computer == '{ComputerName}'\"),\" | where '{GridRefresh}' == 'run' | where TimeGenerated {TimeRange} | where Direction == '{Direction}' {ComputerFilter} | where MaliciousIp != '' | summarize argmax(TimeGenerated, *) by MaliciousIp | project MaliciousIp = strcat(max_TimeGenerated_Computer, '-', max_TimeGenerated_ProcessName, '-', MaliciousIp), Computer = max_TimeGenerated_Computer, Process = strcat(max_TimeGenerated_Computer, '-', max_TimeGenerated_ProcessName), MaliciousIpInfo = pack('Malicious IP', MaliciousIp, 'Is Active', max_TimeGenerated_IsActive, 'Indicator Threat Type', max_TimeGenerated_IndicatorThreatType, 'Remote Country', max_TimeGenerated_RemoteCountry, 'Longitude', max_TimeGenerated_RemoteLongitude, 'Latitude', max_TimeGenerated_RemoteLatitude, 'Confidence', max_TimeGenerated_Confidence, 'Severity', max_TimeGenerated_Severity, 'First Reported DateTime', max_TimeGenerated_FirstReportedDateTime, 'Last Reported DateTime', max_TimeGenerated_LastReportedDateTime, 'Report Reference Link', max_TimeGenerated_ReportReferenceLink);\"));\r\n",
+            "crossComponentResources": [
+              "{Workspace}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          },
+          {
+            "id": "dd933ac8-1273-48fe-8d09-bd65d857ce83",
+            "version": "KqlParameterItem/1.0",
+            "name": "CD",
+            "type": 1,
+            "isRequired": false,
+            "query": "print(strcat(\"let computerData = VMConnection\", iff(\"{ComputerName}\" == \"undefined\", \"\", \" | where Computer == '{ComputerName}'\"), \" | where '{GridRefresh}' == 'run' | where TimeGenerated {TimeRange} | where Direction == '{Direction}' {ComputerFilter} | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) by  Name = strcat('🖥️ ', Computer), Type = 'Computer', TypeKey = 1, Key = Computer, ParentKey = '---' | join kind=leftouter (maliciousIpData | summarize MaliciousIpInfo = tostring(count()) by Computer) on $left.Key == $right.Computer | project-away Computer | order by Name asc;\"));",
+            "crossComponentResources": [
+              "{Workspace}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          },
           {
             "id": "9789ead5-eae5-4f52-86c2-ac197da62f30",
             "version": "KqlParameterItem/1.0",
             "name": "CPIP",
             "type": 1,
             "isRequired": false,
-            "query": "print(\"let computers = ServiceMapComputer_CL | where '{GridRefresh}' == 'run' | where TimeGenerated {TimeRange} | summarize (TimeGenerated, Properties) = arg_max(TimeGenerated, pack_all()) by Computer; let ipComputerMapping = computers | project Computer, Ipv4 = todynamic(tostring(Properties.Ipv4Addresses_s)) | mvexpand Ipv4 to typeof(string); let maliciousIpData = VMConnection | where '{GridRefresh}' == 'run' | where TimeGenerated {TimeRange} | where Direction == '{Direction}' {ComputerFilter} | where MaliciousIp != '' | summarize argmax(TimeGenerated, *) by MaliciousIp | project MaliciousIp = strcat(max_TimeGenerated_Computer, '-', max_TimeGenerated_ProcessName, '-', MaliciousIp), Computer = max_TimeGenerated_Computer, Process = strcat(max_TimeGenerated_Computer, '-', max_TimeGenerated_ProcessName), MaliciousIpInfo = pack('Malicious IP', MaliciousIp, 'Is Active', max_TimeGenerated_IsActive, 'Indicator Threat Type', max_TimeGenerated_IndicatorThreatType, 'Remote Country', max_TimeGenerated_RemoteCountry, 'Longitude', max_TimeGenerated_RemoteLongitude, 'Latitude', max_TimeGenerated_RemoteLatitude, 'Confidence', max_TimeGenerated_Confidence, 'Severity', max_TimeGenerated_Severity, 'First Reported DateTime', max_TimeGenerated_FirstReportedDateTime, 'Last Reported DateTime', max_TimeGenerated_LastReportedDateTime, 'Report Reference Link', max_TimeGenerated_ReportReferenceLink); let totalMaliciousConnectionsCount = maliciousIpData | summarize MaliciousIpInfo = count() | extend Type = 'Overall'; let computerData = VMConnection | where '{GridRefresh}' == 'run' | where TimeGenerated {TimeRange} | where Direction == '{Direction}' {ComputerFilter} | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) by  Name = strcat('🖥️ ', Computer), Type = 'Computer', TypeKey = 1, Key = Computer, ParentKey = '---' | join kind=leftouter (maliciousIpData | summarize MaliciousIpInfo = tostring(count()) by Computer) on $left.Key == $right.Computer | project-away Computer | order by Name asc; let processData = VMConnection | where '{GridRefresh}' == 'run' | where TimeGenerated {TimeRange} | where Direction == '{Direction}' {ComputerFilter} | where ProcessName != '' | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) by  Computer, Name = strcat('🎫 ', ProcessName), Type = 'Process', TypeKey = 2, Key = strcat(Computer, '-', ProcessName), ParentKey = Computer | join kind=inner computerData on $left.ParentKey == $right.Key | project-away Name1, Responses1, LinksFailed1, MaxLinksLive1, TotalBytesSent1, TotalBytesReceived1, AverageResponseTime1, Type1, Key1, ParentKey1 | join kind=leftouter (maliciousIpData | summarize MaliciousIpInfo = tostring(count()) by Process) on $left.Key == $right.Process | project-away Process, MaliciousIpInfo | extend MaliciousIpInfo = tostring(MaliciousIpInfo1) | project-away MaliciousIpInfo1\t\t\t\t\t\t\t   | order by Name asc; let remoteIpData = VMConnection | where '{GridRefresh}' == 'run' | where TimeGenerated {TimeRange} | where '{Direction}' == 'outbound' | where Direction == '{Direction}' {ComputerFilter} | extend RemoteIp = iff(Direction == 'outbound', DestinationIp, SourceIp) | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) by Computer, ProcessName, RemoteIp, Type = 'Remote Computer', TypeKey = 3, Key = strcat(Computer, '-', ProcessName, '-', RemoteIp), ParentKey = strcat(Computer, '-', ProcessName) | join kind=inner processData on $left.ParentKey == $right.Key | project-away Name, Responses1, LinksFailed1, MaxLinksLive1, TotalBytesSent1, TotalBytesReceived1, AverageResponseTime1, Type1, Key1, ParentKey1 | join kind=leftouter maliciousIpData on $left.Key == $right.MaliciousIp | project-away MaliciousIp, Computer, Process, Computer1, Computer2, MaliciousIpInfo | extend MaliciousIpInfo = tostring(MaliciousIpInfo1) | project-away MaliciousIpInfo1 | join kind = leftouter (ipComputerMapping) on $left.RemoteIp == $right.Ipv4 | extend Name = iff(Computer == '', iff(RemoteIp == '127.0.0.1', '🌐 Localhost',  strcat('🌐 External (', RemoteIp, ')')), strcat('🖥️ ', Computer)) | project-away Computer, Ipv4 | order by Name desc; let destinationPortData = VMConnection | where '{GridRefresh}' == 'run' | where TimeGenerated {TimeRange} | where Direction == '{Direction}' | where '{Direction}' == 'outbound' {ComputerFilter} | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) by Computer, ProcessName, DestinationIp, DestinationPort, Name = strcat('🔶 ', DestinationPort), Type = 'Remote Port', TypeKey = 4, Key = strcat(Computer, '-', ProcessName, '-', DestinationIp, '-', tostring(DestinationPort)), ParentKey = strcat(Computer, '-', ProcessName, '-', DestinationIp) | join kind=inner remoteIpData on $left.ParentKey == $right.Key | project-away Name1, Responses1, Type1, Key1, ParentKey1 | order by Name asc; let sourcePortData = VMConnection | where '{GridRefresh}' == 'run' | where TimeGenerated > ago(1h) | where Direction == '{Direction}' | where '{Direction}' == 'inbound' | where Computer contains '' | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) by Computer, ProcessName, DestinationIp, DestinationPort, Name = strcat('🔶 ', DestinationPort), Type = 'Remote Port', TypeKey = 4, Key = strcat(Computer, '-', ProcessName, '-', tostring(DestinationPort)), ParentKey = strcat(Computer, '-', ProcessName) | join kind=inner     processData on $left.ParentKey == $right.Key | project-away Name1, AverageResponseTime1, Computer1, Key1, LinksFailed1, MaxLinksLive1, ParentKey1, Responses1, TotalBytesReceived1, TotalBytesSent1, Type1, TypeKey1, TypeKey2; let remoteIpDataInbound = VMConnection | where '{GridRefresh}' == 'run' | where TimeGenerated > ago(1h) | where Direction == '{Direction}' | where '{Direction}' == 'inbound' | where Computer contains '' | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) by Computer, ProcessName, RemoteIp, Type = 'Remote Computer', TypeKey = 3, Key = strcat(Computer, '-', ProcessName, '-', tostring(DestinationPort), '-', RemoteIp), ParentKey = strcat(Computer, '-', ProcessName, '-', tostring(DestinationPort)), Id = strcat(Computer, '-', ProcessName, '-', RemoteIp) | join kind=inner     sourcePortData on $left.ParentKey == $right.Key | project-away AverageResponseTime1, Computer1, Key1, LinksFailed1, MaxLinksLive1, ParentKey1, ProcessName1, Responses1, TotalBytesReceived1, TotalBytesSent1, Type1, TypeKey1 | order by Name asc | join kind=leftouter     ipComputerMapping on $left.RemoteIp == $right.Ipv4 | extend Name = iff(RemoteIp == '', 'Unknown',  strcat('🌐 External (', RemoteIp, ')')) | project-away Computer, Ipv4 | order by Name desc | join kind=leftouter     maliciousIpData on $left.Id == $right.MaliciousIp | project-away MaliciousIp, Computer, Process, Computer1, MaliciousIpInfo, Id | extend MaliciousIpInfo = tostring(MaliciousIpInfo1) | project-away MaliciousIpInfo1; let overalldata = VMConnection | where '{GridRefresh}' == 'run' | where TimeGenerated {TimeRange} | where Direction == '{Direction}' {ComputerFilter} | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) | extend Name = '🔵 Overall', Type = 'Overall', TypeKey = 0, Key = '--Overall--', ParentKey = '----' | join kind=leftouter totalMaliciousConnectionsCount on Type | extend MaliciousIpInfo = iff(MaliciousIpInfo == '0', '', tostring(MaliciousIpInfo)) | project-away Type1; computerData | union processData | union remoteIpData | union destinationPortData | union remoteIpDataInbound | union sourcePortData | union overalldata\t\t\t\t\t\t\t | extend MaliciousConnectionsCount = iff(MaliciousIpInfo == '', 0, iff(Type == 'Computer' or Type == 'Process' or Type == 'Overall', tolong(MaliciousIpInfo), 1)) | project Name, Type, MaliciousConnections = iff(MaliciousIpInfo == '', '✅ No Malicious Connections', iff(Type == 'Computer' or Type == 'Process' or Type == 'Overall', iff(MaliciousConnectionsCount > 1, strcat('❌ ', MaliciousIpInfo, ' Malicious Connections'), strcat('❌ ', MaliciousIpInfo, ' Malicious Connection')), '❌ Malicious Connection')), Responses, MaxLinksLive, LinksFailed, AverageResponseTime, TotalBytesSent, TotalBytesReceived, Info = iff(MaliciousIpInfo != '', MaliciousIpInfo, ''), Key, ParentKey, TypeKey, MaliciousConnectionsCount | order by TypeKey asc, MaliciousConnectionsCount desc, LinksFailed desc, AverageResponseTime desc, Responses desc, MaxLinksLive desc, Name asc | project-away TypeKey\");",
+            "query": "print(strcat(\"{QC}\", \" let ipComputerMapping = computers | project Computer, Ipv4 = todynamic(tostring(Properties.Ipv4Addresses_s)) | mvexpand Ipv4 to typeof(string); \", \"{MD}\", \" let totalMaliciousConnectionsCount = maliciousIpData | summarize MaliciousIpInfo = count() | extend Type = 'Overall'; \", \"{CD}\", \" let processData = VMConnection | where '{GridRefresh}' == 'run' | where TimeGenerated {TimeRange} | where Direction == '{Direction}' {ComputerFilter} | where ProcessName != '' | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) by  Computer, Name = strcat('🎫 ', ProcessName), Type = 'Process', TypeKey = 2, Key = strcat(Computer, '-', ProcessName), ParentKey = Computer | join kind=inner computerData on $left.ParentKey == $right.Key | project-away Name1, Responses1, LinksFailed1, MaxLinksLive1, TotalBytesSent1, TotalBytesReceived1, AverageResponseTime1, Type1, Key1, ParentKey1 | join kind=leftouter (maliciousIpData | summarize MaliciousIpInfo = tostring(count()) by Process) on $left.Key == $right.Process | project-away Process, MaliciousIpInfo | extend MaliciousIpInfo = tostring(MaliciousIpInfo1) | project-away MaliciousIpInfo1\t\t\t\t\t\t\t   | order by Name asc; let remoteIpData = VMConnection | where '{GridRefresh}' == 'run' | where TimeGenerated {TimeRange} | where '{Direction}' == 'outbound' | where Direction == '{Direction}' {ComputerFilter} | extend RemoteIp = iff(Direction == 'outbound', DestinationIp, SourceIp) | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) by Computer, ProcessName, RemoteIp, Type = 'Remote Computer', TypeKey = 3, Key = strcat(Computer, '-', ProcessName, '-', RemoteIp), ParentKey = strcat(Computer, '-', ProcessName) | join kind=inner processData on $left.ParentKey == $right.Key | project-away Name, Responses1, LinksFailed1, MaxLinksLive1, TotalBytesSent1, TotalBytesReceived1, AverageResponseTime1, Type1, Key1, ParentKey1 | join kind=leftouter maliciousIpData on $left.Key == $right.MaliciousIp | project-away MaliciousIp, Computer, Process, Computer1, Computer2, MaliciousIpInfo | extend MaliciousIpInfo = tostring(MaliciousIpInfo1) | project-away MaliciousIpInfo1 | join kind = leftouter (ipComputerMapping) on $left.RemoteIp == $right.Ipv4 | extend Name = iff(Computer == '', iff(RemoteIp == '127.0.0.1', '🌐 Localhost',  strcat('🌐 External (', RemoteIp, ')')), strcat('🖥️ ', Computer)) | project-away Computer, Ipv4 | order by Name desc; let destinationPortData = VMConnection | where '{GridRefresh}' == 'run' | where TimeGenerated {TimeRange} | where Direction == '{Direction}' | where '{Direction}' == 'outbound' {ComputerFilter} | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) by Computer, ProcessName, DestinationIp, DestinationPort, Name = strcat('🔶 ', DestinationPort), Type = 'Remote Port', TypeKey = 4, Key = strcat(Computer, '-', ProcessName, '-', DestinationIp, '-', tostring(DestinationPort)), ParentKey = strcat(Computer, '-', ProcessName, '-', DestinationIp) | join kind=inner remoteIpData on $left.ParentKey == $right.Key | project-away Name1, Responses1, Type1, Key1, ParentKey1 | order by Name asc; let sourcePortData = VMConnection | where '{GridRefresh}' == 'run' | where TimeGenerated > ago(1h) | where Direction == '{Direction}' | where '{Direction}' == 'inbound' | where Computer contains '' | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) by Computer, ProcessName, DestinationIp, DestinationPort, Name = strcat('🔶 ', DestinationPort), Type = 'Remote Port', TypeKey = 4, Key = strcat(Computer, '-', ProcessName, '-', tostring(DestinationPort)), ParentKey = strcat(Computer, '-', ProcessName) | join kind=inner     processData on $left.ParentKey == $right.Key | project-away Name1, AverageResponseTime1, Computer1, Key1, LinksFailed1, MaxLinksLive1, ParentKey1, Responses1, TotalBytesReceived1, TotalBytesSent1, Type1, TypeKey1, TypeKey2; let remoteIpDataInbound = VMConnection | where '{GridRefresh}' == 'run' | where TimeGenerated > ago(1h) | where Direction == '{Direction}' | where '{Direction}' == 'inbound' | where Computer contains '' | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) by Computer, ProcessName, RemoteIp, Type = 'Remote Computer', TypeKey = 3, Key = strcat(Computer, '-', ProcessName, '-', tostring(DestinationPort), '-', RemoteIp), ParentKey = strcat(Computer, '-', ProcessName, '-', tostring(DestinationPort)), Id = strcat(Computer, '-', ProcessName, '-', RemoteIp) | join kind=inner     sourcePortData on $left.ParentKey == $right.Key | project-away AverageResponseTime1, Computer1, Key1, LinksFailed1, MaxLinksLive1, ParentKey1, ProcessName1, Responses1, TotalBytesReceived1, TotalBytesSent1, Type1, TypeKey1 | order by Name asc | join kind=leftouter     ipComputerMapping on $left.RemoteIp == $right.Ipv4 | extend Name = iff(RemoteIp == '', 'Unknown',  strcat('🌐 External (', RemoteIp, ')')) | project-away Computer, Ipv4 | order by Name desc | join kind=leftouter     maliciousIpData on $left.Id == $right.MaliciousIp | project-away MaliciousIp, Computer, Process, Computer1, MaliciousIpInfo, Id | extend MaliciousIpInfo = tostring(MaliciousIpInfo1) | project-away MaliciousIpInfo1; let overalldata = VMConnection | where '{GridRefresh}' == 'run' | where TimeGenerated {TimeRange} | where Direction == '{Direction}' {ComputerFilter} | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) | extend Name = '🔵 Overall', Type = 'Overall', TypeKey = 0, Key = '--Overall--', ParentKey = '----' | join kind=leftouter totalMaliciousConnectionsCount on Type | extend MaliciousIpInfo = iff(MaliciousIpInfo == '0', '', tostring(MaliciousIpInfo)) | project-away Type1; computerData | union processData | union remoteIpData | union destinationPortData | union remoteIpDataInbound | union sourcePortData | union overalldata\t\t\t\t\t\t\t | extend MaliciousConnectionsCount = iff(MaliciousIpInfo == '', 0, iff(Type == 'Computer' or Type == 'Process' or Type == 'Overall', tolong(MaliciousIpInfo), 1)) | project Name, Type, MaliciousConnections = iff(MaliciousIpInfo == '', '✅ No Malicious Connections', iff(Type == 'Computer' or Type == 'Process' or Type == 'Overall', iff(MaliciousConnectionsCount > 1, strcat('❌ ', MaliciousIpInfo, ' Malicious Connections'), strcat('❌ ', MaliciousIpInfo, ' Malicious Connection')), '❌ Malicious Connection')), Responses, MaxLinksLive, LinksFailed, AverageResponseTime, TotalBytesSent, TotalBytesReceived, Info = iff(MaliciousIpInfo != '', MaliciousIpInfo, ''), Key, ParentKey, TypeKey, MaliciousConnectionsCount | order by TypeKey asc, MaliciousConnectionsCount desc, LinksFailed desc, AverageResponseTime desc, Responses desc, MaxLinksLive desc, Name asc | project-away TypeKey\"));\r\n",
             "crossComponentResources": [
-              "{Workspaces}"
+              "{Workspace}"
             ],
             "isHiddenWhenLocked": true,
             "timeContextFromParameter": null,
@@ -480,9 +731,9 @@
             "name": "CPI",
             "type": 1,
             "isRequired": false,
-            "query": "print(\"let computers = ServiceMapComputer_CL | where '{GridRefresh}' == 'run' | where TimeGenerated {TimeRange} | summarize (TimeGenerated, Properties) = arg_max(TimeGenerated, pack_all()) by Computer; let ipComputerMapping = computers | project Computer, Ipv4 = todynamic(tostring(Properties.Ipv4Addresses_s)) | mvexpand Ipv4 to typeof(string); let maliciousIpData = VMConnection | where '{GridRefresh}' == 'run' | where TimeGenerated {TimeRange} | where Direction == '{Direction}' {ComputerFilter} | where MaliciousIp != '' | summarize argmax(TimeGenerated, *) by MaliciousIp | project MaliciousIp = strcat(max_TimeGenerated_Computer, '-', max_TimeGenerated_ProcessName, '-', MaliciousIp), Computer = max_TimeGenerated_Computer, Process = strcat(max_TimeGenerated_Computer, '-', max_TimeGenerated_ProcessName), MaliciousIpInfo = pack('Malicious IP', MaliciousIp, 'Is Active', max_TimeGenerated_IsActive, 'Indicator Threat Type', max_TimeGenerated_IndicatorThreatType, 'Remote Country', max_TimeGenerated_RemoteCountry, 'Longitude', max_TimeGenerated_RemoteLongitude, 'Latitude', max_TimeGenerated_RemoteLatitude, 'Confidence', max_TimeGenerated_Confidence, 'Severity', max_TimeGenerated_Severity, 'First Reported DateTime', max_TimeGenerated_FirstReportedDateTime, 'Last Reported DateTime', max_TimeGenerated_LastReportedDateTime, 'Report Reference Link', max_TimeGenerated_ReportReferenceLink); let totalMaliciousConnectionsCount = maliciousIpData | summarize MaliciousIpInfo = count() | extend Type = 'Overall'; let computerData = VMConnection | where '{GridRefresh}' == 'run' | where TimeGenerated {TimeRange} | where Direction == '{Direction}' {ComputerFilter} | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) by  Name = strcat('🖥️ ', Computer), Type = 'Computer', TypeKey = 1, Key = Computer, ParentKey = '---' | join kind=leftouter (maliciousIpData | summarize MaliciousIpInfo = tostring(count()) by Computer) on $left.Key == $right.Computer | project-away Computer | order by Name asc; let processData = VMConnection | where '{GridRefresh}' == 'run' | where TimeGenerated {TimeRange} | where Direction == '{Direction}' {ComputerFilter} | where ProcessName != '' | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) by  Computer, Name = strcat('🎫 ', ProcessName), Type = 'Process', TypeKey = 2, Key = strcat(Computer, '-', ProcessName), ParentKey = Computer | join kind=inner computerData on $left.ParentKey == $right.Key | project-away Name1, Responses1, LinksFailed1, MaxLinksLive1, TotalBytesSent1, TotalBytesReceived1, AverageResponseTime1, Type1, Key1, ParentKey1 | join kind=leftouter (maliciousIpData | summarize MaliciousIpInfo = tostring(count()) by Process) on $left.Key == $right.Process | project-away Process, MaliciousIpInfo | extend MaliciousIpInfo = tostring(MaliciousIpInfo1) | project-away MaliciousIpInfo1\t\t\t\t\t\t\t   | order by Name asc; let remoteIpData = VMConnection | where '{GridRefresh}' == 'run' | where TimeGenerated {TimeRange} | where Direction == '{Direction}' {ComputerFilter} | extend RemoteIp = iff(Direction == 'outbound', DestinationIp, SourceIp) | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) by Computer, ProcessName, RemoteIp, Type = 'Remote Computer', TypeKey = 3, Key = strcat(Computer, '-', ProcessName, '-', RemoteIp), ParentKey = strcat(Computer, '-', ProcessName) | join kind=inner processData on $left.ParentKey == $right.Key | project-away Name, Responses1, LinksFailed1, MaxLinksLive1, TotalBytesSent1, TotalBytesReceived1, AverageResponseTime1, Type1, Key1, ParentKey1 | join kind=leftouter maliciousIpData on $left.Key == $right.MaliciousIp | project-away MaliciousIp, Computer, Process, Computer1, Computer2, MaliciousIpInfo | extend MaliciousIpInfo = tostring(MaliciousIpInfo1) | project-away MaliciousIpInfo1 | join kind = leftouter (ipComputerMapping) on $left.RemoteIp == $right.Ipv4 | extend Name = iff(Computer == '', iff(RemoteIp == '127.0.0.1', '🌐 Localhost',  strcat('🌐 External (', RemoteIp, ')')), strcat('🖥️ ', Computer)) | project-away Computer, Ipv4 | order by Name desc; let overalldata = VMConnection | where '{GridRefresh}' == 'run' | where TimeGenerated {TimeRange} | where Direction == '{Direction}' {ComputerFilter} | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) | extend Name = '🔵 Overall', Type = 'Overall', TypeKey = 0, Key = '--Overall--', ParentKey = '----' | join kind=leftouter totalMaliciousConnectionsCount on Type | extend MaliciousIpInfo = iff(MaliciousIpInfo == '0', '', tostring(MaliciousIpInfo)) | project-away Type1; computerData | union processData | union remoteIpData | union overalldata\t\t\t\t\t\t\t | extend MaliciousConnectionsCount = iff(MaliciousIpInfo == '', 0, iff(Type == 'Computer' or Type == 'Process' or Type == 'Overall', tolong(MaliciousIpInfo), 1)) | project Name, Type, MaliciousConnections = iff(MaliciousIpInfo == '', '✅ No Malicious Connections', iff(Type == 'Computer' or Type == 'Process' or Type == 'Overall', iff(MaliciousConnectionsCount > 1, strcat('❌ ', MaliciousIpInfo, ' Malicious Connections'), strcat('❌ ', MaliciousIpInfo, ' Malicious Connection')), '❌ Malicious Connection')), Responses, MaxLinksLive, LinksFailed, AverageResponseTime, TotalBytesSent, TotalBytesReceived, Info = iff(MaliciousIpInfo != '', MaliciousIpInfo, ''), Key, ParentKey, TypeKey, MaliciousConnectionsCount | order by TypeKey asc, MaliciousConnectionsCount desc, LinksFailed desc, AverageResponseTime desc, Responses desc, MaxLinksLive desc, Name asc | project-away TypeKey\")",
+            "query": "print(strcat(\"{QC}\", \" let ipComputerMapping = computers | project Computer, Ipv4 = todynamic(tostring(Properties.Ipv4Addresses_s)) | mvexpand Ipv4 to typeof(string); \", \"{MD}\", \" let totalMaliciousConnectionsCount = maliciousIpData | summarize MaliciousIpInfo = count() | extend Type = 'Overall'; \", \"{CD}\", \" let processData = VMConnection | where '{GridRefresh}' == 'run' | where TimeGenerated {TimeRange} | where Direction == '{Direction}' {ComputerFilter} | where ProcessName != '' | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) by  Computer, Name = strcat('🎫 ', ProcessName), Type = 'Process', TypeKey = 2, Key = strcat(Computer, '-', ProcessName), ParentKey = Computer | join kind=inner computerData on $left.ParentKey == $right.Key | project-away Name1, Responses1, LinksFailed1, MaxLinksLive1, TotalBytesSent1, TotalBytesReceived1, AverageResponseTime1, Type1, Key1, ParentKey1 | join kind=leftouter (maliciousIpData | summarize MaliciousIpInfo = tostring(count()) by Process) on $left.Key == $right.Process | project-away Process, MaliciousIpInfo | extend MaliciousIpInfo = tostring(MaliciousIpInfo1) | project-away MaliciousIpInfo1\t\t\t\t\t\t\t   | order by Name asc; let remoteIpData = VMConnection | where '{GridRefresh}' == 'run' | where TimeGenerated {TimeRange} | where Direction == '{Direction}' {ComputerFilter} | extend RemoteIp = iff(Direction == 'outbound', DestinationIp, SourceIp) | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) by Computer, ProcessName, RemoteIp, Type = 'Remote Computer', TypeKey = 3, Key = strcat(Computer, '-', ProcessName, '-', RemoteIp), ParentKey = strcat(Computer, '-', ProcessName) | join kind=inner processData on $left.ParentKey == $right.Key | project-away Name, Responses1, LinksFailed1, MaxLinksLive1, TotalBytesSent1, TotalBytesReceived1, AverageResponseTime1, Type1, Key1, ParentKey1 | join kind=leftouter maliciousIpData on $left.Key == $right.MaliciousIp | project-away MaliciousIp, Computer, Process, Computer1, Computer2, MaliciousIpInfo | extend MaliciousIpInfo = tostring(MaliciousIpInfo1) | project-away MaliciousIpInfo1 | join kind = leftouter (ipComputerMapping) on $left.RemoteIp == $right.Ipv4 | extend Name = iff(Computer == '', iff(RemoteIp == '127.0.0.1', '🌐 Localhost',  strcat('🌐 External (', RemoteIp, ')')), strcat('🖥️ ', Computer)) | project-away Computer, Ipv4 | order by Name desc; let overalldata = VMConnection | where '{GridRefresh}' == 'run' | where TimeGenerated {TimeRange} | where Direction == '{Direction}' {ComputerFilter} | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) | extend Name = '🔵 Overall', Type = 'Overall', TypeKey = 0, Key = '--Overall--', ParentKey = '----' | join kind=leftouter totalMaliciousConnectionsCount on Type | extend MaliciousIpInfo = iff(MaliciousIpInfo == '0', '', tostring(MaliciousIpInfo)) | project-away Type1; computerData | union processData | union remoteIpData | union overalldata\t\t\t\t\t\t\t | extend MaliciousConnectionsCount = iff(MaliciousIpInfo == '', 0, iff(Type == 'Computer' or Type == 'Process' or Type == 'Overall', tolong(MaliciousIpInfo), 1)) | project Name, Type, MaliciousConnections = iff(MaliciousIpInfo == '', '✅ No Malicious Connections', iff(Type == 'Computer' or Type == 'Process' or Type == 'Overall', iff(MaliciousConnectionsCount > 1, strcat('❌ ', MaliciousIpInfo, ' Malicious Connections'), strcat('❌ ', MaliciousIpInfo, ' Malicious Connection')), '❌ Malicious Connection')), Responses, MaxLinksLive, LinksFailed, AverageResponseTime, TotalBytesSent, TotalBytesReceived, Info = iff(MaliciousIpInfo != '', MaliciousIpInfo, ''), Key, ParentKey, TypeKey, MaliciousConnectionsCount | order by TypeKey asc, MaliciousConnectionsCount desc, LinksFailed desc, AverageResponseTime desc, Responses desc, MaxLinksLive desc, Name asc | project-away TypeKey\"));\r\n",
             "crossComponentResources": [
-              "{Workspaces}"
+              "{Workspace}"
             ],
             "isHiddenWhenLocked": true,
             "timeContextFromParameter": null,
@@ -494,9 +745,9 @@
             "name": "CP",
             "type": 1,
             "isRequired": false,
-            "query": "print(\"let computers = ServiceMapComputer_CL | where '{GridRefresh}' == 'run' | where TimeGenerated {TimeRange} | summarize (TimeGenerated, Properties) = arg_max(TimeGenerated, pack_all()) by Computer; let ipComputerMapping = computers | project Computer, Ipv4 = todynamic(tostring(Properties.Ipv4Addresses_s)) | mvexpand Ipv4 to typeof(string); let maliciousIpData = VMConnection | where '{GridRefresh}' == 'run' | where TimeGenerated {TimeRange} | where Direction == '{Direction}' {ComputerFilter} | where MaliciousIp != '' | summarize argmax(TimeGenerated, *) by MaliciousIp | project MaliciousIp = strcat(max_TimeGenerated_Computer, '-', max_TimeGenerated_ProcessName, '-', MaliciousIp), Computer = max_TimeGenerated_Computer, Process = strcat(max_TimeGenerated_Computer, '-', max_TimeGenerated_ProcessName), MaliciousIpInfo = pack('Malicious IP', MaliciousIp, 'Is Active', max_TimeGenerated_IsActive, 'Indicator Threat Type', max_TimeGenerated_IndicatorThreatType, 'Remote Country', max_TimeGenerated_RemoteCountry, 'Longitude', max_TimeGenerated_RemoteLongitude, 'Latitude', max_TimeGenerated_RemoteLatitude, 'Confidence', max_TimeGenerated_Confidence, 'Severity', max_TimeGenerated_Severity, 'First Reported DateTime', max_TimeGenerated_FirstReportedDateTime, 'Last Reported DateTime', max_TimeGenerated_LastReportedDateTime, 'Report Reference Link', max_TimeGenerated_ReportReferenceLink); let totalMaliciousConnectionsCount = maliciousIpData | summarize MaliciousIpInfo = count() | extend Type = 'Overall'; let computerData = VMConnection | where '{GridRefresh}' == 'run' | where TimeGenerated {TimeRange} | where Direction == '{Direction}' {ComputerFilter} | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) by  Name = strcat('🖥️ ', Computer), Type = 'Computer', TypeKey = 1, Key = Computer, ParentKey = '---' | join kind=leftouter (maliciousIpData | summarize MaliciousIpInfo = tostring(count()) by Computer) on $left.Key == $right.Computer | project-away Computer | order by Name asc; let processData = VMConnection | where '{GridRefresh}' == 'run' | where TimeGenerated {TimeRange} | where Direction == '{Direction}' {ComputerFilter} | where ProcessName != '' | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) by  Computer, Name = strcat('🎫 ', ProcessName), Type = 'Process', TypeKey = 2, Key = strcat(Computer, '-', ProcessName), ParentKey = Computer | join kind=inner computerData on $left.ParentKey == $right.Key | project-away Name1, Responses1, LinksFailed1, MaxLinksLive1, TotalBytesSent1, TotalBytesReceived1, AverageResponseTime1, Type1, Key1, ParentKey1 | join kind=leftouter (maliciousIpData | summarize MaliciousIpInfo = tostring(count()) by Process) on $left.Key == $right.Process | project-away Process, MaliciousIpInfo | extend MaliciousIpInfo = tostring(MaliciousIpInfo1) | project-away MaliciousIpInfo1\t\t\t\t\t\t\t   | order by Name asc; let overalldata = VMConnection | where '{GridRefresh}' == 'run' | where TimeGenerated {TimeRange} | where Direction == '{Direction}' {ComputerFilter} | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) | extend Name = '🔵 Overall', Type = 'Overall', TypeKey = 0, Key = '--Overall--', ParentKey = '----' | join kind=leftouter totalMaliciousConnectionsCount on Type | extend MaliciousIpInfo = iff(MaliciousIpInfo == '0', '', tostring(MaliciousIpInfo)) | project-away Type1; computerData | union processData | union overalldata\t\t\t\t\t\t\t | extend MaliciousConnectionsCount = iff(MaliciousIpInfo == '', 0, iff(Type == 'Computer' or Type == 'Process' or Type == 'Overall', tolong(MaliciousIpInfo), 1)) | project Name, Type, MaliciousConnections = iff(MaliciousIpInfo == '', '✅ No Malicious Connections', iff(Type == 'Computer' or Type == 'Process' or Type == 'Overall', iff(MaliciousConnectionsCount > 1, strcat('❌ ', MaliciousIpInfo, ' Malicious Connections'), strcat('❌ ', MaliciousIpInfo, ' Malicious Connection')), '❌ Malicious Connection')), Responses, MaxLinksLive, LinksFailed, AverageResponseTime, TotalBytesSent, TotalBytesReceived, Info = iff(MaliciousIpInfo != '', MaliciousIpInfo, ''), Key, ParentKey, TypeKey, MaliciousConnectionsCount | order by TypeKey asc, MaliciousConnectionsCount desc, LinksFailed desc, AverageResponseTime desc, Responses desc, MaxLinksLive desc, Name asc | project-away TypeKey\")",
+            "query": "print(strcat(\"{QC}\", \" let ipComputerMapping = computers | project Computer, Ipv4 = todynamic(tostring(Properties.Ipv4Addresses_s)) | mvexpand Ipv4 to typeof(string); \", \"{MD}\", \" let totalMaliciousConnectionsCount = maliciousIpData | summarize MaliciousIpInfo = count() | extend Type = 'Overall'; \", \"{CD}\", \" let processData = VMConnection | where '{GridRefresh}' == 'run' | where TimeGenerated {TimeRange} | where Direction == '{Direction}' {ComputerFilter} | where ProcessName != '' | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) by  Computer, Name = strcat('🎫 ', ProcessName), Type = 'Process', TypeKey = 2, Key = strcat(Computer, '-', ProcessName), ParentKey = Computer | join kind=inner computerData on $left.ParentKey == $right.Key | project-away Name1, Responses1, LinksFailed1, MaxLinksLive1, TotalBytesSent1, TotalBytesReceived1, AverageResponseTime1, Type1, Key1, ParentKey1 | join kind=leftouter (maliciousIpData | summarize MaliciousIpInfo = tostring(count()) by Process) on $left.Key == $right.Process | project-away Process, MaliciousIpInfo | extend MaliciousIpInfo = tostring(MaliciousIpInfo1) | project-away MaliciousIpInfo1\t\t\t\t\t\t\t   | order by Name asc; let overalldata = VMConnection | where '{GridRefresh}' == 'run' | where TimeGenerated {TimeRange} | where Direction == '{Direction}' {ComputerFilter} | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) | extend Name = '🔵 Overall', Type = 'Overall', TypeKey = 0, Key = '--Overall--', ParentKey = '----' | join kind=leftouter totalMaliciousConnectionsCount on Type | extend MaliciousIpInfo = iff(MaliciousIpInfo == '0', '', tostring(MaliciousIpInfo)) | project-away Type1; computerData | union processData | union overalldata\t\t\t\t\t\t\t | extend MaliciousConnectionsCount = iff(MaliciousIpInfo == '', 0, iff(Type == 'Computer' or Type == 'Process' or Type == 'Overall', tolong(MaliciousIpInfo), 1)) | project Name, Type, MaliciousConnections = iff(MaliciousIpInfo == '', '✅ No Malicious Connections', iff(Type == 'Computer' or Type == 'Process' or Type == 'Overall', iff(MaliciousConnectionsCount > 1, strcat('❌ ', MaliciousIpInfo, ' Malicious Connections'), strcat('❌ ', MaliciousIpInfo, ' Malicious Connection')), '❌ Malicious Connection')), Responses, MaxLinksLive, LinksFailed, AverageResponseTime, TotalBytesSent, TotalBytesReceived, Info = iff(MaliciousIpInfo != '', MaliciousIpInfo, ''), Key, ParentKey, TypeKey, MaliciousConnectionsCount | order by TypeKey asc, MaliciousConnectionsCount desc, LinksFailed desc, AverageResponseTime desc, Responses desc, MaxLinksLive desc, Name asc | project-away TypeKey\"));\r\n",
             "crossComponentResources": [
-              "{Workspaces}"
+              "{Workspace}"
             ],
             "isHiddenWhenLocked": true,
             "timeContextFromParameter": null,
@@ -508,9 +759,9 @@
             "name": "C",
             "type": 1,
             "isRequired": false,
-            "query": "print(\"let computers = ServiceMapComputer_CL | where '{GridRefresh}' == 'run' | where TimeGenerated {TimeRange} | summarize (TimeGenerated, Properties) = arg_max(TimeGenerated, pack_all()) by Computer; let ipComputerMapping = computers | project Computer, Ipv4 = todynamic(tostring(Properties.Ipv4Addresses_s)) | mvexpand Ipv4 to typeof(string); let maliciousIpData = VMConnection | where '{GridRefresh}' == 'run' | where TimeGenerated {TimeRange} | where Direction == '{Direction}' {ComputerFilter} | where MaliciousIp != '' | summarize argmax(TimeGenerated, *) by MaliciousIp | project MaliciousIp = strcat(max_TimeGenerated_Computer, '-', max_TimeGenerated_ProcessName, '-', MaliciousIp), Computer = max_TimeGenerated_Computer, Process = strcat(max_TimeGenerated_Computer, '-', max_TimeGenerated_ProcessName), MaliciousIpInfo = pack('Malicious IP', MaliciousIp, 'Is Active', max_TimeGenerated_IsActive, 'Indicator Threat Type', max_TimeGenerated_IndicatorThreatType, 'Remote Country', max_TimeGenerated_RemoteCountry, 'Longitude', max_TimeGenerated_RemoteLongitude, 'Latitude', max_TimeGenerated_RemoteLatitude, 'Confidence', max_TimeGenerated_Confidence, 'Severity', max_TimeGenerated_Severity, 'First Reported DateTime', max_TimeGenerated_FirstReportedDateTime, 'Last Reported DateTime', max_TimeGenerated_LastReportedDateTime, 'Report Reference Link', max_TimeGenerated_ReportReferenceLink); let totalMaliciousConnectionsCount = maliciousIpData | summarize MaliciousIpInfo = count() | extend Type = 'Overall'; let computerData = VMConnection | where '{GridRefresh}' == 'run' | where TimeGenerated {TimeRange} | where Direction == '{Direction}' {ComputerFilter} | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) by  Name = strcat('🖥️ ', Computer), Type = 'Computer', TypeKey = 1, Key = Computer, ParentKey = '---' | join kind=leftouter (maliciousIpData | summarize MaliciousIpInfo = tostring(count()) by Computer) on $left.Key == $right.Computer | project-away Computer | order by Name asc; let overalldata = VMConnection | where '{GridRefresh}' == 'run' | where TimeGenerated {TimeRange} | where Direction == '{Direction}' {ComputerFilter} | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) | extend Name = '🔵 Overall', Type = 'Overall', TypeKey = 0, Key = '--Overall--', ParentKey = '----' | join kind=leftouter totalMaliciousConnectionsCount on Type | extend MaliciousIpInfo = iff(MaliciousIpInfo == '0', '', tostring(MaliciousIpInfo)) | project-away Type1; computerData | union overalldata\t\t\t\t\t\t\t | extend MaliciousConnectionsCount = iff(MaliciousIpInfo == '', 0, iff(Type == 'Computer' or Type == 'Process' or Type == 'Overall', tolong(MaliciousIpInfo), 1)) | project Name, Type, MaliciousConnections = iff(MaliciousIpInfo == '', '✅ No Malicious Connections', iff(Type == 'Computer' or Type == 'Process' or Type == 'Overall', iff(MaliciousConnectionsCount > 1, strcat('❌ ', MaliciousIpInfo, ' Malicious Connections'), strcat('❌ ', MaliciousIpInfo, ' Malicious Connection')), '❌ Malicious Connection')), Responses, MaxLinksLive, LinksFailed, AverageResponseTime, TotalBytesSent, TotalBytesReceived, Info = iff(MaliciousIpInfo != '', MaliciousIpInfo, ''), Key, ParentKey, TypeKey, MaliciousConnectionsCount | order by TypeKey asc, MaliciousConnectionsCount desc, LinksFailed desc, AverageResponseTime desc, Responses desc, MaxLinksLive desc, Name asc | project-away TypeKey\")",
+            "query": "print(strcat(\"{QC}\", \" let ipComputerMapping = computers | project Computer, Ipv4 = todynamic(tostring(Properties.Ipv4Addresses_s)) | mvexpand Ipv4 to typeof(string); \", \"{MD}\", \" let totalMaliciousConnectionsCount = maliciousIpData | summarize MaliciousIpInfo = count() | extend Type = 'Overall'; \", \"{CD}\", \" let overalldata = VMConnection | where '{GridRefresh}' == 'run' | where TimeGenerated {TimeRange} | where Direction == '{Direction}' {ComputerFilter} | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) | extend Name = '🔵 Overall', Type = 'Overall', TypeKey = 0, Key = '--Overall--', ParentKey = '----' | join kind=leftouter totalMaliciousConnectionsCount on Type | extend MaliciousIpInfo = iff(MaliciousIpInfo == '0', '', tostring(MaliciousIpInfo)) | project-away Type1; computerData | union overalldata\t\t\t\t\t\t\t | extend MaliciousConnectionsCount = iff(MaliciousIpInfo == '', 0, iff(Type == 'Computer' or Type == 'Process' or Type == 'Overall', tolong(MaliciousIpInfo), 1)) | project Name, Type, MaliciousConnections = iff(MaliciousIpInfo == '', '✅ No Malicious Connections', iff(Type == 'Computer' or Type == 'Process' or Type == 'Overall', iff(MaliciousConnectionsCount > 1, strcat('❌ ', MaliciousIpInfo, ' Malicious Connections'), strcat('❌ ', MaliciousIpInfo, ' Malicious Connection')), '❌ Malicious Connection')), Responses, MaxLinksLive, LinksFailed, AverageResponseTime, TotalBytesSent, TotalBytesReceived, Info = iff(MaliciousIpInfo != '', MaliciousIpInfo, ''), Key, ParentKey, TypeKey, MaliciousConnectionsCount | order by TypeKey asc, MaliciousConnectionsCount desc, LinksFailed desc, AverageResponseTime desc, Responses desc, MaxLinksLive desc, Name asc | project-away TypeKey\"));\r\n",
             "crossComponentResources": [
-              "{Workspaces}"
+              "{Workspace}"
             ],
             "isHiddenWhenLocked": true,
             "timeContextFromParameter": null,
@@ -524,7 +775,7 @@
             "isRequired": false,
             "query": "print(\r\niff({Hierarchy} == 0, \"{CPIP}\", \r\niff({Hierarchy} == 1, \"{CPI}\",\r\niff({Hierarchy} == 2, \"{CP}\",\r\niff({Hierarchy} == 3, \"{C}\", \"{C}\")))));",
             "crossComponentResources": [
-              "{Workspaces}"
+              "{Workspace}"
             ],
             "isHiddenWhenLocked": true,
             "timeContextFromParameter": null,
@@ -547,13 +798,6 @@
       "conditionalVisibility": null
     },
     {
-      "type": 1,
-      "content": {
-        "json": "<p><strong>TimeRange</strong> specifies how far back in time to gather connection statistics. Selecting a large time range will result in a long query processing time.</p>\r\n<p><strong>Direction</strong> either shows <em>Inbound</em> or <em>Outbound</em> network connections.</p>\r\n<p><strong>ComputerNameContains</strong> by default will show <em>any</em> computers. Specify a string to narrow down the computers you are interested in so more data can be shown in the table below.</p>\r\n<p><strong>Computers</strong> by default all computers in the current workspace will be selected. Select one or more computers to further narrow down the table below.</p>\r\n<p><strong>Hierarchy</strong> specifies the level of detail for each computer. Selecting a larger hierarchy will cause fewer computers to be displayed but more information for each computer in the table below.</p>\r\n\r\n<hr style=\"height: 1px;\" />"
-      },
-      "conditionalVisibility": null
-    },
-    {
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
@@ -568,7 +812,7 @@
         "timeContextFromParameter": null,
         "resourceType": "microsoft.operationalinsights/workspaces",
         "crossComponentResources": [
-          "{Workspaces}"
+          "{Workspace}"
         ],
         "visualization": "table",
         "gridSettings": {

--- a/Workbooks/Virtual Machines - Network Dependencies/Connections Overview/settings.json
+++ b/Workbooks/Virtual Machines - Network Dependencies/Connections Overview/settings.json
@@ -3,6 +3,7 @@
     "name":"Connections Overview",
     "author": "Microsoft",
     "galleries": [
-        { "type": "workbook", "resourceType": "microsoft.operationalinsights/workspaces", "order": 200 }
+        { "type": "workbook", "resourceType": "microsoft.operationalinsights/workspaces", "order": 200 },
+        { "type": "performance-vm", "resourceType": "microsoft.compute/virtualmachines", "order": 200 }
     ]
 }


### PR DESCRIPTION
`Connections Overview` now appears in Single VM workbooks gallery. Additional helper text and support for Virtual Machine resource has been added to the workbook.

Single VM
![image](https://user-images.githubusercontent.com/43890980/51876728-76c31c00-231e-11e9-9419-80db88b06bef.png)

AtScale
![image](https://user-images.githubusercontent.com/43890980/51876768-98240800-231e-11e9-9ae3-9e7dd3a6202e.png)