### PR TITLE
Initial checkin for VMSS workbooks

### DIFF
--- a/Workbooks/Virtual Machine Scale Sets - Performance Analysis/Performance Analysis/Performance Analysis.workbook
+++ b/Workbooks/Virtual Machine Scale Sets - Performance Analysis/Performance Analysis/Performance Analysis.workbook
@@ -1,0 +1,1509 @@
+{
+  "version": "Notebook/1.0",
+  "items": [
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "query": "",
+        "crossComponentResources": [
+          "value::selected"
+        ],
+        "parameters": [
+          {
+            "id": "688dc7cb-bea3-41ae-ae94-32d22e09568c",
+            "version": "KqlParameterItem/1.0",
+            "name": "Resource",
+            "type": 5,
+            "isRequired": true,
+            "value": "value::1",
+            "isHiddenWhenLocked": true,
+            "typeSettings": {
+              "resourceTypeFilter": {
+                "microsoft.compute/virtualmachinescalesets": true
+              },
+              "additionalResourceOptions": [
+                "value::1"
+              ]
+            },
+            "timeContextFromParameter": null
+          }
+        ],
+        "style": "above",
+        "queryType": 1,
+        "resourceType": "microsoft.resourcegraph/resources"
+      },
+      "conditionalVisibility": {
+        "parameterName": "_",
+        "comparison": "isEqualTo",
+        "value": "_"
+      },
+      "name": "parameters - 0"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "# Performance Analysis"
+      },
+      "conditionalVisibility": {
+        "parameterName": "ContextFree",
+        "comparison": "isEqualTo",
+        "value": "value::1"
+      },
+      "name": "text - 1"
+    },
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "query": "",
+        "crossComponentResources": [
+          "{Resource}"
+        ],
+        "parameters": [
+          {
+            "id": "5f8cce4b-9c4c-47da-8683-7e5ccc9faed3",
+            "version": "KqlParameterItem/1.0",
+            "name": "TimeRange",
+            "type": 4,
+            "isRequired": false,
+            "value": {
+              "durationMs": 1800000
+            },
+            "isHiddenWhenLocked": false,
+            "typeSettings": {
+              "selectableValues": [
+                {
+                  "durationMs": 300000,
+                  "createdTime": "2018-10-04T22:01:18.372Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 900000,
+                  "createdTime": "2018-10-04T22:01:18.372Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 1800000,
+                  "createdTime": "2018-10-04T22:01:18.372Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 3600000,
+                  "createdTime": "2018-10-04T22:01:18.372Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 14400000,
+                  "createdTime": "2018-10-04T22:01:18.374Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 43200000,
+                  "createdTime": "2018-10-04T22:01:18.374Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 86400000,
+                  "createdTime": "2018-10-04T22:01:18.374Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 172800000,
+                  "createdTime": "2018-10-04T22:01:18.374Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 259200000,
+                  "createdTime": "2018-10-04T22:01:18.375Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 604800000,
+                  "createdTime": "2018-10-04T22:01:18.375Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 1209600000,
+                  "createdTime": "2018-10-04T22:01:18.375Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 2592000000,
+                  "createdTime": "2018-10-04T22:01:18.375Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 5184000000,
+                  "createdTime": "2018-10-04T22:01:18.375Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 7776000000,
+                  "createdTime": "2018-10-04T22:01:18.375Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                }
+              ],
+              "allowCustom": true
+            }
+          },
+          {
+            "id": "d6de19ff-cde4-41c2-9fba-b441312ea5c9",
+            "version": "KqlParameterItem/1.0",
+            "name": "Test",
+            "type": 1,
+            "isRequired": false,
+            "query": "// {Resource}\r\nPerf\r\n| take 1",
+            "crossComponentResources": [
+              "{Resource}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "queryType": 0,
+            "resourceType": "microsoft.compute/virtualmachinescalesets"
+          }
+        ],
+        "style": "above",
+        "queryType": 0,
+        "resourceType": "microsoft.compute/virtualmachinescalesets"
+      },
+      "conditionalVisibility": null,
+      "name": "parameters - 2"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "⚠ This workbook requires [Azure Monitor for VMs (preview)](https://docs.microsoft.com/en-us/azure/azure-monitor/insights/vminsights-overview) enabled in order to show accurate and complete information for your VMs. Follow the link to onboard machines or select a different workspace."
+      },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isEqualTo",
+        "value": null
+      },
+      "name": "text - 3"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "---"
+      },
+      "conditionalVisibility": null,
+      "name": "text - 4"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "<h2 style=\"margin-bottom:0;padding-bottom:0;\">Top 100 Machines</h2>"
+      },
+      "conditionalVisibility": null,
+      "name": "text - 5"
+    },
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "query": "",
+        "crossComponentResources": [
+          "{Resource}"
+        ],
+        "parameters": [
+          {
+            "id": "aa2368fc-ad30-4608-b96a-72abf7b1e1af",
+            "version": "KqlParameterItem/1.0",
+            "name": "Counter",
+            "type": 2,
+            "description": "Select a VM performance counter for the table below",
+            "isRequired": false,
+            "query": "// {Resource} {Test}\r\nPerf\r\n| where TimeGenerated {TimeRange}\r\n| where ObjectName != 'Network' and ObjectName != 'Network Interface'\r\n| summarize by CounterName, ObjectName, CounterText = CounterName\r\n| order by ObjectName asc, CounterText asc\r\n| project Counter = pack('counter', CounterName, 'object', ObjectName), CounterText, group = ObjectName",
+            "crossComponentResources": [
+              "{Resource}"
+            ],
+            "isHiddenWhenLocked": false,
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "timeContextFromParameter": null,
+            "queryType": 0,
+            "resourceType": "microsoft.compute/virtualmachinescalesets"
+          },
+          {
+            "id": "974d5ac2-4fc5-48e7-a8f7-16fc9dddc4ac",
+            "version": "KqlParameterItem/1.0",
+            "name": "CounterText",
+            "type": 1,
+            "isRequired": false,
+            "query": "let metric = dynamic({Counter});\r\nrange Steps from 1 to 1 step 1\r\n| project strcat(metric.object, \" > \", metric.counter)",
+            "crossComponentResources": [
+              "{Resource}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "queryType": 0,
+            "resourceType": "microsoft.compute/virtualmachinescalesets"
+          },
+          {
+            "id": "ce228deb-88eb-4438-9dce-6c6d1972ff09",
+            "version": "KqlParameterItem/1.0",
+            "name": "IsNetworkCounter",
+            "type": 1,
+            "isRequired": false,
+            "query": "let counter = dynamic({Counter});\r\nprint tostring(counter.object == 'Network Adapter')",
+            "crossComponentResources": [
+              "{Resource}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "queryType": 0,
+            "resourceType": "microsoft.compute/virtualmachinescalesets"
+          },
+          {
+            "id": "3b23aa7a-2afd-40ba-a710-0e2cc73c764b",
+            "version": "KqlParameterItem/1.0",
+            "name": "NetworkDirection",
+            "type": 1,
+            "isRequired": false,
+            "query": "let metric = dynamic({Counter});\r\nprint(iff(metric.counter == 'Bytes Received/sec', 'Received', 'Sent'))",
+            "crossComponentResources": [
+              "{Resource}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "queryType": 0,
+            "resourceType": "microsoft.compute/virtualmachinescalesets"
+          },
+          {
+            "id": "9ad8858d-8ef3-4144-94b1-66a8bf9fa9c9",
+            "version": "KqlParameterItem/1.0",
+            "name": "Aggregators",
+            "type": 2,
+            "description": "Select one or more different aggregates to display in the table below",
+            "isRequired": true,
+            "multiSelect": true,
+            "quote": "",
+            "delimiter": ",",
+            "isHiddenWhenLocked": false,
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "jsonData": "[\r\n    { \"value\":\"Average\", \"label\":\"Average\", \"selected\": true },\r\n    { \"value\":\"P5th\", \"label\":\"P5th\", \"selected\": false },\r\n    { \"value\":\"P10th\", \"label\":\"P10th\", \"selected\": false },\r\n    { \"value\":\"P50th\", \"label\":\"P50th\", \"selected\": false },\r\n    { \"value\":\"P80th\", \"label\":\"P80th\", \"selected\": false },\r\n    { \"value\":\"P90th\", \"label\":\"P90th\", \"selected\": false },\r\n    { \"value\":\"P95th\", \"label\":\"P95th\", \"selected\": true },\r\n    { \"value\":\"Min\", \"label\":\"Min\", \"selected\": false },\r\n    { \"value\":\"Max\", \"label\":\"Max\", \"selected\": true }\r\n]",
+            "timeContextFromParameter": null
+          },
+          {
+            "id": "6a7306ea-247f-46ca-abca-501911f9e9d3",
+            "version": "KqlParameterItem/1.0",
+            "name": "TableTrend",
+            "type": 2,
+            "description": "Select a percentile to display in the Trend column in the table below",
+            "isRequired": true,
+            "isHiddenWhenLocked": false,
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\", \"selected\": true },\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\", \"selected\": false },\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\", \"selected\": false },\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\", \"selected\": false },\r\n    { \"value\":\"P80th = round(percentile(CounterValue, 80), 2)\", \"label\":\"P80th\", \"selected\": false },\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\", \"selected\": false },\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\", \"selected\": false }\r\n]",
+            "timeContextFromParameter": null
+          },
+          {
+            "id": "0327f26e-cdde-4b48-b512-6c35f06ad1d0",
+            "version": "KqlParameterItem/1.0",
+            "name": "tableTrendOrder",
+            "type": 1,
+            "isRequired": false,
+            "query": "range Steps from 1 to 1 step 1\r\n| project value = iff('{TableTrend}' contains 'P5th'  or '{TableTrend}' contains 'P10th', 'asc', 'desc')",
+            "crossComponentResources": [
+              "{Resource}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "queryType": 0,
+            "resourceType": "microsoft.compute/virtualmachinescalesets"
+          },
+          {
+            "id": "c2f05b6d-970d-4fde-88b0-868387c02250",
+            "version": "KqlParameterItem/1.0",
+            "name": "mergedAggregators",
+            "type": 1,
+            "isRequired": false,
+            "query": "let aggregators = iff('{Aggregators}' contains '{TableTrend:label}', '{Aggregators}', '{Aggregators},{TableTrend:label}');\r\nrange Steps from 1 to 1 step 1\r\n| project aggregators",
+            "crossComponentResources": [
+              "{Resource}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "queryType": 0,
+            "resourceType": "microsoft.compute/virtualmachinescalesets"
+          },
+          {
+            "id": "27faa340-a75f-4ae1-a43a-1aa6ece37cff",
+            "version": "KqlParameterItem/1.0",
+            "name": "StandardQuery",
+            "type": 1,
+            "isRequired": false,
+            "query": "// {Resource} {Test}\r\nlet metric = dynamic({Counter}); \r\nlet timeRangeStart = {TimeRange:start};\r\nlet timeRangeEnd = {TimeRange:end};\r\nlet timeRangeGrain = {TimeRange:grain};\r\nprint(iff({IsNetworkCounter} == 'False', strcat(\"let maxResultCount = 100; let metric = dynamic(\", metric, \"); let summaryPerComputer = totable(Perf      | where TimeGenerated {TimeRange}       | where ObjectName == metric.object and CounterName == metric.counter     | summarize hint.shufflekey = Computer Average = avg(CounterValue), Max = max(CounterValue), Min = min(CounterValue), percentiles(CounterValue, 5, 10, 50, 80, 90, 95) by Computer      | project Computer, Average, Max, Min, P5th = percentile_CounterValue_5, P10th = percentile_CounterValue_10, P50th = percentile_CounterValue_50, P80th = percentile_CounterValue_80, P90th = percentile_CounterValue_90, P95th = percentile_CounterValue_95      | order by {TableTrend:label} {tableTrendOrder}, Computer      | limit maxResultCount);  let computerList = summaryPerComputer      | project Computer;  let MachineSummary = ServiceMapComputer_CL     | where TimeGenerated {TimeRange}     | where Computer in (computerList)     | summarize arg_max(TimeGenerated, *) by Computer     | project Computer, MachineSummary = pack('Fully Qualified Domain Name', Computer, 'OS Type', OperatingSystemFamily_s, 'Operating System', OperatingSystemFullName_s, 'Ipv4 Addresses', Ipv4Addresses_s,         'Ipv6 Addresses', Ipv6Addresses_s, 'Mac Addresses', MacAddresses_s, 'DNS Names', DnsNames_s, 'CPUs', strcat(Cpus_d, ' @ ', CpuSpeed_d, ' MHz'), 'Bitness', Bitness_s,         'Physcial Memory', strcat(PhysicalMemory_d, ' MB'), 'Virtualization State', VirtualizationState_s, 'VM Type', VirtualMachineType_s, 'OMS Agent', split(ResourceName_s, 'm-')[1]); let EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) []; let OmsNodeIdentityAndProps = computerList     | extend NodeId = Computer     | extend Priority = 1     | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer); let ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL     | where TimeGenerated {TimeRange}     | where Computer in (computerList)     | summarize arg_max(TimeGenerated, *) by Computer     | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2; let NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                                 | summarize arg_max(Priority, *) by Computer;  let NodeIdentityAndPropsMin = NodeIdentityAndProps     | extend Type = iff(NodeProps.type == 'StandAloneNode', iff(NodeProps.azureResourceId == '', 'Non-Azure Virtual Machine', 'Azure Virtual Machine'), NodeProps.type),      ResourceId = iff(NodeProps.type == 'AzureScaleSetNode', NodeProps.vmScaleSetResourceId,          iff(NodeProps.type == 'AzureCloudServiceNode', NodeProps.cloudServiceDeploymentId, Computer)),     ResourceName = iff(NodeProps.type == 'AzureScaleSetNode', strcat(NodeProps.vmScaleSetName, ' | ', NodeProps.scaleSetInstanceId),          iff(NodeProps.type == 'AzureCloudServiceNode', strcat(NodeProps.cloudServiceRoleName, ' | ', NodeProps.cloudServiceInstanceId), Computer))     | project Computer, Type, ResourceId, ResourceName; let trend = Perf          | where TimeGenerated {TimeRange}         | where Computer in (computerList)          | where ObjectName == metric.object and CounterName == metric.counter        | make-series {TableTrend} default = 0 on TimeGenerated in range(datetime('\", timeRangeStart,\"'), datetime('\", timeRangeEnd ,\"'), totimespan('\", timeRangeGrain, \"')) by Computer     | project Computer, ['Trend ({TableTrend:label})'] = {TableTrend:label}; summaryPerComputer     | join kind=leftouter (trend) on Computer     | join kind=leftouter (NodeIdentityAndProps) on Computer     | join kind=leftouter (NodeIdentityAndPropsMin) on Computer     | join kind=leftouter (MachineSummary) on Computer     | project ResourceName, Type, {mergedAggregators}, ['Trend ({TableTrend:label})'], Properties = MachineSummary     | sort by {TableTrend:label} {tableTrendOrder}\"), ''));",
+            "crossComponentResources": [
+              "{Resource}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "queryType": 0,
+            "resourceType": "microsoft.compute/virtualmachinescalesets"
+          },
+          {
+            "id": "6e392933-2f72-45a6-889b-90351f9130db",
+            "version": "KqlParameterItem/1.0",
+            "name": "NetworkQuery",
+            "type": 1,
+            "isRequired": false,
+            "query": "let metric = dynamic({Counter});\r\nlet timeRangeStart = {TimeRange:start};\r\nlet timeRangeEnd = {TimeRange:end};\r\nlet timeRangeGrain = {TimeRange:grain};\r\nprint(iff({IsNetworkCounter} == 'True', strcat(\"let metric = dynamic(\", metric, \"); let linux = iff(metric.counter == 'Bytes Received/sec', dynamic({'object': 'Network', 'counter': 'Total Bytes Received'}), dynamic({'object': 'Network', 'counter': 'Total Bytes Transmitted'})); let maxResultCount = 100; let windowsNetworkRaw = Perf | where TimeGenerated {TimeRange} | where ObjectName == metric.object and CounterName == metric.couter; let windowsNetworkSum = windowsNetworkRaw | summarize hint.shufflekey=Computer CounterValue=sum(CounterValue) by Computer, TimeGenerated; let windowsNetworkPctl = windowsNetworkRaw | summarize hint.shufflekey=Computer Average = avg(CounterValue), Max = max(CounterValue), Min = min(CounterValue), percentiles(CounterValue, 5, 10, 50, 80, 90, 95) by Computer, TimeGenerated | project TimeGenerated, Computer, Average, Max, Min, P5th = percentile_CounterValue_5, P10th = percentile_CounterValue_10, P50th = percentile_CounterValue_50, P80th = percentile_CounterValue_80, P90th = percentile_CounterValue_90, P95th = percentile_CounterValue_95; let linuxNetworkRaw = Perf | where TimeGenerated {TimeRange} | where ObjectName == linux.object and CounterName == linux.counter | order by InstanceName, TimeGenerated asc | extend prev_Value = prev(CounterValue), prev_t = prev(TimeGenerated), prev_instance = prev(InstanceName) | project TimeGenerated, Computer, CounterValue = iff(prev_instance == InstanceName and CounterValue >= prev_Value and TimeGenerated > prev_t, (CounterValue - prev_Value) / ((TimeGenerated - prev_t) / 1s), real(0)); let linuxNetworkSum = linuxNetworkRaw | summarize hint.shufflekey=Computer CounterValue=sum(CounterValue) by Computer, TimeGenerated; let linuxNetworkPctl = linuxNetworkRaw | summarize hint.shufflekey=Computer Average = avg(CounterValue), Max = max(CounterValue), Min = min(CounterValue), percentiles(CounterValue, 5, 10, 50, 80, 90, 95) by Computer, TimeGenerated | project TimeGenerated, Computer, Average, Max, Min, P5th = percentile_CounterValue_5, P10th = percentile_CounterValue_10, P50th = percentile_CounterValue_50, P80th = percentile_CounterValue_80, P90th = percentile_CounterValue_90, P95th = percentile_CounterValue_95; let networkDataSum = union windowsNetworkSum, linuxNetworkSum; let networkDataPctl = union windowsNetworkPctl, linuxNetworkPctl; let computerList = Perf  | project Computer; let EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) []; let OmsNodeIdentityAndProps = computerList | extend NodeId = Computer | extend Priority = 1 | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer); let ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL | where TimeGenerated {TimeRange} | where Computer in (computerList) | summarize hint.shufflekey=Computer arg_max(TimeGenerated, *) by Computer | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|', columnifexists('AzureCloudServiceDeployment_g', '')), ''), AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')), strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|', columnifexists('AzureVmScaleSetDeployment_g', '')), ''), ComputerProps = pack('type', 'StandAloneNode', 'name', ComputerName_s, 'mappingResourceId', ResourceId, 'subscriptionId', AzureSubscriptionId_g, 'resourceGroup', AzureResourceGroup_s, 'azureResourceId', columnifexists('AzureResourceId_s', '')), AzureCloudServiceNodeProps = pack('type', 'AzureCloudServiceNode', 'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''), 'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''), 'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''), 'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''), 'mappingResourceId', ResourceId), AzureScaleSetNodeProps = pack('type', 'AzureScaleSetNode', 'scaleSetInstanceId', columnifexists('AzureName_s', ''), 'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''), 'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''), 'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''), 'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''), 'resourceGroupName', columnifexists('AzureResourceGroup_s', ''), 'subscriptionId', columnifexists('AzureSubscriptionId_g', ''), 'mappingResourceId', ResourceId)| project   Computer, NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity, isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer), NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps, isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps), Priority = 2; let NodeIdentityAndProps = union kind=inner isfuzzy = true EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps | summarize hint.shufflekey=Computer arg_max(Priority, *) by Computer; let NodeIdentityAndPropsMin = NodeIdentityAndProps | extend Type = iff(NodeProps.type == 'StandAloneNode', iff(NodeProps.azureResourceId == '', 'Non-Azure Virtual Machine', 'Azure Virtual Machine'), NodeProps.type), ResourceId = iff(NodeProps.type == 'AzureScaleSetNode', NodeProps.vmScaleSetResourceId, iff(NodeProps.type == 'AzureCloudServiceNode', NodeProps.cloudServiceDeploymentId, Computer)), ResourceName = iff(NodeProps.type == 'AzureScaleSetNode', strcat(NodeProps.vmScaleSetName, ' | ', NodeProps.scaleSetInstanceId), iff(NodeProps.type == 'AzureCloudServiceNode', strcat(NodeProps.cloudServiceRoleName, ' | ', NodeProps.cloudServiceInstanceId), Computer)) | project Computer, Type, ResourceId, ResourceName; let MachineSummary = ServiceMapComputer_CL | where TimeGenerated {TimeRange} | where Computer in (computerList) | summarize hint.shufflekey=Computer arg_max(TimeGenerated, *) by Computer | project Computer, MachineSummary = pack('Fully Qualified Domain Name', Computer, 'OS Type', OperatingSystemFamily_s, 'Operating System', OperatingSystemFullName_s, 'Ipv4 Addresses', Ipv4Addresses_s, 'Ipv6 Addresses', Ipv6Addresses_s, 'Mac Addresses', MacAddresses_s, 'DNS Names', DnsNames_s, 'CPUs', strcat(Cpus_d, ' @ ', CpuSpeed_d, ' MHz'), 'Bitness', Bitness_s, 'Physcial Memory', strcat(PhysicalMemory_d, ' MB'), 'Virtualization State', VirtualizationState_s, 'VM Type', VirtualMachineType_s, 'OMS Agent', split(ResourceName_s, 'm-')[1]); let trend = networkDataSum | make-series {TableTrend} default=0 on TimeGenerated in range(datetime('\", timeRangeStart,\"'), datetime('\", timeRangeEnd ,\"'), totimespan('\", timeRangeGrain, \"')) by Computer | project Computer, ['Trend ({TableTrend:label})'] = {TableTrend:label}; networkDataPctl | join kind=leftouter hint.shufflekey=Computer (trend) on Computer | join kind=leftouter hint.shufflekey=Computer (NodeIdentityAndPropsMin) on Computer | join kind=leftouter hint.shufflekey=Computer (MachineSummary) on Computer | project ResourceName, Type, {mergedAggregators}, ['Trend ({TableTrend:label})'], Properties = MachineSummary | sort by {TableTrend:label} {tableTrendOrder} | limit maxResultCount\"), ''));",
+            "crossComponentResources": [
+              "{Resource}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "queryType": 0,
+            "resourceType": "microsoft.compute/virtualmachinescalesets"
+          },
+          {
+            "id": "69c79551-68b9-4c84-bf57-202540482a02",
+            "version": "KqlParameterItem/1.0",
+            "name": "ShowTable",
+            "type": 1,
+            "isRequired": false,
+            "query": "print iff(\"{Test:value}\" == \"\", \"False\", iff(\"{IsNetworkCounter:value}\" == \"False\", \"True\", \"False\"))",
+            "crossComponentResources": [
+              "{Resource}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "queryType": 0,
+            "resourceType": "microsoft.compute/virtualmachinescalesets"
+          },
+          {
+            "id": "6b664a24-d9a3-47b0-9d94-9cada9ddb8ce",
+            "version": "KqlParameterItem/1.0",
+            "name": "ShowNetworkTable",
+            "type": 1,
+            "isRequired": false,
+            "query": "print iff(\"{Test:value}\" == \"\", \"False\", \"{IsNetworkCounter:value}\")",
+            "crossComponentResources": [
+              "{Resource}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "queryType": 0,
+            "resourceType": "microsoft.compute/virtualmachinescalesets"
+          },
+          {
+            "id": "343c4eae-e482-4678-a936-c4ad43b2ec19",
+            "version": "KqlParameterItem/1.0",
+            "name": "CounterTest",
+            "type": 1,
+            "isRequired": false,
+            "query": "Perf\r\n| take 1",
+            "crossComponentResources": [
+              "{Resource}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "queryType": 0,
+            "resourceType": "microsoft.compute/virtualmachinescalesets"
+          }
+        ],
+        "style": "above",
+        "queryType": 0,
+        "resourceType": "microsoft.compute/virtualmachinescalesets"
+      },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isNotEqualTo",
+        "value": null
+      },
+      "name": "parameters - 6"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "There are no performance counters, either onboard machines to this workspace or enable performance counters."
+      },
+      "conditionalVisibility": {
+        "parameterName": "CounterTest",
+        "comparison": "isEqualTo",
+        "value": ""
+      },
+      "name": "text - 7"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "// {Resource} {Test}\r\n{StandardQuery}",
+        "size": 0,
+        "noDataMessage": "There is no data for this counter, either enable the counter or onboard machines to this workspace",
+        "queryType": 0,
+        "resourceType": "microsoft.compute/virtualmachinescalesets",
+        "crossComponentResources": [
+          "{Resource}"
+        ],
+        "visualization": "table",
+        "gridSettings": {
+          "formatters": [
+            {
+              "columnMatch": "Type",
+              "formatter": 1,
+              "formatOptions": {}
+            },
+            {
+              "columnMatch": "Average",
+              "formatter": 8,
+              "formatOptions": {
+                "palette": "blue"
+              },
+              "numberFormat": {
+                "unit": 0,
+                "options": {
+                  "style": "decimal"
+                }
+              }
+            },
+            {
+              "columnMatch": "P50th",
+              "formatter": 8,
+              "formatOptions": {
+                "palette": "blue"
+              },
+              "numberFormat": {
+                "unit": 0,
+                "options": {
+                  "style": "decimal"
+                }
+              }
+            },
+            {
+              "columnMatch": "Trend (Average)",
+              "formatter": 10,
+              "formatOptions": {
+                "palette": "blue"
+              }
+            },
+            {
+              "columnMatch": "Properties",
+              "formatter": 7,
+              "formatOptions": {
+                "linkTarget": "CellDetails",
+                "linkLabel": "ℹ️ Info"
+              }
+            },
+            {
+              "columnMatch": "P95th",
+              "formatter": 8,
+              "formatOptions": {
+                "palette": "blue"
+              },
+              "numberFormat": {
+                "unit": 0,
+                "options": {
+                  "style": "decimal"
+                }
+              }
+            },
+            {
+              "columnMatch": "P5th",
+              "formatter": 8,
+              "formatOptions": {
+                "palette": "blue"
+              },
+              "numberFormat": {
+                "unit": 0,
+                "options": {
+                  "style": "decimal"
+                }
+              }
+            },
+            {
+              "columnMatch": "P10th",
+              "formatter": 8,
+              "formatOptions": {
+                "palette": "blue"
+              },
+              "numberFormat": {
+                "unit": 0,
+                "options": {
+                  "style": "decimal"
+                }
+              }
+            },
+            {
+              "columnMatch": "P80th",
+              "formatter": 8,
+              "formatOptions": {
+                "palette": "blue"
+              },
+              "numberFormat": {
+                "unit": 0,
+                "options": {
+                  "style": "decimal"
+                }
+              }
+            },
+            {
+              "columnMatch": "P90th",
+              "formatter": 8,
+              "formatOptions": {
+                "palette": "blue"
+              },
+              "numberFormat": {
+                "unit": 0,
+                "options": {
+                  "style": "decimal"
+                }
+              }
+            },
+            {
+              "columnMatch": "Min",
+              "formatter": 8,
+              "formatOptions": {
+                "palette": "blue"
+              },
+              "numberFormat": {
+                "unit": 0,
+                "options": {
+                  "style": "decimal"
+                }
+              }
+            },
+            {
+              "columnMatch": "Max",
+              "formatter": 8,
+              "formatOptions": {
+                "palette": "blue"
+              },
+              "numberFormat": {
+                "unit": 0,
+                "options": {
+                  "style": "decimal"
+                }
+              }
+            },
+            {
+              "columnMatch": "Trend (P95th)",
+              "formatter": 10,
+              "formatOptions": {
+                "palette": "blue"
+              }
+            },
+            {
+              "columnMatch": "Trend (P5th)",
+              "formatter": 10,
+              "formatOptions": {
+                "palette": "blue"
+              }
+            },
+            {
+              "columnMatch": "Trend (P90th)",
+              "formatter": 10,
+              "formatOptions": {
+                "palette": "blue"
+              }
+            },
+            {
+              "columnMatch": "Trend (P80th)",
+              "formatter": 10,
+              "formatOptions": {
+                "palette": "blue"
+              }
+            },
+            {
+              "columnMatch": "Trend (P50th)",
+              "formatter": 10,
+              "formatOptions": {
+                "palette": "blue"
+              }
+            },
+            {
+              "columnMatch": "Trend (P10th)",
+              "formatter": 10,
+              "formatOptions": {
+                "palette": "blue"
+              }
+            }
+          ]
+        }
+      },
+      "conditionalVisibility": {
+        "parameterName": "ShowTable",
+        "comparison": "isEqualTo",
+        "value": "True"
+      },
+      "name": "query - 8"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "#### ℹ `Total Bytes {NetworkDirection}` counters are also being utilized to display the network table. The delta of `Total Bytes {NetworkDirection}` over a time period is being calculated to match up with the `Bytes {NetworkDirection}/sec` counter to display an accurate representation of network activity over all machines"
+      },
+      "conditionalVisibility": {
+        "parameterName": "ShowNetworkTable",
+        "comparison": "isEqualTo",
+        "value": "True"
+      },
+      "name": "text - 9"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "// {Resource} {Test}\r\n{NetworkQuery}",
+        "size": 0,
+        "noDataMessage": "There is no data for this counter, either enable the counter or onboard machines to this workspace",
+        "queryType": 0,
+        "resourceType": "microsoft.compute/virtualmachinescalesets",
+        "crossComponentResources": [
+          "{Resource}"
+        ],
+        "visualization": "table",
+        "gridSettings": {
+          "formatters": [
+            {
+              "columnMatch": "Type",
+              "formatter": 1,
+              "formatOptions": {}
+            },
+            {
+              "columnMatch": "P95th",
+              "formatter": 8,
+              "formatOptions": {
+                "palette": "blue"
+              },
+              "numberFormat": {
+                "unit": 2,
+                "options": {
+                  "style": "decimal"
+                }
+              }
+            },
+            {
+              "columnMatch": "Average",
+              "formatter": 1,
+              "formatOptions": {
+                "palette": "greenRed"
+              },
+              "numberFormat": {
+                "unit": 2,
+                "options": {
+                  "style": "decimal"
+                }
+              }
+            },
+            {
+              "columnMatch": "P10th",
+              "formatter": 1,
+              "formatOptions": {},
+              "numberFormat": {
+                "unit": 2,
+                "options": {
+                  "style": "decimal"
+                }
+              }
+            },
+            {
+              "columnMatch": "P50th",
+              "formatter": 1,
+              "formatOptions": {
+                "palette": "greenRed"
+              },
+              "numberFormat": {
+                "unit": 2,
+                "options": {
+                  "style": "decimal"
+                }
+              }
+            },
+            {
+              "columnMatch": "Trend (P95th)",
+              "formatter": 10,
+              "formatOptions": {
+                "palette": "blue"
+              }
+            },
+            {
+              "columnMatch": "Properties",
+              "formatter": 7,
+              "formatOptions": {
+                "linkTarget": "CellDetails",
+                "linkLabel": "️️️ℹ Info"
+              }
+            },
+            {
+              "columnMatch": "P5th",
+              "formatter": 8,
+              "formatOptions": {
+                "palette": "blue"
+              },
+              "numberFormat": {
+                "unit": 2,
+                "options": {
+                  "style": "decimal"
+                }
+              }
+            },
+            {
+              "columnMatch": "P80th",
+              "formatter": 1,
+              "formatOptions": {
+                "palette": "greenRed"
+              },
+              "numberFormat": {
+                "unit": 2,
+                "options": {
+                  "style": "decimal"
+                }
+              }
+            },
+            {
+              "columnMatch": "P90th",
+              "formatter": 1,
+              "formatOptions": {
+                "palette": "greenRed"
+              },
+              "numberFormat": {
+                "unit": 2,
+                "options": {
+                  "style": "decimal"
+                }
+              }
+            },
+            {
+              "columnMatch": "Min",
+              "formatter": 1,
+              "formatOptions": {},
+              "numberFormat": {
+                "unit": 2,
+                "options": {
+                  "style": "decimal"
+                }
+              }
+            },
+            {
+              "columnMatch": "Max",
+              "formatter": 1,
+              "formatOptions": {
+                "palette": "greenRed"
+              },
+              "numberFormat": {
+                "unit": 2,
+                "options": {
+                  "style": "decimal"
+                }
+              }
+            },
+            {
+              "columnMatch": "Trend (P5th)",
+              "formatter": 10,
+              "formatOptions": {
+                "palette": "blue"
+              }
+            },
+            {
+              "columnMatch": "Trend (P90th)",
+              "formatter": 10,
+              "formatOptions": {
+                "palette": "blue"
+              }
+            },
+            {
+              "columnMatch": "Trend (P80th)",
+              "formatter": 10,
+              "formatOptions": {
+                "palette": "blue"
+              }
+            },
+            {
+              "columnMatch": "Trend (P50th)",
+              "formatter": 10,
+              "formatOptions": {
+                "palette": "blue"
+              }
+            },
+            {
+              "columnMatch": "Trend (P10th)",
+              "formatter": 10,
+              "formatOptions": {
+                "palette": "blue"
+              }
+            },
+            {
+              "columnMatch": "Trend (Average)",
+              "formatter": 10,
+              "formatOptions": {
+                "palette": "blue"
+              }
+            }
+          ]
+        }
+      },
+      "conditionalVisibility": {
+        "parameterName": "ShowNetworkTable",
+        "comparison": "isEqualTo",
+        "value": "True"
+      },
+      "name": "query - 10"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "---\r\n## Top 10 Machines"
+      },
+      "conditionalVisibility": null,
+      "name": "text - 11"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "### CPU Utilization %"
+      },
+      "conditionalVisibility": null,
+      "customWidth": "50",
+      "name": "text - 12"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "### Available Memory"
+      },
+      "conditionalVisibility": null,
+      "customWidth": "50",
+      "name": "text - 13"
+    },
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "query": "",
+        "crossComponentResources": [
+          "{Resource}"
+        ],
+        "parameters": [
+          {
+            "id": "92358ae0-d5e1-494b-b65b-6d904f1325c5",
+            "version": "KqlParameterItem/1.0",
+            "name": "Aggregate",
+            "type": 2,
+            "isRequired": true,
+            "value": "P95th = round(percentile(CounterValue, 95), 2)",
+            "isHiddenWhenLocked": false,
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\"},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\"},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\"},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\"},\r\n    { \"value\":\"P80th = round(percentile(CounterValue, 80), 2)\", \"label\":\"P80th\"},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\"},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\"}\r\n]",
+            "timeContextFromParameter": null
+          },
+          {
+            "id": "27345375-4376-4e2f-8ac4-59d4eab9d235",
+            "version": "KqlParameterItem/1.0",
+            "name": "aggregateOrderLeft",
+            "type": 1,
+            "isRequired": false,
+            "query": "range Steps from 1 to 1 step 1\r\n| project value = iff('{Aggregate}' contains 'P5th'  or '{Aggregate}' contains 'P10th', 'asc', 'desc')",
+            "crossComponentResources": [
+              "{Resource}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "queryType": 0,
+            "resourceType": "microsoft.compute/virtualmachinescalesets"
+          },
+          {
+            "id": "4d9ba0ec-9d22-4fec-9f85-4be334f42d91",
+            "version": "KqlParameterItem/1.0",
+            "name": "aggregateLeftValue",
+            "type": 1,
+            "isRequired": true,
+            "query": "print \"{Aggregate:value}\"",
+            "crossComponentResources": [
+              "{Resource}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "queryType": 0,
+            "resourceType": "microsoft.compute/virtualmachinescalesets"
+          },
+          {
+            "id": "50242f48-6c7d-449b-ad93-838c94e615a0",
+            "version": "KqlParameterItem/1.0",
+            "name": "aggregateLeftLabel",
+            "type": 1,
+            "isRequired": true,
+            "query": "print \"{Aggregate:label}\"",
+            "crossComponentResources": [
+              "{Resource}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "queryType": 0,
+            "resourceType": "microsoft.compute/virtualmachinescalesets"
+          }
+        ],
+        "style": "above",
+        "queryType": 0,
+        "resourceType": "microsoft.compute/virtualmachinescalesets"
+      },
+      "conditionalVisibility": null,
+      "customWidth": "50",
+      "name": "parameters - 14"
+    },
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "query": "",
+        "crossComponentResources": [
+          "{Resource}"
+        ],
+        "parameters": [
+          {
+            "id": "333837c2-d5a4-4173-9aad-3db1dca17e2a",
+            "version": "KqlParameterItem/1.0",
+            "name": "Aggregate",
+            "type": 2,
+            "isRequired": true,
+            "value": "P95th = round(percentile(CounterValue, 95), 2)",
+            "isHiddenWhenLocked": false,
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\"},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\"},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\"},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\"},\r\n    { \"value\":\"P80th = round(percentile(CounterValue, 80), 2)\", \"label\":\"P80th\"},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\"},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\"}\r\n]",
+            "timeContextFromParameter": null
+          },
+          {
+            "id": "a23b29a5-5e4a-4d8e-ba73-bfdf27b2980e",
+            "version": "KqlParameterItem/1.0",
+            "name": "aggregateOrderRight",
+            "type": 1,
+            "isRequired": false,
+            "query": "range Steps from 1 to 1 step 1\r\n| project value = iff('{Aggregate}' contains 'P5th'  or '{Aggregate}' contains 'P10th', 'asc', 'desc')",
+            "crossComponentResources": [
+              "{Resource}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "queryType": 0,
+            "resourceType": "microsoft.compute/virtualmachinescalesets"
+          },
+          {
+            "id": "cc8dfabc-9eb9-4227-97bb-f5e9319030ec",
+            "version": "KqlParameterItem/1.0",
+            "name": "aggregateRightValue",
+            "type": 1,
+            "isRequired": true,
+            "query": "print \"{Aggregate:value}\"",
+            "crossComponentResources": [
+              "{Resource}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "queryType": 0,
+            "resourceType": "microsoft.compute/virtualmachinescalesets"
+          },
+          {
+            "id": "ff7a79ff-742a-4c6e-8628-c52f45b3bf71",
+            "version": "KqlParameterItem/1.0",
+            "name": "aggregateRightLabel",
+            "type": 1,
+            "isRequired": true,
+            "query": "print \"{Aggregate:label}\"",
+            "crossComponentResources": [
+              "{Resource}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "queryType": 0,
+            "resourceType": "microsoft.compute/virtualmachinescalesets"
+          }
+        ],
+        "style": "above",
+        "queryType": 0,
+        "resourceType": "microsoft.compute/virtualmachinescalesets"
+      },
+      "conditionalVisibility": null,
+      "customWidth": "50",
+      "name": "parameters - 15"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "let cpuSummary=totable(Perf\r\n    | where TimeGenerated {TimeRange} \r\n    | where (ObjectName == 'Processor' and InstanceName == '_Total' and CounterName == '% Processor Time')\r\n    | summarize hint.shufflekey=Computer {aggregateLeftValue} by Computer, CounterName\r\n    | top 10 by {aggregateLeftLabel} {aggregateOrderLeft});\r\nlet computerList=(cpuSummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nPerf\r\n    | where TimeGenerated {TimeRange}\r\n    | where (ObjectName == 'Processor' and InstanceName == '_Total' and CounterName == '% Processor Time')\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {aggregateLeftValue} by bin(TimeGenerated, ({TimeRange:end} - {TimeRange:start})/100), ResourceName",
+        "size": 0,
+        "aggregation": 3,
+        "showAnnotations": true,
+        "noDataMessage": "There is no data for this counter, either enable the counter or onboard machines to this workspace",
+        "queryType": 0,
+        "resourceType": "microsoft.compute/virtualmachinescalesets",
+        "crossComponentResources": [
+          "{Resource}"
+        ],
+        "visualization": "linechart",
+        "tileSettings": {
+          "showBorder": false,
+          "titleContent": {
+            "columnMatch": "Computer",
+            "formatter": 1
+          },
+          "leftContent": {
+            "columnMatch": "value",
+            "formatter": 12,
+            "formatOptions": {
+              "palette": "auto"
+            },
+            "numberFormat": {
+              "unit": 17,
+              "options": {
+                "maximumSignificantDigits": 3,
+                "maximumFractionDigits": 2
+              }
+            }
+          }
+        }
+      },
+      "conditionalVisibility": null,
+      "customWidth": "50",
+      "name": "query - 16"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "let memorySummary=totable(Perf\r\n    | where TimeGenerated {TimeRange} \r\n    | where ObjectName == 'Memory' and CounterName in ('Available MBytes', 'Available MBytes Memory')\r\n    | summarize hint.shufflekey=Computer {aggregateRightValue} by Computer, CounterName\r\n    | top 10 by {aggregateRightLabel} {aggregateOrderRight});\r\nlet computerList=(memorySummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nPerf\r\n    | where TimeGenerated {TimeRange}\r\n    | where ObjectName == 'Memory' and CounterName in ('Available MBytes', 'Available MBytes Memory')\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {aggregateRightValue} by bin(TimeGenerated, ({TimeRange:end} - {TimeRange:start})/100), ResourceName",
+        "size": 0,
+        "aggregation": 3,
+        "showAnnotations": true,
+        "noDataMessage": "There is no data for this counter, either enable the counter or onboard machines to this workspace",
+        "queryType": 0,
+        "resourceType": "microsoft.compute/virtualmachinescalesets",
+        "crossComponentResources": [
+          "{Resource}"
+        ],
+        "visualization": "linechart",
+        "tileSettings": {
+          "showBorder": false,
+          "titleContent": {
+            "columnMatch": "Computer",
+            "formatter": 1
+          },
+          "leftContent": {
+            "columnMatch": "value",
+            "formatter": 12,
+            "formatOptions": {
+              "palette": "auto"
+            },
+            "numberFormat": {
+              "unit": 17,
+              "options": {
+                "maximumSignificantDigits": 3,
+                "maximumFractionDigits": 2
+              }
+            }
+          }
+        }
+      },
+      "conditionalVisibility": null,
+      "customWidth": "50",
+      "name": "query - 17"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "### Bytes Sent Rate"
+      },
+      "conditionalVisibility": null,
+      "customWidth": "50",
+      "name": "text - 18"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "### Bytes Received Rate"
+      },
+      "conditionalVisibility": null,
+      "customWidth": "50",
+      "name": "text - 19"
+    },
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "query": "",
+        "crossComponentResources": [
+          "{Resource}"
+        ],
+        "parameters": [
+          {
+            "id": "360da4c1-97fa-4b15-a008-33a6110d0acd",
+            "version": "KqlParameterItem/1.0",
+            "name": "Aggregate",
+            "type": 2,
+            "isRequired": true,
+            "value": "P95th = round(percentile(CounterValue, 95), 2)",
+            "isHiddenWhenLocked": false,
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\"},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\"},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\"},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\"},\r\n    { \"value\":\"P80th = round(percentile(CounterValue, 80), 2)\", \"label\":\"P80th\"},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\"},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\"}\r\n]",
+            "timeContextFromParameter": null
+          },
+          {
+            "id": "31ccd4a1-d626-44bb-a5de-1780a33b37a5",
+            "version": "KqlParameterItem/1.0",
+            "name": "aggregateOrderLeft",
+            "type": 1,
+            "isRequired": false,
+            "query": "range Steps from 1 to 1 step 1\r\n| project value = iff('{Aggregate}' contains 'P5th'  or '{Aggregate}' contains 'P10th', 'asc', 'desc')",
+            "crossComponentResources": [
+              "{Resource}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "queryType": 0,
+            "resourceType": "microsoft.compute/virtualmachinescalesets"
+          },
+          {
+            "id": "4765abab-a682-49f6-bb41-d64852aba192",
+            "version": "KqlParameterItem/1.0",
+            "name": "aggregateLeftValue",
+            "type": 1,
+            "isRequired": true,
+            "query": "print \"{Aggregate:value}\"",
+            "crossComponentResources": [
+              "{Resource}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "queryType": 0,
+            "resourceType": "microsoft.compute/virtualmachinescalesets"
+          },
+          {
+            "id": "1d9b0ea9-09d4-4c73-8e59-fa7ab760b880",
+            "version": "KqlParameterItem/1.0",
+            "name": "aggregateLeftLabel",
+            "type": 1,
+            "isRequired": true,
+            "query": "print \"{Aggregate:label}\"",
+            "crossComponentResources": [
+              "{Resource}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "queryType": 0,
+            "resourceType": "microsoft.compute/virtualmachinescalesets"
+          }
+        ],
+        "style": "above",
+        "queryType": 0,
+        "resourceType": "microsoft.compute/virtualmachinescalesets"
+      },
+      "conditionalVisibility": null,
+      "customWidth": "50",
+      "name": "parameters - 20"
+    },
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "query": "",
+        "crossComponentResources": [
+          "{Resource}"
+        ],
+        "parameters": [
+          {
+            "id": "6772b281-d17d-4293-a227-1b2ed67f399e",
+            "version": "KqlParameterItem/1.0",
+            "name": "Aggregate",
+            "type": 2,
+            "isRequired": true,
+            "value": "P95th = round(percentile(CounterValue, 95), 2)",
+            "isHiddenWhenLocked": false,
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\"},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\"},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\"},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\"},\r\n    { \"value\":\"P80th = round(percentile(CounterValue, 80), 2)\", \"label\":\"P80th\"},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\"},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\"}\r\n]",
+            "timeContextFromParameter": null
+          },
+          {
+            "id": "5e2eef28-0528-406f-86b5-ceae535455f9",
+            "version": "KqlParameterItem/1.0",
+            "name": "aggregateOrderRight",
+            "type": 1,
+            "isRequired": false,
+            "query": "range Steps from 1 to 1 step 1\r\n| project value = iff('{Aggregate}' contains 'P5th'  or '{Aggregate}' contains 'P10th', 'asc', 'desc')",
+            "crossComponentResources": [
+              "{Resource}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "queryType": 0,
+            "resourceType": "microsoft.compute/virtualmachinescalesets"
+          },
+          {
+            "id": "586fa51c-1a45-4602-adcb-62eb0f619b7f",
+            "version": "KqlParameterItem/1.0",
+            "name": "aggregateRightValue",
+            "type": 1,
+            "isRequired": true,
+            "query": "print \"{Aggregate:value}\"",
+            "crossComponentResources": [
+              "{Resource}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "queryType": 0,
+            "resourceType": "microsoft.compute/virtualmachinescalesets"
+          },
+          {
+            "id": "912085b6-f920-4a37-9ce3-f1ef86bd5df8",
+            "version": "KqlParameterItem/1.0",
+            "name": "aggregateRightLabel",
+            "type": 1,
+            "isRequired": true,
+            "query": "print \"{Aggregate:label}\"",
+            "crossComponentResources": [
+              "{Resource}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "queryType": 0,
+            "resourceType": "microsoft.compute/virtualmachinescalesets"
+          }
+        ],
+        "style": "above",
+        "queryType": 0,
+        "resourceType": "microsoft.compute/virtualmachinescalesets"
+      },
+      "conditionalVisibility": null,
+      "customWidth": "50",
+      "name": "parameters - 21"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "let linuxNetworkSend=Perf \r\n    | where TimeGenerated {TimeRange} \r\n    | where ObjectName == 'Network' and CounterName == 'Total Bytes Transmitted'\r\n    | order by CounterName asc, InstanceName, Computer asc, TimeGenerated asc\r\n    | extend prev_Computer=prev(Computer), prev_Value=prev(CounterValue), prev_t=prev(TimeGenerated), prev_counter=prev(CounterName), prev_instance=prev(InstanceName)\r\n    | project   TimeGenerated,            Computer,            CounterValue = iff(prev_Computer == Computer and prev_instance == InstanceName and prev_counter == CounterName and CounterValue >= prev_Value and TimeGenerated > prev_t, (CounterValue-prev_Value)/((TimeGenerated-prev_t)/1s), real(0))\r\n    | summarize hint.shufflekey=Computer CounterValue = sum(CounterValue) by Computer, bin(TimeGenerated, 2s);\r\nlet windowsNetworkSend = Perf \r\n    | where TimeGenerated {TimeRange} \r\n    | where ObjectName == 'Network Adapter' and CounterName == 'Bytes Sent/sec'\r\n    | summarize hint.shufflekey=Computer CounterValue = sum(CounterValue) by Computer, bin(TimeGenerated, 2s);\r\nlet networkDataSend = union linuxNetworkSend, windowsNetworkSend;\r\nlet networkSendSummary = totable(networkDataSend\r\n    | where TimeGenerated {TimeRange}\r\n    | summarize hint.shufflekey=Computer {aggregateLeftValue} by Computer\r\n    | top 10 by {aggregateLeftLabel} {aggregateOrderLeft});\r\nlet computerList=(networkSendSummary | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nnetworkDataSend\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {aggregateLeftValue} by bin(TimeGenerated, ({TimeRange:end} - {TimeRange:start})/100), ResourceName",
+        "size": 0,
+        "showAnnotations": true,
+        "noDataMessage": "There is no data for this counter, either enable the counter or onboard machines to this workspace",
+        "queryType": 0,
+        "resourceType": "microsoft.compute/virtualmachinescalesets",
+        "crossComponentResources": [
+          "{Resource}"
+        ],
+        "visualization": "linechart",
+        "tileSettings": {
+          "showBorder": false,
+          "titleContent": {
+            "columnMatch": "Computer",
+            "formatter": 1
+          },
+          "leftContent": {
+            "columnMatch": "value",
+            "formatter": 12,
+            "formatOptions": {
+              "palette": "auto"
+            },
+            "numberFormat": {
+              "unit": 17,
+              "options": {
+                "maximumSignificantDigits": 3,
+                "maximumFractionDigits": 2
+              }
+            }
+          }
+        }
+      },
+      "conditionalVisibility": null,
+      "customWidth": "50",
+      "name": "query - 22"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "let linuxNetworkReceive=Perf \r\n    | where TimeGenerated {TimeRange} \r\n    | where ObjectName == 'Network' and CounterName == 'Total Bytes Received'\r\n    | order by CounterName asc, InstanceName, Computer asc, TimeGenerated asc\r\n    | extend prev_Computer=prev(Computer), prev_Value=prev(CounterValue), prev_t=prev(TimeGenerated), prev_counter=prev(CounterName), prev_instance=prev(InstanceName)\r\n    | project   TimeGenerated,            Computer,            CounterValue = iff(prev_Computer == Computer and prev_instance == InstanceName and prev_counter == CounterName and CounterValue >= prev_Value and TimeGenerated > prev_t, (CounterValue-prev_Value)/((TimeGenerated-prev_t)/1s), real(0))\r\n    | summarize hint.shufflekey=Computer CounterValue = sum(CounterValue) by Computer, bin(TimeGenerated, 2s);\r\nlet windowsNetworkReceive = Perf \r\n    | where TimeGenerated {TimeRange} \r\n    | where ObjectName == 'Network Adapter' and CounterName == 'Bytes Received/sec'\r\n    | summarize hint.shufflekey=Computer CounterValue = sum(CounterValue) by Computer, bin(TimeGenerated, 2s);\r\nlet networkDataReceive = union linuxNetworkReceive, windowsNetworkReceive;\r\nlet networkReceiveSummary = totable(networkDataReceive\r\n    | where TimeGenerated {TimeRange}\r\n    | summarize hint.shufflekey=Computer {aggregateRightValue} by Computer\r\n    | top 10 by {aggregateRightLabel} {aggregateOrderRight});\r\nlet computerList=(networkReceiveSummary | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nnetworkDataReceive\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {aggregateRightValue} by bin(TimeGenerated, ({TimeRange:end} - {TimeRange:start})/100), ResourceName",
+        "size": 0,
+        "showAnnotations": true,
+        "noDataMessage": "There is no data for this counter, either enable the counter or onboard machines to this workspace",
+        "queryType": 0,
+        "resourceType": "microsoft.compute/virtualmachinescalesets",
+        "crossComponentResources": [
+          "{Resource}"
+        ],
+        "visualization": "linechart",
+        "tileSettings": {
+          "showBorder": false,
+          "titleContent": {
+            "columnMatch": "Computer",
+            "formatter": 1
+          },
+          "leftContent": {
+            "columnMatch": "value",
+            "formatter": 12,
+            "formatOptions": {
+              "palette": "auto"
+            },
+            "numberFormat": {
+              "unit": 17,
+              "options": {
+                "maximumSignificantDigits": 3,
+                "maximumFractionDigits": 2
+              }
+            }
+          }
+        }
+      },
+      "conditionalVisibility": null,
+      "customWidth": "50",
+      "name": "query - 23"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "### Logical Disk Space Used %"
+      },
+      "conditionalVisibility": null,
+      "customWidth": "50",
+      "name": "text - 24"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": ""
+      },
+      "conditionalVisibility": null,
+      "customWidth": "50",
+      "name": "text - 25"
+    },
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "query": "",
+        "crossComponentResources": [
+          "{Resource}"
+        ],
+        "parameters": [
+          {
+            "id": "5d6afbec-79f6-4cd1-b3a1-361503478304",
+            "version": "KqlParameterItem/1.0",
+            "name": "Aggregate",
+            "type": 2,
+            "isRequired": true,
+            "value": "P95th = round(percentile(CounterValue, 95), 2)",
+            "isHiddenWhenLocked": false,
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\"},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\"},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\"},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\"},\r\n    { \"value\":\"P80th = round(percentile(CounterValue, 80), 2)\", \"label\":\"P80th\"},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\"},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\"}\r\n]",
+            "timeContextFromParameter": null
+          },
+          {
+            "id": "1d5a805c-acce-4afe-a38b-c2740fb3ff26",
+            "version": "KqlParameterItem/1.0",
+            "name": "aggregateOrder",
+            "type": 1,
+            "isRequired": false,
+            "query": "range Steps from 1 to 1 step 1\r\n| project value = iff('{Aggregate}' contains 'P5th'  or '{Aggregate}' contains 'P10th', 'asc', 'desc')",
+            "crossComponentResources": [
+              "{Resource}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "queryType": 0,
+            "resourceType": "microsoft.compute/virtualmachinescalesets"
+          }
+        ],
+        "style": "above",
+        "queryType": 0,
+        "resourceType": "microsoft.compute/virtualmachinescalesets"
+      },
+      "conditionalVisibility": null,
+      "customWidth": "50",
+      "name": "parameters - 26"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": ""
+      },
+      "conditionalVisibility": null,
+      "customWidth": "50",
+      "name": "text - 27"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "let diskSummary=totable(Perf\r\n    | where TimeGenerated {TimeRange} \r\n    | where (ObjectName == 'LogicalDisk' and InstanceName != '_Total' and CounterName in ('% Free Space')) or        (ObjectName == 'Logical Disk' and InstanceName != '_Total' and CounterName in ('% Used Space'))\r\n    | project TimeGenerated, Computer,    CounterName = '% Used Space',    CounterValue = case(ObjectName == 'LogicalDisk' and CounterName == '% Free Space', 100 - CounterValue,                CounterValue < 0, real(0),                CounterValue)\r\n    | summarize hint.shufflekey=Computer {Aggregate} by Computer, CounterName\r\n    | top 10 by {Aggregate:label} {aggregateOrder});\r\nlet computerList=(diskSummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nPerf\r\n    | where TimeGenerated {TimeRange}\r\n    | where (ObjectName == 'LogicalDisk' and InstanceName != '_Total' and CounterName in ('% Free Space')) or        (ObjectName == 'Logical Disk' and InstanceName != '_Total' and CounterName in ('% Used Space'))\r\n    | where Computer in (computerList)\r\n    | project TimeGenerated, Computer,    CounterName = '% Used Space',    CounterValue = case(ObjectName == 'LogicalDisk' and CounterName == '% Free Space', 100 - CounterValue,                CounterValue < 0, real(0),                CounterValue)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {Aggregate} by bin(TimeGenerated, ({TimeRange:end} - {TimeRange:start})/100), ResourceName",
+        "size": 0,
+        "aggregation": 3,
+        "showAnnotations": true,
+        "noDataMessage": "There is no data for this counter, either enable the counter or onboard machines to this workspace",
+        "queryType": 0,
+        "resourceType": "microsoft.compute/virtualmachinescalesets",
+        "crossComponentResources": [
+          "{Resource}"
+        ],
+        "visualization": "linechart",
+        "tileSettings": {
+          "showBorder": false,
+          "titleContent": {
+            "columnMatch": "Computer",
+            "formatter": 1
+          },
+          "leftContent": {
+            "columnMatch": "value",
+            "formatter": 12,
+            "formatOptions": {
+              "palette": "auto"
+            },
+            "numberFormat": {
+              "unit": 17,
+              "options": {
+                "maximumSignificantDigits": 3,
+                "maximumFractionDigits": 2
+              }
+            }
+          }
+        }
+      },
+      "conditionalVisibility": null,
+      "customWidth": "50",
+      "name": "query - 28"
+    }
+  ],
+  "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
+}

