### PR TITLE
Fix TableFilter dropdown

### DIFF
--- a/Workbooks/Virtual Machines - Network Dependencies/Connections Overview - Single VM/Connections Overview.workbook
+++ b/Workbooks/Virtual Machines - Network Dependencies/Connections Overview - Single VM/Connections Overview.workbook
@@ -42,21 +42,7 @@
             "name": "Test",
             "type": 1,
             "isRequired": false,
-            "query": "VMConnection\r\n| summarize count()",
-            "crossComponentResources": [
-              "{Computer}"
-            ],
-            "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
-            "resourceType": "microsoft.compute/virtualmachines"
-          },
-          {
-            "id": "57fbe5b3-bf7c-445d-ab80-f76e56615f67",
-            "version": "KqlParameterItem/1.0",
-            "name": "EmptyOrOnboard",
-            "type": 1,
-            "isRequired": false,
-            "query": "print '{Test}'",
+            "query": "VMConnection\r\n| take 1\r\n| summarize count()",
             "crossComponentResources": [
               "{Computer}"
             ],
@@ -70,7 +56,7 @@
             "name": "DisclaimerText",
             "type": 1,
             "isRequired": false,
-            "query": "print iff('{EmptyOrOnboard}' == '' , 'This workbook requires [Azure Monitor for VMs (preview)](https://docs.microsoft.com/en-us/azure/azure-monitor/insights/vminsights-overview) enabled', iff('{EmptyOrOnboard}' == '0', '⚠ There is currently no `VMConnection` data for this virtual machine', ''))",
+            "query": "print iff('{Test}' == '' , 'This workbook requires [Azure Monitor for VMs (preview)](https://docs.microsoft.com/en-us/azure/azure-monitor/insights/vminsights-overview) enabled', iff('{Test}' == '0', '⚠ There is currently no `VMConnection` data for this virtual machine', ''))",
             "crossComponentResources": [
               "{Computer}"
             ],
@@ -284,7 +270,7 @@
             "typeSettings": {
               "additionalResourceOptions": []
             },
-            "jsonData": "[\r\n    {\r\n        \"label\": \"Only Malicious Connections\",\r\n        \"value\": \" | where MaliciousConnectionsCount >= 1\"\r\n    },\r\n    {\r\n        \"label\": \"Only Links Failed\",\r\n        \"value\": \" | where LinksFailed >= 1\"\r\n    },\r\n]",
+            "jsonData": "[\r\n    {\r\n        \"label\": \"Only Malicious Connections\",\r\n        \"value\": \" | where MaliciousConnectionsCount >= 1\"\r\n    },\r\n    {\r\n        \"label\": \"Only Links Failed\",\r\n        \"value\": \" | where LinksFailed >= 1\"\r\n    }\r\n]",
             "timeContextFromParameter": null
           }
         ],
@@ -567,7 +553,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "// {Computer} {Test} {EmptyOrOnboard} {TimeRange} {Direction} {ComputerFilter} {Hierarchy} {TableFilter} {ServiceMapComputers} {MaliciousIpData} {ComputerData} {RemoteIpDataInbound} {ProcessName} {RemoteIpData} {SourcePortData} {DestinationPortData} {QueryProject} {Computer_Process_IP_Port} {Computer_Process_IP} {Computer_Process} {Computer_Query} {FinalQuery}\r\n{FinalQuery:value}",
+        "query": "// {Computer} {Test} {TimeRange} {Direction} {ComputerFilter} {Hierarchy} {TableFilter} {ServiceMapComputers} {MaliciousIpData} {ComputerData} {RemoteIpDataInbound} {ProcessName} {RemoteIpData} {SourcePortData} {DestinationPortData} {QueryProject} {Computer_Process_IP_Port} {Computer_Process_IP} {Computer_Process} {Computer_Query} {FinalQuery}\r\n{FinalQuery:value}",
         "showQuery": false,
         "size": 0,
         "aggregation": 0,


### PR DESCRIPTION
Minor fix to `TableFilter` dropdown with improperly defined JSON. Also consolidate `EmptyOrOnboarded` into `Test` hidden parameter to check to see if VM has been onboarded or not.

![image](https://user-images.githubusercontent.com/43890980/53600956-c84e0900-3b5f-11e9-9787-c72008e28f75.png)