### PR TITLE
Update VM Group Performance Workbook

### DIFF
--- a/Workbooks/Virtual Machines - Performance Analysis/Performance Analysis for a Group of VMs/Performance Analysis for a Group of VMs.workbook
+++ b/Workbooks/Virtual Machines - Performance Analysis/Performance Analysis for a Group of VMs/Performance Analysis for a Group of VMs.workbook
@@ -17,29 +17,6 @@
         "crossComponentResources": [],
         "parameters": [
           {
-            "id": "e41c2177-932a-4c58-ba24-03ef070eb197",
-            "version": "KqlParameterItem/1.0",
-            "name": "Workspaces",
-            "type": 5,
-            "isRequired": true,
-            "multiSelect": true,
-            "quote": "'",
-            "delimiter": ",",
-            "value": [
-              "value::1"
-            ],
-            "isHiddenWhenLocked": true,
-            "typeSettings": {
-              "resourceTypeFilter": {
-                "microsoft.operationalinsights/workspaces": true
-              },
-              "additionalResourceOptions": [
-                "value::1"
-              ]
-            },
-            "timeContextFromParameter": null
-          },
-          {
             "id": "5f8cce4b-9c4c-47da-8683-7e5ccc9faed3",
             "version": "KqlParameterItem/1.0",
             "name": "TimeRange",
@@ -156,19 +133,71 @@
               ],
               "allowCustom": true
             }
