### PR TITLE
move text step headings into chart headings, set no rows text

### DIFF
--- a/Workbooks/Failures/Failure Insights/Failure Insights.workbook
+++ b/Workbooks/Failures/Failure Insights/Failure Insights.workbook
@@ -1,14 +1,13 @@
 {
-  "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json",
   "version": "Notebook/1.0",
-  "isLocked": true,
   "items": [
     {
       "type": 1,
       "content": {
         "json": "# Failures Insights\n"
       },
-      "conditionalVisibility": null
+      "conditionalVisibility": null,
+      "name": "text - 0"
     },
     {
       "type": 9,
@@ -46,89 +45,46 @@
             "name": "TimeRange",
             "type": 4,
             "isRequired": false,
+            "value": {
+              "durationMs": 14400000
+            },
             "isHiddenWhenLocked": false,
             "typeSettings": {
               "selectableValues": [
                 {
-                  "durationMs": 300000,
-                  "createdTime": "2018-08-06T23:52:38.870Z",
-                  "isInitialTime": false,
-                  "grain": 1,
-                  "useDashboardTimeRange": false
+                  "durationMs": 300000
                 },
                 {
-                  "durationMs": 900000,
-                  "createdTime": "2018-08-06T23:52:38.871Z",
-                  "isInitialTime": false,
-                  "grain": 1,
-                  "useDashboardTimeRange": false
+                  "durationMs": 900000
                 },
                 {
-                  "durationMs": 1800000,
-                  "createdTime": "2018-08-06T23:52:38.871Z",
-                  "isInitialTime": false,
-                  "grain": 1,
-                  "useDashboardTimeRange": false
+                  "durationMs": 1800000
                 },
                 {
-                  "durationMs": 3600000,
-                  "createdTime": "2018-08-06T23:52:38.871Z",
-                  "isInitialTime": false,
-                  "grain": 1,
-                  "useDashboardTimeRange": false
+                  "durationMs": 3600000
                 },
                 {
-                  "durationMs": 14400000,
-                  "createdTime": "2018-08-06T23:52:38.871Z",
-                  "isInitialTime": false,
-                  "grain": 1,
-                  "useDashboardTimeRange": false
+                  "durationMs": 14400000
                 },
                 {
-                  "durationMs": 43200000,
-                  "createdTime": "2018-08-06T23:52:38.871Z",
-                  "isInitialTime": false,
-                  "grain": 1,
-                  "useDashboardTimeRange": false
+                  "durationMs": 43200000
                 },
                 {
-                  "durationMs": 86400000,
-                  "createdTime": "2018-08-06T23:52:38.871Z",
-                  "isInitialTime": false,
-                  "grain": 1,
-                  "useDashboardTimeRange": false
+                  "durationMs": 86400000
                 },
                 {
-                  "durationMs": 172800000,
-                  "createdTime": "2018-08-06T23:52:38.871Z",
-                  "isInitialTime": false,
-                  "grain": 1,
-                  "useDashboardTimeRange": false
+                  "durationMs": 172800000
                 },
                 {
-                  "durationMs": 259200000,
-                  "createdTime": "2018-08-06T23:52:38.871Z",
-                  "isInitialTime": false,
-                  "grain": 1,
-                  "useDashboardTimeRange": false
+                  "durationMs": 259200000
                 },
                 {
-                  "durationMs": 604800000,
-                  "createdTime": "2018-08-06T23:52:38.871Z",
-                  "isInitialTime": false,
-                  "grain": 1,
-                  "useDashboardTimeRange": false
+                  "durationMs": 604800000
                 }
               ],
               "allowCustom": null
             },
-            "value": {
-              "durationMs": 14400000,
-              "createdTime": "2018-08-06T23:52:38.871Z",
-              "isInitialTime": false,
-              "grain": 1,
-              "useDashboardTimeRange": false
-            }
+            "timeContextFromParameter": null
           },
           {
             "id": "1014e6d9-72b9-4729-a3a0-f5704768854e",
@@ -140,21 +96,21 @@
             "value": "{\"App\":\"\",\"Operation\":\"\"}"
           }
         ],
+        "style": "pills",
+        "queryType": 0,
         "resourceType": "microsoft.insights/components"
       },
