### PR TITLE
Add log analytics button to grid

### DIFF
--- a/Workbooks/Virtual Machines - Network Dependencies/Connections Overview - Single VM/Connections Overview.workbook
+++ b/Workbooks/Virtual Machines - Network Dependencies/Connections Overview - Single VM/Connections Overview.workbook
@@ -752,6 +752,7 @@
         }
       },
       "conditionalVisibility": null,
+      "showPin": true,
       "name": "query - 6"
     },
     {

--- a/Workbooks/Virtual Machines - Network Dependencies/Connections Overview - Single VM/Connections Overview.workbook
+++ b/Workbooks/Virtual Machines - Network Dependencies/Connections Overview - Single VM/Connections Overview.workbook
@@ -1,13 +1,13 @@
 {
   "version": "Notebook/1.0",
-  "isLocked": true,
   "items": [
     {
       "type": 1,
       "content": {
         "json": "<h1>Connections Overview</h1>"
       },
-      "conditionalVisibility": null
+      "conditionalVisibility": null,
+      "name": "text - 0"
     },
     {
       "type": 9,
@@ -66,20 +66,23 @@
           }
         ],
         "style": "above",
+        "queryType": 0,
         "resourceType": "microsoft.compute/virtualmachines"
       },
       "conditionalVisibility": {
         "parameterName": "_",
         "comparison": "isNotEqualTo",
         "value": null
-      }
+      },
+      "name": "parameters - 1"
     },
     {
       "type": 1,
       "content": {
         "json": "{DisclaimerText}\r\n\r\n---"
       },
-      "conditionalVisibility": null
+      "conditionalVisibility": null,
+      "name": "text - 2"
     },
     {
       "type": 9,
@@ -95,11 +98,7 @@
             "type": 4,
             "isRequired": true,
             "value": {
-              "durationMs": 3600000,
-              "createdTime": "2019-01-28T23:37:45.024Z",
-              "isInitialTime": false,
-              "grain": 1,
-              "useDashboardTimeRange": false
+              "durationMs": 3600000
             },
             "isHiddenWhenLocked": false,
             "typeSettings": {
@@ -275,9 +274,11 @@
           }
         ],
         "style": "above",
+        "queryType": 0,
         "resourceType": "microsoft.compute/virtualmachines"
       },
-      "conditionalVisibility": null
+      "conditionalVisibility": null,
+      "name": "parameters - 3"
     },
     {
       "type": 9,
@@ -538,30 +539,30 @@
           }
         ],
         "style": "above",
+        "queryType": 0,
         "resourceType": "microsoft.compute/virtualmachines"
       },
-      "conditionalVisibility": null
+      "conditionalVisibility": null,
+      "name": "parameters - 4"
     },
     {
       "type": 1,
       "content": {
         "json": "💡 <em>Select a row from the table below to view connection details for that entry.</em>"
       },
-      "conditionalVisibility": null
+      "conditionalVisibility": null,
+      "name": "text - 5"
     },
     {
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
         "query": "// {Computer} {Test} {TimeRange} {Direction} {ComputerFilter} {Hierarchy} {TableFilter} {ServiceMapComputers} {MaliciousIpData} {ComputerData} {RemoteIpDataInbound} {ProcessName} {RemoteIpData} {SourcePortData} {DestinationPortData} {QueryProject} {Computer_Process_IP_Port} {Computer_Process_IP} {Computer_Process} {Computer_Query} {FinalQuery}\r\n{FinalQuery:value}",
-        "showQuery": false,
         "size": 0,
-        "aggregation": 0,
-        "showAnnotations": false,
         "exportParameterName": "ConnectionGrid",
-        "showAnalytics": false,
+        "showAnalytics": true,
         "noDataMessage": "No data to be shown for this particular scope combination, please adjust the time range, table filters, etc.",
-        "timeContextFromParameter": null,
+        "queryType": 0,
         "resourceType": "microsoft.compute/virtualmachines",
         "crossComponentResources": [
           "{Computer}"
@@ -750,7 +751,8 @@
           }
         }
       },
-      "conditionalVisibility": null
+      "conditionalVisibility": null,
+      "name": "query - 6"
     },
     {
       "type": 9,
@@ -858,9 +860,11 @@
           }
         ],
         "style": "above",
+        "queryType": 0,
         "resourceType": "microsoft.compute/virtualmachines"
       },
