### PR TITLE
Move helper text within parameters

### DIFF
--- a/Workbooks/Virtual Machines - Performance Analysis/Performance Analysis for a Group of VMs/Performance Analysis for a Group of VMs.workbook
+++ b/Workbooks/Virtual Machines - Performance Analysis/Performance Analysis for a Group of VMs/Performance Analysis for a Group of VMs.workbook
@@ -159,7 +159,9 @@
       "content": {
         "version": "KqlParameterItem/1.0",
         "query": "",
-        "crossComponentResources": [],
+        "crossComponentResources": [
+          "{Workspaces}"
+        ],
         "parameters": [
           {
             "id": "e41c2177-932a-4c58-ba24-03ef070eb197",
@@ -189,8 +191,9 @@
             "version": "KqlParameterItem/1.0",
             "name": "Counter",
             "type": 2,
+            "description": "Select a VM performance counter for the table below",
             "isRequired": true,
-            "query": "Perf\r\n| where TimeGenerated {TimeRange}\r\n| where ObjectName != 'Network' and ObjectName != 'Network Interface'\r\n| summarize by CounterName, ObjectName, CounterText = CounterName\r\n| order by ObjectName asc, CounterText asc\r\n| project Counter = pack('counter', CounterName, 'object', ObjectName), CounterText, group = ObjectName",
+            "query": "// {Workspaces:label}\r\nPerf\r\n| where TimeGenerated {TimeRange}\r\n| where ObjectName != 'Network' and ObjectName != 'Network Interface'\r\n| summarize by CounterName, ObjectName, CounterText = CounterName\r\n| order by ObjectName asc, CounterText asc\r\n| project Counter = pack('counter', CounterName, 'object', ObjectName), CounterText, group = ObjectName",
             "crossComponentResources": [
               "{Workspaces}"
             ],
@@ -199,7 +202,8 @@
               "additionalResourceOptions": []
             },
             "timeContextFromParameter": null,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "resourceType": "microsoft.operationalinsights/workspaces",
+            "value": "{\"counter\":\"% Processor Time\",\"object\":\"Processor\"}"
           },
           {
             "id": "974d5ac2-4fc5-48e7-a8f7-16fc9dddc4ac",
@@ -242,6 +246,7 @@
             "version": "KqlParameterItem/1.0",
             "name": "Aggregators",
             "type": 2,
+            "description": "Select one or more different aggregates to display in the table below",
             "isRequired": true,
             "multiSelect": true,
             "quote": "",
@@ -263,6 +268,7 @@
             "version": "KqlParameterItem/1.0",
             "name": "TableTrend",
             "type": 2,
+            "description": "Select a percentile to display in the Trend column in the table below",
             "isRequired": true,
             "value": "Average = round(avg(CounterValue), 2)",
             "isHiddenWhenLocked": false,
@@ -331,13 +337,6 @@
         ],
         "style": "above",
         "resourceType": "microsoft.operationalinsights/workspaces"
-      },
-      "conditionalVisibility": null
-    },
-    {
-      "type": 1,
-      "content": {
-        "json": "<p><strong style=\"color:#333;\">Counter</strong> Select a <span style=\"border-bottom:1px dotted #aaa;cursor:default;\" title=\"Virtual Machine\">VM</span> performance counter for the table below</span></p>\r\n<p><strong style=\"color:#333;\">Aggregators</strong> Select one or more different aggregates to display in the table below</p>\r\n<p><strong style=\"color:#333;\">TableTrend</strong> Select a percentile to display in the Trend column in the table below</p>"
       },
       "conditionalVisibility": null
     },
@@ -798,7 +797,7 @@
     {
       "type": 1,
       "content": {
-        "json": "---\r\n## Top 10 Machines\r\n<p><strong>Aggregate</strong> for each chart below, select an aggregate to display for that particular chart</p>"
+        "json": "---\r\n## Top 10 Machines"
       },
       "conditionalVisibility": null
     },


### PR DESCRIPTION
Save additional vertical real-estate by moving helper text within the
parameters. Also set the default counter of the table to `Processor
Time`

Preview:
![image](https://user-images.githubusercontent.com/43890980/52587077-fe645c80-2ded-11e9-8b40-eecdf0d5f6cc.png)
