### PR TITLE
Update Performance Analysis for Single VM

### DIFF
--- a/Workbooks/Virtual Machines - Performance Analysis/Performance Analysis for a Single VM/Performance Analysis for a Single VM.workbook
+++ b/Workbooks/Virtual Machines - Performance Analysis/Performance Analysis for a Single VM/Performance Analysis for a Single VM.workbook
@@ -3,6 +3,13 @@
   "isLocked": true,
   "items": [
     {
+      "type": 1,
+      "content": {
+        "json": "# Performance Analysis"
+      },
+      "conditionalVisibility": null
+    },
+    {
       "type": 9,
       "content": {
         "version": "KqlParameterItem/1.0",
@@ -26,27 +33,7 @@
               ]
             },
             "timeContextFromParameter": null
-          }
-        ],
-        "style": "above",
-        "resourceType": "microsoft.compute/virtualmachines"
-      },
-      "conditionalVisibility": null
-    },
-    {
-      "type": 1,
-      "content": {
-        "json": "# Performance Analysis\nAnalyze the performance counters (processor, memory, disk, etc.) of `{Computer:label}`. You can also customize this workbook by clicking on the `Edit` button in the toolbar.\n\n<hr style=\"height: 3px;\" />\n\n## Trend\n\n💡 In the graph below a default counter (`Counter`) has been selected, select the pill to choose a different counter."
-      },
-      "conditionalVisibility": null
-    },
-    {
-      "type": 9,
-      "content": {
-        "version": "KqlParameterItem/1.0",
-        "query": "",
-        "crossComponentResources": [],
-        "parameters": [
+          },
           {
             "id": "cb7fdad2-dd9c-4c53-b2cb-572351dbbb3d",
             "version": "KqlParameterItem/1.0",
@@ -165,15 +152,41 @@
               "allowCustom": true
             },
             "timeContextFromParameter": null
-          },
+          }
+        ],
+        "style": "above",
+        "resourceType": "microsoft.compute/virtualmachines"
+      },
+      "conditionalVisibility": null
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "---\n## Trend\n💡 In the graph below a default counter (`Counter`) has been selected, select the dropdown to choose a different counter."
+      },
+      "conditionalVisibility": null
+    },
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "query": "",
+        "crossComponentResources": [
+          "{Computer}"
+        ],
+        "parameters": [
           {
             "id": "d495f8c1-c6b2-490e-8eb6-43d151bc20c0",
             "version": "KqlParameterItem/1.0",
             "name": "Counter",
             "type": 2,
+            "description": "Select a virtual machine performance counter to display in the chart below",
             "isRequired": true,
-            "query": "Perf\r\n| where TimeGenerated {TimeRange}\r\n| summarize by CounterName, ObjectName, CounterText = strcat(ObjectName, ' > ', CounterName)\r\n| order by ObjectName asc, CounterText asc\r\n| project Counter = pack('counter', CounterName, 'object', ObjectName), CounterText",
-            "value": "{\"counter\":\"% Used Inodes\",\"object\":\"Logical Disk\"}",
+            "query": "// {Computer:label}\r\nPerf\r\n| where TimeGenerated {TimeRange}\r\n| summarize by CounterName, ObjectName, CounterText = CounterName\r\n| order by ObjectName asc, CounterText asc\r\n| project Counter = pack('counter', CounterName, 'object', ObjectName), CounterText, group = ObjectName",
+            "crossComponentResources": [
+              "{Computer}"
+            ],
+            "value": "{\"counter\":\"% Processor Time\",\"object\":\"Processor\"}",
             "isHiddenWhenLocked": false,
             "typeSettings": {
               "additionalResourceOptions": []
@@ -206,8 +219,9 @@
           {
             "id": "dff91367-8a90-4d46-8a43-8595972eacc8",
             "version": "KqlParameterItem/1.0",
-            "name": "Percentiles",
+            "name": "Aggregates",
             "type": 2,
+            "description": "Select one or more aggregates for the performance counter to display in the chart below",
             "isRequired": true,
             "multiSelect": true,
             "quote": "",
@@ -226,28 +240,10 @@
       "conditionalVisibility": null
     },
     {
-      "type": 1,
-      "content": {
-        "json": "<p><strong>TimeRange</strong> Select a range of time in which to display data</p>\r\n\r\n<p><strong>Counter</strong> Select a virtual machine performance counter to display in the chart below</p>\r\n\r\n<p><strong>Percentiles</strong> Select one or more percentiles for the performance counter to display in the chart below</p>\r\n\r\n<hr style=\"height: 2px;\" />"
-      },
-      "conditionalVisibility": null
-    },
-    {
-      "type": 1,
-      "content": {
-        "json": "### {CounterText}"
-      },
-      "conditionalVisibility": {
-        "parameterName": "Counter",
-        "comparison": "isNotEqualTo",
-        "value": null
-      }
-    },
-    {
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let metric = dynamic({Counter});\r\nPerf\r\n| where TimeGenerated {TimeRange}\r\n| where ObjectName == metric.object and CounterName == metric.counter\r\n| summarize {Percentiles} by bin(TimeGenerated, totimespan('{grain}'))",
+        "query": "// {Computer:label}\r\nlet metric = dynamic({Counter});\r\nPerf\r\n| where TimeGenerated {TimeRange}\r\n| where ObjectName == metric.object and CounterName == metric.counter\r\n| summarize {Aggregates} by bin(TimeGenerated, totimespan('{grain}'))",
         "showQuery": false,
         "size": 0,
         "aggregation": 3,
@@ -266,7 +262,7 @@
     {
       "type": 1,
       "content": {
-        "json": "<hr style=\"height: 3px;\" />\n\n## Performance Charts\n💡 *Customize or add your own charts below in edit mode or by using the advanced editor*\n\n<hr style=\"height: 2px;\" />"
+        "json": "---\n## Performance Charts\n💡 *Customize or add your own charts below in edit mode or by using the advanced editor*"
       },
       "conditionalVisibility": null
     },
@@ -296,7 +292,7 @@
           {
             "id": "f4ab7159-2f3a-4720-96b2-2365a3e93617",
             "version": "KqlParameterItem/1.0",
-            "name": "Percentiles",
+            "name": "Aggregates",
             "type": 2,
             "isRequired": false,
             "multiSelect": true,
@@ -312,10 +308,10 @@
           {
             "id": "069034ca-ed62-48e7-b6ae-d90d1d6d7aaf",
             "version": "KqlParameterItem/1.0",
-            "name": "PercentilesLeft",
+            "name": "AggregatesLeft",
             "type": 1,
             "isRequired": false,
-            "query": "print \"{Percentiles}\"",
+            "query": "print \"{Aggregates}\"",
             "isHiddenWhenLocked": true,
             "timeContextFromParameter": null,
             "resourceType": "microsoft.compute/virtualmachines"
@@ -337,7 +333,7 @@
           {
             "id": "a1d2a8b9-9c5b-4d1f-b709-49dbd0fe94bd",
             "version": "KqlParameterItem/1.0",
-            "name": "Percentiles",
+            "name": "Aggregates",
             "type": 2,
             "isRequired": false,
             "multiSelect": true,
@@ -353,10 +349,10 @@
           {
             "id": "1f360103-df10-41c7-8f82-13edd11461aa",
             "version": "KqlParameterItem/1.0",
-            "name": "PercentilesRight",
+            "name": "AggregatesRight",
             "type": 1,
             "isRequired": false,
-            "query": "print \"{Percentiles}\"",
+            "query": "print \"{Aggregates}\"",
             "isHiddenWhenLocked": true,
             "timeContextFromParameter": null,
             "resourceType": "microsoft.compute/virtualmachines"
@@ -372,7 +368,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let metric = dynamic({\"counter\": \"% Processor Time\", \"object\": \"Processor\"});\nPerf\n| where TimeGenerated {TimeRange}\n| where (ObjectName == 'Processor' and InstanceName == '_Total' and CounterName == '% Processor Time')\n| where InstanceName == '_Total'\n| summarize {PercentilesLeft} by bin(TimeGenerated, totimespan('{grain}'))",
+        "query": "let metric = dynamic({\"counter\": \"% Processor Time\", \"object\": \"Processor\"});\nPerf\n| where TimeGenerated {TimeRange}\n| where (ObjectName == 'Processor' and InstanceName == '_Total' and CounterName == '% Processor Time')\n| where InstanceName == '_Total'\n| summarize {AggregatesLeft} by bin(TimeGenerated, totimespan('{grain}'))",
         "showQuery": false,
         "size": 0,
         "aggregation": 3,
@@ -393,7 +389,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "Perf\r\n| where TimeGenerated {TimeRange}\r\n| where (ObjectName == 'Memory' and CounterName in ('Available MBytes', 'Available MBytes Memory'))\r\n| summarize {PercentilesRight} by bin(TimeGenerated, totimespan('{grain}'))",
+        "query": "Perf\r\n| where TimeGenerated {TimeRange}\r\n| where (ObjectName == 'Memory' and CounterName in ('Available MBytes', 'Available MBytes Memory'))\r\n| summarize {AggregatesRight} by bin(TimeGenerated, totimespan('{grain}'))",
         "showQuery": false,
         "size": 0,
         "aggregation": 3,
@@ -436,7 +432,7 @@
           {
             "id": "547dae05-22bf-47a5-ad44-043a23995759",
             "version": "KqlParameterItem/1.0",
-            "name": "Percentiles",
+            "name": "Aggregates",
             "type": 2,
             "isRequired": false,
             "multiSelect": true,
@@ -452,10 +448,10 @@
           {
             "id": "1af979b2-3131-4771-bf02-30193138c565",
             "version": "KqlParameterItem/1.0",
-            "name": "PercentilesLeft",
+            "name": "AggregatesLeft",
             "type": 1,
             "isRequired": false,
-            "query": "print \"{Percentiles}\"",
+            "query": "print \"{Aggregates}\"",
             "isHiddenWhenLocked": true,
             "timeContextFromParameter": null,
             "resourceType": "microsoft.compute/virtualmachines"
@@ -477,7 +473,7 @@
           {
             "id": "8aaa181d-7182-4d9d-b74e-22f37e3acbce",
             "version": "KqlParameterItem/1.0",
-            "name": "Percentiles",
+            "name": "Aggregates",
             "type": 2,
             "isRequired": false,
             "multiSelect": true,
@@ -493,10 +489,10 @@
           {
             "id": "c021b342-6bc8-4870-a88b-8ddf0b8b9cfa",
             "version": "KqlParameterItem/1.0",
-            "name": "PercentilesRight",
+            "name": "AggregatesRight",
             "type": 1,
             "isRequired": false,
-            "query": "print \"{Percentiles}\"",
+            "query": "print \"{Aggregates}\"",
             "isHiddenWhenLocked": true,
             "timeContextFromParameter": null,
             "resourceType": "microsoft.compute/virtualmachines"
@@ -512,7 +508,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "Perf\r\n| where TimeGenerated {TimeRange}\r\n| where (ObjectName == 'Logical Disk' and InstanceName != '_Total' and CounterName == 'Disk Transfers/sec')\r\n| summarize {PercentilesLeft} by bin(TimeGenerated, totimespan('{grain}'))",
+        "query": "Perf\r\n| where TimeGenerated {TimeRange}\r\n| where (ObjectName == 'Logical Disk' and InstanceName != '_Total' and CounterName == 'Disk Transfers/sec')\r\n| summarize {AggregatesLeft} by bin(TimeGenerated, totimespan('{grain}'))",
         "showQuery": false,
         "size": 0,
         "aggregation": 3,
@@ -533,7 +529,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "Perf\r\n| where TimeGenerated {TimeRange}\r\n| where (ObjectName == 'Logical Disk' and InstanceName != '_Total' and CounterName == 'Logical Disk Bytes/sec')\r\n| summarize {PercentilesRight} by bin(TimeGenerated, totimespan('{grain}'))",
+        "query": "Perf\r\n| where TimeGenerated {TimeRange}\r\n| where (ObjectName == 'Logical Disk' and InstanceName != '_Total' and CounterName == 'Logical Disk Bytes/sec')\r\n| summarize {AggregatesRight} by bin(TimeGenerated, totimespan('{grain}'))",
         "showQuery": false,
         "size": 0,
         "aggregation": 3,
@@ -589,7 +585,7 @@
           {
             "id": "f963e52a-2099-4cd3-a3ad-0fdf78f38238",
             "version": "KqlParameterItem/1.0",
-            "name": "Percentiles",
+            "name": "Aggregates",
             "type": 2,
             "isRequired": false,
             "multiSelect": true,
@@ -605,10 +601,10 @@
           {
             "id": "6c5d9373-5403-44e5-b496-7155c338f958",
             "version": "KqlParameterItem/1.0",
-            "name": "PercentilesRight",
+            "name": "AggregatesRight",
             "type": 1,
             "isRequired": false,
-            "query": "print \"{Percentiles}\"",
+            "query": "print \"{Aggregates}\"",
             "isHiddenWhenLocked": true,
             "timeContextFromParameter": null,
             "resourceType": "microsoft.compute/virtualmachines"
@@ -645,7 +641,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let grain = totimespan('{grain}');\r\nlet windowsNetwork=Perf\r\n| where TimeGenerated {TimeRange}\r\n| where ObjectName == 'Network Adapter' and CounterName == 'Bytes Sent/sec'\r\n| summarize CounterValue = sum(CounterValue) by bin(TimeGenerated, 2s);\r\nlet linuxNetwork=Perf\r\n| where TimeGenerated {TimeRange}\r\n| where ObjectName == 'Network' and CounterName == 'Total Bytes Transmitted'\r\n| order by InstanceName, TimeGenerated asc\r\n| extend prev_Value=prev(CounterValue), prev_t=prev(TimeGenerated), prev_instance=prev(InstanceName)\r\n| project TimeGenerated, CounterValue=iff(prev_instance == InstanceName and CounterValue >= prev_Value and TimeGenerated > prev_t, (CounterValue - prev_Value) / ((TimeGenerated - prev_t) / 1s), real(0))\r\n| summarize CounterValue = sum(CounterValue) by bin(TimeGenerated, 2s);\r\nlet networkDataSend = union windowsNetwork, linuxNetwork;\r\nnetworkDataSend\r\n| summarize {PercentilesRight} by bin(TimeGenerated, grain)",
+        "query": "let grain = totimespan('{grain}');\r\nlet windowsNetwork=Perf\r\n| where TimeGenerated {TimeRange}\r\n| where ObjectName == 'Network Adapter' and CounterName == 'Bytes Sent/sec'\r\n| summarize CounterValue = sum(CounterValue) by bin(TimeGenerated, 2s);\r\nlet linuxNetwork=Perf\r\n| where TimeGenerated {TimeRange}\r\n| where ObjectName == 'Network' and CounterName == 'Total Bytes Transmitted'\r\n| order by InstanceName, TimeGenerated asc\r\n| extend prev_Value=prev(CounterValue), prev_t=prev(TimeGenerated), prev_instance=prev(InstanceName)\r\n| project TimeGenerated, CounterValue=iff(prev_instance == InstanceName and CounterValue >= prev_Value and TimeGenerated > prev_t, (CounterValue - prev_Value) / ((TimeGenerated - prev_t) / 1s), real(0))\r\n| summarize CounterValue = sum(CounterValue) by bin(TimeGenerated, 2s);\r\nlet networkDataSend = union windowsNetwork, linuxNetwork;\r\nnetworkDataSend\r\n| summarize {AggregatesRight} by bin(TimeGenerated, grain)",
         "showQuery": false,
         "size": 0,
         "aggregation": 3,
@@ -688,7 +684,7 @@
           {
             "id": "c0592d9a-edd4-4a69-86c0-098ac0c72cf2",
             "version": "KqlParameterItem/1.0",
-            "name": "Percentiles",
+            "name": "Aggregates",
             "type": 2,
             "isRequired": false,
             "multiSelect": true,
@@ -704,10 +700,10 @@
           {
             "id": "d4795fc0-c995-4975-8bc6-e515dbad00be",
             "version": "KqlParameterItem/1.0",
-            "name": "PercentilesLeft",
+            "name": "AggregatesLeft",
             "type": 1,
             "isRequired": false,
-            "query": "print \"{Percentiles}\"",
+            "query": "print \"{Aggregates}\"",
             "isHiddenWhenLocked": true,
             "timeContextFromParameter": null,
             "resourceType": "microsoft.compute/virtualmachines"
@@ -736,7 +732,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let grain = totimespan('{grain}');\r\nlet windowsNetwork=Perf\r\n| where TimeGenerated {TimeRange}\r\n| where ObjectName == 'Network Adapter' and CounterName == 'Bytes Received/sec'\r\n| summarize CounterValue = sum(CounterValue) by bin(TimeGenerated, 2s);\r\nlet linuxNetwork=Perf\r\n| where TimeGenerated {TimeRange}\r\n| where ObjectName == 'Network' and CounterName == 'Total Bytes Received'\r\n| order by InstanceName, TimeGenerated asc\r\n| extend prev_Value = prev(CounterValue), prev_t = prev(TimeGenerated), prev_instance = prev(InstanceName)\r\n| project TimeGenerated, CounterValue = iff(prev_instance == InstanceName and CounterValue >= prev_Value and TimeGenerated > prev_t, (CounterValue - prev_Value) / ((TimeGenerated - prev_t) / 1s), real(0))\r\n| summarize CounterValue = sum(CounterValue) by bin(TimeGenerated, 2s);\r\nlet networkDataReceive = union windowsNetwork, linuxNetwork;\r\nnetworkDataReceive\r\n| summarize {PercentilesLeft} by bin(TimeGenerated, grain)",
+        "query": "let grain = totimespan('{grain}');\r\nlet windowsNetwork=Perf\r\n| where TimeGenerated {TimeRange}\r\n| where ObjectName == 'Network Adapter' and CounterName == 'Bytes Received/sec'\r\n| summarize CounterValue = sum(CounterValue) by bin(TimeGenerated, 2s);\r\nlet linuxNetwork=Perf\r\n| where TimeGenerated {TimeRange}\r\n| where ObjectName == 'Network' and CounterName == 'Total Bytes Received'\r\n| order by InstanceName, TimeGenerated asc\r\n| extend prev_Value = prev(CounterValue), prev_t = prev(TimeGenerated), prev_instance = prev(InstanceName)\r\n| project TimeGenerated, CounterValue = iff(prev_instance == InstanceName and CounterValue >= prev_Value and TimeGenerated > prev_t, (CounterValue - prev_Value) / ((TimeGenerated - prev_t) / 1s), real(0))\r\n| summarize CounterValue = sum(CounterValue) by bin(TimeGenerated, 2s);\r\nlet networkDataReceive = union windowsNetwork, linuxNetwork;\r\nnetworkDataReceive\r\n| summarize {AggregatesLeft} by bin(TimeGenerated, grain)",
         "showQuery": false,
         "size": 0,
         "aggregation": 3,


### PR DESCRIPTION
Align Performance Analysis workbook with its AtScale counterpart. Minor
cosmetic changes including changing `Percentiles` label back to
`Aggregates`. Also improve `Counter` dropdown.

Preview:
![image](https://user-images.githubusercontent.com/43890980/52680970-25568780-2eef-11e9-8cc2-be1d0846a7ae.png)