-      "conditionalVisibility": null
+      "conditionalVisibility": null,
+      "name": "parameters - 7"
     },
     {
       "type": 1,
@@ -871,7 +875,8 @@
         "parameterName": "ShowDetail",
         "comparison": "isEqualTo",
         "value": "True"
-      }
+      },
+      "name": "text - 8"
     },
     {
       "type": 1,
@@ -883,7 +888,8 @@
         "comparison": "isEqualTo",
         "value": "True"
       },
-      "customWidth": "25"
+      "customWidth": "25",
+      "name": "text - 9"
     },
     {
       "type": 1,
@@ -895,7 +901,8 @@
         "comparison": "isEqualTo",
         "value": "True"
       },
-      "customWidth": "25"
+      "customWidth": "25",
+      "name": "text - 10"
     },
     {
       "type": 1,
@@ -907,7 +914,8 @@
         "comparison": "isEqualTo",
         "value": "True"
       },
-      "customWidth": "25"
+      "customWidth": "25",
+      "name": "text - 11"
     },
     {
       "type": 1,
@@ -919,19 +927,16 @@
         "comparison": "isEqualTo",
         "value": "True"
       },
-      "customWidth": "25"
+      "customWidth": "25",
+      "name": "text - 12"
     },
     {
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
         "query": "// {Computer:label}\r\nlet SourceMachineData = VMConnection\r\n| where TimeGenerated {TimeRange}\r\n| {QueryFilter}\r\n| where Direction == '{Direction}'\r\n| summarize Responses = sum(Responses) by bin(TimeGenerated, time('{TimeRange:grain}'));\r\nSourceMachineData",
-        "showQuery": false,
         "size": 1,
-        "aggregation": 0,
-        "showAnnotations": false,
-        "showAnalytics": false,
-        "timeContextFromParameter": null,
+        "queryType": 0,
         "resourceType": "microsoft.compute/virtualmachines",
         "crossComponentResources": [
           "{Computer}"
@@ -943,19 +948,17 @@
         "comparison": "isEqualTo",
         "value": "True"
       },
-      "customWidth": "25"
+      "customWidth": "25",
+      "name": "query - 13"
     },
     {
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
         "query": "// {Computer:label}\r\nlet SourceMachineData = VMConnection\r\n| where TimeGenerated {TimeRange}\r\n| {QueryFilter}\r\n| where Direction == '{Direction}'\r\n| summarize P50 = percentiles(ResponseTimeSum, 50), P90 = percentiles(ResponseTimeSum, 90), P95 = percentiles(ResponseTimeSum, 95) by bin(TimeGenerated, time('{TimeRange:grain}'));\r\nSourceMachineData",
-        "showQuery": false,
         "size": 1,
         "aggregation": 3,
-        "showAnnotations": false,
-        "showAnalytics": false,
-        "timeContextFromParameter": null,
+        "queryType": 0,
         "resourceType": "microsoft.compute/virtualmachines",
         "crossComponentResources": [
           "{Computer}"
@@ -967,19 +970,16 @@
         "comparison": "isEqualTo",
         "value": "True"
       },
-      "customWidth": "25"
+      "customWidth": "25",
+      "name": "query - 14"
     },
     {
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
         "query": "// {Computer:label}\r\nlet SourceMachineData = VMConnection\r\n| where TimeGenerated {TimeRange}\r\n| {QueryFilter}\r\n| where Direction == '{Direction}'\r\n| summarize Sent = sum(BytesSent), Received = sum(BytesReceived) by bin(TimeGenerated, time('{TimeRange:grain}'));\r\nSourceMachineData",
-        "showQuery": false,
         "size": 1,
-        "aggregation": 0,
-        "showAnnotations": false,
-        "showAnalytics": false,
-        "timeContextFromParameter": null,
+        "queryType": 0,
         "resourceType": "microsoft.compute/virtualmachines",
         "crossComponentResources": [
           "{Computer}"
@@ -991,19 +991,17 @@
         "comparison": "isEqualTo",
         "value": "True"
       },
-      "customWidth": "25"
+      "customWidth": "25",
+      "name": "query - 15"
     },
     {
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
         "query": "// {Computer:label}\r\nlet SourceMachineData = VMConnection\r\n| where TimeGenerated {TimeRange}\r\n| {QueryFilter}\r\n| where Direction == '{Direction}'\r\n| summarize MaxOpenPorts = max(LinksLive), SumFailed = sum(LinksFailed) by bin(TimeGenerated, time('{TimeRange:grain}'));\r\nSourceMachineData",
-        "showQuery": false,
         "size": 1,
         "aggregation": 3,
-        "showAnnotations": false,
-        "showAnalytics": false,
-        "timeContextFromParameter": null,
+        "queryType": 0,
         "resourceType": "microsoft.compute/virtualmachines",
         "crossComponentResources": [
           "{Computer}"
@@ -1015,7 +1013,8 @@
         "comparison": "isEqualTo",
         "value": "True"
       },
-      "customWidth": "25"
+      "customWidth": "25",
+      "name": "query - 16"
     }
   ],
   "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"