+          }
+        ],
+        "style": "above",
+        "resourceType": "microsoft.operationalinsights/workspaces"
+      },
+      "conditionalVisibility": null
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "---"
+      },
+      "conditionalVisibility": null
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "<h2 style=\"margin-bottom:0;padding-bottom:0;\">Top 100 Machines</h2>"
+      },
+      "conditionalVisibility": null
+    },
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "query": "",
+        "crossComponentResources": [],
+        "parameters": [
+          {
+            "id": "e41c2177-932a-4c58-ba24-03ef070eb197",
+            "version": "KqlParameterItem/1.0",
+            "name": "Workspaces",
+            "type": 5,
+            "isRequired": true,
+            "multiSelect": true,
+            "quote": "'",
+            "delimiter": ",",
+            "value": [
+              "value::1"
+            ],
+            "isHiddenWhenLocked": true,
+            "typeSettings": {
+              "resourceTypeFilter": {
+                "microsoft.operationalinsights/workspaces": true
+              },
+              "additionalResourceOptions": [
+                "value::1"
+              ]
+            },
+            "timeContextFromParameter": null
           },
           {
             "id": "aa2368fc-ad30-4608-b96a-72abf7b1e1af",
             "version": "KqlParameterItem/1.0",
             "name": "Counter",
             "type": 2,
-            "isRequired": false,
-            "query": "Perf\r\n| summarize by CounterName, ObjectName, CounterText = strcat(ObjectName, ' > ', CounterName)\r\n| order by ObjectName asc, CounterText asc\r\n| where ObjectName != 'Network' and ObjectName != 'Network Interface'\r\n| extend Counter = pack('counter', CounterName, 'object', ObjectName)\r\n| project Counter, CounterText\r\n| order by CounterText asc",
+            "isRequired": true,
+            "query": "Perf\r\n| where TimeGenerated {TimeRange}\r\n| where ObjectName != 'Network' and ObjectName != 'Network Interface'\r\n| summarize by CounterName, ObjectName, CounterText = CounterName\r\n| order by ObjectName asc, CounterText asc\r\n| project Counter = pack('counter', CounterName, 'object', ObjectName), CounterText, group = ObjectName",
             "crossComponentResources": [
               "{Workspaces}"
             ],
-            "value": "{\"counter\":\"% Processor Time\",\"object\":\"Processor\"}",
             "isHiddenWhenLocked": false,
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
             "timeContextFromParameter": null,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
@@ -207,54 +236,7 @@
             "isHiddenWhenLocked": true,
             "timeContextFromParameter": null,
             "resourceType": "microsoft.operationalinsights/workspaces"
-          }
-        ],
-        "style": "above",
-        "resourceType": "microsoft.operationalinsights/workspaces"
-      },
-      "conditionalVisibility": null
-    },
-    {
-      "type": 1,
-      "content": {
-        "json": "#### ℹ `Total Bytes {NetworkDirection}` counters are also being utilized to display the network charts. The delta of `Total Bytes {NetworkDirection}` over a time period is being calculated to match up with the `Bytes {NetworkDirection}/sec` counter to display an accurate representation of network activity over all machines"
-      },
-      "conditionalVisibility": {
-        "parameterName": "IsNetworkCounter",
-        "comparison": "isEqualTo",
-        "value": "True"
-      }
-    },
-    {
-      "type": 1,
-      "content": {
-        "json": "---"
-      },
-      "conditionalVisibility": null
-    },
-    {
-      "type": 1,
-      "content": {
-        "json": "## Top 100 Machines\r\n#### <span style=\"color: #444;\">{CounterText}</span>"
-      },
-      "conditionalVisibility": null,
-      "customWidth": "50"
-    },
-    {
-      "type": 1,
-      "content": {
-        "json": "## Top 5 Machines\r\n#### <span style=\"color: #444;\">{CounterText}</span>"
-      },
-      "conditionalVisibility": null,
-      "customWidth": "50"
-    },
-    {
-      "type": 9,
-      "content": {
-        "version": "KqlParameterItem/1.0",
-        "query": "",
-        "crossComponentResources": [],
-        "parameters": [
+          },
           {
             "id": "9ad8858d-8ef3-4144-94b1-66a8bf9fa9c9",
             "version": "KqlParameterItem/1.0",
@@ -317,44 +299,28 @@
             "isHiddenWhenLocked": true,
             "timeContextFromParameter": null,
             "resourceType": "microsoft.operationalinsights/workspaces"
-          }
-        ],
-        "style": "above",
-        "resourceType": "microsoft.operationalinsights/workspaces"
-      },
-      "conditionalVisibility": null,
-      "customWidth": "50"
-    },
-    {
-      "type": 9,
-      "content": {
-        "version": "KqlParameterItem/1.0",
-        "query": "",
-        "crossComponentResources": [
-          "{Workspaces}"
-        ],
-        "parameters": [
-          {
-            "id": "6a7306ea-247f-46ca-abca-501911f9e9d3",
-            "version": "KqlParameterItem/1.0",
-            "name": "Percentile",
-            "type": 2,
-            "isRequired": true,
-            "value": "Average = round(avg(CounterValue), 2)",
-            "isHiddenWhenLocked": false,
-            "typeSettings": {
-              "additionalResourceOptions": []
-            },
-            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\"},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\"},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\"},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\"},\r\n    { \"value\":\"P80th = round(percentile(CounterValue, 80), 2)\", \"label\":\"P80th\"},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\"},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\"}\r\n]",
-            "timeContextFromParameter": null
           },
           {
-            "id": "541f295c-8426-410a-be40-5a858a0261c1",
+            "id": "27faa340-a75f-4ae1-a43a-1aa6ece37cff",
             "version": "KqlParameterItem/1.0",
-            "name": "percentileOrder",
+            "name": "StandardQuery",
             "type": 1,
             "isRequired": false,
-            "query": "range Steps from 1 to 1 step 1\r\n| project value = iff('{Percentile}' contains 'P5th'  or '{Percentile}' contains 'P10th', 'asc', 'desc')",
+            "query": "let metric = dynamic({Counter}); \r\nlet timeRangeStart = {TimeRange:start};\r\nlet timeRangeEnd = {TimeRange:end};\r\nlet timeRangeGrain = {TimeRange:grain};\r\nprint(iff({IsNetworkCounter} == 'False', strcat(\"let maxResultCount = 100; let metric = dynamic(\", metric, \"); let summaryPerComputer = totable(Perf      | where TimeGenerated {TimeRange}       | where ObjectName == metric.object and CounterName == metric.counter     | summarize hint.shufflekey = Computer Average = avg(CounterValue), Max = max(CounterValue), Min = min(CounterValue), percentiles(CounterValue, 5, 10, 50, 80, 90, 95) by Computer      | project Computer, Average, Max, Min, P5th = percentile_CounterValue_5, P10th = percentile_CounterValue_10, P50th = percentile_CounterValue_50, P80th = percentile_CounterValue_80, P90th = percentile_CounterValue_90, P95th = percentile_CounterValue_95      | order by {TableTrend:label} {tableTrendOrder}, Computer      | limit maxResultCount);  let computerList = summaryPerComputer      | project Computer;  let MachineSummary = ServiceMapComputer_CL     | where TimeGenerated {TimeRange}     | where Computer in (computerList)     | summarize arg_max(TimeGenerated, *) by Computer     | project Computer, MachineSummary = pack('Fully Qualified Domain Name', Computer, 'OS Type', OperatingSystemFamily_s, 'Operating System', OperatingSystemFullName_s, 'Ipv4 Addresses', Ipv4Addresses_s,         'Ipv6 Addresses', Ipv6Addresses_s, 'Mac Addresses', MacAddresses_s, 'DNS Names', DnsNames_s, 'CPUs', strcat(Cpus_d, ' @ ', CpuSpeed_d, ' MHz'), 'Bitness', Bitness_s,         'Physcial Memory', strcat(PhysicalMemory_d, ' MB'), 'Virtualization State', VirtualizationState_s, 'VM Type', VirtualMachineType_s, 'OMS Agent', split(ResourceName_s, 'm-')[1]); let EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) []; let OmsNodeIdentityAndProps = computerList     | extend NodeId = Computer     | extend Priority = 1     | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer); let ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL     | where TimeGenerated {TimeRange}     | where Computer in (computerList)     | summarize arg_max(TimeGenerated, *) by Computer     | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2; let NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                                 | summarize arg_max(Priority, *) by Computer;  let NodeIdentityAndPropsMin = NodeIdentityAndProps     | extend Type = iff(NodeProps.type == 'StandAloneNode', iff(NodeProps.azureResourceId == '', 'Non-Azure Virtual Machine', 'Azure Virtual Machine'), NodeProps.type),      ResourceId = iff(NodeProps.type == 'AzureScaleSetNode', NodeProps.vmScaleSetResourceId,          iff(NodeProps.type == 'AzureCloudServiceNode', NodeProps.cloudServiceDeploymentId, Computer)),     ResourceName = iff(NodeProps.type == 'AzureScaleSetNode', strcat(NodeProps.vmScaleSetName, ' | ', NodeProps.scaleSetInstanceId),          iff(NodeProps.type == 'AzureCloudServiceNode', strcat(NodeProps.cloudServiceRoleName, ' | ', NodeProps.cloudServiceInstanceId), Computer))     | project Computer, Type, ResourceId, ResourceName; let trend = Perf          | where TimeGenerated {TimeRange}         | where Computer in (computerList)          | where ObjectName == metric.object and CounterName == metric.counter        | make-series {TableTrend} default = 0 on TimeGenerated in range(datetime('\", timeRangeStart,\"'), datetime('\", timeRangeEnd ,\"'), totimespan('\", timeRangeGrain, \"')) by Computer     | project Computer, ['Trend ({TableTrend:label})'] = {TableTrend:label}; summaryPerComputer     | join kind=leftouter (trend) on Computer     | join kind=leftouter (NodeIdentityAndProps) on Computer     | join kind=leftouter (NodeIdentityAndPropsMin) on Computer     | join kind=leftouter (MachineSummary) on Computer     | project ResourceName, Type, {mergedAggregators}, ['Trend ({TableTrend:label})'], Properties = MachineSummary     | sort by {TableTrend:label} {tableTrendOrder}\"), ''));",
+            "crossComponentResources": [
+              "{Workspaces}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          },
+          {
+            "id": "6e392933-2f72-45a6-889b-90351f9130db",
+            "version": "KqlParameterItem/1.0",
+            "name": "NetworkQuery",
+            "type": 1,
+            "isRequired": false,
+            "query": "let metric = dynamic({Counter});\r\nlet timeRangeStart = {TimeRange:start};\r\nlet timeRangeEnd = {TimeRange:end};\r\nlet timeRangeGrain = {TimeRange:grain};\r\nprint(iff({IsNetworkCounter} == 'True', strcat(\"let metric = dynamic(\", metric, \"); let linux = iff(metric.counter == 'Bytes Received/sec', dynamic({'object': 'Network', 'counter': 'Total Bytes Received'}), dynamic({'object': 'Network', 'counter': 'Total Bytes Transmitted'})); let maxResultCount = 100; let windowsNetworkRaw = Perf | where TimeGenerated {TimeRange} | where ObjectName == metric.object and CounterName == metric.couter; let windowsNetworkSum = windowsNetworkRaw | summarize hint.shufflekey=Computer CounterValue=sum(CounterValue) by Computer, TimeGenerated; let windowsNetworkPctl = windowsNetworkRaw | summarize hint.shufflekey=Computer Average = avg(CounterValue), Max = max(CounterValue), Min = min(CounterValue), percentiles(CounterValue, 5, 10, 50, 80, 90, 95) by Computer, TimeGenerated | project TimeGenerated, Computer, Average, Max, Min, P5th = percentile_CounterValue_5, P10th = percentile_CounterValue_10, P50th = percentile_CounterValue_50, P80th = percentile_CounterValue_80, P90th = percentile_CounterValue_90, P95th = percentile_CounterValue_95; let linuxNetworkRaw = Perf | where TimeGenerated {TimeRange} | where ObjectName == linux.object and CounterName == linux.counter | order by InstanceName, TimeGenerated asc | extend prev_Value = prev(CounterValue), prev_t = prev(TimeGenerated), prev_instance = prev(InstanceName) | project TimeGenerated, Computer, CounterValue = iff(prev_instance == InstanceName and CounterValue >= prev_Value and TimeGenerated > prev_t, (CounterValue - prev_Value) / ((TimeGenerated - prev_t) / 1s), real(0)); let linuxNetworkSum = linuxNetworkRaw | summarize hint.shufflekey=Computer CounterValue=sum(CounterValue) by Computer, TimeGenerated; let linuxNetworkPctl = linuxNetworkRaw | summarize hint.shufflekey=Computer Average = avg(CounterValue), Max = max(CounterValue), Min = min(CounterValue), percentiles(CounterValue, 5, 10, 50, 80, 90, 95) by Computer, TimeGenerated | project TimeGenerated, Computer, Average, Max, Min, P5th = percentile_CounterValue_5, P10th = percentile_CounterValue_10, P50th = percentile_CounterValue_50, P80th = percentile_CounterValue_80, P90th = percentile_CounterValue_90, P95th = percentile_CounterValue_95; let networkDataSum = union windowsNetworkSum, linuxNetworkSum; let networkDataPctl = union windowsNetworkPctl, linuxNetworkPctl; let computerList = Perf  | project Computer; let EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) []; let OmsNodeIdentityAndProps = computerList | extend NodeId = Computer | extend Priority = 1 | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer); let ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL | where TimeGenerated {TimeRange} | where Computer in (computerList) | summarize hint.shufflekey=Computer arg_max(TimeGenerated, *) by Computer | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|', columnifexists('AzureCloudServiceDeployment_g', '')), ''), AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')), strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|', columnifexists('AzureVmScaleSetDeployment_g', '')), ''), ComputerProps = pack('type', 'StandAloneNode', 'name', ComputerName_s, 'mappingResourceId', ResourceId, 'subscriptionId', AzureSubscriptionId_g, 'resourceGroup', AzureResourceGroup_s, 'azureResourceId', columnifexists('AzureResourceId_s', '')), AzureCloudServiceNodeProps = pack('type', 'AzureCloudServiceNode', 'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''), 'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''), 'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''), 'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''), 'mappingResourceId', ResourceId), AzureScaleSetNodeProps = pack('type', 'AzureScaleSetNode', 'scaleSetInstanceId', columnifexists('AzureName_s', ''), 'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''), 'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''), 'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''), 'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''), 'resourceGroupName', columnifexists('AzureResourceGroup_s', ''), 'subscriptionId', columnifexists('AzureSubscriptionId_g', ''), 'mappingResourceId', ResourceId)| project   Computer, NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity, isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer), NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps, isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps), Priority = 2; let NodeIdentityAndProps = union kind=inner isfuzzy = true EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps | summarize hint.shufflekey=Computer arg_max(Priority, *) by Computer; let NodeIdentityAndPropsMin = NodeIdentityAndProps | extend Type = iff(NodeProps.type == 'StandAloneNode', iff(NodeProps.azureResourceId == '', 'Non-Azure Virtual Machine', 'Azure Virtual Machine'), NodeProps.type), ResourceId = iff(NodeProps.type == 'AzureScaleSetNode', NodeProps.vmScaleSetResourceId, iff(NodeProps.type == 'AzureCloudServiceNode', NodeProps.cloudServiceDeploymentId, Computer)), ResourceName = iff(NodeProps.type == 'AzureScaleSetNode', strcat(NodeProps.vmScaleSetName, ' | ', NodeProps.scaleSetInstanceId), iff(NodeProps.type == 'AzureCloudServiceNode', strcat(NodeProps.cloudServiceRoleName, ' | ', NodeProps.cloudServiceInstanceId), Computer)) | project Computer, Type, ResourceId, ResourceName; let MachineSummary = ServiceMapComputer_CL | where TimeGenerated {TimeRange} | where Computer in (computerList) | summarize hint.shufflekey=Computer arg_max(TimeGenerated, *) by Computer | project Computer, MachineSummary = pack('Fully Qualified Domain Name', Computer, 'OS Type', OperatingSystemFamily_s, 'Operating System', OperatingSystemFullName_s, 'Ipv4 Addresses', Ipv4Addresses_s, 'Ipv6 Addresses', Ipv6Addresses_s, 'Mac Addresses', MacAddresses_s, 'DNS Names', DnsNames_s, 'CPUs', strcat(Cpus_d, ' @ ', CpuSpeed_d, ' MHz'), 'Bitness', Bitness_s, 'Physcial Memory', strcat(PhysicalMemory_d, ' MB'), 'Virtualization State', VirtualizationState_s, 'VM Type', VirtualMachineType_s, 'OMS Agent', split(ResourceName_s, 'm-')[1]); let trend = networkDataSum | make-series {TableTrend} default=0 on TimeGenerated in range(datetime('\", timeRangeStart,\"'), datetime('\", timeRangeEnd ,\"'), totimespan('\", timeRangeGrain, \"')) by Computer | project Computer, ['Trend ({TableTrend:label})'] = {TableTrend:label}; networkDataPctl | join kind=leftouter hint.shufflekey=Computer (trend) on Computer | join kind=leftouter hint.shufflekey=Computer (NodeIdentityAndPropsMin) on Computer | join kind=leftouter hint.shufflekey=Computer (MachineSummary) on Computer | project ResourceName, Type, {mergedAggregators}, ['Trend ({TableTrend:label})'], Properties = MachineSummary | sort by {TableTrend:label} {tableTrendOrder} | limit maxResultCount\"), ''));",
             "crossComponentResources": [
               "{Workspaces}"
             ],
@@ -366,30 +332,20 @@
         "style": "above",
         "resourceType": "microsoft.operationalinsights/workspaces"
       },
-      "conditionalVisibility": null,
-      "customWidth": "50"
+      "conditionalVisibility": null
     },
     {
       "type": 1,
       "content": {
-        "json": "<p><strong style=\"color:#333;\">Aggregators</strong> Select one or more different percentiles to display in the table below</p>\r\n<p><strong style=\"color:#333;\">TableTrend</strong> Select a percentile to display in the Trend column in the table below</p>"
+        "json": "<p><strong style=\"color:#333;\">Counter</strong> Select a <span style=\"border-bottom:1px dotted #aaa;cursor:default;\" title=\"Virtual Machine\">VM</span> performance counter for the table below</span></p>\r\n<p><strong style=\"color:#333;\">Aggregators</strong> Select one or more different aggregates to display in the table below</p>\r\n<p><strong style=\"color:#333;\">TableTrend</strong> Select a percentile to display in the Trend column in the table below</p>"
       },
-      "conditionalVisibility": null,
-      "customWidth": "50"
-    },
-    {
-      "type": 1,
-      "content": {
-        "json": "<p><strong style=\"color:#333;\">Percentile</strong> Select a percentile for the chart below</span></p>"
-      },
-      "conditionalVisibility": null,
-      "customWidth": "50"
+      "conditionalVisibility": null
     },
     {
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let maxResultCount = 100;  \r\nlet metric = dynamic({Counter});\r\nlet summaryPerComputer = totable(Perf \r\n    | where TimeGenerated {TimeRange}  \r\n    | where ObjectName == metric.object and CounterName == metric.counter\r\n    | summarize hint.shufflekey = Computer Average = avg(CounterValue), Max = max(CounterValue), Min = min(CounterValue), percentiles(CounterValue, 5, 10, 50, 80, 90, 95) by Computer \r\n    | project Computer, Average, Max, Min, P5th = percentile_CounterValue_5, P10th = percentile_CounterValue_10, P50th = percentile_CounterValue_50, P80th = percentile_CounterValue_80, P90th = percentile_CounterValue_90, P95th = percentile_CounterValue_95 \r\n    | order by {TableTrend:label} {tableTrendOrder}, Computer \r\n    | limit maxResultCount); \r\nlet computerList = summaryPerComputer \r\n    | project Computer; \r\nlet MachineSummary = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | project Computer, MachineSummary = pack(\"Fully Qualified Domain Name\", Computer, \"OS Type\", OperatingSystemFamily_s, \"Operating System\", OperatingSystemFullName_s, \"Ipv4 Addresses\", Ipv4Addresses_s,\r\n        \"Ipv6 Addresses\", Ipv6Addresses_s, \"Mac Addresses\", MacAddresses_s, \"DNS Names\", DnsNames_s, \"CPUs\", strcat(Cpus_d, \" @ \", CpuSpeed_d, \" MHz\"), \"Bitness\", Bitness_s,\r\n        \"Physcial Memory\", strcat(PhysicalMemory_d, \" MB\"), \"Virtualization State\", VirtualizationState_s, \"VM Type\", VirtualMachineType_s, \"OMS Agent\", split(ResourceName_s, \"m-\")[1]);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Type = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", strcat(NodeProps.vmScaleSetName, \" | \", NodeProps.scaleSetInstanceId), \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", strcat(NodeProps.cloudServiceRoleName, \" | \", NodeProps.cloudServiceInstanceId), Computer))\r\n    | project Computer, Type, ResourceId, ResourceName;\r\nlet trend = Perf     \r\n    | where TimeGenerated {TimeRange}    \r\n    | where Computer in (computerList)     \r\n    | where ObjectName == metric.object and CounterName == metric.counter   \r\n    | make-series {TableTrend} default = 0 on TimeGenerated in range({TimeRange:start}, {TimeRange:end}, {TimeRange:grain}) by Computer\r\n    | project Computer, ['Trend ({TableTrend:label})'] = {TableTrend:label};\r\nsummaryPerComputer\r\n    | join kind=leftouter (trend) on Computer\r\n    | join kind=leftouter (NodeIdentityAndProps) on Computer\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | join kind=leftouter (MachineSummary) on Computer\r\n    | project ResourceName, Type, {mergedAggregators}, ['Trend ({TableTrend:label})'], Properties = MachineSummary\r\n    | sort by {TableTrend:label} {tableTrendOrder}",
+        "query": "{StandardQuery}",
         "showQuery": false,
         "size": 0,
         "aggregation": 0,
@@ -589,14 +545,24 @@
         "parameterName": "IsNetworkCounter",
         "comparison": "isNotEqualTo",
         "value": "True"
+      }
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "#### ℹ `Total Bytes {NetworkDirection}` counters are also being utilized to display the network table. The delta of `Total Bytes {NetworkDirection}` over a time period is being calculated to match up with the `Bytes {NetworkDirection}/sec` counter to display an accurate representation of network activity over all machines"
       },
-      "customWidth": "50"
+      "conditionalVisibility": {
+        "parameterName": "IsNetworkCounter",
+        "comparison": "isEqualTo",
+        "value": "True"
+      }
     },
     {
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let metric = dynamic({Counter});\r\nlet linux = iff(metric.counter == 'Bytes Received/sec', dynamic({'object': 'Network', 'counter': 'Total Bytes Received'}), dynamic({'object': 'Network', 'counter': 'Total Bytes Transmitted'}));\r\nlet maxResultCount = 100;\r\nlet windowsNetworkRaw = Perf\r\n| where TimeGenerated {TimeRange}\r\n| where ObjectName == metric.object and CounterName == metric.couter;\r\nlet windowsNetworkSum = windowsNetworkRaw\r\n| summarize hint.shufflekey=Computer CounterValue=sum(CounterValue) by Computer, TimeGenerated;\r\nlet windowsNetworkPctl = windowsNetworkRaw\r\n| summarize hint.shufflekey=Computer Average = avg(CounterValue), Max = max(CounterValue), Min = min(CounterValue), percentiles(CounterValue, 5, 10, 50, 80, 90, 95) by Computer, TimeGenerated\r\n| project TimeGenerated, Computer, Average, Max, Min, P5th = percentile_CounterValue_5, P10th = percentile_CounterValue_10, P50th = percentile_CounterValue_50, P80th = percentile_CounterValue_80, P90th = percentile_CounterValue_90, P95th = percentile_CounterValue_95;\r\nlet linuxNetworkRaw = Perf\r\n| where TimeGenerated {TimeRange}\r\n| where ObjectName == linux.object and CounterName == linux.counter\r\n| order by InstanceName, TimeGenerated asc\r\n| extend prev_Value = prev(CounterValue), prev_t = prev(TimeGenerated), prev_instance = prev(InstanceName)\r\n| project TimeGenerated, Computer, CounterValue = iff(prev_instance == InstanceName and CounterValue >= prev_Value and TimeGenerated > prev_t, (CounterValue - prev_Value) / ((TimeGenerated - prev_t) / 1s), real(0));\r\nlet linuxNetworkSum = linuxNetworkRaw\r\n| summarize hint.shufflekey=Computer CounterValue=sum(CounterValue) by Computer, TimeGenerated;\r\nlet linuxNetworkPctl = linuxNetworkRaw\r\n| summarize hint.shufflekey=Computer Average = avg(CounterValue), Max = max(CounterValue), Min = min(CounterValue), percentiles(CounterValue, 5, 10, 50, 80, 90, 95) by Computer, TimeGenerated\r\n| project TimeGenerated, Computer, Average, Max, Min, P5th = percentile_CounterValue_5, P10th = percentile_CounterValue_10, P50th = percentile_CounterValue_50, P80th = percentile_CounterValue_80, P90th = percentile_CounterValue_90, P95th = percentile_CounterValue_95;\r\nlet networkDataSum = union windowsNetworkSum, linuxNetworkSum;\r\nlet networkDataPctl = union windowsNetworkPctl, linuxNetworkPctl;\r\nlet computerList = Perf \r\n| project Computer;\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n| extend NodeId = Computer\r\n| extend Priority = 1\r\n| extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n| where TimeGenerated {TimeRange}\r\n| where Computer in (computerList)\r\n| summarize hint.shufflekey=Computer arg_max(TimeGenerated, *) by Computer\r\n| extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|', columnifexists('AzureCloudServiceDeployment_g', '')), ''), AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')), strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|', columnifexists('AzureVmScaleSetDeployment_g', '')), ''), ComputerProps = pack('type', 'StandAloneNode', 'name', ComputerName_s, 'mappingResourceId', ResourceId, 'subscriptionId', AzureSubscriptionId_g, 'resourceGroup', AzureResourceGroup_s, 'azureResourceId', columnifexists('AzureResourceId_s', '')), AzureCloudServiceNodeProps = pack('type', 'AzureCloudServiceNode', 'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''), 'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''), 'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''), 'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''), 'mappingResourceId', ResourceId), AzureScaleSetNodeProps = pack('type', 'AzureScaleSetNode', 'scaleSetInstanceId', columnifexists('AzureName_s', ''), 'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''), 'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''), 'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''), 'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''), 'resourceGroupName', columnifexists('AzureResourceGroup_s', ''), 'subscriptionId', columnifexists('AzureSubscriptionId_g', ''), 'mappingResourceId', ResourceId)| project   Computer, NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity, isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer), NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps, isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps), Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps\r\n| summarize hint.shufflekey=Computer arg_max(Priority, *) by Computer;\r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n| extend Type = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)), ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", strcat(NodeProps.vmScaleSetName, \" | \", NodeProps.scaleSetInstanceId), iff(NodeProps.type == \"AzureCloudServiceNode\", strcat(NodeProps.cloudServiceRoleName, \" | \", NodeProps.cloudServiceInstanceId), Computer))\r\n| project Computer, Type, ResourceId, ResourceName;\r\nlet MachineSummary = ServiceMapComputer_CL\r\n| where TimeGenerated {TimeRange}\r\n| where Computer in (computerList)\r\n| summarize hint.shufflekey=Computer arg_max(TimeGenerated, *) by Computer\r\n| project Computer, MachineSummary = pack(\"Fully Qualified Domain Name\", Computer, \"OS Type\", OperatingSystemFamily_s, \"Operating System\", OperatingSystemFullName_s, \"Ipv4 Addresses\", Ipv4Addresses_s, \"Ipv6 Addresses\", Ipv6Addresses_s, \"Mac Addresses\", MacAddresses_s, \"DNS Names\", DnsNames_s, \"CPUs\", strcat(Cpus_d, \" @ \", CpuSpeed_d, \" MHz\"), \"Bitness\", Bitness_s, \"Physcial Memory\", strcat(PhysicalMemory_d, \" MB\"), \"Virtualization State\", VirtualizationState_s, \"VM Type\", VirtualMachineType_s, \"OMS Agent\", split(ResourceName_s, \"m-\")[1]);\r\nlet trend = networkDataSum\r\n| make-series {TableTrend} default=0 on TimeGenerated in range({TimeRange:start}, {TimeRange:end}, {TimeRange:grain}) by Computer\r\n| project Computer, ['Trend ({TableTrend:label})'] = {TableTrend:label};\r\nnetworkDataPctl\r\n| join kind=leftouter hint.shufflekey=Computer (trend) on Computer\r\n| join kind=leftouter hint.shufflekey=Computer (NodeIdentityAndPropsMin) on Computer\r\n| join kind=leftouter hint.shufflekey=Computer (MachineSummary) on Computer\r\n| project ResourceName, Type, {mergedAggregators}, ['Trend ({TableTrend:label})'], Properties = MachineSummary\r\n| sort by {TableTrend:label} {tableTrendOrder}\r\n| limit maxResultCount",
+        "query": "{NetworkQuery}",
         "showQuery": false,
         "size": 0,
         "aggregation": 0,