--- a/Workbooks/Virtual Machine Scale Sets - Performance Analysis/Performance Analysis/settings.json
+++ b/Workbooks/Virtual Machine Scale Sets - Performance Analysis/Performance Analysis/settings.json
@@ -1,0 +1,8 @@
+{
+    "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/settings.json",
+    "name":"Performance",
+    "author": "Microsoft",
+    "galleries": [
+        { "type": "workbook", "resourceType": "microsoft.compute/virtualmachinescalesets", "order": 175 }
+    ]
+}

--- a/Workbooks/Virtual Machine Scale Sets - Performance Analysis/categoryResources.json
+++ b/Workbooks/Virtual Machine Scale Sets - Performance Analysis/categoryResources.json
@@ -1,0 +1,3 @@
+{
+    "en-us": {"name":"Performance Analysis", "description": "Look for common issues with your Virtual Machine Scale Sets via metrics", "order": 200}
+}

--- a/Workbooks/Virtual machine Scale Sets - Network Dependencies/Active Ports/Active Ports.workbook
+++ b/Workbooks/Virtual machine Scale Sets - Network Dependencies/Active Ports/Active Ports.workbook
@@ -1,0 +1,292 @@
+{
+  "version": "Notebook/1.0",
+  "items": [
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "query": "",
+        "crossComponentResources": [],
+        "parameters": [
+          {
+            "id": "80a15801-7442-49f3-a82f-6e55849ec7fb",
+            "version": "KqlParameterItem/1.0",
+            "name": "DefaultResource",
+            "type": 5,
+            "isRequired": true,
+            "value": "value::1",
+            "isHiddenWhenLocked": true,
+            "typeSettings": {
+              "resourceTypeFilter": {
+                "microsoft.compute/virtualmachinescalesets": true
+              },
+              "additionalResourceOptions": [
+                "value::1"
+              ]
+            },
+            "timeContextFromParameter": null
+          },
+          {
+            "id": "7da21a07-10f4-4455-9105-c37132dcee0d",
+            "version": "KqlParameterItem/1.0",
+            "name": "Context",
+            "type": 1,
+            "isRequired": false,
+            "query": "// {DefaultResource}\r\nwhere strcat(\"'\", id, \"'\") =~ \"{DefaultResource:value}\"\r\n| project value = tostring(pack('sub', subscriptionId, 'type', type, 'id', id))",
+            "crossComponentResources": [
+              "value::selected"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "queryType": 1,
+            "resourceType": "microsoft.resourcegraph/resources"
+          }
+        ],
+        "style": "pills",
+        "queryType": 0,
+        "resourceType": "microsoft.insights/components"
+      },
+      "conditionalVisibility": null,
+      "name": "parameters - 0"
+    },
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "query": "",
+        "crossComponentResources": [
+          "{Subscriptions}"
+        ],
+        "parameters": [
+          {
+            "id": "59d0c633-2f35-48d0-ab7e-0b25e81f6eb2",
+            "version": "KqlParameterItem/1.0",
+            "name": "Subscriptions",
+            "type": 6,
+            "isRequired": true,
+            "quote": "'",
+            "delimiter": ",",
+            "query": "summarize by subscriptionId\r\n| project strcat('/subscriptions/', subscriptionId), selected = subscriptionId == todynamic('{Context}').sub",
+            "crossComponentResources": [
+              "value::selected"
+            ],
+            "isHiddenWhenLocked": false,
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "timeContextFromParameter": null,
+            "queryType": 1,
+            "resourceType": "microsoft.resourcegraph/resources"
+          },
+          {
+            "id": "45c1e9b3-ff85-4825-85b1-a41a256cb060",
+            "version": "KqlParameterItem/1.0",
+            "name": "ResourceType",
+            "type": 7,
+            "isRequired": true,
+            "query": "summarize by type\r\n| where type =~ \"microsoft.compute/virtualmachines\" or type =~ \"microsoft.compute/virtualmachinescalesets\" or type =~ \"microsoft.operationalinsights/workspaces\"\r\n| project type, selected = todynamic('{Context}').type =~ type",
+            "crossComponentResources": [
+              "{Subscriptions}"
+            ],
+            "isHiddenWhenLocked": false,
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "timeContextFromParameter": null,
+            "queryType": 1,
+            "resourceType": "microsoft.resourcegraph/resources"
+          },
+          {
+            "id": "0e9819ac-8b12-4827-98e0-f93e26077517",
+            "version": "KqlParameterItem/1.0",
+            "name": "Resources",
+            "type": 5,
+            "isRequired": true,
+            "query": "where type =~ '{ResourceType}'\r\n| summarize by id, name\r\n| project id, selected = id == todynamic('{Context}').id",
+            "crossComponentResources": [
+              "{Subscriptions}"
+            ],
+            "isHiddenWhenLocked": false,
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "timeContextFromParameter": null,
+            "queryType": 1,
+            "resourceType": "microsoft.resourcegraph/resources"
+          }
+        ],
+        "style": "pills",
+        "queryType": 1,
+        "resourceType": "microsoft.resourcegraph/resources"
+      },
+      "conditionalVisibility": {
+        "parameterName": "Context",
+        "comparison": "isEqualTo",
+        "value": null
+      },
+      "name": "parameters - 3"
+    },
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "query": "",
+        "crossComponentResources": [],
+        "parameters": [
+          {
+            "id": "d50b9c51-4e63-4a89-8793-64292a082c4e",
+            "version": "KqlParameterItem/1.0",
+            "name": "TimeRange",
+            "type": 4,
+            "isRequired": true,
+            "value": {
+              "durationMs": 3600000
+            },
+            "isHiddenWhenLocked": false,
+            "typeSettings": {
+              "selectableValues": [
+                {
+                  "durationMs": 900000
+                },
+                {
+                  "durationMs": 1800000
+                },
+                {
+                  "durationMs": 3600000
+                },
+                {
+                  "durationMs": 14400000
+                },
+                {
+                  "durationMs": 43200000
+                },
+                {
+                  "durationMs": 86400000
+                },
+                {
+                  "durationMs": 172800000
+                },
+                {
+                  "durationMs": 259200000
+                },
+                {
+                  "durationMs": 604800000
+                },
+                {
+                  "durationMs": 1209600000
+                },
+                {
+                  "durationMs": 2419200000
+                },
+                {
+                  "durationMs": 2592000000
+                },
+                {
+                  "durationMs": 5184000000
+                },
+                {
+                  "durationMs": 7776000000
+                }
+              ]
+            },
+            "timeContextFromParameter": null
+          }
+        ],
+        "style": "pills",
+        "queryType": 0,
+        "resourceType": "microsoft.insights/components"
+      },
+      "conditionalVisibility": null,
+      "name": "parameters - 4"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "## Port activity by Computer, Process, IP and Port"
+      },
+      "conditionalVisibility": null,
+      "name": "text - 1"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "// {DefaultResource} {Subscriptions} {ResourceType} {Resources}\nVMBoundPort\n| where Ip != \"127.0.0.1\"\n| summarize BytesSent=sum(BytesSent), BytesReceived=sum(BytesReceived), LinksEstablished=sum(LinksEstablished), LinksTerminated=sum(LinksTerminated), arg_max(TimeGenerated, LinksLive) by Computer, ProcessName, Ip, Port, IsWildcardBind\n| project-away TimeGenerated\n| order by BytesSent desc",
+        "size": 2,
+        "showAnalytics": true,
+        "timeContext": {
+          "durationMs": 0
+        },
+        "timeContextFromParameter": "TimeRange",
+        "queryType": 0,
+        "resourceType": "{ResourceType}",
+        "crossComponentResources": [
+          "{Resources}"
+        ],
+        "gridSettings": {
+          "formatters": [
+            {
+              "columnMatch": "BytesSent",
+              "formatter": 4,
+              "formatOptions": {
+                "palette": "orange",
+                "showIcon": true
+              },
+              "numberFormat": {
+                "unit": 17,
+                "options": {
+                  "style": "decimal",
+                  "useGrouping": true
+                }
+              }
+            },
+            {
+              "columnMatch": "BytesReceived",
+              "formatter": 4,
+              "formatOptions": {
+                "palette": "green",
+                "showIcon": true
+              },
+              "numberFormat": {
+                "unit": 17,
+                "options": {
+                  "style": "decimal",
+                  "useGrouping": true
+                }
+              }
+            },
+            {
+              "columnMatch": "LinksEstablished",
+              "formatter": 4,
+              "formatOptions": {
+                "palette": "blueDark",
+                "showIcon": true
+              }
+            },
+            {
+              "columnMatch": "LinksTerminated",
+              "formatter": 4,
+              "formatOptions": {
+                "palette": "blueDark",
+                "showIcon": true
+              }
+            },
+            {
+              "columnMatch": "LinksLive",
+              "formatter": 4,
+              "formatOptions": {
+                "palette": "blueDark",
+                "showIcon": true
+              }
+            }
+          ],
+          "rowLimit": 10000,
+          "filter": true
+        }
+      },
+      "conditionalVisibility": null,
+      "name": "query - 2"
+    }
+  ],
+  "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
+}