-      "conditionalVisibility": null
+      "conditionalVisibility": null,
+      "name": "parameters - 1"
     },
     {
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
         "query": "let data = requests\n| where timestamp {TimeRange};\ndata\n| summarize Users = dcount(user_Id), CountFailed = countif(success == false), Count = count() by name, appName\n| project App = appName, Operation = name, ['Count (Failed)'] = CountFailed, Count, ['Success %'] = round(100.0 * (Count - CountFailed) / Count, 2), Users\n| union (data\n    | summarize Users = dcount(user_Id), CountFailed = countif(success == false), Count = count()\n    | project App = '🔸 All Apps', Operation = '🔸 All operations', Users, ['Count (Failed)'] = CountFailed, Count, ['Success %'] = round(100.0 * (Count - CountFailed) / Count, 2))\n| order by ['Count (Failed)'] desc\n",
-        "showQuery": false,
         "size": 0,
-        "aggregation": 0,
-        "showAnnotations": false,
         "exportParameterName": "Operation",
-        "showAnalytics": false,
+        "queryType": 0,
         "resourceType": "microsoft.insights/components",
         "crossComponentResources": [
           "{Apps}"
@@ -200,14 +156,16 @@
           ]
         }
       },
-      "conditionalVisibility": null
+      "conditionalVisibility": null,
+      "name": "query - 2"
     },
     {
       "type": 1,
       "content": {
         "json": "💡 *Click on the rows of the table above to see details for other operations*"
       },
-      "conditionalVisibility": null
+      "conditionalVisibility": null,
+      "name": "text - 3"
     },
     {
       "type": 9,
@@ -227,43 +185,29 @@
             "resourceType": "microsoft.insights/components"
           }
         ],
+        "style": "pills",
+        "queryType": 0,
         "resourceType": "microsoft.insights/components"
       },
-      "conditionalVisibility": null
+      "conditionalVisibility": null,
+      "name": "parameters - 4"
     },
     {
       "type": 1,
       "content": {
         "json": "## Details -- {SelectedOperation}\n"
       },
-      "conditionalVisibility": null
-    },
-    {
-      "type": 1,
-      "content": {
-        "json": "### Failed Operations"
-      },
       "conditionalVisibility": null,
-      "customWidth": "50"
-    },
-    {
-      "type": 1,
-      "content": {
-        "json": "### All Operations"
-      },
-      "conditionalVisibility": null,
-      "customWidth": "50"
+      "name": "text - 5"
     },
     {
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
         "query": "let row = dynamic({Operation});\nlet operation = tostring(row.Operation);\nlet app = tostring(row.App);\nrequests\n| where timestamp {TimeRange}\n| where (name == operation and appName == app) or (operation == '' and app == '') or (operation == '🔸 All operations' and app == '🔸 All Apps')\n| make-series FailedRequest = countif(success == false) default = 0 on timestamp in range({TimeRange:start}, {TimeRange:end}, {TimeRange:grain})\n| mvexpand timestamp to typeof(datetime), FailedRequest to typeof(long)\n",
-        "showQuery": false,
         "size": 1,
-        "aggregation": 0,
-        "showAnnotations": false,
-        "showAnalytics": false,
+        "title": "Failed Operations",
+        "queryType": 0,
         "resourceType": "microsoft.insights/components",
         "crossComponentResources": [
           "{Apps}"
@@ -271,18 +215,17 @@
         "visualization": "areachart"
       },
       "conditionalVisibility": null,
-      "customWidth": "50"
+      "customWidth": "50",
+      "name": "query - 8"
     },
     {
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
         "query": "let row = dynamic({Operation});\nlet operation = tostring(row.Operation);\nlet app = tostring(row.App);\nrequests\n| where timestamp {TimeRange}\n| where (name == operation and appName == app) or (operation == '' and app == '') or (operation == '🔸 All operations' and app == '🔸 All Apps')\n| make-series Requests = count() default = 0 on timestamp in range({TimeRange:start}, {TimeRange:end}, {TimeRange:grain})\n| mvexpand timestamp to typeof(datetime), Requests to typeof(long)\n",
-        "showQuery": false,
         "size": 1,
-        "aggregation": 0,
-        "showAnnotations": false,
-        "showAnalytics": false,
+        "title": "All Operations",
+        "queryType": 0,
         "resourceType": "microsoft.insights/components",
         "crossComponentResources": [
           "{Apps}"
@@ -290,34 +233,18 @@
         "visualization": "areachart"
       },
       "conditionalVisibility": null,
-      "customWidth": "50"
-    },
-    {
-      "type": 1,
-      "content": {
-        "json": "### Top Failure Codes"
-      },
-      "conditionalVisibility": null,
-      "customWidth": "50"
-    },
-    {
-      "type": 1,
-      "content": {
-        "json": "### Top Exceptions"
-      },
-      "conditionalVisibility": null,
-      "customWidth": "50"
+      "customWidth": "50",
+      "name": "query - 9"
     },
     {
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
         "query": "let row = dynamic({Operation});\nlet operation = tostring(row.Operation);\nlet app = tostring(row.App);\nrequests\n| where timestamp {TimeRange}\n| where (name == operation and appName == app) or (operation == '' and app == '') or (operation == '🔸 All operations' and app == '🔸 All Apps')\n| where success == false\n| summarize ['Failing Requests'] = count() by ['Result Code'] = tostring(resultCode)\n| top 4 by ['Failing Requests'] desc\n",
-        "showQuery": false,
         "size": 1,
-        "aggregation": 0,
-        "showAnnotations": false,
-        "showAnalytics": false,
+        "title": "Top Failure Codes",
+        "noDataMessage": "No failiures found.",
+        "queryType": 0,
         "resourceType": "microsoft.insights/components",
         "crossComponentResources": [
           "{Apps}"
@@ -338,18 +265,18 @@
         }
       },
       "conditionalVisibility": null,
