### PR TITLE
Connections Overview: fix a couple params not using the workspace param

### DIFF
--- a/Workbooks/Virtual Machines - Network Dependencies/Connections Overview/Connections Overview.workbook
+++ b/Workbooks/Virtual Machines - Network Dependencies/Connections Overview/Connections Overview.workbook
@@ -271,6 +271,9 @@
             "description": "Select the level of detail to be shown in the table below",
             "isRequired": true,
             "query": "let outboundTable = datatable (value:string, Display:string)\r\n    [\"0\", \"Computer -> Process -> Remote IP -> Port\",\r\n     \"1\", \"Computer -> Process -> Remote IP\",\r\n     \"2\", \"Computer -> Process\",\r\n     \"3\", \"Computer\"];\r\nlet outbound = outboundTable | extend type = 'outbound';\r\nlet inboundTable = datatable (value:string, Display:string)\r\n    [\"0\", \"Computer -> Process -> Port -> Remote IP\",\r\n     \"1\", \"Computer -> Process -> Port\",\r\n     \"2\", \"Computer -> Process\",\r\n     \"3\", \"Computer\"];\r\nlet inbound = inboundTable | extend type = 'inbound';\r\nlet table = outbound | union inbound;\r\ntable\r\n| where type == iif('{Direction}' == 'outbound', 'outbound', 'inbound')\r\n| project value, Display",
+            "crossComponentResources": [
+              "{Workspace}"
+            ],
             "value": "2",
             "isHiddenWhenLocked": false,
             "typeSettings": {
@@ -847,6 +850,9 @@
             "type": 1,
             "isRequired": true,
             "query": "print(strcat('{ComputerName}{ProcessName}{RemoteIp}{DestinationPort}' != ''))",
+            "crossComponentResources": [
+              "{Workspace}"
+            ],
             "isHiddenWhenLocked": true,
             "timeContextFromParameter": null,
             "resourceType": "microsoft.operationalinsights/workspaces"


### PR DESCRIPTION
while working on workbook links, I found 2 parameters here that were working by inheriting the workspace from resources instead of using the workspace parameter.  

(in my links branch, the resourceIds for the workspace is *only* a vm id, it might be the case that from your blade you're passing both the workspace *and* virtual machine ids in resource ids?)