--- a/Workbooks/Virtual Machines - Network Dependencies/Connections Overview/Connections Overview.workbook
+++ b/Workbooks/Virtual Machines - Network Dependencies/Connections Overview/Connections Overview.workbook
@@ -772,6 +772,7 @@
         }
       },
       "conditionalVisibility": null,
+      "showPin": true,
       "name": "query - 5"
     },
     {

--- a/Workbooks/Virtual Machines - Network Dependencies/Connections Overview/Connections Overview.workbook
+++ b/Workbooks/Virtual Machines - Network Dependencies/Connections Overview/Connections Overview.workbook
@@ -65,14 +65,16 @@
         "parameterName": "_",
         "comparison": "isNotEqualTo",
         "value": null
-      }
+      },
+      "name": "parameters - 0"
     },
     {
       "type": 1,
       "content": {
         "json": "{DisclaimerText}\r\n\r\n---"
       },
-      "conditionalVisibility": null
+      "conditionalVisibility": null,
+      "name": "text - 1"
     },
     {
       "type": 9,
@@ -300,7 +302,8 @@
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces"
       },
-      "conditionalVisibility": null
+      "conditionalVisibility": null,
+      "name": "parameters - 2"
     },
     {
       "type": 9,
@@ -576,26 +579,25 @@
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces"
       },
-      "conditionalVisibility": null
+      "conditionalVisibility": null,
+      "name": "parameters - 3"
     },
     {
       "type": 1,
       "content": {
         "json": "💡 <em>Select a row from the table below to view connection details for that entry.</em>"
       },
-      "conditionalVisibility": null
+      "conditionalVisibility": null,
+      "name": "text - 4"
     },
     {
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
         "query": "// {Workspace} {Test} {TimeRange} {Direction} {ComputerNameContains} {Computers} {ComputerFilter} {Hierarchy} {TableFilter} {ServiceMapComputers} {MaliciousIpData} {ComputerData} {RemoteIpDataInbound} {ProcessName} {RemoteIpData} {SourcePortData} {DestinationPortData} {QueryProject} {Computer_Process_IP_Port} {Computer_Process_IP} {Computer_Process} {Computer} {FinalQuery}\r\n{FinalQuery:value}",
-        "showQuery": false,
         "size": 0,
-        "aggregation": 0,
-        "showAnnotations": false,
         "exportParameterName": "ConnectionGrid",
-        "showAnalytics": false,
+        "showAnalytics": true,
         "noDataMessage": "No data to be shown for this particular scope combination, please adjust the time range, table filters, etc.",
         "timeContext": {
           "durationMs": 0
@@ -769,7 +771,8 @@
           }
         }
       },
-      "conditionalVisibility": null
+      "conditionalVisibility": null,
+      "name": "query - 5"
     },
     {
       "type": 9,
@@ -880,7 +883,8 @@
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces"
       },
-      "conditionalVisibility": null
+      "conditionalVisibility": null,
+      "name": "parameters - 6"
     },
     {
       "type": 1,
@@ -891,7 +895,8 @@
         "parameterName": "ShowDetail",
         "comparison": "isEqualTo",
         "value": "True"
-      }
+      },
+      "name": "text - 7"
     },
     {
       "type": 1,
@@ -903,7 +908,8 @@
         "comparison": "isEqualTo",
         "value": "True"
       },
-      "customWidth": "25"
+      "customWidth": "25",
+      "name": "text - 8"
     },
     {
       "type": 1,
@@ -915,7 +921,8 @@
         "comparison": "isEqualTo",
         "value": "True"
       },
-      "customWidth": "25"
+      "customWidth": "25",
+      "name": "text - 9"
     },
     {
       "type": 1,
@@ -927,7 +934,8 @@
         "comparison": "isEqualTo",
         "value": "True"
       },
