### PR TITLE
Update Connections Overview for Single VM

### DIFF
--- a/Workbooks/Virtual Machines - Network Dependencies/Connections Overview - Single VM/Connections Overview.workbook
+++ b/Workbooks/Virtual Machines - Network Dependencies/Connections Overview - Single VM/Connections Overview.workbook
@@ -3,32 +3,23 @@
   "isLocked": true,
   "items": [
     {
+      "type": 1,
+      "content": {
+        "json": "<h1>Connections Overview</h1>"
+      },
+      "conditionalVisibility": null
+    },
+    {
       "type": 9,
       "content": {
         "version": "KqlParameterItem/1.0",
         "query": "",
-        "crossComponentResources": [],
+        "crossComponentResources": [
+          "{Computer}"
+        ],
         "parameters": [
           {
             "id": "e41c2177-932a-4c58-ba24-03ef070eb197",
-            "version": "KqlParameterItem/1.0",
-            "name": "Workspace",
-            "type": 5,
-            "isRequired": true,
-            "value": "value::1",
-            "isHiddenWhenLocked": true,
-            "typeSettings": {
-              "resourceTypeFilter": {
-                "microsoft.operationalinsights/workspaces": true
-              },
-              "additionalResourceOptions": [
-                "value::1"
-              ]
-            },
-            "timeContextFromParameter": null
-          },
-          {
-            "id": "67b8a28c-f7f9-4903-883d-4a308a6ffe71",
             "version": "KqlParameterItem/1.0",
             "name": "Computer",
             "type": 5,
@@ -46,18 +37,46 @@
             "timeContextFromParameter": null
           },
           {
-            "id": "68692e38-3c2c-4fd2-8e03-2357f2275142",
+            "id": "a9393837-8ef0-40e5-b223-4df1208a691e",
             "version": "KqlParameterItem/1.0",
-            "name": "ComputerName",
+            "name": "Test",
             "type": 1,
-            "isRequired": true,
-            "query": "print '{Computer:label}'",
+            "isRequired": false,
+            "query": "VMConnection\r\n| summarize count()",
             "crossComponentResources": [
-              "{Workspace}"
+              "{Computer}"
             ],
             "isHiddenWhenLocked": true,
             "timeContextFromParameter": null,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "resourceType": "microsoft.compute/virtualmachines"
+          },
+          {
+            "id": "57fbe5b3-bf7c-445d-ab80-f76e56615f67",
+            "version": "KqlParameterItem/1.0",
+            "name": "EmptyOrOnboard",
+            "type": 1,
+            "isRequired": false,
+            "query": "print '{Test}'",
+            "crossComponentResources": [
+              "{Computer}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "resourceType": "microsoft.compute/virtualmachines"
+          },
+          {
+            "id": "648ac90d-4be5-4c08-ac13-bcff7f8ddbf9",
+            "version": "KqlParameterItem/1.0",
+            "name": "DisclaimerText",
+            "type": 1,
+            "isRequired": false,
+            "query": "print iff('{EmptyOrOnboard}' == '' , 'This workbook requires [Azure Monitor for VMs (preview)](https://docs.microsoft.com/en-us/azure/azure-monitor/insights/vminsights-overview) enabled', iff('{EmptyOrOnboard}' == '0', '⚠ There is currently no `VMConnection` data for this virtual machine', ''))",
+            "crossComponentResources": [
+              "{Computer}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "resourceType": "microsoft.compute/virtualmachines"
           }
         ],
         "style": "above",
@@ -70,96 +89,20 @@
       }
     },
     {
+      "type": 1,
+      "content": {
+        "json": "{DisclaimerText}\r\n\r\n---"
+      },
+      "conditionalVisibility": null
+    },
+    {
       "type": 9,
       "content": {
         "version": "KqlParameterItem/1.0",
         "query": "",
         "crossComponentResources": [
-          "{Workspace}"
+          "{Computer}"
         ],
-        "parameters": [
-          {
-            "id": "2debcfba-e410-4300-9886-78069cef42e0",
-            "version": "KqlParameterItem/1.0",
-            "name": "_A_ComputerName",
-            "type": 1,
-            "isRequired": false,
-            "query": "print(iff(\"{ComputerName}\" == \"undefined\", \"\", \"<h2 style='color:#777;font-weight:normal;margin-top:0;padding-top:0;font-size:1rem;'>{ComputerName}</h2>\"));",
-            "crossComponentResources": [
-              "{Workspace}"
-            ],
-            "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
-            "resourceType": "microsoft.operationalinsights/workspaces"
-          },
-          {
-            "id": "648ac90d-4be5-4c08-ac13-bcff7f8ddbf9",
-            "version": "KqlParameterItem/1.0",
-            "name": "_A_HeaderTextPrefix",
-            "type": 1,
-            "isRequired": false,
-            "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
-            "value": "This workbook requires [Azure Monitor for VMs (preview)](https://docs.microsoft.com/en-us/azure/azure-monitor/insights/vminsights-overview) enabled"
-          },
-          {
-            "id": "b902566a-20d1-4137-9944-24fcd5f2fe1b",
-            "version": "KqlParameterItem/1.0",
-            "name": "_A_HeaderTextSuffix",
-            "type": 1,
-            "isRequired": false,
-            "query": "print(iff(\"{ComputerName}\" == \"undefined\", \"in your workspace\", \"for your machine `{ComputerName}`\"));",
-            "crossComponentResources": [
-              "{Workspace}"
-            ],
-            "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
-            "resourceType": "microsoft.operationalinsights/workspaces"
-          },
-          {
-            "id": "fccd76d3-382b-4c2b-a39b-2653503c504b",
-            "version": "KqlParameterItem/1.0",
-            "name": "_A_HeaderStyle",
-            "type": 1,
-            "isRequired": false,
-            "query": "print(iff(\"{ComputerName}\" == \"undefined\", \"\", \"margin:0;padding:0;\"));",
-            "crossComponentResources": [
-              "{Workspace}"
-            ],
-            "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
-            "resourceType": "microsoft.operationalinsights/workspaces"
-          }
-        ],
-        "style": "above",
-        "resourceType": "microsoft.operationalinsights/workspaces"
-      },
-      "conditionalVisibility": {
-        "parameterName": "_",
-        "comparison": "isNotEqualTo",
-        "value": null
-      }
-    },
-    {
-      "type": 1,
-      "content": {
-        "json": "<h1 style=\"{_A_HeaderStyle}\">Connections Overview</h1>{_A_ComputerName}\r\n{_A_HeaderTextPrefix} {_A_HeaderTextSuffix}"
-      },
-      "conditionalVisibility": null
-    },
-    {
-      "type": 1,
-      "content": {
-        "json": "---\r\n\r\n## Connection Statistics\r\n\r\nThe following table presents the connection statistics for computers in your workspace (max `10,000` rows).\r\n\r\nUse the <em>Hierarchy</em> dropdown for more detailed information for each computer but fewer computers will be shown if the total number of rows rendered exceeds `10,000`.\r\n\r\n<hr style=\"border: none;height: 2px;color: grey;\" />"
-      },
-      "conditionalVisibility": null
-    },
-    {
-      "type": 9,
-      "content": {
-        "version": "KqlParameterItem/1.0",
-        "query": "",
-        "crossComponentResources": [],
         "parameters": [
           {
             "id": "306614b4-14f2-4777-a044-8c1121f04d6d",
@@ -299,78 +242,15 @@
             "version": "KqlParameterItem/1.0",
             "name": "Direction",
             "type": 2,
+            "description": "Direction of the network connection from the VMs",
             "isRequired": true,
             "value": "outbound",
-            "isHiddenWhenLocked": false,
-            "jsonData": "[\r\n    { \"value\":\"inbound\", \"label\":\"Inbound\" },\r\n    { \"value\":\"outbound\", \"label\":\"Outbound\" }\r\n]",
-            "timeContextFromParameter": null
-          },
-          {
-            "id": "56ab6626-c12d-4de1-8a3d-8a6099db3cd3",
-            "version": "KqlParameterItem/1.0",
-            "name": "Hierarchy",
-            "type": 2,
-            "isRequired": true,
-            "query": "datatable (value:string, Display:string)\r\n    [\"0\", \"Computer -> Process -> IP -> Port\",\r\n     \"1\", \"Computer -> Process -> IP\",\r\n     \"2\", \"Computer -> Process\",\r\n     \"3\", \"Computer\"]",
-            "crossComponentResources": [],
-            "value": "2",
-            "isHiddenWhenLocked": false,
-            "timeContextFromParameter": null,
-            "resourceType": "microsoft.operationalinsights/workspaces"
-          }
-        ],
-        "style": "above",
-        "resourceType": "microsoft.operationalinsights/workspaces"
-      },
-      "conditionalVisibility": null
-    },
-    {
-      "type": 1,
-      "content": {
-        "json": "<p><strong>TimeRange</strong> specifies how far back in time to gather connection statistics. Selecting a large time range will result in a long query processing time.</p>\r\n<p><strong>Direction</strong> either shows <em>Inbound</em> or <em>Outbound</em> network connections.</p>\r\n<p><strong>Hierarchy</strong> specifies the level of detail for each computer. Selecting a larger hierarchy will cause fewer computers to be displayed but more information for each computer in the table below.</p>\r\n\r\n<hr style=\"height: 1px;\" />"
-      },
-      "conditionalVisibility": null
-    },
-    {
-      "type": 9,
-      "content": {
-        "version": "KqlParameterItem/1.0",
-        "query": "",
-        "crossComponentResources": [
-          "{Workspace}"
-        ],
-        "parameters": [
-          {
-            "id": "8744c427-f060-4725-95af-850af2fa08b1",
-            "version": "KqlParameterItem/1.0",
-            "name": "ComputerNameContains",
-            "type": 1,
-            "isRequired": false,
-            "isHiddenWhenLocked": false,
-            "timeContextFromParameter": null
-          },
-          {
-            "id": "b141bd6c-cd8d-488e-a5f6-83ab00d31161",
-            "version": "KqlParameterItem/1.0",
-            "name": "Computers",
-            "type": 2,
-            "isRequired": false,
-            "multiSelect": true,
-            "quote": "'",
-            "delimiter": ",",
-            "query": "VMConnection\r\n| where TimeGenerated {TimeRange}\r\n| where Computer contains '{ComputerNameContains}'\r\n| summarize by Computer\r\n| project Value = Computer, Display = Computer\r\n| order by Display asc\r\n| union (datatable(Value:string, Display:string)['*', 'All'])",
-            "crossComponentResources": [
-              "{Workspace}"
-            ],
-            "value": [
-              "*"
-            ],
             "isHiddenWhenLocked": false,
             "typeSettings": {
               "additionalResourceOptions": []
             },
-            "timeContextFromParameter": null,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "jsonData": "[\r\n    { \"value\":\"inbound\", \"label\":\"Inbound\" },\r\n    { \"value\":\"outbound\", \"label\":\"Outbound\" }\r\n]",
+            "timeContextFromParameter": null
           },
           {
             "id": "488d1f86-cabc-4fcc-8dc9-9a2e5803fb20",
@@ -378,34 +258,83 @@
             "name": "ComputerFilter",
             "type": 1,
             "isRequired": true,
-            "query": "let computerFilter = iff('*' in ({Computers}), \"| where Computer contains '{ComputerNameContains}'\", \"| where Computer in ({Computers})\");\r\nprint(computerFilter)",
+            "query": "let computerFilter = strcat(\"| where Computer == \", \"'{Computer:label}'\");\r\nprint(computerFilter)",
             "crossComponentResources": [
-              "{Workspace}"
+              "{Computer}"
             ],
             "isHiddenWhenLocked": true,
             "timeContextFromParameter": null,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "resourceType": "microsoft.compute/virtualmachines"
+          },
+          {
+            "id": "56ab6626-c12d-4de1-8a3d-8a6099db3cd3",
+            "version": "KqlParameterItem/1.0",
+            "name": "Hierarchy",
+            "type": 2,
+            "description": "Select the level of detail to be shown in the table below",
+            "isRequired": true,
+            "query": "let outboundTable = datatable (value:string, Display:string)\r\n    [\"0\", \"Computer -> Process -> Remote IP -> Port\",\r\n     \"1\", \"Computer -> Process -> Remote IP\",\r\n     \"2\", \"Computer -> Process\",\r\n     \"3\", \"Computer\"];\r\nlet outbound = outboundTable | extend type = 'outbound';\r\nlet inboundTable = datatable (value:string, Display:string)\r\n    [\"0\", \"Computer -> Process -> Port -> Remote IP\",\r\n     \"1\", \"Computer -> Process -> Port\",\r\n     \"2\", \"Computer -> Process\",\r\n     \"3\", \"Computer\"];\r\nlet inbound = inboundTable | extend type = 'inbound';\r\nlet table = outbound | union inbound;\r\ntable\r\n| where type == iif('{Direction}' == 'outbound', 'outbound', 'inbound')\r\n| project value, Display",
+            "crossComponentResources": [
+              "{Computer}"
+            ],
+            "value": "0",
+            "isHiddenWhenLocked": false,
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "timeContextFromParameter": null,
+            "resourceType": "microsoft.compute/virtualmachines"
+          },
+          {
+            "id": "45b5c7ed-5003-4cbf-88d6-33cfe45bb4e4",
+            "version": "KqlParameterItem/1.0",
+            "name": "OnlyMaliciousConnections",
+            "type": 2,
+            "description": "Show only malicious connections",
+            "isRequired": true,
+            "value": "0",
+            "isHiddenWhenLocked": false,
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "jsonData": "[\r\n    {\r\n        \"label\": \"Yes\",\r\n        \"value\": \"1\"\r\n    },\r\n    {\r\n        \"label\": \"No\",\r\n        \"value\": \"0\"\r\n    }\r\n]",
+            "timeContextFromParameter": null
+          },
+          {
+            "id": "6fb4b7bc-8007-4e30-bcf1-dc87fc37e45c",
+            "version": "KqlParameterItem/1.0",
+            "name": "OnlyLinksFailed",
+            "type": 2,
+            "description": "Show entries with at least one failed link",
+            "isRequired": true,
+            "value": "0",
+            "isHiddenWhenLocked": false,
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "jsonData": "[\r\n    {\r\n        \"label\": \"Yes\",\r\n        \"value\": \"1\"\r\n    },\r\n    {\r\n        \"label\": \"No\",\r\n        \"value\": \"0\"\r\n    }\r\n]",
+            "timeContextFromParameter": null
+          },
+          {
+            "id": "3c1af9eb-0a2b-4b1d-a17d-749a9f437208",
+            "version": "KqlParameterItem/1.0",
+            "name": "HighResponseTime",
+            "type": 2,
+            "description": "Show entries with average response time greater than or equal to 1s",
+            "isRequired": true,
+            "value": "0",
+            "isHiddenWhenLocked": false,
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "jsonData": "[\r\n    {\r\n        \"label\": \"Yes\",\r\n        \"value\": \"1000\"\r\n    },\r\n    {\r\n        \"label\": \"No\",\r\n        \"value\": \"0\"\r\n    }\r\n]",
+            "timeContextFromParameter": null
           }
         ],
         "style": "above",
-        "resourceType": "microsoft.operationalinsights/workspaces"
+        "resourceType": "microsoft.compute/virtualmachines"
       },
-      "conditionalVisibility": {
-        "parameterName": "ComputerName",
-        "comparison": "isEqualTo",
-        "value": "undefined"
-      }
-    },
-    {
-      "type": 1,
-      "content": {
-        "json": "<p><strong>ComputerNameContains</strong> by default will show <em>any</em> computers. Specify a string to narrow down the computers you are interested in so more data can be shown in the table below.</p>\r\n<p><strong>Computers</strong> by default all computers in the current workspace will be selected. Select one or more computers to further narrow down the table below.</p>\r\n\r\n<hr style=\"height: 1px;\" />"
-      },
-      "conditionalVisibility": {
-        "parameterName": "ComputerName",
-        "comparison": "isEqualTo",
-        "value": "undefined"
-      }
+      "conditionalVisibility": null
     },
     {
       "type": 9,
@@ -413,7 +342,7 @@
         "version": "KqlParameterItem/1.0",
         "query": "",
         "crossComponentResources": [
-          "{Workspace}"
+          "{Computer}"
         ],
         "parameters": [
           {
@@ -422,10 +351,13 @@
             "name": "ServiceMapComputers",
             "type": 1,
             "isRequired": true,
-            "query": "print(strcat(\"let computers = ServiceMapComputer_CL \", iff(\"{ComputerName}\" == \"undefined\", \"\", \" | where Computer == '{ComputerName}'\"), \"| where 'run' == 'run' | where TimeGenerated > ago(1h) | summarize (TimeGenerated, Properties) = arg_max(TimeGenerated, pack_all()) by Computer;\"));",
+            "query": "// {Computer:label}\r\nprint(\"let computers = ServiceMapComputer_CL | where 'run' == 'run' | where TimeGenerated {TimeRange} | summarize (TimeGenerated, Properties) = arg_max(TimeGenerated, pack_all()) by Computer;\");",
+            "crossComponentResources": [
+              "{Computer}"
+            ],
             "isHiddenWhenLocked": true,
             "timeContextFromParameter": null,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "resourceType": "microsoft.compute/virtualmachines"
           },
           {
             "id": "c69fbaae-4fd2-4527-acdd-a2c358eebffa",
@@ -433,13 +365,13 @@
             "name": "MaliciousIpData",
             "type": 1,
             "isRequired": false,
-            "query": "print(strcat(\"let maliciousIpData = VMConnection\", iff(\"{ComputerName}\" == \"undefined\", \"\", \" | where Computer == '{ComputerName}'\"),\" | where '{GridRefresh}' == 'run' | where TimeGenerated {TimeRange} | where Direction == '{Direction}' {ComputerFilter} | where MaliciousIp != '' | summarize argmax(TimeGenerated, *) by MaliciousIp | project MaliciousIp = strcat(max_TimeGenerated_Computer, '-', max_TimeGenerated_ProcessName, '-', MaliciousIp), Computer = max_TimeGenerated_Computer, Process = strcat(max_TimeGenerated_Computer, '-', max_TimeGenerated_ProcessName), MaliciousIpInfo = pack('Malicious IP', MaliciousIp, 'Is Active', max_TimeGenerated_IsActive, 'Indicator Threat Type', max_TimeGenerated_IndicatorThreatType, 'Remote Country', max_TimeGenerated_RemoteCountry, 'Longitude', max_TimeGenerated_RemoteLongitude, 'Latitude', max_TimeGenerated_RemoteLatitude, 'Confidence', max_TimeGenerated_Confidence, 'Severity', max_TimeGenerated_Severity, 'First Reported DateTime', max_TimeGenerated_FirstReportedDateTime, 'Last Reported DateTime', max_TimeGenerated_LastReportedDateTime, 'Report Reference Link', max_TimeGenerated_ReportReferenceLink);\"));\r\n",
+            "query": "// {Computer:label}\r\nprint(\"let maliciousIpData = VMConnection | where '{GridRefresh}' == 'run' | where TimeGenerated {TimeRange} | where Direction == '{Direction}' {ComputerFilter} | where MaliciousIp != '' | summarize by Computer, ProcessName, MaliciousIp, DestinationPort, RemoteIp, IsActive, IndicatorThreatType, RemoteCountry, RemoteLongitude, RemoteLatitude, Confidence, Severity, FirstReportedDateTime, LastReportedDateTime | project MaliciousIp = strcat(Computer, '-', ProcessName, '-', MaliciousIp), MaliciousPort = strcat(Computer, '-', ProcessName, '-', DestinationPort), MaliciousPortIp = strcat(Computer, '-', ProcessName, '-', DestinationPort, '-', RemoteIp), Computer = Computer, Process = strcat(Computer, '-', ProcessName), MaliciousIpInfo = pack('Malicious IP', MaliciousIp, 'Is Active', IsActive, 'Indicator Threat Type', IndicatorThreatType, 'Remote Country', RemoteCountry, 'Longitude', RemoteLongitude, 'Latitude', RemoteLatitude, 'Confidence', Confidence, 'Severity', Severity, 'First Reported DateTime', FirstReportedDateTime, 'Last Reported DateTime', LastReportedDateTime, 'Destination Port', DestinationPort, 'Remote IP', RemoteIp);\");",
             "crossComponentResources": [
-              "{Workspace}"
+              "{Computer}"
             ],
             "isHiddenWhenLocked": true,
             "timeContextFromParameter": null,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "resourceType": "microsoft.compute/virtualmachines"
           },
           {
             "id": "dd933ac8-1273-48fe-8d09-bd65d857ce83",
@@ -447,13 +379,97 @@
             "name": "ComputerData",
             "type": 1,
             "isRequired": false,
-            "query": "print(strcat(\"let computerData = VMConnection\", iff(\"{ComputerName}\" == \"undefined\", \"\", \" | where Computer == '{ComputerName}'\"), \" | where '{GridRefresh}' == 'run' | where TimeGenerated {TimeRange} | where Direction == '{Direction}' {ComputerFilter} | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) by  Name = strcat('🖥️ ', Computer), Type = 'Computer', TypeKey = 1, Key = Computer, ParentKey = '---' | join kind=leftouter (maliciousIpData | summarize MaliciousIpInfo = tostring(count()) by Computer) on $left.Key == $right.Computer | project-away Computer | order by Name asc;\"));",
+            "query": "// {Computer:label}\r\nprint(\"let computerData = VMConnection | where '{GridRefresh}' == 'run' | where TimeGenerated {TimeRange} | where Direction == '{Direction}' {ComputerFilter} | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 * sum(ResponseTimeSum) / sum(Responses) by Name = strcat('🖥️ ', Computer), ComputerName = Computer, Type = 'Computer', TypeKey = 1, Key = Computer, ParentKey = '---' | join kind=leftouter (maliciousIpData | summarize MaliciousIpInfo = tostring(count()) by Computer) on $left.Key == $right.Computer | project-away Computer | order by Name asc;\");",
             "crossComponentResources": [
-              "{Workspace}"
+              "{Computer}"
             ],
             "isHiddenWhenLocked": true,
             "timeContextFromParameter": null,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "resourceType": "microsoft.compute/virtualmachines"
+          },
+          {
+            "id": "fb879823-c082-4c53-af7e-18d044032f99",
+            "version": "KqlParameterItem/1.0",
+            "name": "RemoteIpDataInbound",
+            "type": 1,
+            "isRequired": false,
+            "query": "// {Computer:label}\r\nprint(\"let remoteIpDataInbound = VMConnection | where 'run' == 'run' | where TimeGenerated {TimeRange} | where Direction == 'inbound' | where 'inbound' == 'inbound' | where Computer contains '' | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) by Computer, ProcessName, RemoteIp, Type = 'Remote Computer', TypeKey = 3, Key = strcat(Computer, '-', ProcessName, '-', tostring(DestinationPort), '-', RemoteIp), ParentKey = strcat(Computer, '-', ProcessName, '-', tostring(DestinationPort)), Id = strcat(Computer, '-', ProcessName, '-', RemoteIp), ComputerName = Computer | join kind=inner     sourcePortData on $left.ParentKey == $right.Key | project-away AverageResponseTime1, Computer1, Key1, LinksFailed1, MaxLinksLive1, ParentKey1, ProcessName1, Responses1, TotalBytesReceived1, TotalBytesSent1, Type1, TypeKey1 | order by Name asc | join kind=leftouter     ipComputerMapping on $left.RemoteIp == $right.Ipv4 | extend Name = iff(RemoteIp == '', 'Unknown',  strcat('🌐 External (', RemoteIp, ')')) | project-away Computer, Ipv4 | order by Name desc | join kind=leftouter     maliciousIpData on $left.Key == $right.MaliciousPortIp | extend MaliciousIpInfo = tostring(MaliciousIpInfo1) | project-away MaliciousIp, Computer, Process, Computer1, MaliciousIpInfo1, Id;\");",
+            "crossComponentResources": [
+              "{Computer}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "resourceType": "microsoft.compute/virtualmachines"
+          },
+          {
+            "id": "3ad60c70-b530-49c0-a59b-8df690dffbc8",
+            "version": "KqlParameterItem/1.0",
+            "name": "ProcessName",
+            "type": 1,
+            "isRequired": false,
+            "query": "// {Computer:label}\r\nprint(\"let processData = VMConnection | where '{GridRefresh}' == 'run' | where TimeGenerated {TimeRange} | where Direction == '{Direction}' {ComputerFilter} | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) by Computer, ProcessName, Name = strcat('🎫 ', ProcessName), Type = 'Process', TypeKey = 2, Key = strcat(Computer, '-', ProcessName), ParentKey = Computer, ComputerName = Computer | join kind=inner computerData on $left.ParentKey == $right.Key | project-away Name1, Responses1, LinksFailed1, MaxLinksLive1, TotalBytesSent1, TotalBytesReceived1, AverageResponseTime1, Type1, Key1, ParentKey1 | join kind=leftouter (maliciousIpData | summarize MaliciousIpInfo = tostring(count()) by Process) on $left.Key == $right.Process | project-away Process, MaliciousIpInfo | extend MaliciousIpInfo = tostring(MaliciousIpInfo1) | project-away MaliciousIpInfo1 | order by Name asc;\");",
+            "crossComponentResources": [
+              "{Computer}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "resourceType": "microsoft.compute/virtualmachines"
+          },
+          {
+            "id": "c9eea7db-3d14-4fbf-8ae6-b7507ec1d43f",
+            "version": "KqlParameterItem/1.0",
+            "name": "RemoteIpData",
+            "type": 1,
+            "isRequired": true,
+            "query": "// {Computer:label}\r\nprint(\"let remoteIpData = VMConnection | where '{GridRefresh}' == 'run' | where TimeGenerated {TimeRange} | where '{Direction}' == 'outbound' | where Direction == '{Direction}' {ComputerFilter} | extend RemoteIp = iff(Direction == 'outbound', DestinationIp, SourceIp) | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) by Computer, ProcessName, RemoteIp, Type = 'Remote Computer', TypeKey = 3, Key = strcat(Computer, '-', ProcessName, '-', RemoteIp), ParentKey = strcat(Computer, '-', ProcessName), ComputerName = Computer | join kind=inner processData on $left.ParentKey == $right.Key | project-away Name, Responses1, LinksFailed1, MaxLinksLive1, TotalBytesSent1, TotalBytesReceived1, AverageResponseTime1, Type1, Key1, ParentKey1 | join kind=leftouter maliciousIpData on $left.Key == $right.MaliciousIp | project-away MaliciousIp, Computer, Process, Computer1, Computer2, MaliciousIpInfo | extend MaliciousIpInfo = tostring(MaliciousIpInfo1) | project-away MaliciousIpInfo1 | join kind = leftouter (ipComputerMapping) on $left.RemoteIp == $right.Ipv4 | extend Name = iff(Computer == '', iff(RemoteIp == '127.0.0.1', '🌐 Localhost',  strcat('🌐 External (', RemoteIp, ')')), strcat('🖥️ ', Computer)) | project-away Computer, Ipv4 | order by Name desc;\")",
+            "crossComponentResources": [
+              "{Computer}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "resourceType": "microsoft.compute/virtualmachines"
+          },
+          {
+            "id": "4a9ed59b-002e-4c81-b437-8456faeef6a6",
+            "version": "KqlParameterItem/1.0",
+            "name": "SourcePortData",
+            "type": 1,
+            "isRequired": false,
+            "query": "// {Computer:label}\r\nprint(\"let sourcePortData = VMConnection | where '{GridRefresh}' == 'run' | where TimeGenerated {TimeRange} | where Direction == '{Direction}' | where '{Direction}' == 'inbound' | where Computer contains '' | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) by Computer, ProcessName, DestinationIp, DestinationPort, Name = strcat('🔶 ', DestinationPort), Type = 'Remote Port', TypeKey = 4, Key = strcat(Computer, '-', ProcessName, '-', tostring(DestinationPort)), ParentKey = strcat(Computer, '-', ProcessName), ComputerName = Computer | join kind=leftouter maliciousIpData on $left.Key == $right.MaliciousPort | extend MaliciousIpInfo = tostring(MaliciousIpInfo) | project-away Computer1, MaliciousIp, MaliciousPort, MaliciousPortIp, Process; {RemoteIpDataInbound}\");",
+            "crossComponentResources": [
+              "{Computer}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "resourceType": "microsoft.compute/virtualmachines"
+          },
+          {
+            "id": "e31a8d21-e24b-45ec-9806-e6c45bca15aa",
+            "version": "KqlParameterItem/1.0",
+            "name": "DestinationPortData",
+            "type": 1,
+            "isRequired": false,
+            "query": "// {Computer:label}\r\nprint(\"let destinationPortData = VMConnection | where '{GridRefresh}' == 'run' | where TimeGenerated {TimeRange} | where Direction == '{Direction}' | where '{Direction}' == 'outbound' {ComputerFilter} | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) by Computer, ProcessName, DestinationIp, DestinationPort, Name = strcat('🔶 ', DestinationPort), Type = 'Remote Port', TypeKey = 4, Key = strcat(Computer, '-', ProcessName, '-', DestinationIp, '-', tostring(DestinationPort)), ParentKey = strcat(Computer, '-', ProcessName, '-', DestinationIp), ComputerName = Computer | join kind=inner remoteIpData on $left.ParentKey == $right.Key | project-away Name1, Responses1, Type1, Key1, ParentKey1 | order by Name asc;\");",
+            "crossComponentResources": [
+              "{Computer}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "resourceType": "microsoft.compute/virtualmachines"
+          },
+          {
+            "id": "a54f3df8-c872-4a19-a280-84b203987ec8",
+            "version": "KqlParameterItem/1.0",
+            "name": "QueryProject",
+            "type": 1,
+            "isRequired": false,
+            "query": "print(\"| where Type != 'Overall' | extend MaliciousConnectionsCount = iff(MaliciousIpInfo == '', 0, iff(Type == 'Computer' or Type == 'Process' or Type == 'Overall', tolong(MaliciousIpInfo), 1)) | project ComputerName, ProcessName, RemoteIp, DestinationPort, Name = iff(Name == '🎫 ', '🎫 <Unknown>', Name), Type, MaliciousConnections = iff(MaliciousIpInfo == '', '✅ No Malicious Connections', iff(Type == 'Computer' or Type == 'Process' or Type == 'Overall', iff(MaliciousConnectionsCount > 1, strcat('❌ ', MaliciousIpInfo, ' Malicious Connections'), strcat('❌ ', MaliciousIpInfo, ' Malicious Connection')), '❌ Malicious Connection')), Responses, MaxLinksLive, LinksFailed, AverageResponseTime, TotalBytesSent, TotalBytesReceived, Info = iff(MaliciousIpInfo != '', MaliciousIpInfo, ''), Key, ParentKey, TypeKey, MaliciousConnectionsCount | order by TypeKey asc, MaliciousConnectionsCount desc, LinksFailed desc, AverageResponseTime desc, Responses desc, MaxLinksLive desc, Name asc | project-away TypeKey\");",
+            "crossComponentResources": [
+              "{Computer}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "resourceType": "microsoft.compute/virtualmachines"
           },
           {
             "id": "9789ead5-eae5-4f52-86c2-ac197da62f30",
@@ -461,13 +477,13 @@
             "name": "Computer_Process_IP_Port",
             "type": 1,
             "isRequired": false,
-            "query": "print(strcat(\"{ServiceMapComputers}\", \" let ipComputerMapping = computers | project Computer, Ipv4 = todynamic(tostring(Properties.Ipv4Addresses_s)) | mvexpand Ipv4 to typeof(string); \", \"{MaliciousIpData}\", \" let totalMaliciousConnectionsCount = maliciousIpData | summarize MaliciousIpInfo = count() | extend Type = 'Overall'; \", \"{ComputerData}\", \" let processData = VMConnection | where '{GridRefresh}' == 'run' | where TimeGenerated {TimeRange} | where Direction == '{Direction}' {ComputerFilter} | where ProcessName != '' | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) by  Computer, Name = strcat('🎫 ', ProcessName), Type = 'Process', TypeKey = 2, Key = strcat(Computer, '-', ProcessName), ParentKey = Computer | join kind=inner computerData on $left.ParentKey == $right.Key | project-away Name1, Responses1, LinksFailed1, MaxLinksLive1, TotalBytesSent1, TotalBytesReceived1, AverageResponseTime1, Type1, Key1, ParentKey1 | join kind=leftouter (maliciousIpData | summarize MaliciousIpInfo = tostring(count()) by Process) on $left.Key == $right.Process | project-away Process, MaliciousIpInfo | extend MaliciousIpInfo = tostring(MaliciousIpInfo1) | project-away MaliciousIpInfo1\t\t\t\t\t\t\t   | order by Name asc; let remoteIpData = VMConnection | where '{GridRefresh}' == 'run' | where TimeGenerated {TimeRange} | where '{Direction}' == 'outbound' | where Direction == '{Direction}' {ComputerFilter} | extend RemoteIp = iff(Direction == 'outbound', DestinationIp, SourceIp) | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) by Computer, ProcessName, RemoteIp, Type = 'Remote Computer', TypeKey = 3, Key = strcat(Computer, '-', ProcessName, '-', RemoteIp), ParentKey = strcat(Computer, '-', ProcessName) | join kind=inner processData on $left.ParentKey == $right.Key | project-away Name, Responses1, LinksFailed1, MaxLinksLive1, TotalBytesSent1, TotalBytesReceived1, AverageResponseTime1, Type1, Key1, ParentKey1 | join kind=leftouter maliciousIpData on $left.Key == $right.MaliciousIp | project-away MaliciousIp, Computer, Process, Computer1, Computer2, MaliciousIpInfo | extend MaliciousIpInfo = tostring(MaliciousIpInfo1) | project-away MaliciousIpInfo1 | join kind = leftouter (ipComputerMapping) on $left.RemoteIp == $right.Ipv4 | extend Name = iff(Computer == '', iff(RemoteIp == '127.0.0.1', '🌐 Localhost',  strcat('🌐 External (', RemoteIp, ')')), strcat('🖥️ ', Computer)) | project-away Computer, Ipv4 | order by Name desc; let destinationPortData = VMConnection | where '{GridRefresh}' == 'run' | where TimeGenerated {TimeRange} | where Direction == '{Direction}' | where '{Direction}' == 'outbound' {ComputerFilter} | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) by Computer, ProcessName, DestinationIp, DestinationPort, Name = strcat('🔶 ', DestinationPort), Type = 'Remote Port', TypeKey = 4, Key = strcat(Computer, '-', ProcessName, '-', DestinationIp, '-', tostring(DestinationPort)), ParentKey = strcat(Computer, '-', ProcessName, '-', DestinationIp) | join kind=inner remoteIpData on $left.ParentKey == $right.Key | project-away Name1, Responses1, Type1, Key1, ParentKey1 | order by Name asc; let sourcePortData = VMConnection | where '{GridRefresh}' == 'run' | where TimeGenerated > ago(1h) | where Direction == '{Direction}' | where '{Direction}' == 'inbound' | where Computer contains '' | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) by Computer, ProcessName, DestinationIp, DestinationPort, Name = strcat('🔶 ', DestinationPort), Type = 'Remote Port', TypeKey = 4, Key = strcat(Computer, '-', ProcessName, '-', tostring(DestinationPort)), ParentKey = strcat(Computer, '-', ProcessName) | join kind=inner     processData on $left.ParentKey == $right.Key | project-away Name1, AverageResponseTime1, Computer1, Key1, LinksFailed1, MaxLinksLive1, ParentKey1, Responses1, TotalBytesReceived1, TotalBytesSent1, Type1, TypeKey1, TypeKey2; let remoteIpDataInbound = VMConnection | where '{GridRefresh}' == 'run' | where TimeGenerated > ago(1h) | where Direction == '{Direction}' | where '{Direction}' == 'inbound' | where Computer contains '' | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) by Computer, ProcessName, RemoteIp, Type = 'Remote Computer', TypeKey = 3, Key = strcat(Computer, '-', ProcessName, '-', tostring(DestinationPort), '-', RemoteIp), ParentKey = strcat(Computer, '-', ProcessName, '-', tostring(DestinationPort)), Id = strcat(Computer, '-', ProcessName, '-', RemoteIp) | join kind=inner     sourcePortData on $left.ParentKey == $right.Key | project-away AverageResponseTime1, Computer1, Key1, LinksFailed1, MaxLinksLive1, ParentKey1, ProcessName1, Responses1, TotalBytesReceived1, TotalBytesSent1, Type1, TypeKey1 | order by Name asc | join kind=leftouter     ipComputerMapping on $left.RemoteIp == $right.Ipv4 | extend Name = iff(RemoteIp == '', 'Unknown',  strcat('🌐 External (', RemoteIp, ')')) | project-away Computer, Ipv4 | order by Name desc | join kind=leftouter     maliciousIpData on $left.Id == $right.MaliciousIp | project-away MaliciousIp, Computer, Process, Computer1, MaliciousIpInfo, Id | extend MaliciousIpInfo = tostring(MaliciousIpInfo1) | project-away MaliciousIpInfo1; let overalldata = VMConnection | where '{GridRefresh}' == 'run' | where TimeGenerated {TimeRange} | where Direction == '{Direction}' {ComputerFilter} | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) | extend Name = '🔵 Overall', Type = 'Overall', TypeKey = 0, Key = '--Overall--', ParentKey = '----' | join kind=leftouter totalMaliciousConnectionsCount on Type | extend MaliciousIpInfo = iff(MaliciousIpInfo == '0', '', tostring(MaliciousIpInfo)) | project-away Type1; computerData | union processData | union remoteIpData | union destinationPortData | union remoteIpDataInbound | union sourcePortData | union overalldata\t\t\t\t\t\t\t | extend MaliciousConnectionsCount = iff(MaliciousIpInfo == '', 0, iff(Type == 'Computer' or Type == 'Process' or Type == 'Overall', tolong(MaliciousIpInfo), 1)) | project Name, Type, MaliciousConnections = iff(MaliciousIpInfo == '', '✅ No Malicious Connections', iff(Type == 'Computer' or Type == 'Process' or Type == 'Overall', iff(MaliciousConnectionsCount > 1, strcat('❌ ', MaliciousIpInfo, ' Malicious Connections'), strcat('❌ ', MaliciousIpInfo, ' Malicious Connection')), '❌ Malicious Connection')), Responses, MaxLinksLive, LinksFailed, AverageResponseTime, TotalBytesSent, TotalBytesReceived, Info = iff(MaliciousIpInfo != '', MaliciousIpInfo, ''), Key, ParentKey, TypeKey, MaliciousConnectionsCount | order by TypeKey asc, MaliciousConnectionsCount desc, LinksFailed desc, AverageResponseTime desc, Responses desc, MaxLinksLive desc, Name asc | project-away TypeKey\"));\r\n",
+            "query": "print(strcat(\"{ServiceMapComputers}\", \" let ipComputerMapping = computers | project Computer, Ipv4 = todynamic(tostring(Properties.Ipv4Addresses_s)) | mvexpand Ipv4 to typeof(string); \", \"{MaliciousIpData}\", \" let totalMaliciousConnectionsCount = maliciousIpData | summarize MaliciousIpInfo = count() | extend Type = 'Overall'; \", \"{ComputerData}\", \"{ProcessName}\", \"{RemoteIpData}\", \"{DestinationPortData}\", \"{SourcePortData}\", \" let overalldata = VMConnection | where '{GridRefresh}' == 'run' | where TimeGenerated {TimeRange} | where Direction == '{Direction}' {ComputerFilter} | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) | extend Name = '🔵 Overall', Type = 'Overall', TypeKey = 0, Key = '--Overall--', ParentKey = '----' | join kind=leftouter totalMaliciousConnectionsCount on Type | extend MaliciousIpInfo = iff(MaliciousIpInfo == '0', '', tostring(MaliciousIpInfo)) | project-away Type1; computerData | union processData | union remoteIpData | union destinationPortData | union remoteIpDataInbound | union sourcePortData | union overalldata\t\", \"{QueryProject}\"));",
             "crossComponentResources": [
-              "{Workspace}"
+              "{Computer}"
             ],
             "isHiddenWhenLocked": true,
             "timeContextFromParameter": null,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "resourceType": "microsoft.compute/virtualmachines"
           },
           {
             "id": "0d6a320e-2cef-44fd-ac0b-ad833f8d0c03",
@@ -475,13 +491,41 @@
             "name": "Computer_Process_IP",
             "type": 1,
             "isRequired": false,
-            "query": "print(strcat(\"{ServiceMapComputers}\", \" let ipComputerMapping = computers | project Computer, Ipv4 = todynamic(tostring(Properties.Ipv4Addresses_s)) | mvexpand Ipv4 to typeof(string); \", \"{MaliciousIpData}\", \" let totalMaliciousConnectionsCount = maliciousIpData | summarize MaliciousIpInfo = count() | extend Type = 'Overall'; \", \"{ComputerData}\", \" let processData = VMConnection | where '{GridRefresh}' == 'run' | where TimeGenerated {TimeRange} | where Direction == '{Direction}' {ComputerFilter} | where ProcessName != '' | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) by  Computer, Name = strcat('🎫 ', ProcessName), Type = 'Process', TypeKey = 2, Key = strcat(Computer, '-', ProcessName), ParentKey = Computer | join kind=inner computerData on $left.ParentKey == $right.Key | project-away Name1, Responses1, LinksFailed1, MaxLinksLive1, TotalBytesSent1, TotalBytesReceived1, AverageResponseTime1, Type1, Key1, ParentKey1 | join kind=leftouter (maliciousIpData | summarize MaliciousIpInfo = tostring(count()) by Process) on $left.Key == $right.Process | project-away Process, MaliciousIpInfo | extend MaliciousIpInfo = tostring(MaliciousIpInfo1) | project-away MaliciousIpInfo1\t\t\t\t\t\t\t   | order by Name asc; let remoteIpData = VMConnection | where '{GridRefresh}' == 'run' | where TimeGenerated {TimeRange} | where Direction == '{Direction}' {ComputerFilter} | extend RemoteIp = iff(Direction == 'outbound', DestinationIp, SourceIp) | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) by Computer, ProcessName, RemoteIp, Type = 'Remote Computer', TypeKey = 3, Key = strcat(Computer, '-', ProcessName, '-', RemoteIp), ParentKey = strcat(Computer, '-', ProcessName) | join kind=inner processData on $left.ParentKey == $right.Key | project-away Name, Responses1, LinksFailed1, MaxLinksLive1, TotalBytesSent1, TotalBytesReceived1, AverageResponseTime1, Type1, Key1, ParentKey1 | join kind=leftouter maliciousIpData on $left.Key == $right.MaliciousIp | project-away MaliciousIp, Computer, Process, Computer1, Computer2, MaliciousIpInfo | extend MaliciousIpInfo = tostring(MaliciousIpInfo1) | project-away MaliciousIpInfo1 | join kind = leftouter (ipComputerMapping) on $left.RemoteIp == $right.Ipv4 | extend Name = iff(Computer == '', iff(RemoteIp == '127.0.0.1', '🌐 Localhost',  strcat('🌐 External (', RemoteIp, ')')), strcat('🖥️ ', Computer)) | project-away Computer, Ipv4 | order by Name desc; let overalldata = VMConnection | where '{GridRefresh}' == 'run' | where TimeGenerated {TimeRange} | where Direction == '{Direction}' {ComputerFilter} | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) | extend Name = '🔵 Overall', Type = 'Overall', TypeKey = 0, Key = '--Overall--', ParentKey = '----' | join kind=leftouter totalMaliciousConnectionsCount on Type | extend MaliciousIpInfo = iff(MaliciousIpInfo == '0', '', tostring(MaliciousIpInfo)) | project-away Type1; computerData | union processData | union remoteIpData | union overalldata\t\t\t\t\t\t\t | extend MaliciousConnectionsCount = iff(MaliciousIpInfo == '', 0, iff(Type == 'Computer' or Type == 'Process' or Type == 'Overall', tolong(MaliciousIpInfo), 1)) | project Name, Type, MaliciousConnections = iff(MaliciousIpInfo == '', '✅ No Malicious Connections', iff(Type == 'Computer' or Type == 'Process' or Type == 'Overall', iff(MaliciousConnectionsCount > 1, strcat('❌ ', MaliciousIpInfo, ' Malicious Connections'), strcat('❌ ', MaliciousIpInfo, ' Malicious Connection')), '❌ Malicious Connection')), Responses, MaxLinksLive, LinksFailed, AverageResponseTime, TotalBytesSent, TotalBytesReceived, Info = iff(MaliciousIpInfo != '', MaliciousIpInfo, ''), Key, ParentKey, TypeKey, MaliciousConnectionsCount | order by TypeKey asc, MaliciousConnectionsCount desc, LinksFailed desc, AverageResponseTime desc, Responses desc, MaxLinksLive desc, Name asc | project-away TypeKey\"));\r\n",
+            "query": "print(strcat(\"{ServiceMapComputers}\", \" let ipComputerMapping = computers | project Computer, Ipv4 = todynamic(tostring(Properties.Ipv4Addresses_s)) | mvexpand Ipv4 to typeof(string); \", \"{MaliciousIpData}\", \" let totalMaliciousConnectionsCount = maliciousIpData | summarize MaliciousIpInfo = count() | extend Type = 'Overall'; \", \"{ComputerData}\", \"{ProcessName}\", \"{RemoteIpData}\", \"{SourcePortData}\", \" let overalldata = VMConnection | where '{GridRefresh}' == 'run' | where TimeGenerated {TimeRange} | where Direction == '{Direction}' {ComputerFilter} | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) | extend Name = '🔵 Overall', Type = 'Overall', TypeKey = 0, Key = '--Overall--', ParentKey = '----' | join kind=leftouter totalMaliciousConnectionsCount on Type | extend MaliciousIpInfo = iff(MaliciousIpInfo == '0', '', tostring(MaliciousIpInfo)) | project-away Type1;\" ,\" computerData | union processData | union remoteIpData | union sourcePortData | union overalldata \", \"{QueryProject}\"));",
             "crossComponentResources": [
-              "{Workspace}"
+              "{Computer}"
             ],
             "isHiddenWhenLocked": true,
             "timeContextFromParameter": null,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "resourceType": "microsoft.compute/virtualmachines"
+          },
+          {
+            "id": "2de0d685-4382-4822-a8aa-f3583ff11b66",
+            "version": "KqlParameterItem/1.0",
+            "name": "QueryPadDestinationPortTable",
+            "type": 1,
+            "isRequired": true,
+            "query": "// {Computer:label}\r\nprint(\"let destinationPortPadding = datatable (DestinationPort: string) [];\");",
+            "crossComponentResources": [
+              "{Computer}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "resourceType": "microsoft.compute/virtualmachines"
+          },
+          {
+            "id": "df8a6322-511e-40e0-a258-fe717099a072",
+            "version": "KqlParameterItem/1.0",
+            "name": "QueryPadRemoteIpTable",
+            "type": 1,
+            "isRequired": true,
+            "query": "// {Computer:label}\r\nprint(\"let remoteIpPadding = datatable (RemoteIp: string) [];\");",
+            "crossComponentResources": [
+              "{Computer}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "resourceType": "microsoft.compute/virtualmachines"
           },
           {
             "id": "e8f2c394-18e8-4d6d-8f5e-8453cb67128c",
@@ -489,27 +533,41 @@
             "name": "Computer_Process",
             "type": 1,
             "isRequired": false,
-            "query": "print(strcat(\"{ServiceMapComputers}\", \" let ipComputerMapping = computers | project Computer, Ipv4 = todynamic(tostring(Properties.Ipv4Addresses_s)) | mvexpand Ipv4 to typeof(string); \", \"{MaliciousIpData}\", \" let totalMaliciousConnectionsCount = maliciousIpData | summarize MaliciousIpInfo = count() | extend Type = 'Overall'; \", \"{ComputerData}\", \" let processData = VMConnection | where '{GridRefresh}' == 'run' | where TimeGenerated {TimeRange} | where Direction == '{Direction}' {ComputerFilter} | where ProcessName != '' | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) by  Computer, Name = strcat('🎫 ', ProcessName), Type = 'Process', TypeKey = 2, Key = strcat(Computer, '-', ProcessName), ParentKey = Computer | join kind=inner computerData on $left.ParentKey == $right.Key | project-away Name1, Responses1, LinksFailed1, MaxLinksLive1, TotalBytesSent1, TotalBytesReceived1, AverageResponseTime1, Type1, Key1, ParentKey1 | join kind=leftouter (maliciousIpData | summarize MaliciousIpInfo = tostring(count()) by Process) on $left.Key == $right.Process | project-away Process, MaliciousIpInfo | extend MaliciousIpInfo = tostring(MaliciousIpInfo1) | project-away MaliciousIpInfo1\t\t\t\t\t\t\t   | order by Name asc; let overalldata = VMConnection | where '{GridRefresh}' == 'run' | where TimeGenerated {TimeRange} | where Direction == '{Direction}' {ComputerFilter} | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) | extend Name = '🔵 Overall', Type = 'Overall', TypeKey = 0, Key = '--Overall--', ParentKey = '----' | join kind=leftouter totalMaliciousConnectionsCount on Type | extend MaliciousIpInfo = iff(MaliciousIpInfo == '0', '', tostring(MaliciousIpInfo)) | project-away Type1; computerData | union processData | union overalldata\t\t\t\t\t\t\t | extend MaliciousConnectionsCount = iff(MaliciousIpInfo == '', 0, iff(Type == 'Computer' or Type == 'Process' or Type == 'Overall', tolong(MaliciousIpInfo), 1)) | project Name, Type, MaliciousConnections = iff(MaliciousIpInfo == '', '✅ No Malicious Connections', iff(Type == 'Computer' or Type == 'Process' or Type == 'Overall', iff(MaliciousConnectionsCount > 1, strcat('❌ ', MaliciousIpInfo, ' Malicious Connections'), strcat('❌ ', MaliciousIpInfo, ' Malicious Connection')), '❌ Malicious Connection')), Responses, MaxLinksLive, LinksFailed, AverageResponseTime, TotalBytesSent, TotalBytesReceived, Info = iff(MaliciousIpInfo != '', MaliciousIpInfo, ''), Key, ParentKey, TypeKey, MaliciousConnectionsCount | order by TypeKey asc, MaliciousConnectionsCount desc, LinksFailed desc, AverageResponseTime desc, Responses desc, MaxLinksLive desc, Name asc | project-away TypeKey\"));\r\n",
+            "query": "print(strcat(\"{ServiceMapComputers}\", \" let ipComputerMapping = computers | project Computer, Ipv4 = todynamic(tostring(Properties.Ipv4Addresses_s)) | mvexpand Ipv4 to typeof(string); \", \"{MaliciousIpData}\", \" let totalMaliciousConnectionsCount = maliciousIpData | summarize MaliciousIpInfo = count() | extend Type = 'Overall'; \", \"{ComputerData}\", \"{ProcessName}\", \" let overalldata = VMConnection | where '{GridRefresh}' == 'run' | where TimeGenerated {TimeRange} | where Direction == '{Direction}' {ComputerFilter} | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) | extend Name = '🔵 Overall', Type = 'Overall', TypeKey = 0, Key = '--Overall--', ParentKey = '----' | join kind=leftouter totalMaliciousConnectionsCount on Type | extend MaliciousIpInfo = iff(MaliciousIpInfo == '0', '', tostring(MaliciousIpInfo)) | project-away Type1;\", \"{QueryPadDestinationPortTable}\", \"{QueryPadRemoteIpTable}\",\" computerData | union remoteIpPadding | union destinationPortPadding | union processData | union overalldata \", \"{QueryProject}\"));",
             "crossComponentResources": [
-              "{Workspace}"
+              "{Computer}"
             ],
             "isHiddenWhenLocked": true,
             "timeContextFromParameter": null,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "resourceType": "microsoft.compute/virtualmachines"
+          },
+          {
+            "id": "084fb5fc-e8e4-42df-8a9f-ac1001950ba2",
+            "version": "KqlParameterItem/1.0",
+            "name": "QueryPadProcessNameTable",
+            "type": 1,
+            "isRequired": true,
+            "query": "// {Computer:label}\r\nprint(\"let processNamePadding = datatable (ProcessName: string) [];\");",
+            "crossComponentResources": [
+              "{Computer}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "resourceType": "microsoft.compute/virtualmachines"
           },
           {
             "id": "a4b0e146-7c89-40bb-ade2-ed2e392e9311",
             "version": "KqlParameterItem/1.0",
-            "name": "Computer",
+            "name": "Computer_Query",
             "type": 1,
             "isRequired": false,
-            "query": "print(strcat(\"{ServiceMapComputers}\", \" let ipComputerMapping = computers | project Computer, Ipv4 = todynamic(tostring(Properties.Ipv4Addresses_s)) | mvexpand Ipv4 to typeof(string); \", \"{MaliciousIpData}\", \" let totalMaliciousConnectionsCount = maliciousIpData | summarize MaliciousIpInfo = count() | extend Type = 'Overall'; \", \"{ComputerData}\", \" let overalldata = VMConnection | where '{GridRefresh}' == 'run' | where TimeGenerated {TimeRange} | where Direction == '{Direction}' {ComputerFilter} | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) | extend Name = '🔵 Overall', Type = 'Overall', TypeKey = 0, Key = '--Overall--', ParentKey = '----' | join kind=leftouter totalMaliciousConnectionsCount on Type | extend MaliciousIpInfo = iff(MaliciousIpInfo == '0', '', tostring(MaliciousIpInfo)) | project-away Type1; computerData | union overalldata\t\t\t\t\t\t\t | extend MaliciousConnectionsCount = iff(MaliciousIpInfo == '', 0, iff(Type == 'Computer' or Type == 'Process' or Type == 'Overall', tolong(MaliciousIpInfo), 1)) | project Name, Type, MaliciousConnections = iff(MaliciousIpInfo == '', '✅ No Malicious Connections', iff(Type == 'Computer' or Type == 'Process' or Type == 'Overall', iff(MaliciousConnectionsCount > 1, strcat('❌ ', MaliciousIpInfo, ' Malicious Connections'), strcat('❌ ', MaliciousIpInfo, ' Malicious Connection')), '❌ Malicious Connection')), Responses, MaxLinksLive, LinksFailed, AverageResponseTime, TotalBytesSent, TotalBytesReceived, Info = iff(MaliciousIpInfo != '', MaliciousIpInfo, ''), Key, ParentKey, TypeKey, MaliciousConnectionsCount | order by TypeKey asc, MaliciousConnectionsCount desc, LinksFailed desc, AverageResponseTime desc, Responses desc, MaxLinksLive desc, Name asc | project-away TypeKey\"));\r\n",
+            "query": "print(strcat(\"{ServiceMapComputers}\", \" let ipComputerMapping = computers | project Computer, Ipv4 = todynamic(tostring(Properties.Ipv4Addresses_s)) | mvexpand Ipv4 to typeof(string); \", \"{MaliciousIpData}\", \" let totalMaliciousConnectionsCount = maliciousIpData | summarize MaliciousIpInfo = count() | extend Type = 'Overall'; \", \"{ComputerData}\", \" let overalldata = VMConnection | where '{GridRefresh}' == 'run' | where TimeGenerated {TimeRange} | where Direction == '{Direction}' {ComputerFilter} | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) | extend Name = '🔵 Overall', Type = 'Overall', TypeKey = 0, Key = '--Overall--', ParentKey = '----' | join kind=leftouter totalMaliciousConnectionsCount on Type | extend MaliciousIpInfo = iff(MaliciousIpInfo == '0', '', tostring(MaliciousIpInfo)) | project-away Type1;\", \"{QueryPadDestinationPortTable}\", \"{QueryPadRemoteIpTable}\", \"{QueryPadProcessNameTable}\",\" computerData | union remoteIpPadding | union processNamePadding | union destinationPortPadding | union overalldata \", \"{QueryProject}\"));",
             "crossComponentResources": [
-              "{Workspace}"
+              "{Computer}"
             ],
             "isHiddenWhenLocked": true,
             "timeContextFromParameter": null,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "resourceType": "microsoft.compute/virtualmachines"
           },
           {
             "id": "a08757da-e72b-474d-a1d2-65fb7020cc14",
@@ -517,13 +575,13 @@
             "name": "FinalQuery",
             "type": 1,
             "isRequired": false,
-            "query": "print(\r\niff({Hierarchy} == 0, \"{Computer_Process_IP_Port}\", \r\niff({Hierarchy} == 1, \"{Computer_Process_IP}\",\r\niff({Hierarchy} == 2, \"{Computer_Process}\",\r\niff({Hierarchy} == 3, \"{Computer}\", \"{Computer}\")))));",
+            "query": "print(strcat(\r\niff({Hierarchy} == 0, \"{Computer_Process_IP_Port}\", \r\niff({Hierarchy} == 1, \"{Computer_Process_IP}\",\r\niff({Hierarchy} == 2, \"{Computer_Process}\",\r\niff({Hierarchy} == 3, \"{Computer_Query}\", \"{Computer_Query}\")))),' | where MaliciousConnectionsCount >= {OnlyMaliciousConnections}',' | where LinksFailed >= {OnlyLinksFailed}',' | where AverageResponseTime >= {HighResponseTime}'));",
             "crossComponentResources": [
-              "{Workspace}"
+              "{Computer}"
             ],
             "isHiddenWhenLocked": true,
             "timeContextFromParameter": null,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "resourceType": "microsoft.compute/virtualmachines"
           },
           {
             "id": "874eeebe-2ea2-4c04-a3b9-ab3b30e95573",
@@ -537,14 +595,14 @@
           }
         ],
         "style": "above",
-        "resourceType": "microsoft.operationalinsights/workspaces"
+        "resourceType": "microsoft.compute/virtualmachines"
       },
       "conditionalVisibility": null
     },
     {
       "type": 1,
       "content": {
-        "json": "💡 <em>Select a computer from the table below to view connection details for that machine.</em>"
+        "json": "💡 <em>Select a row from the table below to view connection details for that entry.</em>"
       },
       "conditionalVisibility": null
     },
@@ -554,25 +612,60 @@
         "version": "KqlItem/1.0",
         "query": "{FinalQuery:value}",
         "showQuery": false,
-        "size": 2,
+        "size": 0,
         "aggregation": 0,
         "showAnnotations": false,
         "exportParameterName": "ConnectionGrid",
         "showAnalytics": false,
-        "noDataMessage": "No Machines reporting to this workspace.",
+        "noDataMessage": "No networking data exists for this machine.",
         "timeContextFromParameter": null,
-        "resourceType": "microsoft.operationalinsights/workspaces",
+        "resourceType": "microsoft.compute/virtualmachines",
         "crossComponentResources": [
-          "{Workspace}"
+          "{Computer}"
         ],
         "visualization": "table",
         "gridSettings": {
           "formatters": [
             {
+              "columnMatch": "Computer",
+              "formatter": 5,
+              "formatOptions": {
+                "showIcon": true
+              }
+            },
+            {
+              "columnMatch": "ProcessName",
+              "formatter": 5,
+              "formatOptions": {
+                "showIcon": true
+              }
+            },
+            {
+              "columnMatch": "RemoteIp",
+              "formatter": 5,
+              "formatOptions": {
+                "showIcon": true
+              }
+            },
+            {
+              "columnMatch": "DestinationPort",
+              "formatter": 5,
+              "formatOptions": {
+                "showIcon": true
+              },
+              "numberFormat": {
+                "unit": 0,
+                "options": {
+                  "style": "decimal"
+                }
+              }
+            },
+            {
               "columnMatch": "Responses",
               "formatter": 4,
               "formatOptions": {
-                "palette": "blueDark"
+                "palette": "blueDark",
+                "showIcon": true
               },
               "numberFormat": {
                 "unit": 17,
@@ -585,7 +678,8 @@
               "columnMatch": "MaxLinksLive",
               "formatter": 4,
               "formatOptions": {
-                "palette": "lightBlue"
+                "palette": "lightBlue",
+                "showIcon": true
               },
               "numberFormat": {
                 "unit": 17,
@@ -598,7 +692,8 @@
               "columnMatch": "LinksFailed",
               "formatter": 4,
               "formatOptions": {
-                "palette": "red"
+                "palette": "red",
+                "showIcon": true
               },
               "numberFormat": {
                 "unit": 17,
@@ -611,7 +706,8 @@
               "columnMatch": "AverageResponseTime",
               "formatter": 4,
               "formatOptions": {
-                "palette": "purple"
+                "palette": "purple",
+                "showIcon": true
               },
               "numberFormat": {
                 "unit": 23,
@@ -624,7 +720,8 @@
               "columnMatch": "TotalBytesSent",
               "formatter": 4,
               "formatOptions": {
-                "palette": "orange"
+                "palette": "orange",
+                "showIcon": true
               },
               "numberFormat": {
                 "unit": 2,
@@ -637,7 +734,8 @@
               "columnMatch": "TotalBytesReceived",
               "formatter": 4,
               "formatOptions": {
-                "palette": "green"
+                "palette": "green",
+                "showIcon": true
               },
               "numberFormat": {
                 "unit": 2,
@@ -648,41 +746,32 @@
             },
             {
               "columnMatch": "Info",
-              "formatter": 7,
+              "formatter": 5,
               "formatOptions": {
                 "linkTarget": "CellDetails",
-                "linkLabel": "ℹ️ Info"
+                "linkLabel": "ℹ️ Info",
+                "showIcon": true
               }
             },
             {
               "columnMatch": "Key",
               "formatter": 5,
-              "formatOptions": {}
+              "formatOptions": {
+                "showIcon": true
+              }
             },
             {
               "columnMatch": "ParentKey",
               "formatter": 5,
-              "formatOptions": {}
+              "formatOptions": {
+                "showIcon": true
+              }
             },
             {
               "columnMatch": "MaliciousConnectionsCount",
               "formatter": 5,
-              "formatOptions": {}
-            },
-            {
-              "columnMatch": "Computer",
-              "formatter": 5,
-              "formatOptions": {}
-            },
-            {
-              "columnMatch": "DestinationPort",
-              "formatter": 1,
-              "formatOptions": {},
-              "numberFormat": {
-                "unit": 0,
-                "options": {
-                  "style": "decimal"
-                }
+              "formatOptions": {
+                "showIcon": true
               }
             }
           ],
@@ -693,7 +782,7 @@
             "parentColumn": "ParentKey",
             "treeType": 0,
             "expanderColumn": "Name",
-            "expandTopLevel": false
+            "expandTopLevel": true
           }
         },
         "tileSettings": {
@@ -725,54 +814,118 @@
       "content": {
         "version": "KqlParameterItem/1.0",
         "query": "",
-        "crossComponentResources": [],
+        "crossComponentResources": [
+          "{Computer}"
+        ],
         "parameters": [
           {
-            "id": "4c14e89e-dbd3-421b-a041-c8fc87ce6e43",
+            "id": "7e4c3d29-2be6-4288-903b-95502ddab577",
             "version": "KqlParameterItem/1.0",
-            "name": "SourceComputer",
+            "name": "ComputerName",
             "type": 1,
-            "isRequired": true,
-            "query": "let row = dynamic({ConnectionGrid});\r\nlet computer = tostring(row.Key);\r\nrange i from 1 to 1 step 1\r\n| project computer",
+            "isRequired": false,
+            "query": "// {Computer:label}\r\nlet row = dynamic({ConnectionGrid});\r\nlet computerName = row.ComputerName;\r\nprint computerName",
+            "crossComponentResources": [
+              "{Computer}"
+            ],
             "isHiddenWhenLocked": true,
             "timeContextFromParameter": null,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "resourceType": "microsoft.compute/virtualmachines"
           },
           {
-            "id": "238d2334-e164-411d-b99a-70095fce615f",
+            "id": "3bda15ac-c4ea-487f-acf5-2c14c8d33038",
             "version": "KqlParameterItem/1.0",
-            "name": "ChildComputer",
+            "name": "ProcessName",
             "type": 1,
-            "isRequired": true,
-            "query": "print 'any'",
+            "isRequired": false,
+            "query": "// {Computer:label}\r\nlet row = dynamic({ConnectionGrid});\r\nlet ProcessName = row.ProcessName;\r\nprint ProcessName",
+            "crossComponentResources": [
+              "{Computer}"
+            ],
             "isHiddenWhenLocked": true,
             "timeContextFromParameter": null,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "resourceType": "microsoft.compute/virtualmachines"
+          },
+          {
+            "id": "e424020b-8c6e-4a06-9639-ed696192442a",
+            "version": "KqlParameterItem/1.0",
+            "name": "RemoteIp",
+            "type": 1,
+            "isRequired": false,
+            "query": "// {Computer:label}\r\nlet row = dynamic({ConnectionGrid});\r\nlet RemoteIp = row.RemoteIp;\r\nprint RemoteIp",
+            "crossComponentResources": [
+              "{Computer}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "resourceType": "microsoft.compute/virtualmachines"
+          },
+          {
+            "id": "a479367c-f99b-4c93-b18c-51f07ce5069d",
+            "version": "KqlParameterItem/1.0",
+            "name": "DestinationPort",
+            "type": 1,
+            "isRequired": false,
+            "query": "// {Computer:label}\r\nlet row = dynamic({ConnectionGrid});\r\nlet destinationPort = row.DestinationPort;\r\nprint destinationPort",
+            "crossComponentResources": [
+              "{Computer}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "resourceType": "microsoft.compute/virtualmachines"
           },
           {
             "id": "dcf5f274-fbbf-4fb8-8c35-6b528a08cac9",
             "version": "KqlParameterItem/1.0",
-            "name": "IsComputer",
+            "name": "ShowDetail",
             "type": 1,
             "isRequired": true,
-            "query": "let row = dynamic({ConnectionGrid});\r\nlet isComputer = row.ParentKey == '---';\r\nprint strcat(isComputer)",
+            "query": "print(strcat('{ComputerName}{ProcessName}{RemoteIp}{DestinationPort}' != ''))",
             "isHiddenWhenLocked": true,
             "timeContextFromParameter": null,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "resourceType": "microsoft.compute/virtualmachines"
+          },
+          {
+            "id": "1ce27926-6842-497b-ac53-70c006e11231",
+            "version": "KqlParameterItem/1.0",
+            "name": "Heading",
+            "type": 1,
+            "isRequired": false,
+            "query": "// {Computer:label}\r\nprint(strcat('💻 {ComputerName}',iff('{ProcessName}' != '',' > 🎫 {ProcessName}',''),iff('{Direction}' == 'outbound',strcat(iff('{RemoteIp}' != '',' > 🌐 {RemoteIp}',''),iff('{DestinationPort}' != '',' > 🔸 {DestinationPort}','')),strcat(iff('{DestinationPort}' != '',' > 🔸 {DestinationPort}',''),iff('{RemoteIp}' != '',' > 🌐 {RemoteIp}','')))))",
+            "crossComponentResources": [
+              "{Computer}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "resourceType": "microsoft.compute/virtualmachines"
+          },
+          {
+            "id": "b44edb14-76ad-48b3-9921-b5dfb5a6db60",
+            "version": "KqlParameterItem/1.0",
+            "name": "QueryFilter",
+            "type": 1,
+            "isRequired": false,
+            "query": "// {Computer:label}\r\nprint(strcat(' where Computer == \"{ComputerName}\"',iff('{ProcessName}' != '', ' | where ProcessName == \"{ProcessName}\"', ''),iff('{RemoteIp}' != '',' | where RemoteIp == \"{RemoteIp}\"',''),iff('{DestinationPort}' != '',' | where DestinationPort == \"{DestinationPort}\"','')));",
+            "crossComponentResources": [
+              "{Computer}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "resourceType": "microsoft.compute/virtualmachines"
           }
         ],
         "style": "above",
-        "resourceType": "microsoft.operationalinsights/workspaces"
+        "resourceType": "microsoft.compute/virtualmachines"
       },
       "conditionalVisibility": null
     },
     {
       "type": 1,
       "content": {
-        "json": "## Selected Machine: {SourceComputer}"
+        "json": "<h2 style=\"font-weight:normal;\">{Heading}</h2>"
       },
       "conditionalVisibility": {
-        "parameterName": "IsComputer",
+        "parameterName": "ShowDetail",
         "comparison": "isEqualTo",
         "value": "True"
       }
@@ -783,7 +936,7 @@
         "json": "### Responses"
       },
       "conditionalVisibility": {
-        "parameterName": "IsComputer",
+        "parameterName": "ShowDetail",
         "comparison": "isEqualTo",
         "value": "True"
       },
@@ -792,10 +945,10 @@
     {
       "type": 1,
       "content": {
-        "json": "## Latency"
+        "json": "### Latency"
       },
       "conditionalVisibility": {
-        "parameterName": "IsComputer",
+        "parameterName": "ShowDetail",
         "comparison": "isEqualTo",
         "value": "True"
       },
@@ -804,10 +957,10 @@
     {
       "type": 1,
       "content": {
-        "json": "## Network"
+        "json": "### Network"
       },
       "conditionalVisibility": {
-        "parameterName": "IsComputer",
+        "parameterName": "ShowDetail",
         "comparison": "isEqualTo",
         "value": "True"
       },
@@ -816,10 +969,10 @@
     {
       "type": 1,
       "content": {
-        "json": "## Links"
+        "json": "### Links"
       },
       "conditionalVisibility": {
-        "parameterName": "IsComputer",
+        "parameterName": "ShowDetail",
         "comparison": "isEqualTo",
         "value": "True"
       },
@@ -829,18 +982,21 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let length = strlen('{ChildComputer}');\r\nlet SourceMachine = iff('{SourceComputer}' contains '🖥️', substring('{SourceComputer}', 3), '{SourceComputer}');\r\nlet ChildMachine = iff('{ChildComputer}' contains '🖥️', substring('{ChildComputer}', 3), \r\n                        iff('{ChildComputer}' contains '🔸',  substring('{ChildComputer}', 2), \r\n                        iff('{ChildComputer}' contains \"External\", substring('{ChildComputer}', 12, length - 13), '{ChildComputer}')));\r\nlet SouceMachineData = VMConnection\r\n| where TimeGenerated {TimeRange}\r\n| where Computer == SourceMachine\r\n| where ChildMachine == \"any\"\r\n| where Direction == '{Direction}'\r\n| summarize Computer = sum(Responses) by bin(TimeGenerated, time('{TimeRange:grain}')), Type = SourceMachine;\r\nlet computers = ServiceMapComputer_CL\r\n| where TimeGenerated {TimeRange}\r\n| summarize (TimeGenerated, Properties) = arg_max(TimeGenerated, pack_all()) by Computer;\r\nlet ipComputerMapping = computers \r\n| project Computer, Ipv4 = todynamic(tostring(Properties.Ipv4Addresses_s))\r\n| mvexpand Ipv4 to typeof(string);\r\nlet remoteMachineIps = ipComputerMapping\r\n| where Computer == ChildMachine\r\n| project Ipv4;\r\nlet ConnectionData = VMConnection\r\n| where TimeGenerated {TimeRange}\r\n| where Computer == SourceMachine\r\n| where RemoteIp in (remoteMachineIps) or RemoteIp == ChildMachine\r\n| where Direction == '{Direction}'\r\n| summarize Computer = sum(Responses) by bin(TimeGenerated, time('{TimeRange:grain}')), Type = ChildMachine;\r\nSouceMachineData\r\n| union ConnectionData",
+        "query": "// {Computer:label}\r\nlet SourceMachineData = VMConnection\r\n| where TimeGenerated {TimeRange}\r\n| {QueryFilter}\r\n| where Direction == '{Direction}'\r\n| summarize Responses = sum(Responses) by bin(TimeGenerated, time('{TimeRange:grain}'));\r\nSourceMachineData",
         "showQuery": false,
         "size": 1,
         "aggregation": 0,
         "showAnnotations": false,
         "showAnalytics": false,
         "timeContextFromParameter": null,
-        "resourceType": "microsoft.operationalinsights/workspaces",
+        "resourceType": "microsoft.compute/virtualmachines",
+        "crossComponentResources": [
+          "{Computer}"
+        ],
         "visualization": "areachart"
       },
       "conditionalVisibility": {
-        "parameterName": "IsComputer",
+        "parameterName": "ShowDetail",
         "comparison": "isEqualTo",
         "value": "True"
       },
@@ -850,60 +1006,69 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let length = strlen('{ChildComputer}');\r\nlet SourceMachine = iff('{SourceComputer}' contains '🖥️', substring('{SourceComputer}', 3), '{SourceComputer}');\r\nlet ChildMachine = iff('{ChildComputer}' contains '🖥️', substring('{ChildComputer}', 3), \r\n                        iff('{ChildComputer}' contains '🔸',  substring('{ChildComputer}', 2), \r\n                        iff('{ChildComputer}' contains \"External\", substring('{ChildComputer}', 12, length - 13), '{ChildComputer}')));\r\nlet SouceMachineData = VMConnection\r\n| where TimeGenerated {TimeRange}\r\n| where Computer == SourceMachine\r\n| where ChildMachine == \"any\"\r\n| where Direction == '{Direction}'\r\n| summarize P50 = percentiles(ResponseTimeSum, 50), P90 = percentiles(ResponseTimeSum, 90), P95 = percentiles(ResponseTimeSum, 95) by bin(TimeGenerated, time('{TimeRange:grain}'));\r\nlet computers = ServiceMapComputer_CL\r\n| where TimeGenerated {TimeRange}\r\n| summarize (TimeGenerated, Properties) = arg_max(TimeGenerated, pack_all()) by Computer;\r\nlet ipComputerMapping = computers \r\n| project Computer, Ipv4 = todynamic(tostring(Properties.Ipv4Addresses_s))\r\n| mvexpand Ipv4 to typeof(string);\r\nlet remoteMachineIps = ipComputerMapping\r\n| where Computer == ChildMachine\r\n| project Ipv4;\r\nlet ConnectionData = VMConnection\r\n| where TimeGenerated {TimeRange}\r\n| where Computer == SourceMachine\r\n| where RemoteIp in (remoteMachineIps) or RemoteIp == ChildMachine\r\n| where Direction == '{Direction}'\r\n| summarize P50 = percentiles(ResponseTimeSum, 50), P90 = percentiles(ResponseTimeSum, 90), P95 = percentiles(ResponseTimeSum, 95) by bin(TimeGenerated, time('{TimeRange:grain}'));\r\nSouceMachineData\r\n| union ConnectionData",
-        "showQuery": false,
-        "size": 1,
-        "aggregation": 0,
-        "showAnnotations": false,
-        "showAnalytics": false,
-        "timeContextFromParameter": null,
-        "resourceType": "microsoft.operationalinsights/workspaces",
-        "visualization": "linechart"
-      },
-      "conditionalVisibility": {
-        "parameterName": "IsComputer",
-        "comparison": "isEqualTo",
-        "value": "True"
-      },
-      "customWidth": "25"
-    },
-    {
-      "type": 3,
-      "content": {
-        "version": "KqlItem/1.0",
-        "query": "let length = strlen('{ChildComputer}');\r\nlet SourceMachine = iff('{SourceComputer}' contains '🖥️', substring('{SourceComputer}', 3), '{SourceComputer}');\r\nlet ChildMachine = iff('{ChildComputer}' contains '🖥️', substring('{ChildComputer}', 3), \r\n                        iff('{ChildComputer}' contains '🔸',  substring('{ChildComputer}', 2), \r\n                        iff('{ChildComputer}' contains \"External\", substring('{ChildComputer}', 12, length - 13), '{ChildComputer}')));\r\nlet SouceMachineData = VMConnection\r\n| where TimeGenerated {TimeRange}\r\n| where Computer == SourceMachine\r\n| where ChildMachine == \"any\"\r\n| where Direction == '{Direction}'\r\n| summarize Sent = sum(BytesSent), Received = sum(BytesReceived) by bin(TimeGenerated, time('{TimeRange:grain}')), Type = SourceMachine;\r\nlet computers = ServiceMapComputer_CL\r\n| where TimeGenerated {TimeRange}\r\n| summarize (TimeGenerated, Properties) = arg_max(TimeGenerated, pack_all()) by Computer;\r\nlet ipComputerMapping = computers \r\n| project Computer, Ipv4 = todynamic(tostring(Properties.Ipv4Addresses_s))\r\n| mvexpand Ipv4 to typeof(string);\r\nlet remoteMachineIps = ipComputerMapping\r\n| where Computer == ChildMachine\r\n| project Ipv4;\r\nlet ConnectionData = VMConnection\r\n| where TimeGenerated {TimeRange}\r\n| where Computer == SourceMachine\r\n| where RemoteIp in (remoteMachineIps) or RemoteIp == ChildMachine\r\n| where Direction == '{Direction}'\r\n| summarize Sent = sum(BytesSent), Received = sum(BytesReceived) by bin(TimeGenerated, time('{TimeRange:grain}')), Type = ChildMachine;\r\nSouceMachineData\r\n| union ConnectionData",
-        "showQuery": false,
-        "size": 1,
-        "aggregation": 0,
-        "showAnnotations": false,
-        "showAnalytics": false,
-        "timeContextFromParameter": null,
-        "resourceType": "microsoft.operationalinsights/workspaces",
-        "visualization": "areachart"
-      },
-      "conditionalVisibility": {
-        "parameterName": "IsComputer",
-        "comparison": "isEqualTo",
-        "value": "True"
-      },
-      "customWidth": "25"
-    },
-    {
-      "type": 3,
-      "content": {
-        "version": "KqlItem/1.0",
-        "query": "let length = strlen('{ChildComputer}');\r\nlet SourceMachine = iff('{SourceComputer}' contains '🖥️', substring('{SourceComputer}', 3), '{SourceComputer}');\r\nlet ChildMachine = iff('{ChildComputer}' contains '🖥️', substring('{ChildComputer}', 3), \r\n                        iff('{ChildComputer}' contains '🔸',  substring('{ChildComputer}', 2), \r\n                        iff('{ChildComputer}' contains \"External\", substring('{ChildComputer}', 12, length - 13), '{ChildComputer}')));\r\nlet SouceMachineData = VMConnection\r\n| where TimeGenerated {TimeRange}\r\n| where Computer == SourceMachine\r\n| where ChildMachine == \"any\"\r\n| where Direction == '{Direction}'\r\n| summarize MaxOpenPorts = max(LinksLive), SumFailed = sum(LinksFailed) by bin(TimeGenerated, time('{TimeRange:grain}')), Type = SourceMachine;\r\nlet computers = ServiceMapComputer_CL\r\n| where TimeGenerated {TimeRange}\r\n| summarize (TimeGenerated, Properties) = arg_max(TimeGenerated, pack_all()) by Computer;\r\nlet ipComputerMapping = computers \r\n| project Computer, Ipv4 = todynamic(tostring(Properties.Ipv4Addresses_s))\r\n| mvexpand Ipv4 to typeof(string);\r\nlet remoteMachineIps = ipComputerMapping\r\n| where Computer == ChildMachine\r\n| project Ipv4;\r\nlet ConnectionData = VMConnection\r\n| where TimeGenerated {TimeRange}\r\n| where Computer == SourceMachine\r\n| where RemoteIp in (remoteMachineIps) or RemoteIp == ChildMachine\r\n| where Direction == '{Direction}'\r\n| summarize MaxOpenPorts = max(LinksLive), SumFailed = sum(LinksFailed) by bin(TimeGenerated, time('{TimeRange:grain}')), Type = ChildMachine;\r\nSouceMachineData\r\n| union ConnectionData",
+        "query": "// {Computer:label}\r\nlet SourceMachineData = VMConnection\r\n| where TimeGenerated {TimeRange}\r\n| {QueryFilter}\r\n| where Direction == '{Direction}'\r\n| summarize P50 = percentiles(ResponseTimeSum, 50), P90 = percentiles(ResponseTimeSum, 90), P95 = percentiles(ResponseTimeSum, 95) by bin(TimeGenerated, time('{TimeRange:grain}'));\r\nSourceMachineData",
         "showQuery": false,
         "size": 1,
         "aggregation": 3,
         "showAnnotations": false,
         "showAnalytics": false,
         "timeContextFromParameter": null,
-        "resourceType": "microsoft.operationalinsights/workspaces",
+        "resourceType": "microsoft.compute/virtualmachines",
+        "crossComponentResources": [
+          "{Computer}"
+        ],
+        "visualization": "linechart"
+      },
+      "conditionalVisibility": {
+        "parameterName": "ShowDetail",
+        "comparison": "isEqualTo",
+        "value": "True"
+      },
+      "customWidth": "25"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "// {Computer:label}\r\nlet SourceMachineData = VMConnection\r\n| where TimeGenerated {TimeRange}\r\n| {QueryFilter}\r\n| where Direction == '{Direction}'\r\n| summarize Sent = sum(BytesSent), Received = sum(BytesReceived) by bin(TimeGenerated, time('{TimeRange:grain}'));\r\nSourceMachineData",
+        "showQuery": false,
+        "size": 1,
+        "aggregation": 0,
+        "showAnnotations": false,
+        "showAnalytics": false,
+        "timeContextFromParameter": null,
+        "resourceType": "microsoft.compute/virtualmachines",
+        "crossComponentResources": [
+          "{Computer}"
+        ],
         "visualization": "areachart"
       },
       "conditionalVisibility": {
-        "parameterName": "IsComputer",
+        "parameterName": "ShowDetail",
+        "comparison": "isEqualTo",
+        "value": "True"
+      },
+      "customWidth": "25"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "// {Computer:label}\r\nlet SourceMachineData = VMConnection\r\n| where TimeGenerated {TimeRange}\r\n| {QueryFilter}\r\n| where Direction == '{Direction}'\r\n| summarize MaxOpenPorts = max(LinksLive), SumFailed = sum(LinksFailed) by bin(TimeGenerated, time('{TimeRange:grain}'));\r\nSourceMachineData",
+        "showQuery": false,
+        "size": 1,
+        "aggregation": 3,
+        "showAnnotations": false,
+        "showAnalytics": false,
+        "timeContextFromParameter": null,
+        "resourceType": "microsoft.compute/virtualmachines",
+        "crossComponentResources": [
+          "{Computer}"
+        ],
+        "visualization": "areachart"
+      },
+      "conditionalVisibility": {
+        "parameterName": "ShowDetail",
         "comparison": "isEqualTo",
         "value": "True"
       },


### PR DESCRIPTION
Bring Connections Overview workbook for Single VM to parity with its
AtScale counterpart. Includes all fixes such as inbound connections and
additional filters.

Preview:
![image](https://user-images.githubusercontent.com/43890980/52688139-eeda3600-2f09-11e9-9d41-6ca203889e30.png)