@@ -789,103 +755,57 @@
         "parameterName": "IsNetworkCounter",
         "comparison": "isEqualTo",
         "value": "True"
-      },
-      "customWidth": "50"
+      }
     },
     {
-      "type": 3,
+      "type": 9,
       "content": {
-        "version": "KqlItem/1.0",
-        "query": "let metric = dynamic({Counter});\r\nlet cpuSummary=totable(Perf\r\n    | where TimeGenerated {TimeRange} \r\n    | where ObjectName == metric.object and CounterName == metric.counter\r\n    | summarize hint.shufflekey=Computer {Percentile} by Computer, CounterName\r\n    | top 5 by {Percentile:label} {percentileOrder});\r\nlet computerList=(cpuSummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nPerf\r\n    | where TimeGenerated {TimeRange}\r\n    | where ObjectName == metric.object and CounterName == metric.counter\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {Percentile} by bin(TimeGenerated, ({TimeRange:end} - {TimeRange:start})/100), ResourceName",
-        "showQuery": false,
-        "size": 0,
-        "aggregation": 3,
-        "showAnnotations": true,
-        "showAnalytics": false,
-        "timeContextFromParameter": null,
-        "resourceType": "microsoft.operationalinsights/workspaces",
+        "version": "KqlParameterItem/1.0",
+        "query": "",
         "crossComponentResources": [
           "{Workspaces}"
         ],
-        "visualization": "linechart",
-        "tileSettings": {
-          "showBorder": false,
-          "titleContent": {
-            "columnMatch": "Computer",
-            "formatter": 1
-          },
-          "leftContent": {
-            "columnMatch": "value",
-            "formatter": 12,
-            "formatOptions": {
-              "palette": "auto"
+        "parameters": [
+          {
+            "id": "fe57c085-e029-4b37-9cd3-34c39c8734da",
+            "version": "KqlParameterItem/1.0",
+            "name": "Workspaces",
+            "type": 5,
+            "isRequired": true,
+            "multiSelect": true,
+            "quote": "'",
+            "delimiter": ",",
+            "value": [
+              "value::1"
+            ],
+            "isHiddenWhenLocked": true,
+            "typeSettings": {
+              "resourceTypeFilter": {
+                "microsoft.operationalinsights/workspaces": true
+              },
+              "additionalResourceOptions": [
+                "value::1"
+              ]
             },
-            "numberFormat": {
-              "unit": 17,
-              "options": {
-                "maximumSignificantDigits": 3,
-                "maximumFractionDigits": 2
-              }
-            }
+            "timeContextFromParameter": null
           }
-        }
-      },
-      "conditionalVisibility": {
-        "parameterName": "IsNetworkCounter",
-        "comparison": "isNotEqualTo",
-        "value": "True"
-      },
-      "customWidth": "50"
-    },
-    {
-      "type": 3,
-      "content": {
-        "version": "KqlItem/1.0",
-        "query": "let metric = dynamic({Counter});\r\nlet linux = iff(metric.counter == 'Bytes Received/sec', dynamic({'object': 'Network', 'counter': 'Total Bytes Received'}), dynamic({'object': 'Network', 'counter': 'Total Bytes Transmitted'}));\r\nlet windowsNetworkRaw = Perf\r\n| where TimeGenerated {TimeRange}\r\n| where ObjectName == metric.object and CounterName == metric.counter;\r\nlet windowsNetworkPctl = windowsNetworkRaw\r\n| summarize hint.shufflekey=Computer Average = avg(CounterValue), Max = max(CounterValue), Min = min(CounterValue), percentiles(CounterValue, 5, 10, 50, 80, 90, 95) by bin(TimeGenerated, ({TimeRange:end} - {TimeRange:start})/100), Computer\r\n| project TimeGenerated, Computer, Average, Max, Min, P5th = percentile_CounterValue_5, P10th = percentile_CounterValue_10, P50th = percentile_CounterValue_50, P80th = percentile_CounterValue_80, P90th = percentile_CounterValue_90, P95th = percentile_CounterValue_95;\r\nlet linuxNetworkRaw = Perf\r\n| where TimeGenerated {TimeRange}\r\n| where ObjectName == linux.object and CounterName == linux.counter\r\n| order by InstanceName, TimeGenerated asc\r\n| extend prev_Value = prev(CounterValue), prev_t = prev(TimeGenerated), prev_instance = prev(InstanceName)\r\n| project TimeGenerated, Computer, CounterValue = iff(prev_instance == InstanceName and CounterValue >= prev_Value and TimeGenerated > prev_t, (CounterValue - prev_Value) / ((TimeGenerated - prev_t) / 1s), real(0));\r\nlet linuxNetworkPctl = linuxNetworkRaw\r\n| summarize hint.shufflekey=Computer Average = avg(CounterValue), Max = max(CounterValue), Min = min(CounterValue), percentiles(CounterValue, 5, 10, 50, 80, 90, 95) by bin(TimeGenerated, ({TimeRange:end} - {TimeRange:start})/100), Computer\r\n| project TimeGenerated, Computer, Average, Max, Min, P5th = percentile_CounterValue_5, P10th = percentile_CounterValue_10, P50th = percentile_CounterValue_50, P80th = percentile_CounterValue_80, P90th = percentile_CounterValue_90, P95th = percentile_CounterValue_95;\r\nlet networkDataPctl = union windowsNetworkPctl, linuxNetworkPctl;\r\nlet networkDataPctlTopComputers = networkDataPctl\r\n| summarize CounterValue=sum({Percentile:label}) by Computer\r\n| top 5 by CounterValue desc\r\n| project Computer;\r\nlet computerList=(Perf\r\n| project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n| extend NodeId = Computer\r\n| extend Priority = 1\r\n| extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n| where TimeGenerated {TimeRange}\r\n| where Computer in (computerList)\r\n| summarize hint.shufflekey=Computer arg_max(TimeGenerated, *) by Computer\r\n| extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|', columnifexists('AzureCloudServiceDeployment_g', '')), ''), AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')), strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|', columnifexists('AzureVmScaleSetDeployment_g', '')), ''), ComputerProps = pack('type', 'StandAloneNode', 'name', ComputerName_s, 'mappingResourceId', ResourceId, 'subscriptionId', AzureSubscriptionId_g, 'resourceGroup', AzureResourceGroup_s, 'azureResourceId', columnifexists('AzureResourceId_s', '')), AzureCloudServiceNodeProps = pack('type', 'AzureCloudServiceNode', 'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''), 'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''), 'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''), 'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''), 'mappingResourceId', ResourceId), AzureScaleSetNodeProps = pack('type', 'AzureScaleSetNode', 'scaleSetInstanceId', columnifexists('AzureName_s', ''), 'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''), 'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''), 'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''), 'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''), 'resourceGroupName', columnifexists('AzureResourceGroup_s', ''), 'subscriptionId', columnifexists('AzureSubscriptionId_g', ''), 'mappingResourceId', ResourceId)| project   Computer, NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity, isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer), NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps, isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps), Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps\r\n| summarize hint.shufflekey=Computer arg_max(Priority, *) by Computer;\r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n| extend Type = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)), ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", strcat(NodeProps.vmScaleSetName, \" | \", NodeProps.scaleSetInstanceId), iff(NodeProps.type == \"AzureCloudServiceNode\", strcat(NodeProps.cloudServiceRoleName, \" | \", NodeProps.cloudServiceInstanceId), Computer))\r\n| project Computer, Type, ResourceId, ResourceName;\r\nnetworkDataPctl\r\n| where TimeGenerated {TimeRange}\r\n| where Computer in (networkDataPctlTopComputers)\r\n| join kind=leftouter hint.shufflekey=Computer (NodeIdentityAndPropsMin) on Computer\r\n| project TimeGenerated, ResourceName, {Percentile:label}",
-        "showQuery": false,
-        "size": 0,
-        "aggregation": 3,
-        "showAnnotations": true,
-        "showAnalytics": false,
-        "timeContextFromParameter": null,
-        "resourceType": "microsoft.operationalinsights/workspaces",
-        "crossComponentResources": [
-          "{Workspaces}"
         ],
-        "visualization": "linechart",
-        "tileSettings": {
-          "showBorder": false,
-          "titleContent": {
-            "columnMatch": "Computer",
-            "formatter": 1
-          },
-          "leftContent": {
-            "columnMatch": "value",
-            "formatter": 12,
-            "formatOptions": {
-              "palette": "auto"
-            },
-            "numberFormat": {
-              "unit": 17,
-              "options": {
-                "maximumSignificantDigits": 3,
-                "maximumFractionDigits": 2
-              }
-            }
-          }
-        }
+        "style": "above",
+        "resourceType": "microsoft.operationalinsights/workspaces"
       },
-      "conditionalVisibility": {
-        "parameterName": "IsNetworkCounter",
-        "comparison": "isEqualTo",
-        "value": "True"
-      },
-      "customWidth": "50"
+      "conditionalVisibility": null
     },
     {
       "type": 1,
       "content": {
-        "json": "---\r\n## Top 10 Machines\r\n<p><strong>Percentile</strong> for each chart below, select a percentile to display for that particular chart</p>"
+        "json": "---\r\n## Top 10 Machines\r\n<p><strong>Aggregate</strong> for each chart below, select an aggregate to display for that particular chart</p>"
+      },
+      "conditionalVisibility": null
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "### CPU Utilization %"
       },
       "conditionalVisibility": null
     },
@@ -899,7 +819,7 @@
           {
             "id": "92358ae0-d5e1-494b-b65b-6d904f1325c5",
             "version": "KqlParameterItem/1.0",
-            "name": "Percentile",
+            "name": "Aggregate",
             "type": 2,
             "isRequired": true,
             "value": "P95th = round(percentile(CounterValue, 95), 2)",
@@ -913,10 +833,10 @@
           {
             "id": "27345375-4376-4e2f-8ac4-59d4eab9d235",
             "version": "KqlParameterItem/1.0",
-            "name": "percentileOrder",
+            "name": "aggregateOrder",
             "type": 1,
             "isRequired": false,
-            "query": "range Steps from 1 to 1 step 1\r\n| project value = iff('{Percentile}' contains 'P5th'  or '{Percentile}' contains 'P10th', 'asc', 'desc')",
+            "query": "range Steps from 1 to 1 step 1\r\n| project value = iff('{Aggregate}' contains 'P5th'  or '{Aggregate}' contains 'P10th', 'asc', 'desc')",
             "isHiddenWhenLocked": true,
             "timeContextFromParameter": null,
             "resourceType": "microsoft.operationalinsights/workspaces"
@@ -928,17 +848,10 @@
       "conditionalVisibility": null
     },
     {
-      "type": 1,
-      "content": {
-        "json": "### CPU Utilization % ({Percentile:label})"
-      },
-      "conditionalVisibility": null
-    },
-    {
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let cpuSummary=totable(Perf\r\n    | where TimeGenerated {TimeRange} \r\n    | where (ObjectName == 'Processor' and InstanceName == '_Total' and CounterName == '% Processor Time')\r\n    | summarize hint.shufflekey=Computer {Percentile} by Computer, CounterName\r\n    | top 10 by {Percentile:label} {percentileOrder});\r\nlet computerList=(cpuSummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nPerf\r\n    | where TimeGenerated {TimeRange}\r\n    | where (ObjectName == 'Processor' and InstanceName == '_Total' and CounterName == '% Processor Time')\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {Percentile} by bin(TimeGenerated, ({TimeRange:end} - {TimeRange:start})/100), ResourceName",
+        "query": "let cpuSummary=totable(Perf\r\n    | where TimeGenerated {TimeRange} \r\n    | where (ObjectName == 'Processor' and InstanceName == '_Total' and CounterName == '% Processor Time')\r\n    | summarize hint.shufflekey=Computer {Aggregate} by Computer, CounterName\r\n    | top 10 by {Aggregate:label} {aggregateOrder});\r\nlet computerList=(cpuSummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nPerf\r\n    | where TimeGenerated {TimeRange}\r\n    | where (ObjectName == 'Processor' and InstanceName == '_Total' and CounterName == '% Processor Time')\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {Aggregate} by bin(TimeGenerated, ({TimeRange:end} - {TimeRange:start})/100), ResourceName",
         "showQuery": false,
         "size": 0,
         "aggregation": 3,
@@ -971,6 +884,13 @@
             }
           }
         }
+      },
+      "conditionalVisibility": null
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "### Available Memory"
       },
       "conditionalVisibility": null
     },