-      "customWidth": "25"
+      "customWidth": "25",
+      "name": "text - 10"
     },
     {
       "type": 1,
@@ -939,19 +947,15 @@
         "comparison": "isEqualTo",
         "value": "True"
       },
-      "customWidth": "25"
+      "customWidth": "25",
+      "name": "text - 11"
     },
     {
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
         "query": "// {Workspace:label}\r\nlet SourceMachineData = VMConnection\r\n| where TimeGenerated {TimeRange}\r\n| {QueryFilter}\r\n| where Direction == '{Direction}'\r\n| summarize Responses = sum(Responses) by bin(TimeGenerated, time('{TimeRange:grain}'));\r\nSourceMachineData",
-        "showQuery": false,
         "size": 1,
-        "aggregation": 0,
-        "showAnnotations": false,
-        "showAnalytics": false,
-        "timeContextFromParameter": null,
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
         "crossComponentResources": [
@@ -964,19 +968,16 @@
         "comparison": "isEqualTo",
         "value": "True"
       },
-      "customWidth": "25"
+      "customWidth": "25",
+      "name": "query - 12"
     },
     {
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
         "query": "// {Workspace:label}\r\nlet SourceMachineData = VMConnection\r\n| where TimeGenerated {TimeRange}\r\n| {QueryFilter}\r\n| where Direction == '{Direction}'\r\n| summarize P50 = percentiles(ResponseTimeSum, 50), P90 = percentiles(ResponseTimeSum, 90), P95 = percentiles(ResponseTimeSum, 95) by bin(TimeGenerated, time('{TimeRange:grain}'));\r\nSourceMachineData",
-        "showQuery": false,
         "size": 1,
         "aggregation": 3,
-        "showAnnotations": false,
-        "showAnalytics": false,
-        "timeContextFromParameter": null,
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
         "crossComponentResources": [
@@ -989,19 +990,15 @@
         "comparison": "isEqualTo",
         "value": "True"
       },
-      "customWidth": "25"
+      "customWidth": "25",
+      "name": "query - 13"
     },
     {
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
         "query": "// {Workspace:label}\r\nlet SourceMachineData = VMConnection\r\n| where TimeGenerated {TimeRange}\r\n| {QueryFilter}\r\n| where Direction == '{Direction}'\r\n| summarize Sent = sum(BytesSent), Received = sum(BytesReceived) by bin(TimeGenerated, time('{TimeRange:grain}'));\r\nSourceMachineData",
-        "showQuery": false,
         "size": 1,
-        "aggregation": 0,
-        "showAnnotations": false,
-        "showAnalytics": false,
-        "timeContextFromParameter": null,
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
         "crossComponentResources": [
@@ -1014,19 +1011,16 @@
         "comparison": "isEqualTo",
         "value": "True"
       },
-      "customWidth": "25"
+      "customWidth": "25",
+      "name": "query - 14"
     },
     {
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
         "query": "// {Workspace:label}\r\nlet SourceMachineData = VMConnection\r\n| where TimeGenerated {TimeRange}\r\n| {QueryFilter}\r\n| where Direction == '{Direction}'\r\n| summarize MaxOpenPorts = max(LinksLive), SumFailed = sum(LinksFailed) by bin(TimeGenerated, time('{TimeRange:grain}'));\r\nSourceMachineData",
-        "showQuery": false,
         "size": 1,
         "aggregation": 3,
-        "showAnnotations": false,
-        "showAnalytics": false,
-        "timeContextFromParameter": null,
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
         "crossComponentResources": [
@@ -1039,7 +1033,8 @@
         "comparison": "isEqualTo",
         "value": "True"
       },
-      "customWidth": "25"
+      "customWidth": "25",
+      "name": "query - 15"
     }
   ],
   "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"


### PR DESCRIPTION
Add log analytics button to always show on grid. Requested by customer. More diffs than usual due to template changes on PPE.

AtScale
![image](https://user-images.githubusercontent.com/43890980/55495971-e097c480-55f2-11e9-8a33-4758a5b25042.png)

SingleVM
![image](https://user-images.githubusercontent.com/43890980/55496188-4d12c380-55f3-11e9-9b6d-37362122e700.png)

Pin to dashboard
![image](https://user-images.githubusercontent.com/43890980/55496267-80555280-55f3-11e9-95f3-05db8d35a308.png)

Test
* Verified log analytics blade works
* Verified pin to dashboard works