--- a/Workbooks/Virtual machine Scale Sets - Network Dependencies/Active Ports/settings.json
+++ b/Workbooks/Virtual machine Scale Sets - Network Dependencies/Active Ports/settings.json
@@ -1,0 +1,8 @@
+{
+    "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/settings.json",
+    "name":"Active Ports",
+    "author": "Microsoft",
+    "galleries": [
+        { "type": "workbook", "resourceType": "microsoft.compute/virtualmachinescalesets", "order": 175 }
+    ]
+}

--- a/Workbooks/Virtual machine Scale Sets - Network Dependencies/Connections Overview/Connections Overview.workbook
+++ b/Workbooks/Virtual machine Scale Sets - Network Dependencies/Connections Overview/Connections Overview.workbook
@@ -1,0 +1,986 @@
+{
+  "version": "Notebook/1.0",
+  "items": [
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "query": "",
+        "crossComponentResources": [],
+        "parameters": [
+          {
+            "id": "e41c2177-932a-4c58-ba24-03ef070eb197",
+            "version": "KqlParameterItem/1.0",
+            "name": "Resource",
+            "type": 5,
+            "isRequired": true,
+            "value": "value::1",
+            "isHiddenWhenLocked": true,
+            "typeSettings": {
+              "resourceTypeFilter": {
+                "microsoft.compute/virtualmachinescalesets": true
+              },
+              "additionalResourceOptions": [
+                "value::1"
+              ]
+            },
+            "timeContextFromParameter": null
+          },
+          {
+            "id": "a9393837-8ef0-40e5-b223-4df1208a691e",
+            "version": "KqlParameterItem/1.0",
+            "name": "Test",
+            "type": 1,
+            "isRequired": false,
+            "query": "VMConnection\r\n| take 1\r\n| summarize count()",
+            "crossComponentResources": [
+              "{Resource}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "queryType": 0,
+            "resourceType": "microsoft.compute/virtualmachinescalesets"
+          },
+          {
+            "id": "648ac90d-4be5-4c08-ac13-bcff7f8ddbf9",
+            "version": "KqlParameterItem/1.0",
+            "name": "DisclaimerText",
+            "type": 1,
+            "isRequired": false,
+            "query": "print iff('{Test}' == '' , 'This workbook requires [Azure Monitor for VMs (preview)](https://docs.microsoft.com/en-us/azure/azure-monitor/insights/vminsights-overview) enabled', iff('{Test}' == '0', '⚠ There is currently no `VMConnection` data in this workspace', 'The following table presents the connection statistics for computers in your workspace (max `10,000` rows). Use the <em>Hierarchy</em> dropdown for more detailed information for each computer but fewer computers will be shown if the total number of rows rendered exceeds `10,000`.'))",
+            "crossComponentResources": [
+              "{Resource}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "queryType": 0,
+            "resourceType": "microsoft.compute/virtualmachinescalesets"
+          }
+        ],
+        "style": "above",
+        "queryType": 0,
+        "resourceType": "microsoft.compute/virtualmachinescalesets"
+      },
+      "conditionalVisibility": {
+        "parameterName": "_",
+        "comparison": "isNotEqualTo",
+        "value": null
+      },
+      "name": "parameters - 0"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "{DisclaimerText}\r\n\r\n---"
+      },
+      "conditionalVisibility": null,
+      "name": "text - 1"
+    },
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "query": "",
+        "crossComponentResources": [],
+        "parameters": [
+          {
+            "id": "addcec31-b7ac-4715-a78d-9b803f86af8a",
+            "version": "KqlParameterItem/1.0",
+            "name": "TimeRange",
+            "type": 4,
+            "isRequired": true,
+            "value": {
+              "durationMs": 3600000
+            },
+            "isHiddenWhenLocked": false,
+            "typeSettings": {
+              "selectableValues": [
+                {
+                  "durationMs": 300000,
+                  "createdTime": "2019-01-28T23:37:45.024Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 900000,
+                  "createdTime": "2019-01-28T23:37:45.024Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 1800000,
+                  "createdTime": "2019-01-28T23:37:45.024Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 3600000,
+                  "createdTime": "2019-01-28T23:37:45.024Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 14400000,
+                  "createdTime": "2019-01-28T23:37:45.024Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 43200000,
+                  "createdTime": "2019-01-28T23:37:45.024Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 86400000,
+                  "createdTime": "2019-01-28T23:37:45.025Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 172800000,
+                  "createdTime": "2019-01-28T23:37:45.025Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 259200000,
+                  "createdTime": "2019-01-28T23:37:45.025Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 604800000,
+                  "createdTime": "2019-01-28T23:37:45.025Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 1209600000,
+                  "createdTime": "2019-01-28T23:37:45.025Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 2592000000,
+                  "createdTime": "2019-01-28T23:37:45.026Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 5184000000,
+                  "createdTime": "2019-01-28T23:37:45.026Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 7776000000,
+                  "createdTime": "2019-01-28T23:37:45.026Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                }
+              ],
+              "allowCustom": true
+            },
+            "timeContextFromParameter": null
+          },
+          {
+            "id": "db9b2f1d-188a-4dda-af4a-b39deeb34da3",
+            "version": "KqlParameterItem/1.0",
+            "name": "Direction",
+            "type": 2,
+            "description": "Direction of the network connection from the VMs",
+            "isRequired": true,
+            "value": "outbound",
+            "isHiddenWhenLocked": false,
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "jsonData": "[\r\n    { \"value\":\"inbound\", \"label\":\"Inbound\" },\r\n    { \"value\":\"outbound\", \"label\":\"Outbound\" }\r\n]",
+            "timeContextFromParameter": null
+          },
+          {
+            "id": "8744c427-f060-4725-95af-850af2fa08b1",
+            "version": "KqlParameterItem/1.0",
+            "name": "ComputerNameContains",
+            "type": 1,
+            "isRequired": false,
+            "isHiddenWhenLocked": false,
+            "timeContextFromParameter": null
+          },
+          {
+            "id": "b141bd6c-cd8d-488e-a5f6-83ab00d31161",
+            "version": "KqlParameterItem/1.0",
+            "name": "Computers",
+            "type": 2,
+            "isRequired": false,
+            "multiSelect": true,
+            "quote": "'",
+            "delimiter": ",",
+            "query": "VMConnection\r\n| where Computer contains '{ComputerNameContains}'\r\n| summarize by Computer\r\n| project Value = Computer, Display = Computer, isSelected = false\r\n| order by Display asc\r\n| union (datatable(Value:string, Display:string, isSelected:boolean)['*', 'All',true])",
+            "crossComponentResources": [
+              "{Resource}"
+            ],
+            "isHiddenWhenLocked": false,
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "timeContext": {
+              "durationMs": 0
+            },
+            "timeContextFromParameter": "TimeRange",
+            "queryType": 0,
+            "resourceType": "microsoft.compute/virtualmachinescalesets"
+          },
+          {
+            "id": "488d1f86-cabc-4fcc-8dc9-9a2e5803fb20",
+            "version": "KqlParameterItem/1.0",
+            "name": "ComputerFilter",
+            "type": 1,
+            "isRequired": true,
+            "query": "let computerFilter = iff('*' in ({Computers}), \"| where Computer contains '{ComputerNameContains}'\", \"| where Computer in ({Computers})\");\r\nprint(computerFilter)",
+            "crossComponentResources": [
+              "{Resource}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "queryType": 0,
+            "resourceType": "microsoft.compute/virtualmachinescalesets"
+          },
+          {
+            "id": "56ab6626-c12d-4de1-8a3d-8a6099db3cd3",
+            "version": "KqlParameterItem/1.0",
+            "name": "Hierarchy",
+            "type": 2,
+            "description": "Select the level of detail to be shown in the table below",
+            "isRequired": true,
+            "query": "let outboundTable = datatable (value:string, Display:string)\r\n    [\"0\", \"Computer -> Process -> Remote IP -> Port\",\r\n     \"1\", \"Computer -> Process -> Remote IP\",\r\n     \"2\", \"Computer -> Process\",\r\n     \"3\", \"Computer\"];\r\nlet outbound = outboundTable | extend type = 'outbound';\r\nlet inboundTable = datatable (value:string, Display:string)\r\n    [\"0\", \"Computer -> Process -> Port -> Remote IP\",\r\n     \"1\", \"Computer -> Process -> Port\",\r\n     \"2\", \"Computer -> Process\",\r\n     \"3\", \"Computer\"];\r\nlet inbound = inboundTable | extend type = 'inbound';\r\nlet table = outbound | union inbound;\r\ntable\r\n| where type == iif('{Direction}' == 'outbound', 'outbound', 'inbound')\r\n| project value, Display",
+            "crossComponentResources": [
+              "{Resource}"
+            ],
+            "value": "2",
+            "isHiddenWhenLocked": false,
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "timeContextFromParameter": null,
+            "resourceType": "microsoft.compute/virtualmachinescalesets"
+          },
+          {
+            "id": "5526f711-6d04-469e-8d06-351508f1014e",
+            "version": "KqlParameterItem/1.0",
+            "name": "TableFilter",
+            "type": 2,
+            "description": "Filter table based on presence of malicious connections or at least one link failing",
+            "isRequired": false,
+            "multiSelect": true,
+            "quote": "",
+            "delimiter": "",
+            "value": [],
+            "isHiddenWhenLocked": false,
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "jsonData": "[\r\n    {\r\n        \"label\": \"Only Malicious Connections\",\r\n        \"value\": \" | where MaliciousConnectionsCount >= 1\"\r\n    },\r\n    {\r\n        \"label\": \"Only Links Failed\",\r\n        \"value\": \" | where LinksFailed >= 1\"\r\n    }\r\n]",
+            "timeContextFromParameter": null
+          }
+        ],
+        "style": "above",
+        "queryType": 0,
+        "resourceType": "microsoft.compute/virtualmachinescalesets"
+      },
+      "conditionalVisibility": null,
+      "name": "parameters - 2"
+    },
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "query": "",
+        "crossComponentResources": [
+          "{Resource}"
+        ],
+        "parameters": [
+          {
+            "id": "5e335a1b-7f99-4647-854a-d7b5cb489bb2",
+            "version": "KqlParameterItem/1.0",
+            "name": "ServiceMapComputers",
+            "type": 1,
+            "isRequired": true,
+            "query": "{\"version\":\"1.0.0\",\"content\":\"{\\\"snippet\\\":\\\"let computers = ServiceMapComputer_CL | summarize (TimeGenerated, Properties) = arg_max(TimeGenerated, pack_all()) by Computer;\\\"}\"}",
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "queryType": 8,
+            "resourceType": "microsoft.compute/virtualmachinescalesets"
+          },
+          {
+            "id": "c69fbaae-4fd2-4527-acdd-a2c358eebffa",
+            "version": "KqlParameterItem/1.0",
+            "name": "MaliciousIpData",
+            "type": 1,
+            "isRequired": false,
+            "query": "{\"version\":\"1.0.0\",\"content\":\"{\\\"snippet\\\":\\\"let maliciousIpData = VMConnection  | where Direction == '{Direction}' {ComputerFilter} | where MaliciousIp != '' | summarize by Computer, ProcessName, MaliciousIp, DestinationPort, RemoteIp, IsActive, IndicatorThreatType, RemoteCountry, RemoteLongitude, RemoteLatitude, Confidence, Severity, FirstReportedDateTime, LastReportedDateTime | project MaliciousIp = strcat(Computer, '-', ProcessName, '-', MaliciousIp), MaliciousPort = strcat(Computer, '-', ProcessName, '-', DestinationPort), MaliciousPortIp = strcat(Computer, '-', ProcessName, '-', DestinationPort, '-', RemoteIp), Computer = Computer, Process = strcat(Computer, '-', ProcessName), MaliciousIpInfo = pack('Malicious IP', MaliciousIp, 'Is Active', IsActive, 'Indicator Threat Type', IndicatorThreatType, 'Remote Country', RemoteCountry, 'Longitude', RemoteLongitude, 'Latitude', RemoteLatitude, 'Confidence', Confidence, 'Severity', Severity, 'First Reported DateTime', FirstReportedDateTime, 'Last Reported DateTime', LastReportedDateTime, 'Destination Port', DestinationPort, 'Remote IP', RemoteIp);\\\"}\"}",
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "queryType": 8,
+            "resourceType": "microsoft.compute/virtualmachinescalesets"
+          },
+          {
+            "id": "dd933ac8-1273-48fe-8d09-bd65d857ce83",
+            "version": "KqlParameterItem/1.0",
+            "name": "ComputerData",
+            "type": 1,
+            "isRequired": false,
+            "query": "{\"version\":\"1.0.0\",\"content\":\"{\\\"snippet\\\":\\\"let computerData = VMConnection | where Direction == '{Direction}' {ComputerFilter} | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 * sum(ResponseTimeSum) / sum(Responses) by Name = strcat('🖥️ ', Computer), ComputerName = Computer, Type = 'Computer', TypeKey = 1, Key = Computer, ParentKey = '---' | join kind=leftouter (maliciousIpData | summarize MaliciousIpInfo = tostring(count()) by Computer) on $left.Key == $right.Computer | project-away Computer | order by Name asc;\\\"}\"}",
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "queryType": 8,
+            "resourceType": "microsoft.compute/virtualmachinescalesets"
+          },
+          {
+            "id": "fb879823-c082-4c53-af7e-18d044032f99",
+            "version": "KqlParameterItem/1.0",
+            "name": "RemoteIpDataInbound",
+            "type": 1,
+            "isRequired": false,
+            "query": "{\"version\":\"1.0.0\",\"content\":\"{\\\"snippet\\\":\\\"let remoteIpDataInbound = VMConnection | where Direction == 'inbound' | where 'inbound' == 'inbound' {ComputerFilter} | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) by Computer, ProcessName, RemoteIp, Type = 'Remote Computer', TypeKey = 3, Key = strcat(Computer, '-', ProcessName, '-', tostring(DestinationPort), '-', RemoteIp), ParentKey = strcat(Computer, '-', ProcessName, '-', tostring(DestinationPort)), Id = strcat(Computer, '-', ProcessName, '-', RemoteIp), ComputerName = Computer | join kind=inner     sourcePortData on $left.ParentKey == $right.Key | project-away AverageResponseTime1, Computer1, Key1, LinksFailed1, MaxLinksLive1, ParentKey1, ProcessName1, Responses1, TotalBytesReceived1, TotalBytesSent1, Type1, TypeKey1 | order by Name asc | join kind=leftouter     ipComputerMapping on $left.RemoteIp == $right.Ipv4 | extend Name = iff(RemoteIp == '', 'Unknown',  strcat('🌐 External (', RemoteIp, ')')) | project-away Computer, Ipv4 | order by Name desc | join kind=leftouter     maliciousIpData on $left.Key == $right.MaliciousPortIp | extend MaliciousIpInfo = tostring(MaliciousIpInfo1) | project-away MaliciousIp, Computer, Process, Computer1, MaliciousIpInfo1, Id;\\\"}\"}",
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "queryType": 8,
+            "resourceType": "microsoft.compute/virtualmachinescalesets"
+          },
+          {
+            "id": "3ad60c70-b530-49c0-a59b-8df690dffbc8",
+            "version": "KqlParameterItem/1.0",
+            "name": "ProcessName",
+            "type": 1,
+            "isRequired": false,
+            "query": "{\"version\":\"1.0.0\",\"content\":\"{\\\"snippet\\\":\\\"let processData = VMConnection | where Direction == '{Direction}' {ComputerFilter} | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) by Computer, ProcessName, Name = strcat('🎫 ', ProcessName), Type = 'Process', TypeKey = 2, Key = strcat(Computer, '-', ProcessName), ParentKey = Computer, ComputerName = Computer | join kind=inner computerData on $left.ParentKey == $right.Key | project-away Name1, Responses1, LinksFailed1, MaxLinksLive1, TotalBytesSent1, TotalBytesReceived1, AverageResponseTime1, Type1, Key1, ParentKey1 | join kind=leftouter (maliciousIpData | summarize MaliciousIpInfo = tostring(count()) by Process) on $left.Key == $right.Process | project-away Process, MaliciousIpInfo | extend MaliciousIpInfo = tostring(MaliciousIpInfo1) | project-away MaliciousIpInfo1 | order by Name asc;\\\"}\"}",
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "queryType": 8,
+            "resourceType": "microsoft.compute/virtualmachinescalesets"
+          },
+          {
+            "id": "c9eea7db-3d14-4fbf-8ae6-b7507ec1d43f",
+            "version": "KqlParameterItem/1.0",
+            "name": "RemoteIpData",
+            "type": 1,
+            "isRequired": true,
+            "query": "{\"version\":\"1.0.0\",\"content\":\"{\\\"snippet\\\":\\\"let remoteIpData = VMConnection | where '{Direction}' == 'outbound' | where Direction == '{Direction}' {ComputerFilter} | extend RemoteIp = iff(Direction == 'outbound', DestinationIp, SourceIp) | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) by Computer, ProcessName, RemoteIp, Type = 'Remote Computer', TypeKey = 3, Key = strcat(Computer, '-', ProcessName, '-', RemoteIp), ParentKey = strcat(Computer, '-', ProcessName), ComputerName = Computer | join kind=inner processData on $left.ParentKey == $right.Key | project-away Name, Responses1, LinksFailed1, MaxLinksLive1, TotalBytesSent1, TotalBytesReceived1, AverageResponseTime1, Type1, Key1, ParentKey1 | join kind=leftouter maliciousIpData on $left.Key == $right.MaliciousIp | project-away MaliciousIp, Computer, Process, Computer1, Computer2, MaliciousIpInfo | extend MaliciousIpInfo = tostring(MaliciousIpInfo1) | project-away MaliciousIpInfo1 | join kind = leftouter (ipComputerMapping) on $left.RemoteIp == $right.Ipv4 | extend Name = iff(Computer == '', iff(RemoteIp == '127.0.0.1', '🌐 Localhost',  strcat('🌐 External (', RemoteIp, ')')), strcat('🖥️ ', Computer)) | project-away Computer, Ipv4 | order by Name desc;\\\"}\"}",
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "queryType": 8,
+            "resourceType": "microsoft.compute/virtualmachinescalesets"
+          },
+          {
+            "id": "4a9ed59b-002e-4c81-b437-8456faeef6a6",
+            "version": "KqlParameterItem/1.0",
+            "name": "SourcePortData",
+            "type": 1,
+            "isRequired": false,
+            "query": "{\"version\":\"1.0.0\",\"content\":\"{\\\"snippet\\\":\\\"let sourcePortData = VMConnection | where Direction == '{Direction}' | where '{Direction}' == 'inbound' {ComputerFilter} | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) by Computer, ProcessName, DestinationIp, DestinationPort, Name = strcat('🔶 ', DestinationPort), Type = 'Remote Port', TypeKey = 4, Key = strcat(Computer, '-', ProcessName, '-', tostring(DestinationPort)), ParentKey = strcat(Computer, '-', ProcessName), ComputerName = Computer | join kind=leftouter maliciousIpData on $left.Key == $right.MaliciousPort | extend MaliciousIpInfo = tostring(MaliciousIpInfo) | project-away Computer1, MaliciousIp, MaliciousPort, MaliciousPortIp, Process; {RemoteIpDataInbound}\\\"}\"}",
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "queryType": 8,
+            "resourceType": "microsoft.compute/virtualmachinescalesets"
+          },
+          {
+            "id": "e31a8d21-e24b-45ec-9806-e6c45bca15aa",
+            "version": "KqlParameterItem/1.0",
+            "name": "DestinationPortData",
+            "type": 1,
+            "isRequired": false,
+            "query": "{\"version\":\"1.0.0\",\"content\":\"{\\\"snippet\\\":\\\"let destinationPortData = VMConnection | where Direction == '{Direction}' | where '{Direction}' == 'outbound' {ComputerFilter} | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) by Computer, ProcessName, DestinationIp, DestinationPort, Name = strcat('🔶 ', DestinationPort), Type = 'Remote Port', TypeKey = 4, Key = strcat(Computer, '-', ProcessName, '-', DestinationIp, '-', tostring(DestinationPort)), ParentKey = strcat(Computer, '-', ProcessName, '-', DestinationIp), ComputerName = Computer | join kind=inner remoteIpData on $left.ParentKey == $right.Key | project-away Name1, Responses1, Type1, Key1, ParentKey1 | order by Name asc;\\\"}\"}",
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "queryType": 8,
+            "resourceType": "microsoft.compute/virtualmachinescalesets"
+          },
+          {
+            "id": "a54f3df8-c872-4a19-a280-84b203987ec8",
+            "version": "KqlParameterItem/1.0",
+            "name": "QueryProject",
+            "type": 1,
+            "isRequired": false,
+            "query": "{\"version\":\"1.0.0\",\"content\":\"{\\\"snippet\\\":\\\"| extend MaliciousConnectionsCount = iff(MaliciousIpInfo == '', 0, iff(Type == 'Computer' or Type == 'Process' or Type == 'Overall', tolong(MaliciousIpInfo), 1)) | project ComputerName, ProcessName, RemoteIp, DestinationPort, Name = iff(Name == '🎫 ', '🎫 <Unknown>', Name), Type, MaliciousConnections = iff(MaliciousIpInfo == '', '✅ No Malicious Connections', iff(Type == 'Computer' or Type == 'Process' or Type == 'Overall', iff(MaliciousConnectionsCount > 1, strcat('❌ ', MaliciousIpInfo, ' Malicious Connections'), strcat('❌ ', MaliciousIpInfo, ' Malicious Connection')), '❌ Malicious Connection')), Responses, MaxLinksLive, LinksFailed, AverageResponseTime, TotalBytesSent, TotalBytesReceived, Info = iff(MaliciousIpInfo != '', MaliciousIpInfo, ''), Key, ParentKey, TypeKey, MaliciousConnectionsCount | order by TypeKey asc, MaliciousConnectionsCount desc, LinksFailed desc, AverageResponseTime desc, Responses desc, MaxLinksLive desc, Name asc | project-away TypeKey\\\"}\"}",
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "queryType": 8,
+            "resourceType": "microsoft.compute/virtualmachinescalesets"
+          },
+          {
+            "id": "9789ead5-eae5-4f52-86c2-ac197da62f30",
+            "version": "KqlParameterItem/1.0",
+            "name": "Computer_Process_IP_Port",
+            "type": 1,
+            "isRequired": false,
+            "query": "{\"version\":\"1.0.0\",\"content\":\"{\\\"snippet\\\":\\\"{ServiceMapComputers} let ipComputerMapping = computers | project Computer, Ipv4 = todynamic(tostring(Properties.Ipv4Addresses_s)) | mvexpand Ipv4 to typeof(string); {MaliciousIpData} let totalMaliciousConnectionsCount = maliciousIpData | summarize MaliciousIpInfo = count() | extend Type = 'Overall'; {ComputerData} {ProcessName} {RemoteIpData} {DestinationPortData} {SourcePortData} let overalldata = VMConnection | where Direction == '{Direction}' {ComputerFilter} | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) | extend Name = '🔵 Overall', Type = 'Overall', TypeKey = 0, Key = '--Overall--', ParentKey = '----' | join kind=leftouter totalMaliciousConnectionsCount on Type | extend MaliciousIpInfo = iff(MaliciousIpInfo == '0', '', tostring(MaliciousIpInfo)) | project-away Type1; computerData | union processData | union remoteIpData | union destinationPortData | union remoteIpDataInbound | union sourcePortData | union overalldata {QueryProject}\\\"}\"}",
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "queryType": 8,
+            "resourceType": "microsoft.compute/virtualmachinescalesets"
+          },
+          {
+            "id": "0d6a320e-2cef-44fd-ac0b-ad833f8d0c03",
+            "version": "KqlParameterItem/1.0",
+            "name": "Computer_Process_IP",
+            "type": 1,
+            "isRequired": false,
+            "query": "{\"version\":\"1.0.0\",\"content\":\"{\\\"snippet\\\":\\\"{ServiceMapComputers} let ipComputerMapping = computers | project Computer, Ipv4 = todynamic(tostring(Properties.Ipv4Addresses_s)) | mvexpand Ipv4 to typeof(string); {MaliciousIpData} let totalMaliciousConnectionsCount = maliciousIpData | summarize MaliciousIpInfo = count() | extend Type = 'Overall'; {ComputerData} {ProcessName} {RemoteIpData} {SourcePortData} let overalldata = VMConnection | where Direction == '{Direction}' {ComputerFilter} | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) | extend Name = '🔵 Overall', Type = 'Overall', TypeKey = 0, Key = '--Overall--', ParentKey = '----' | join kind=leftouter totalMaliciousConnectionsCount on Type | extend MaliciousIpInfo = iff(MaliciousIpInfo == '0', '', tostring(MaliciousIpInfo)) | project-away Type1;  computerData | union processData | union remoteIpData | union sourcePortData | union overalldata {QueryProject}\\\"}\"}",
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "queryType": 8,
+            "resourceType": "microsoft.compute/virtualmachinescalesets"
+          },
+          {
+            "id": "2de0d685-4382-4822-a8aa-f3583ff11b66",
+            "version": "KqlParameterItem/1.0",
+            "name": "QueryPadDestinationPortTable",
+            "type": 1,
+            "isRequired": true,
+            "query": "{\"version\":\"1.0.0\",\"content\":\"{\\\"snippet\\\":\\\"let destinationPortPadding = datatable (DestinationPort: string) [];\\\"}\"}",
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "queryType": 8,
+            "resourceType": "microsoft.compute/virtualmachinescalesets"
+          },
+          {
+            "id": "df8a6322-511e-40e0-a258-fe717099a072",
+            "version": "KqlParameterItem/1.0",
+            "name": "QueryPadRemoteIpTable",
+            "type": 1,
+            "isRequired": true,
+            "query": "{\"version\":\"1.0.0\",\"content\":\"{\\\"snippet\\\":\\\"let remoteIpPadding = datatable (RemoteIp: string) [];\\\"}\"}",
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "queryType": 8,
+            "resourceType": "microsoft.compute/virtualmachinescalesets"
+          },
+          {
+            "id": "e8f2c394-18e8-4d6d-8f5e-8453cb67128c",
+            "version": "KqlParameterItem/1.0",
+            "name": "Computer_Process",
+            "type": 1,
+            "isRequired": false,
+            "query": "{\"version\":\"1.0.0\",\"content\":\"{\\\"snippet\\\":\\\"{ServiceMapComputers} let ipComputerMapping = computers | project Computer, Ipv4 = todynamic(tostring(Properties.Ipv4Addresses_s)) | mvexpand Ipv4 to typeof(string); {MaliciousIpData} let totalMaliciousConnectionsCount = maliciousIpData | summarize MaliciousIpInfo = count() | extend Type = 'Overall'; {ComputerData} {ProcessName} let overalldata = VMConnection | where Direction == '{Direction}' {ComputerFilter} | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) | extend Name = '🔵 Overall', Type = 'Overall', TypeKey = 0, Key = '--Overall--', ParentKey = '----' | join kind=leftouter totalMaliciousConnectionsCount on Type | extend MaliciousIpInfo = iff(MaliciousIpInfo == '0', '', tostring(MaliciousIpInfo)) | project-away Type1; {QueryPadDestinationPortTable} {QueryPadRemoteIpTable}  computerData | union remoteIpPadding | union destinationPortPadding | union processData | union overalldata  {QueryProject}\\\"}\"}",
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "queryType": 8,
+            "resourceType": "microsoft.compute/virtualmachinescalesets"
+          },
+          {
+            "id": "a4b0e146-7c89-40bb-ade2-ed2e392e9311",
+            "version": "KqlParameterItem/1.0",
+            "name": "Computer",
+            "type": 1,
+            "isRequired": false,
+            "query": "{\"version\":\"1.0.0\",\"content\":\"{\\\"snippet\\\":\\\"{ServiceMapComputers} let ipComputerMapping = computers | project Computer, Ipv4 = todynamic(tostring(Properties.Ipv4Addresses_s)) | mvexpand Ipv4 to typeof(string); {MaliciousIpData} let totalMaliciousConnectionsCount = maliciousIpData | summarize MaliciousIpInfo = count() | extend Type = 'Overall'; {ComputerData} let overalldata = VMConnection | where Direction == '{Direction}' {ComputerFilter} | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) | extend Name = '🔵 Overall', Type = 'Overall', TypeKey = 0, Key = '--Overall--', ParentKey = '----' | join kind=leftouter totalMaliciousConnectionsCount on Type | extend MaliciousIpInfo = iff(MaliciousIpInfo == '0', '', tostring(MaliciousIpInfo)) | project-away Type1; {QueryPadDestinationPortTable} {QueryPadRemoteIpTable} {QueryPadProcessNameTable} computerData | union remoteIpPadding | union processNamePadding | union destinationPortPadding | union overalldata {QueryProject}\\\"}\"}",
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "queryType": 8,
+            "resourceType": "microsoft.compute/virtualmachinescalesets"
+          },
+          {
+            "id": "084fb5fc-e8e4-42df-8a9f-ac1001950ba2",
+            "version": "KqlParameterItem/1.0",
+            "name": "QueryPadProcessNameTable",
+            "type": 1,
+            "isRequired": true,
+            "query": "{\"version\":\"1.0.0\",\"content\":\"{\\\"snippet\\\":\\\"let processNamePadding = datatable (ProcessName: string) [];\\\"}\"}",
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "queryType": 8,
+            "resourceType": "microsoft.compute/virtualmachinescalesets"
+          },
+          {
+            "id": "a08757da-e72b-474d-a1d2-65fb7020cc14",
+            "version": "KqlParameterItem/1.0",
+            "name": "FinalQuery",
+            "type": 1,
+            "isRequired": false,
+            "query": "print(strcat(\r\niff({Hierarchy} == 0, \"{Computer_Process_IP_Port}\", \r\niff({Hierarchy} == 1, \"{Computer_Process_IP}\",\r\niff({Hierarchy} == 2, \"{Computer_Process}\",\r\niff({Hierarchy} == 3, \"{Computer}\", \"{Computer}\")))),'{TableFilter:value}'));",
+            "crossComponentResources": [
+              "{Resource}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "queryType": 0,
+            "resourceType": "microsoft.compute/virtualmachinescalesets"
+          },
+          {
+            "id": "874eeebe-2ea2-4c04-a3b9-ab3b30e95573",
+            "version": "KqlParameterItem/1.0",
+            "name": "ConnectionGrid",
+            "type": 1,
+            "isRequired": false,
+            "value": "{}",
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null
+          }
+        ],
+        "style": "above",
+        "queryType": 0,
+        "resourceType": "microsoft.compute/virtualmachinescalesets"
+      },
+      "conditionalVisibility": null,
+      "name": "parameters - 3"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "💡 <em>Select a row from the table below to view connection details for that entry.</em>"
+      },
+      "conditionalVisibility": null,
+      "name": "text - 4"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "{FinalQuery:value}",
+        "size": 0,
+        "exportParameterName": "ConnectionGrid",
+        "showAnalytics": true,
+        "noDataMessage": "No data to be shown for this particular scope combination, please adjust the time range, table filters, etc.",
+        "timeContext": {
+          "durationMs": 0
+        },
+        "timeContextFromParameter": "TimeRange",
+        "queryType": 0,
+        "resourceType": "microsoft.compute/virtualmachinescalesets",
+        "visualization": "table",
+        "gridSettings": {
+          "formatters": [
+            {
+              "columnMatch": "Computer",
+              "formatter": 5,
+              "formatOptions": {}
+            },
+            {
+              "columnMatch": "ProcessName",
+              "formatter": 5,
+              "formatOptions": {}
+            },
+            {
+              "columnMatch": "RemoteIp",
+              "formatter": 5,
+              "formatOptions": {}
+            },
+            {
+              "columnMatch": "DestinationPort",
+              "formatter": 5,
+              "formatOptions": {},
+              "numberFormat": {
+                "unit": 0,
+                "options": {
+                  "style": "decimal"
+                }
+              }
+            },
+            {
+              "columnMatch": "Responses",
+              "formatter": 4,
+              "formatOptions": {
+                "palette": "blueDark"
+              },
+              "numberFormat": {
+                "unit": 17,
+                "options": {
+                  "style": "decimal"
+                }
+              }
+            },
+            {
+              "columnMatch": "MaxLinksLive",
+              "formatter": 4,
+              "formatOptions": {
+                "palette": "lightBlue"
+              },
+              "numberFormat": {
+                "unit": 17,
+                "options": {
+                  "style": "decimal"
+                }
+              }
+            },
+            {
+              "columnMatch": "LinksFailed",
+              "formatter": 4,
+              "formatOptions": {
+                "palette": "red"
+              },
+              "numberFormat": {
+                "unit": 17,
+                "options": {
+                  "style": "decimal"
+                }
+              }
+            },
+            {
+              "columnMatch": "AverageResponseTime",
+              "formatter": 4,
+              "formatOptions": {
+                "palette": "purple"
+              },
+              "numberFormat": {
+                "unit": 23,
+                "options": {
+                  "style": "decimal"
+                }
+              }
+            },
+            {
+              "columnMatch": "TotalBytesSent",
+              "formatter": 4,
+              "formatOptions": {
+                "palette": "orange"
+              },
+              "numberFormat": {
+                "unit": 2,
+                "options": {
+                  "style": "decimal"
+                }
+              }
+            },
+            {
+              "columnMatch": "TotalBytesReceived",
+              "formatter": 4,
+              "formatOptions": {
+                "palette": "green"
+              },
+              "numberFormat": {
+                "unit": 2,
+                "options": {
+                  "style": "decimal"
+                }
+              }
+            },
+            {
+              "columnMatch": "Info",
+              "formatter": 5,
+              "formatOptions": {
+                "linkTarget": "CellDetails",
+                "linkLabel": "ℹ️ Info"
+              }
+            },
+            {
+              "columnMatch": "Key",
+              "formatter": 5,
+              "formatOptions": {}
+            },
+            {
+              "columnMatch": "ParentKey",
+              "formatter": 5,
+              "formatOptions": {}
+            },
+            {
+              "columnMatch": "MaliciousConnectionsCount",
+              "formatter": 5,
+              "formatOptions": {}
+            }
+          ],
+          "rowLimit": 10000,
+          "filter": true,
+          "hierarchySettings": {
+            "idColumn": "Key",
+            "parentColumn": "ParentKey",
+            "treeType": 0,
+            "expanderColumn": "Name",
+            "expandTopLevel": false
+          }
+        },
+        "tileSettings": {
+          "showBorder": false,
+          "titleContent": {
+            "columnMatch": "Computer",
+            "formatter": 1
+          },
+          "leftContent": {
+            "columnMatch": "KPIValue",
+            "formatter": 12,
+            "formatOptions": {
+              "palette": "auto"
+            },
+            "numberFormat": {
+              "unit": 17,
+              "options": {
+                "maximumSignificantDigits": 3,
+                "maximumFractionDigits": 2
+              }
+            }
+          }
+        }
+      },
+      "conditionalVisibility": null,
+      "showPin": true,
+      "name": "query - 5"
+    },
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "query": "",
+        "crossComponentResources": [],
+        "parameters": [
+          {
+            "id": "7e4c3d29-2be6-4288-903b-95502ddab577",
+            "version": "KqlParameterItem/1.0",
+            "name": "ComputerName",
+            "type": 1,
+            "isRequired": false,
+            "query": "// {Resource:label}\r\nlet row = dynamic({ConnectionGrid});\r\nlet computerName = row.ComputerName;\r\nprint computerName",
+            "crossComponentResources": [
+              "{Resource}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "resourceType": "microsoft.compute/virtualmachinescalesets"
+          },
+          {
+            "id": "3bda15ac-c4ea-487f-acf5-2c14c8d33038",
+            "version": "KqlParameterItem/1.0",
+            "name": "ProcessName",
+            "type": 1,
+            "isRequired": false,
+            "query": "// {Resource:label}\r\nlet row = dynamic({ConnectionGrid});\r\nlet ProcessName = row.ProcessName;\r\nprint ProcessName",
+            "crossComponentResources": [
+              "{Resource}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "resourceType": "microsoft.compute/virtualmachinescalesets"
+          },
+          {
+            "id": "e424020b-8c6e-4a06-9639-ed696192442a",
+            "version": "KqlParameterItem/1.0",
+            "name": "RemoteIp",
+            "type": 1,
+            "isRequired": false,
+            "query": "// {Resource:label}\r\nlet row = dynamic({ConnectionGrid});\r\nlet RemoteIp = row.RemoteIp;\r\nprint RemoteIp",
+            "crossComponentResources": [
+              "{Resource}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "resourceType": "microsoft.compute/virtualmachinescalesets"
+          },
+          {
+            "id": "a479367c-f99b-4c93-b18c-51f07ce5069d",
+            "version": "KqlParameterItem/1.0",
+            "name": "DestinationPort",
+            "type": 1,
+            "isRequired": false,
+            "query": "// {Resource:label}\r\nlet row = dynamic({ConnectionGrid});\r\nlet destinationPort = row.DestinationPort;\r\nprint destinationPort",
+            "crossComponentResources": [
+              "{Resource}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "resourceType": "microsoft.compute/virtualmachinescalesets"
+          },
+          {
+            "id": "dcf5f274-fbbf-4fb8-8c35-6b528a08cac9",
+            "version": "KqlParameterItem/1.0",
+            "name": "ShowDetail",
+            "type": 1,
+            "isRequired": true,
+            "query": "print(strcat('{ComputerName}{ProcessName}{RemoteIp}{DestinationPort}' != ''))",
+            "crossComponentResources": [
+              "{Resource}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "resourceType": "microsoft.compute/virtualmachinescalesets"
+          },
+          {
+            "id": "1ce27926-6842-497b-ac53-70c006e11231",
+            "version": "KqlParameterItem/1.0",
+            "name": "Heading",
+            "type": 1,
+            "isRequired": false,
+            "query": "// {Resource:label}\r\nprint(strcat('💻 {ComputerName}',iff('{ProcessName}' != '',' > 🎫 {ProcessName}',''),iff('{Direction}' == 'outbound',strcat(iff('{RemoteIp}' != '',' > 🌐 {RemoteIp}',''),iff('{DestinationPort}' != '',' > 🔸 {DestinationPort}','')),strcat(iff('{DestinationPort}' != '',' > 🔸 {DestinationPort}',''),iff('{RemoteIp}' != '',' > 🌐 {RemoteIp}','')))))",
+            "crossComponentResources": [
+              "{Resource}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "resourceType": "microsoft.compute/virtualmachinescalesets"
+          },
+          {
+            "id": "b44edb14-76ad-48b3-9921-b5dfb5a6db60",
+            "version": "KqlParameterItem/1.0",
+            "name": "QueryFilter",
+            "type": 1,
+            "isRequired": false,
+            "query": "// {Resource:label}\r\nprint(strcat(' where Computer == \"{ComputerName}\"',iff('{ProcessName}' != '', ' | where ProcessName == \"{ProcessName}\"', ''),iff('{RemoteIp}' != '',' | where RemoteIp == \"{RemoteIp}\"',''),iff('{DestinationPort}' != '',' | where DestinationPort == \"{DestinationPort}\"','')));",
+            "crossComponentResources": [
+              "{Resource}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "resourceType": "microsoft.compute/virtualmachinescalesets"
+          }
+        ],
+        "style": "above",
+        "queryType": 0,
+        "resourceType": "microsoft.compute/virtualmachinescalesets"
+      },
+      "conditionalVisibility": null,
+      "name": "parameters - 6"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "<h2 style=\"font-weight:normal;\">{Heading}</h2>"
+      },
+      "conditionalVisibility": {
+        "parameterName": "ShowDetail",
+        "comparison": "isEqualTo",
+        "value": "True"
+      },
+      "name": "text - 7"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "### Responses"
+      },
+      "conditionalVisibility": {
+        "parameterName": "ShowDetail",
+        "comparison": "isEqualTo",
+        "value": "True"
+      },
+      "customWidth": "25",
+      "name": "text - 8"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "### Latency"
+      },
+      "conditionalVisibility": {
+        "parameterName": "ShowDetail",
+        "comparison": "isEqualTo",
+        "value": "True"
+      },
+      "customWidth": "25",
+      "name": "text - 9"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "### Network"
+      },
+      "conditionalVisibility": {
+        "parameterName": "ShowDetail",
+        "comparison": "isEqualTo",
+        "value": "True"
+      },
+      "customWidth": "25",
+      "name": "text - 10"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "### Links"
+      },
+      "conditionalVisibility": {
+        "parameterName": "ShowDetail",
+        "comparison": "isEqualTo",
+        "value": "True"
+      },
+      "customWidth": "25",
+      "name": "text - 11"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "// {Resource:label}\r\nlet SourceMachineData = VMConnection\r\n| where TimeGenerated {TimeRange}\r\n| {QueryFilter}\r\n| where Direction == '{Direction}'\r\n| summarize Responses = sum(Responses) by bin(TimeGenerated, time('{TimeRange:grain}'));\r\nSourceMachineData",
+        "size": 1,
+        "queryType": 0,
+        "resourceType": "microsoft.compute/virtualmachinescalesets",
+        "visualization": "areachart"
+      },
+      "conditionalVisibility": {
+        "parameterName": "ShowDetail",
+        "comparison": "isEqualTo",
+        "value": "True"
+      },
+      "customWidth": "25",
+      "name": "query - 12"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "// {Resource:label}\r\nlet SourceMachineData = VMConnection\r\n| where TimeGenerated {TimeRange}\r\n| {QueryFilter}\r\n| where Direction == '{Direction}'\r\n| summarize P50 = percentiles(ResponseTimeSum, 50), P90 = percentiles(ResponseTimeSum, 90), P95 = percentiles(ResponseTimeSum, 95) by bin(TimeGenerated, time('{TimeRange:grain}'));\r\nSourceMachineData",
+        "size": 1,
+        "aggregation": 3,
+        "queryType": 0,
+        "resourceType": "microsoft.compute/virtualmachinescalesets",
+        "visualization": "linechart"
+      },
+      "conditionalVisibility": {
+        "parameterName": "ShowDetail",
+        "comparison": "isEqualTo",
+        "value": "True"
+      },
+      "customWidth": "25",
+      "name": "query - 13"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "// {Resource:label}\r\nlet SourceMachineData = VMConnection\r\n| where TimeGenerated {TimeRange}\r\n| {QueryFilter}\r\n| where Direction == '{Direction}'\r\n| summarize Sent = sum(BytesSent), Received = sum(BytesReceived) by bin(TimeGenerated, time('{TimeRange:grain}'));\r\nSourceMachineData",
+        "size": 1,
+        "queryType": 0,
+        "resourceType": "microsoft.compute/virtualmachinescalesets",
+        "visualization": "areachart"
+      },
+      "conditionalVisibility": {
+        "parameterName": "ShowDetail",
+        "comparison": "isEqualTo",
+        "value": "True"
+      },
+      "customWidth": "25",
+      "name": "query - 14"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "// {Resource:label}\r\nlet SourceMachineData = VMConnection\r\n| where TimeGenerated {TimeRange}\r\n| {QueryFilter}\r\n| where Direction == '{Direction}'\r\n| summarize MaxOpenPorts = max(LinksLive), SumFailed = sum(LinksFailed) by bin(TimeGenerated, time('{TimeRange:grain}'));\r\nSourceMachineData",
+        "size": 1,
+        "aggregation": 3,
+        "queryType": 0,
+        "resourceType": "microsoft.compute/virtualmachinescalesets",
+        "visualization": "areachart"
+      },
+      "conditionalVisibility": {
+        "parameterName": "ShowDetail",
+        "comparison": "isEqualTo",
+        "value": "True"
+      },
+      "customWidth": "25",
+      "name": "query - 15"
+    }
+  ],
+  "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
+}