@@ -984,7 +904,7 @@
           {
             "id": "333837c2-d5a4-4173-9aad-3db1dca17e2a",
             "version": "KqlParameterItem/1.0",
-            "name": "Percentile",
+            "name": "Aggregate",
             "type": 2,
             "isRequired": true,
             "value": "P5th = round(percentile(CounterValue, 5), 2)",
@@ -998,10 +918,10 @@
           {
             "id": "a23b29a5-5e4a-4d8e-ba73-bfdf27b2980e",
             "version": "KqlParameterItem/1.0",
-            "name": "percentileOrder",
+            "name": "aggregateOrder",
             "type": 1,
             "isRequired": false,
-            "query": "range Steps from 1 to 1 step 1\r\n| project value = iff('{Percentile}' contains 'P5th'  or '{Percentile}' contains 'P10th', 'asc', 'desc')",
+            "query": "range Steps from 1 to 1 step 1\r\n| project value = iff('{Aggregate}' contains 'P5th'  or '{Aggregate}' contains 'P10th', 'asc', 'desc')",
             "isHiddenWhenLocked": true,
             "timeContextFromParameter": null,
             "resourceType": "microsoft.operationalinsights/workspaces"
@@ -1013,17 +933,10 @@
       "conditionalVisibility": null
     },
     {
-      "type": 1,
-      "content": {
-        "json": "### Available Memory ({Percentile:label})"
-      },
-      "conditionalVisibility": null
-    },
-    {
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let memorySummary=totable(Perf\r\n    | where TimeGenerated {TimeRange} \r\n    | where ObjectName == 'Memory' and CounterName in ('Available MBytes', 'Available MBytes Memory')\r\n    | summarize hint.shufflekey=Computer {Percentile} by Computer, CounterName\r\n    | top 10 by {Percentile:label} {percentileOrder});\r\nlet computerList=(memorySummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nPerf\r\n    | where TimeGenerated {TimeRange}\r\n    | where ObjectName == 'Memory' and CounterName in ('Available MBytes', 'Available MBytes Memory')\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {Percentile} by bin(TimeGenerated, ({TimeRange:end} - {TimeRange:start})/100), ResourceName",
+        "query": "let memorySummary=totable(Perf\r\n    | where TimeGenerated {TimeRange} \r\n    | where ObjectName == 'Memory' and CounterName in ('Available MBytes', 'Available MBytes Memory')\r\n    | summarize hint.shufflekey=Computer {Aggregate} by Computer, CounterName\r\n    | top 10 by {Aggregate:label} {aggregateOrder});\r\nlet computerList=(memorySummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nPerf\r\n    | where TimeGenerated {TimeRange}\r\n    | where ObjectName == 'Memory' and CounterName in ('Available MBytes', 'Available MBytes Memory')\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {Aggregate} by bin(TimeGenerated, ({TimeRange:end} - {TimeRange:start})/100), ResourceName",
         "showQuery": false,
         "size": 0,
         "aggregation": 3,
@@ -1060,6 +973,13 @@
       "conditionalVisibility": null
     },
     {
+      "type": 1,
+      "content": {
+        "json": "### Bytes Sent Rate"
+      },
+      "conditionalVisibility": null
+    },
+    {
       "type": 9,
       "content": {
         "version": "KqlParameterItem/1.0",
@@ -1069,7 +989,7 @@
           {
             "id": "360da4c1-97fa-4b15-a008-33a6110d0acd",
             "version": "KqlParameterItem/1.0",
-            "name": "Percentile",
+            "name": "Aggregate",
             "type": 2,
             "isRequired": true,
             "value": "P95th = round(percentile(CounterValue, 95), 2)",
@@ -1083,10 +1003,10 @@
           {
             "id": "31ccd4a1-d626-44bb-a5de-1780a33b37a5",
             "version": "KqlParameterItem/1.0",
-            "name": "percentileOrder",
+            "name": "aggregateOrder",
             "type": 1,
             "isRequired": false,
-            "query": "range Steps from 1 to 1 step 1\r\n| project value = iff('{Percentile}' contains 'P5th'  or '{Percentile}' contains 'P10th', 'asc', 'desc')",
+            "query": "range Steps from 1 to 1 step 1\r\n| project value = iff('{Aggregate}' contains 'P5th'  or '{Aggregate}' contains 'P10th', 'asc', 'desc')",
             "isHiddenWhenLocked": true,
             "timeContextFromParameter": null,
             "resourceType": "microsoft.operationalinsights/workspaces"
@@ -1098,17 +1018,10 @@
       "conditionalVisibility": null
     },
     {
-      "type": 1,
-      "content": {
-        "json": "### Bytes Sent Rate ({Percentile:label})"
-      },
-      "conditionalVisibility": null
-    },
-    {
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let linuxNetworkSend=Perf \r\n    | where TimeGenerated {TimeRange} \r\n    | where ObjectName == 'Network' and CounterName == 'Total Bytes Transmitted'\r\n    | order by CounterName asc, InstanceName, Computer asc, TimeGenerated asc\r\n    | extend prev_Computer=prev(Computer), prev_Value=prev(CounterValue), prev_t=prev(TimeGenerated), prev_counter=prev(CounterName), prev_instance=prev(InstanceName)\r\n    | project   TimeGenerated,            Computer,            CounterValue = iff(prev_Computer == Computer and prev_instance == InstanceName and prev_counter == CounterName and CounterValue >= prev_Value and TimeGenerated > prev_t, (CounterValue-prev_Value)/((TimeGenerated-prev_t)/1s), real(0))\r\n    | summarize hint.shufflekey=Computer CounterValue = sum(CounterValue) by Computer, bin(TimeGenerated, 2s);\r\nlet windowsNetworkSend = Perf \r\n    | where TimeGenerated {TimeRange} \r\n    | where ObjectName == 'Network Adapter' and CounterName == 'Bytes Sent/sec'\r\n    | summarize hint.shufflekey=Computer CounterValue = sum(CounterValue) by Computer, bin(TimeGenerated, 2s);\r\nlet networkDataSend = union linuxNetworkSend, windowsNetworkSend;\r\nlet networkSendSummary = totable(networkDataSend\r\n    | where TimeGenerated {TimeRange}\r\n    | summarize hint.shufflekey=Computer {Percentile} by Computer\r\n    | top 10 by {Percentile:label} {percentileOrder});\r\nlet computerList=(networkSendSummary | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nnetworkDataSend\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {Percentile} by bin(TimeGenerated, ({TimeRange:end} - {TimeRange:start})/100), ResourceName",
+        "query": "let linuxNetworkSend=Perf \r\n    | where TimeGenerated {TimeRange} \r\n    | where ObjectName == 'Network' and CounterName == 'Total Bytes Transmitted'\r\n    | order by CounterName asc, InstanceName, Computer asc, TimeGenerated asc\r\n    | extend prev_Computer=prev(Computer), prev_Value=prev(CounterValue), prev_t=prev(TimeGenerated), prev_counter=prev(CounterName), prev_instance=prev(InstanceName)\r\n    | project   TimeGenerated,            Computer,            CounterValue = iff(prev_Computer == Computer and prev_instance == InstanceName and prev_counter == CounterName and CounterValue >= prev_Value and TimeGenerated > prev_t, (CounterValue-prev_Value)/((TimeGenerated-prev_t)/1s), real(0))\r\n    | summarize hint.shufflekey=Computer CounterValue = sum(CounterValue) by Computer, bin(TimeGenerated, 2s);\r\nlet windowsNetworkSend = Perf \r\n    | where TimeGenerated {TimeRange} \r\n    | where ObjectName == 'Network Adapter' and CounterName == 'Bytes Sent/sec'\r\n    | summarize hint.shufflekey=Computer CounterValue = sum(CounterValue) by Computer, bin(TimeGenerated, 2s);\r\nlet networkDataSend = union linuxNetworkSend, windowsNetworkSend;\r\nlet networkSendSummary = totable(networkDataSend\r\n    | where TimeGenerated {TimeRange}\r\n    | summarize hint.shufflekey=Computer {Aggregate} by Computer\r\n    | top 10 by {Aggregate:label} {aggregateOrder});\r\nlet computerList=(networkSendSummary | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nnetworkDataSend\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {Aggregate} by bin(TimeGenerated, ({TimeRange:end} - {TimeRange:start})/100), ResourceName",
         "showQuery": false,
         "size": 0,
         "aggregation": 0,
@@ -1141,6 +1054,13 @@
             }
           }
         }
+      },
+      "conditionalVisibility": null
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "### Bytes Received Rate"
       },
       "conditionalVisibility": null
     },
@@ -1154,7 +1074,7 @@
           {
             "id": "6772b281-d17d-4293-a227-1b2ed67f399e",
             "version": "KqlParameterItem/1.0",
-            "name": "Percentile",
+            "name": "Aggregate",
             "type": 2,
             "isRequired": true,
             "value": "P95th = round(percentile(CounterValue, 95), 2)",
@@ -1168,10 +1088,10 @@
           {
             "id": "5e2eef28-0528-406f-86b5-ceae535455f9",
             "version": "KqlParameterItem/1.0",
-            "name": "percentileOrder",
+            "name": "aggregateOrder",
             "type": 1,
             "isRequired": false,
-            "query": "range Steps from 1 to 1 step 1\r\n| project value = iff('{Percentile}' contains 'P5th'  or '{Percentile}' contains 'P10th', 'asc', 'desc')",
+            "query": "range Steps from 1 to 1 step 1\r\n| project value = iff('{Aggregate}' contains 'P5th'  or '{Aggregate}' contains 'P10th', 'asc', 'desc')",
             "isHiddenWhenLocked": true,
             "timeContextFromParameter": null,
             "resourceType": "microsoft.operationalinsights/workspaces"
@@ -1183,17 +1103,10 @@
       "conditionalVisibility": null
     },
     {
-      "type": 1,
-      "content": {
-        "json": "### Bytes Received Rate ({Percentile:label})"
-      },
-      "conditionalVisibility": null
-    },
-    {
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let linuxNetworkReceive=Perf \r\n    | where TimeGenerated {TimeRange} \r\n    | where ObjectName == 'Network' and CounterName == 'Total Bytes Received'\r\n    | order by CounterName asc, InstanceName, Computer asc, TimeGenerated asc\r\n    | extend prev_Computer=prev(Computer), prev_Value=prev(CounterValue), prev_t=prev(TimeGenerated), prev_counter=prev(CounterName), prev_instance=prev(InstanceName)\r\n    | project   TimeGenerated,            Computer,            CounterValue = iff(prev_Computer == Computer and prev_instance == InstanceName and prev_counter == CounterName and CounterValue >= prev_Value and TimeGenerated > prev_t, (CounterValue-prev_Value)/((TimeGenerated-prev_t)/1s), real(0))\r\n    | summarize hint.shufflekey=Computer CounterValue = sum(CounterValue) by Computer, bin(TimeGenerated, 2s);\r\nlet windowsNetworkReceive = Perf \r\n    | where TimeGenerated {TimeRange} \r\n    | where ObjectName == 'Network Adapter' and CounterName == 'Bytes Received/sec'\r\n    | summarize hint.shufflekey=Computer CounterValue = sum(CounterValue) by Computer, bin(TimeGenerated, 2s);\r\nlet networkDataReceive = union linuxNetworkReceive, windowsNetworkReceive;\r\nlet networkReceiveSummary = totable(networkDataReceive\r\n    | where TimeGenerated {TimeRange}\r\n    | summarize hint.shufflekey=Computer {Percentile} by Computer\r\n    | top 10 by {Percentile:label} {percentileOrder});\r\nlet computerList=(networkReceiveSummary | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nnetworkDataReceive\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {Percentile} by bin(TimeGenerated, ({TimeRange:end} - {TimeRange:start})/100), ResourceName",
+        "query": "let linuxNetworkReceive=Perf \r\n    | where TimeGenerated {TimeRange} \r\n    | where ObjectName == 'Network' and CounterName == 'Total Bytes Received'\r\n    | order by CounterName asc, InstanceName, Computer asc, TimeGenerated asc\r\n    | extend prev_Computer=prev(Computer), prev_Value=prev(CounterValue), prev_t=prev(TimeGenerated), prev_counter=prev(CounterName), prev_instance=prev(InstanceName)\r\n    | project   TimeGenerated,            Computer,            CounterValue = iff(prev_Computer == Computer and prev_instance == InstanceName and prev_counter == CounterName and CounterValue >= prev_Value and TimeGenerated > prev_t, (CounterValue-prev_Value)/((TimeGenerated-prev_t)/1s), real(0))\r\n    | summarize hint.shufflekey=Computer CounterValue = sum(CounterValue) by Computer, bin(TimeGenerated, 2s);\r\nlet windowsNetworkReceive = Perf \r\n    | where TimeGenerated {TimeRange} \r\n    | where ObjectName == 'Network Adapter' and CounterName == 'Bytes Received/sec'\r\n    | summarize hint.shufflekey=Computer CounterValue = sum(CounterValue) by Computer, bin(TimeGenerated, 2s);\r\nlet networkDataReceive = union linuxNetworkReceive, windowsNetworkReceive;\r\nlet networkReceiveSummary = totable(networkDataReceive\r\n    | where TimeGenerated {TimeRange}\r\n    | summarize hint.shufflekey=Computer {Aggregate} by Computer\r\n    | top 10 by {Aggregate:label} {aggregateOrder});\r\nlet computerList=(networkReceiveSummary | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nnetworkDataReceive\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {Aggregate} by bin(TimeGenerated, ({TimeRange:end} - {TimeRange:start})/100), ResourceName",
         "showQuery": false,
         "size": 0,
         "aggregation": 0,
@@ -1230,6 +1143,13 @@
       "conditionalVisibility": null
     },
     {
+      "type": 1,
+      "content": {
+        "json": "### Logical Disk Space Used %"
+      },
+      "conditionalVisibility": null
+    },
+    {
       "type": 9,
       "content": {
         "version": "KqlParameterItem/1.0",
@@ -1239,7 +1159,7 @@
           {
             "id": "5d6afbec-79f6-4cd1-b3a1-361503478304",
             "version": "KqlParameterItem/1.0",
-            "name": "Percentile",
+            "name": "Aggregate",
             "type": 2,
             "isRequired": true,
             "value": "P95th = round(percentile(CounterValue, 95), 2)",
@@ -1253,10 +1173,10 @@
           {
             "id": "1d5a805c-acce-4afe-a38b-c2740fb3ff26",
             "version": "KqlParameterItem/1.0",
-            "name": "percentileOrder",
+            "name": "aggregateOrder",
             "type": 1,
             "isRequired": false,
-            "query": "range Steps from 1 to 1 step 1\r\n| project value = iff('{Percentile}' contains 'P5th'  or '{Percentile}' contains 'P10th', 'asc', 'desc')",
+            "query": "range Steps from 1 to 1 step 1\r\n| project value = iff('{Aggregate}' contains 'P5th'  or '{Aggregate}' contains 'P10th', 'asc', 'desc')",
             "isHiddenWhenLocked": true,
             "timeContextFromParameter": null,
             "resourceType": "microsoft.operationalinsights/workspaces"
@@ -1268,17 +1188,10 @@
       "conditionalVisibility": null
     },
     {
-      "type": 1,
-      "content": {
-        "json": "### Logical Disk Space Used % ({Percentile:label})"
-      },
-      "conditionalVisibility": null
-    },
-    {
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let diskSummary=totable(Perf\r\n    | where TimeGenerated {TimeRange} \r\n    | where (ObjectName == 'LogicalDisk' and InstanceName != '_Total' and CounterName in ('% Free Space')) or        (ObjectName == 'Logical Disk' and InstanceName != '_Total' and CounterName in ('% Used Space'))\r\n    | project TimeGenerated, Computer,    CounterName = '% Used Space',    CounterValue = case(ObjectName == 'LogicalDisk' and CounterName == '% Free Space', 100 - CounterValue,                CounterValue < 0, real(0),                CounterValue)\r\n    | summarize hint.shufflekey=Computer {Percentile} by Computer, CounterName\r\n    | top 10 by {Percentile:label} {percentileOrder});\r\nlet computerList=(diskSummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nPerf\r\n    | where TimeGenerated {TimeRange}\r\n    | where (ObjectName == 'LogicalDisk' and InstanceName != '_Total' and CounterName in ('% Free Space')) or        (ObjectName == 'Logical Disk' and InstanceName != '_Total' and CounterName in ('% Used Space'))\r\n    | where Computer in (computerList)\r\n    | project TimeGenerated, Computer,    CounterName = '% Used Space',    CounterValue = case(ObjectName == 'LogicalDisk' and CounterName == '% Free Space', 100 - CounterValue,                CounterValue < 0, real(0),                CounterValue)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {Percentile} by bin(TimeGenerated, ({TimeRange:end} - {TimeRange:start})/100), ResourceName",
+        "query": "let diskSummary=totable(Perf\r\n    | where TimeGenerated {TimeRange} \r\n    | where (ObjectName == 'LogicalDisk' and InstanceName != '_Total' and CounterName in ('% Free Space')) or        (ObjectName == 'Logical Disk' and InstanceName != '_Total' and CounterName in ('% Used Space'))\r\n    | project TimeGenerated, Computer,    CounterName = '% Used Space',    CounterValue = case(ObjectName == 'LogicalDisk' and CounterName == '% Free Space', 100 - CounterValue,                CounterValue < 0, real(0),                CounterValue)\r\n    | summarize hint.shufflekey=Computer {Aggregate} by Computer, CounterName\r\n    | top 10 by {Aggregate:label} {aggregateOrder});\r\nlet computerList=(diskSummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nPerf\r\n    | where TimeGenerated {TimeRange}\r\n    | where (ObjectName == 'LogicalDisk' and InstanceName != '_Total' and CounterName in ('% Free Space')) or        (ObjectName == 'Logical Disk' and InstanceName != '_Total' and CounterName in ('% Used Space'))\r\n    | where Computer in (computerList)\r\n    | project TimeGenerated, Computer,    CounterName = '% Used Space',    CounterValue = case(ObjectName == 'LogicalDisk' and CounterName == '% Free Space', 100 - CounterValue,                CounterValue < 0, real(0),                CounterValue)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {Aggregate} by bin(TimeGenerated, ({TimeRange:end} - {TimeRange:start})/100), ResourceName",
         "showQuery": false,
         "size": 0,
         "aggregation": 3,


### PR DESCRIPTION
Cosmetic and performance updates to the workbook. 25% faster chart
rendering time by only querying the chart that is being shown. Fix
extraneous charts being re-rendered when `Counter` dropdown is changed.
Improve cosemtic change for `Counter` dropdown.

- Make top table full-length

- Remove top graph

- Improve performance with query snippets

- Minor change to `Aggregation`

- Move `Aggregation`s under each chart title

- Move `Counter` dropdown same section as the top table

- Fix `Counter` not selecting a default counter upon initialization

- Improve `Counter` dropdown

- Fix only top chart being refreshed when `Counter` is selected

Preview:
![image](https://user-images.githubusercontent.com/43890980/52157645-79d34a80-2645-11e9-9105-9aed51f46f6f.png)
