### PR TITLE
Hotfix Connections Overview

### DIFF
--- a/Workbooks/Virtual Machines - Network Dependencies/Connections Overview/Connections Overview.workbook
+++ b/Workbooks/Virtual Machines - Network Dependencies/Connections Overview/Connections Overview.workbook
@@ -52,8 +52,8 @@
             "version": "KqlParameterItem/1.0",
             "name": "ComputerName",
             "type": 1,
-            "isRequired": true,
-            "query": "print '{Computer:label}'",
+            "isRequired": false,
+            "query": "print 'undefined'",
             "crossComponentResources": [
               "{Workspace}"
             ],
@@ -144,7 +144,9 @@
       "content": {
         "version": "KqlParameterItem/1.0",
         "query": "",
-        "crossComponentResources": [],
+        "crossComponentResources": [
+          "{Workspace}"
+        ],
         "parameters": [
           {
             "id": "306614b4-14f2-4777-a044-8c1121f04d6d",
@@ -364,9 +366,7 @@
       "content": {
         "version": "KqlParameterItem/1.0",
         "query": "",
-        "crossComponentResources": [
-          "{Workspace}"
-        ],
+        "crossComponentResources": [],
         "parameters": [
           {
             "id": "5e335a1b-7f99-4647-854a-d7b5cb489bb2",


### PR DESCRIPTION
Fixed computers not showing in the table list for AtScale Connections
Overview. Recent changes in default workbooks query broke this workbook
causing the computer name to be wrongly populated.

Preview
![image](https://user-images.githubusercontent.com/43890980/52448319-6530ff80-2ae8-11e9-8ca8-d3627515e16c.png)