--- a/Workbooks/Virtual machine Scale Sets - Network Dependencies/Connections Overview/settings.json
+++ b/Workbooks/Virtual machine Scale Sets - Network Dependencies/Connections Overview/settings.json
@@ -1,0 +1,8 @@
+{
+    "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/settings.json",
+    "name":"Connections Overview",
+    "author": "Microsoft",
+    "galleries": [
+        { "type": "workbook", "resourceType": "microsoft.compute/virtualmachinescalesets", "order": 175 }
+    ]
+}

--- a/Workbooks/Virtual machine Scale Sets - Network Dependencies/categoryResources.json
+++ b/Workbooks/Virtual machine Scale Sets - Network Dependencies/categoryResources.json
@@ -1,0 +1,3 @@
+{
+    "en-us": {"name":"Network Dependencies", "description": "Look for network dependencies of your Virtual Machine Scale Sets.", "order": 200}
+}


### PR DESCRIPTION
Workbooks for VMSS.

Since most of the workbooks applicable to At Scale are also applicable to VMSS and some to VMs, we should be creating ResourceType agnostic workbooks when we can. 

'Active Ports' is an attempt at that, unfortunately there is a bug which restricts the parameter use. Hence I have duplicated 'Connections Overview' and 'Performance Analysis' workbooks. 

'Connections Overview' also takes advantage of JSON type, making the workbook run query much faster.  This can be enhanced to complex JSON structures, but due to shortage of time, I have kept it as simple  as possible.