### PR TITLE
remove hardcoded subscription selection

### DIFF
--- a/Workbooks/Azure Monitor - Workspaces/Workspace Usage/Workspace Usage.workbook
+++ b/Workbooks/Azure Monitor - Workspaces/Workspace Usage/Workspace Usage.workbook
@@ -43,7 +43,6 @@
             "crossComponentResources": [
               "value::selected"
             ],
-            "value": "/subscriptions/72993b69-db12-44fc-9a66-9c2005c30513",
             "isHiddenWhenLocked": false,
             "typeSettings": {
               "additionalResourceOptions": []


### PR DESCRIPTION
this template has a resource id in it, causing it to try to select that sub instead of the value returned as default in the query