-      "customWidth": "50"
+      "customWidth": "50",
+      "name": "query - 12"
     },
     {
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
         "query": "let row = dynamic({Operation});\nlet operation = tostring(row.Operation);\nlet app = tostring(row.App);\nlet operations = toscalar(requests\n| where timestamp {TimeRange}\n| where (name == operation and appName == app) or (operation == '' and app == '') or (operation == '🔸 All operations' and app == '🔸 All Apps')\n| summarize by operation_Id\n| summarize makelist(operation_Id, 1000000));\nexceptions\n| where timestamp {TimeRange}\n| where operation_Id in (operations)\n| summarize ['Failing Requests'] = count() by ['Exception'] = type\n| top 4 by ['Failing Requests'] desc\n",
-        "showQuery": false,
         "size": 1,
-        "aggregation": 0,
-        "showAnnotations": false,
-        "showAnalytics": false,
+        "title": "Top Exceptions",
+        "noDataMessage": "No exceptions found.",
+        "queryType": 0,
         "resourceType": "microsoft.insights/components",
         "crossComponentResources": [
           "{Apps}"
@@ -379,25 +306,18 @@
         }
       },
       "conditionalVisibility": null,
-      "customWidth": "50"
-    },
-    {
-      "type": 1,
-      "content": {
-        "json": "### Top Failing Dependencies"
-      },
-      "conditionalVisibility": null
+      "customWidth": "50",
+      "name": "query - 13"
     },
     {
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
         "query": "let row = dynamic({Operation});\r\nlet operation = tostring(row.Operation);\r\nlet app = tostring(row.App);\r\nlet operations = toscalar(requests\r\n| where timestamp {TimeRange}\r\n| where (name == operation and appName == app) or (operation == '' and app == '') or (operation == '🔸 All operations' and app == '🔸 All Apps')\r\n| summarize by operation_Id\r\n| summarize makelist(operation_Id, 1000000));\r\ndependencies\r\n| where timestamp {TimeRange}\r\n| where operation_Id in (operations)\r\n| where success == false\r\n| summarize ['Failing Dependencies'] = count() by ['Dependency'] = name\r\n| top 4 by ['Failing Dependencies'] desc\r\n",
-        "showQuery": false,
         "size": 0,
-        "aggregation": 0,
-        "showAnnotations": false,
-        "showAnalytics": false,
+        "title": "Top Failing Dependencies",
+        "noDataMessage": "No failed dependencies found.",
+        "queryType": 0,
         "resourceType": "microsoft.insights/components",
         "crossComponentResources": [
           "{Apps}"
@@ -417,7 +337,9 @@
         }
       },
       "conditionalVisibility": null,
-      "customWidth": "50"
+      "customWidth": "50",
+      "name": "query - 15"
     }
-  ]
+  ],
+  "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
 }


### PR DESCRIPTION
for Bug 1441498: [Screen Reader - Application Insights E2E - Failure Analysis] When focus received 'Failed Operations' and 'All Operations' graph chart, screen reader not given relevant information

switched text steps for chart headers to actual chart headers, added failure text:
![image](https://user-images.githubusercontent.com/10158007/56978785-27fb6d00-6b2d-11e9-8186-88b75ad32723.png)
