### PR TITLE
Clean-up Resource Monitor workbook

### DIFF
--- a/Workbooks/Virtual Machines - Performance Analysis/Resource Monitor/Resource Monitor.workbook
+++ b/Workbooks/Virtual Machines - Performance Analysis/Resource Monitor/Resource Monitor.workbook
@@ -2,13 +2,19 @@
   "version": "Notebook/1.0",
   "items": [
     {
+      "type": 1,
+      "content": {
+        "json": "💠 Only the first query is turned on, turn on `RunQuery` on the other metrics to run the respective query."
+      },
+      "conditionalVisibility": null,
+      "name": "text - 17"
+    },
+    {
       "type": 9,
       "content": {
         "version": "KqlParameterItem/1.0",
         "query": "",
-        "crossComponentResources": [
-          "{Workspace}"
-        ],
+        "crossComponentResources": [],
         "parameters": [
           {
             "id": "2781694c-ace8-4cc0-b861-26f56a957d0d",
@@ -198,32 +204,82 @@
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces"
       },
-      "conditionalVisibility": null
+      "conditionalVisibility": null,
+      "name": "parameters - 0"
     },
     {
       "type": 1,
       "content": {
-        "json": "## CPU\r\n\r\n⚠ *Only processes from Windows VMs are shown*"
+        "json": "## CPU"
       },
-      "conditionalVisibility": null
+      "conditionalVisibility": null,
+      "name": "text - 1"
+    },
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "query": "",
+        "crossComponentResources": [],
+        "parameters": [
+          {
+            "id": "6d65fdf3-1e3f-4924-8511-465bcb003d7d",
+            "version": "KqlParameterItem/1.0",
+            "name": "ShowHelp",
+            "type": 2,
+            "isRequired": true,
+            "value": "0",
+            "isHiddenWhenLocked": false,
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "jsonData": "[\r\n    { \"value\": \"1\", \"label\": \"Yes\" },\r\n    { \"value\": \"0\", \"label\": \"No\"}\r\n]",
+            "timeContextFromParameter": null
+          },
+          {
+            "id": "40039c8a-2b3d-4f6b-9443-81ce51372220",
+            "version": "KqlParameterItem/1.0",
+            "name": "RunQuery",
+            "type": 2,
+            "isRequired": true,
+            "value": "1",
+            "isHiddenWhenLocked": false,
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "jsonData": "[\r\n    { \"value\": \"1\", \"label\": \"Yes\" },\r\n    { \"value\": \"0\", \"label\": \"No\"}\r\n]",
+            "timeContextFromParameter": null
+          }
+        ],
+        "style": "pills",
+        "queryType": 0,
+        "resourceType": "microsoft.operationalinsights/workspaces"
+      },
+      "conditionalVisibility": null,
+      "name": "parameters - 12"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "⚠ *Only processes from Windows VMs are shown*\r\n\r\n**Counters**\r\n- PerfMon Windows (Process/% Processor Time, Process/% User Time, Processor/% Processor Time, Processor/% User Time)\r\n- PerfMon Linux (Process/Pct Privileged Time, Process/Pct User Time, Processor/% Processor Time, Processor/% User Time, Processor/% Privileged Time)\r\n- ServiceMap (ServiceMapComputer_CL)"
+      },
+      "conditionalVisibility": {
+        "parameterName": "ShowHelp",
+        "comparison": "isEqualTo",
+        "value": "1"
+      },
+      "name": "text - 13"
     },
     {
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let filters = Perf {ComputerFilter} | where TimeGenerated {TimeRange};\r\nlet ptime = filters | where ObjectName == 'Process' and CounterName == '% Processor Time' | where InstanceName != '_Total' and InstanceName != 'Idle';\r\nlet utime = filters | where ObjectName == 'Process' and CounterName == '% User Time' | where InstanceName != '_Total' and InstanceName != 'Idle';\r\nlet ctime = filters | where ObjectName == 'Processor' and CounterName == '% Processor Time' | where InstanceName == '_Total';\r\nlet cutime = filters | where ObjectName == 'Processor' and CounterName == '% User Time' | where InstanceName == '_Total';\r\nlet cores = ServiceMapComputer_CL | distinct Computer, Cpus_d;\r\nlet ccomps = ctime | summarize CPU=avg(CounterValue) by Computer | project CPU, Name=strcat('💻 ', Computer), Key=Computer, ParentKey='', Computer;\r\nlet ucomps = cutime | summarize UserTime=avg(CounterValue) by Computer | project UserTime, Key=Computer;\r\nlet comps = ccomps | join hint.shufflekey=Key kind=leftouter ucomps on Key | project CPU, Name, Key, ParentKey, Computer, UserTime;\r\nlet pprocs = ptime | summarize CPU=avg(CounterValue) by Computer, InstanceName | project CPU, Name=strcat('🎫 ', InstanceName), ParentKey=Computer, Key=strcat(Computer, '-', InstanceName), Computer, Process=InstanceName;\r\nlet uprocs = utime | summarize UserTime=avg(CounterValue) by Computer, InstanceName | project UserTime, Key=strcat(Computer, '-', InstanceName), Process=InstanceName;\r\nlet procs = pprocs | join hint.shufflekey=Key kind=leftouter uprocs on Key | project CPU, Name, ParentKey, Key, Computer, UserTime, Process;\r\nlet table = comps | union procs;\r\ntable\r\n| join hint.strategy=shuffle kind=leftouter cores on Computer\r\n| project Name, Key, ParentKey, CPU, CPU_cores = CPU / Cpus_d, CPU_user = (UserTime / 100) * CPU, CPU_user_cores = (UserTime / 100) * (CPU / Cpus_d), UserTime, Cores = Cpus_d, Process\r\n| order by CPU desc",
-        "showQuery": false,
+        "query": "let filters = Perf {ComputerFilter} | where \"{RunQuery:value}\" == \"1\" | where TimeGenerated {TimeRange};\r\nlet ptime = filters | where ObjectName == 'Process' and CounterName == '% Processor Time' | where InstanceName != '_Total' and InstanceName != 'Idle';\r\nlet utime = filters | where ObjectName == 'Process' and CounterName == '% User Time' | where InstanceName != '_Total' and InstanceName != 'Idle';\r\nlet ctime = filters | where ObjectName == 'Processor' and CounterName == '% Processor Time' | where InstanceName == '_Total';\r\nlet cutime = filters | where ObjectName == 'Processor' and CounterName == '% User Time' | where InstanceName == '_Total';\r\nlet cores = ServiceMapComputer_CL | distinct Computer, Cpus_d;\r\nlet ccomps = ctime | summarize CPU=avg(CounterValue) by Computer | project CPU, Name=strcat('💻 ', Computer), Key=Computer, ParentKey='', Computer;\r\nlet ucomps = cutime | summarize UserTime=avg(CounterValue) by Computer | project UserTime, Key=Computer;\r\nlet comps = ccomps | join hint.shufflekey=Key kind=leftouter ucomps on Key | project CPU, Name, Key, ParentKey, Computer, UserTime;\r\nlet pprocs = ptime | summarize CPU=avg(CounterValue) by Computer, InstanceName | project CPU, Name=strcat('🎫 ', InstanceName), ParentKey=Computer, Key=strcat(Computer, '-', InstanceName), Computer, Process=InstanceName;\r\nlet uprocs = utime | summarize UserTime=avg(CounterValue) by Computer, InstanceName | project UserTime, Key=strcat(Computer, '-', InstanceName), Process=InstanceName;\r\nlet procs = pprocs | join hint.shufflekey=Key kind=leftouter uprocs on Key | project CPU, Name, ParentKey, Key, Computer, UserTime, Process;\r\nlet table = comps | union procs;\r\ntable\r\n| join hint.strategy=shuffle kind=leftouter cores on Computer\r\n| project Name, Key, ParentKey, CPU, CPU_cores = CPU / Cpus_d, CPU_user = (UserTime / 100) * CPU, CPU_user_cores = (UserTime / 100) * (CPU / Cpus_d), UserTime, Cores = Cpus_d, Process\r\n| order by CPU desc",
         "size": 0,
-        "aggregation": 0,
-        "showAnnotations": false,
         "exportDefaultValue": "{\"ParentKey\":\"\", \"Process\":\"\"}",
-        "showAnalytics": false,
-        "timeContextFromParameter": null,
+        "showAnalytics": true,
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
-        "crossComponentResources": [
-          "{Workspace}"
-        ],
         "gridSettings": {
           "formatters": [
             {
@@ -360,38 +416,82 @@
           }
         }
       },
-      "conditionalVisibility": null
+      "conditionalVisibility": null,
+      "showPin": true,
+      "name": "query - 2"
     },
     {
       "type": 1,
       "content": {
-        "json": "**Counters**\r\n- PerfMon Windows (Process/% Processor Time, Process/% User Time, Processor/% Processor Time, Processor/% User Time)\r\n- PerfMon Linux (Process/Pct Privileged Time, Process/Pct User Time, Processor/% Processor Time, Processor/% User Time, Processor/% Privileged Time)\r\n- ServiceMap (ServiceMapComputer_CL)"
+        "json": "## Disk"
       },
-      "conditionalVisibility": null
+      "conditionalVisibility": null,
+      "name": "text - 4"
+    },
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "query": "",
+        "crossComponentResources": [],
+        "parameters": [
+          {
+            "id": "80fbb524-2de3-4eec-8667-35d6d673a33b",
+            "version": "KqlParameterItem/1.0",
+            "name": "ShowHelp",
+            "type": 2,
+            "isRequired": true,
+            "value": "0",
+            "isHiddenWhenLocked": false,
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "jsonData": "[\r\n    { \"value\": \"1\", \"label\": \"Yes\" },\r\n    { \"value\": \"0\", \"label\": \"No\"}\r\n]",
+            "timeContextFromParameter": null
+          },
+          {
+            "id": "b3c5bdd5-503c-4e67-b1a6-4ecfbac8cebf",
+            "version": "KqlParameterItem/1.0",
+            "name": "RunQuery",
+            "type": 2,
+            "isRequired": true,
+            "value": "0",
+            "isHiddenWhenLocked": false,
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "jsonData": "[\r\n    { \"value\": \"1\", \"label\": \"Yes\" },\r\n    { \"value\": \"0\", \"label\": \"No\"}\r\n]",
+            "timeContextFromParameter": null
+          }
+        ],
+        "style": "pills",
+        "queryType": 0,
+        "resourceType": "microsoft.operationalinsights/workspaces"
+      },
+      "conditionalVisibility": null,
+      "name": "parameters - 13"
     },
     {
       "type": 1,
       "content": {
-        "json": "## Disk\r\n⚠ *Only Windows VMs are shown*\r\n\r\n⚠ *Computer stats aggregated over processes, not per computer*"
+        "json": "⚠ *Only Windows VMs are shown*\r\n⚠ *Computer stats aggregated over processes, not per computer*\r\n\r\n**Counters**\r\n- PerfMon Windows (Process/IO Read Bytes/sec, Process/IO Write Bytes/sec, Process/IO Read Operations/sec, Process/IO Write Operations/sec)"
       },
-      "conditionalVisibility": null
+      "conditionalVisibility": {
+        "parameterName": "ShowHelp",
+        "comparison": "isEqualTo",
+        "value": "1"
+      },
+      "name": "text - 14"
     },
     {
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let disk = Perf | where ObjectName == 'Process' {ComputerFilter} and InstanceName != '_Total' and InstanceName != 'Idle' | where TimeGenerated {TimeRange};\r\nlet readc = disk | where CounterName == 'IO Read Bytes/sec' | summarize ReadBytes=sum(CounterValue) by Computer;\r\nlet readp = disk | where CounterName == 'IO Read Bytes/sec' | summarize ReadBytes=avg(CounterValue) by Computer, InstanceName;\r\nlet writec = disk | where CounterName == 'IO Write Bytes/sec' | summarize WriteBytes=sum(CounterValue) by Computer;\r\nlet writep = disk | where CounterName == 'IO Write Bytes/sec' | summarize WriteBytes=avg(CounterValue) by Computer, InstanceName;\r\nlet ropsc = disk | where CounterName == 'IO Read Operations/sec' | summarize ReadOps=sum(CounterValue) by Computer;\r\nlet ropsp = disk | where CounterName == 'IO Read Operations/sec' | summarize ReadOps=avg(CounterValue) by Computer, InstanceName;\r\nlet wopsc = disk | where CounterName == 'IO Write Operations/sec' | summarize WriteOps=sum(CounterValue) by Computer;\r\nlet wopsp = disk | where CounterName == 'IO Write Operations/sec' | summarize WriteOps=avg(CounterValue) by Computer, InstanceName;\r\nlet comp = readc | join kind=leftouter writec on Computer | join kind=leftouter ropsc on Computer | join kind=leftouter wopsc on Computer | project Name=strcat('💻 ', Computer), Key=Computer, ReadBytes, WriteBytes, TotalBytes = ReadBytes + WriteBytes, ReadOps, WriteOps, TotalOps = ReadOps + WriteOps, ParentKey='';\r\nlet proc = readp | join kind=leftouter writep on Computer, InstanceName | join kind=leftouter ropsp on Computer, InstanceName | join kind=leftouter wopsp on Computer, InstanceName | project Name=strcat('🎫 ', InstanceName), ParentKey=Computer, ReadBytes, WriteBytes, TotalBytes = ReadBytes + WriteBytes, ReadOps, WriteOps, TotalOps = ReadOps + WriteOps, Key=strcat(Computer, '-', InstanceName);\r\ncomp\r\n| union proc\r\n| order by TotalBytes desc, TotalOps desc",
-        "showQuery": false,
+        "query": "let disk = Perf | where \"{RunQuery:value}\" == \"1\" | where ObjectName == 'Process' {ComputerFilter} and InstanceName != '_Total' and InstanceName != 'Idle' | where TimeGenerated {TimeRange};\r\nlet readc = disk | where CounterName == 'IO Read Bytes/sec' | summarize ReadBytes=sum(CounterValue) by Computer;\r\nlet readp = disk | where CounterName == 'IO Read Bytes/sec' | summarize ReadBytes=avg(CounterValue) by Computer, InstanceName;\r\nlet writec = disk | where CounterName == 'IO Write Bytes/sec' | summarize WriteBytes=sum(CounterValue) by Computer;\r\nlet writep = disk | where CounterName == 'IO Write Bytes/sec' | summarize WriteBytes=avg(CounterValue) by Computer, InstanceName;\r\nlet ropsc = disk | where CounterName == 'IO Read Operations/sec' | summarize ReadOps=sum(CounterValue) by Computer;\r\nlet ropsp = disk | where CounterName == 'IO Read Operations/sec' | summarize ReadOps=avg(CounterValue) by Computer, InstanceName;\r\nlet wopsc = disk | where CounterName == 'IO Write Operations/sec' | summarize WriteOps=sum(CounterValue) by Computer;\r\nlet wopsp = disk | where CounterName == 'IO Write Operations/sec' | summarize WriteOps=avg(CounterValue) by Computer, InstanceName;\r\nlet comp = readc | join kind=leftouter writec on Computer | join kind=leftouter ropsc on Computer | join kind=leftouter wopsc on Computer | project Name=strcat('💻 ', Computer), Key=Computer, ReadBytes, WriteBytes, TotalBytes = ReadBytes + WriteBytes, ReadOps, WriteOps, TotalOps = ReadOps + WriteOps, ParentKey='';\r\nlet proc = readp | join kind=leftouter writep on Computer, InstanceName | join kind=leftouter ropsp on Computer, InstanceName | join kind=leftouter wopsp on Computer, InstanceName | project Name=strcat('🎫 ', InstanceName), ParentKey=Computer, ReadBytes, WriteBytes, TotalBytes = ReadBytes + WriteBytes, ReadOps, WriteOps, TotalOps = ReadOps + WriteOps, Key=strcat(Computer, '-', InstanceName);\r\ncomp\r\n| union proc\r\n| order by TotalBytes desc, TotalOps desc",
         "size": 0,
-        "aggregation": 0,
-        "showAnnotations": false,
-        "showAnalytics": false,
-        "timeContextFromParameter": null,
+        "showAnalytics": true,
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
-        "crossComponentResources": [
-          "{Workspace}"
-        ],
         "gridSettings": {
           "formatters": [
             {
@@ -509,33 +609,80 @@
           }
         }
       },
-      "conditionalVisibility": null
+      "conditionalVisibility": null,
+      "showPin": true,
+      "name": "query - 5"
     },
     {
       "type": 1,
       "content": {
-        "json": "**Counters**\r\n- PerfMon Windows (Process/IO Read Bytes/sec, Process/IO Write Bytes/sec, Process/IO Read Operations/sec, Process/IO Write Operations/sec)"
+        "json": "## Network"
       },
-      "conditionalVisibility": null
+      "conditionalVisibility": null,
+      "name": "text - 7"
+    },
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "query": "",
+        "crossComponentResources": [],
+        "parameters": [
+          {
+            "id": "1ae04b51-fa65-4cb0-9298-43f3341abf82",
+            "version": "KqlParameterItem/1.0",
+            "name": "ShowHelp",
+            "type": 2,
+            "isRequired": true,
+            "value": "0",
+            "isHiddenWhenLocked": false,
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "jsonData": "[\r\n    { \"value\": \"1\", \"label\": \"Yes\" },\r\n    { \"value\": \"0\", \"label\": \"No\"}\r\n]",
+            "timeContextFromParameter": null
+          },
+          {
+            "id": "d42ba498-6c6a-4f4d-8752-930c460dc682",
+            "version": "KqlParameterItem/1.0",
+            "name": "RunQuery",
+            "type": 2,
+            "isRequired": true,
+            "value": "0",
+            "isHiddenWhenLocked": false,
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "jsonData": "[\r\n    { \"value\": \"1\", \"label\": \"Yes\" },\r\n    { \"value\": \"0\", \"label\": \"No\"}\r\n]",
+            "timeContextFromParameter": null
+          }
+        ],
+        "style": "pills",
+        "queryType": 0,
+        "resourceType": "microsoft.operationalinsights/workspaces"
+      },
+      "conditionalVisibility": null,
+      "name": "parameters - 15"
     },
     {
       "type": 1,
       "content": {
-        "json": "## Network\r\n\r\n⚠ *Computer stats aggregated over processes, not per computer*"
+        "json": "⚠ *Computer stats aggregated over processes, not per computer*\r\n\r\n**Counters**\r\n- ServiceMap (VMConnection)"
       },
-      "conditionalVisibility": null
+      "conditionalVisibility": {
+        "parameterName": "ShowHelp",
+        "comparison": "isEqualTo",
+        "value": "1"
+      },
+      "name": "text - 16"
     },
     {
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let network = VMConnection {ComputerFilter} | where TimeGenerated {TimeRange};\r\nlet rxc = network | summarize RX=avg(BytesReceived) by Computer;\r\nlet rxp = network | summarize RX=avg(BytesReceived) by Computer, ProcessName;\r\nlet txc = network | summarize TX=avg(BytesSent) by Computer;\r\nlet txp = network | summarize TX=avg(BytesSent) by Computer, ProcessName;\r\nlet tlc = network | summarize Total=avg(BytesReceived) + avg(BytesSent) by Computer;\r\nlet tlp = network | summarize Total=avg(BytesReceived) + avg(BytesSent) by Computer, ProcessName;\r\nlet comp = rxc | join hint.shufflekey=Computer txc on Computer | join tlc on Computer | project Name=strcat('💻 ', Computer), RX, TX, Total, Key=Computer, ParentKey='';\r\nlet proc = rxp | join hint.shufflekey=Computer txp on Computer, ProcessName | join tlp on Computer, ProcessName | project Name=strcat('🎫 ', ProcessName), RX, TX, Total, Key=strcat(Computer, '-', ProcessName), ParentKey=Computer;\r\ncomp\r\n| union proc\r\n| order by Total desc",
-        "showQuery": false,
+        "query": "let network = VMConnection {ComputerFilter} | where \"{RunQuery:value}\" == \"1\" | where TimeGenerated {TimeRange};\r\nlet rxc = network | summarize RX=avg(BytesReceived) by Computer;\r\nlet rxp = network | summarize RX=avg(BytesReceived) by Computer, ProcessName;\r\nlet txc = network | summarize TX=avg(BytesSent) by Computer;\r\nlet txp = network | summarize TX=avg(BytesSent) by Computer, ProcessName;\r\nlet tlc = network | summarize Total=avg(BytesReceived) + avg(BytesSent) by Computer;\r\nlet tlp = network | summarize Total=avg(BytesReceived) + avg(BytesSent) by Computer, ProcessName;\r\nlet comp = rxc | join hint.shufflekey=Computer txc on Computer | join tlc on Computer | project Name=strcat('💻 ', Computer), RX, TX, Total, Key=Computer, ParentKey='';\r\nlet proc = rxp | join hint.shufflekey=Computer txp on Computer, ProcessName | join tlp on Computer, ProcessName | project Name=strcat('🎫 ', ProcessName), RX, TX, Total, Key=strcat(Computer, '-', ProcessName), ParentKey=Computer;\r\ncomp\r\n| union proc\r\n| order by Total desc",
         "size": 0,
-        "aggregation": 0,
-        "showAnnotations": false,
-        "showAnalytics": false,
-        "timeContextFromParameter": null,
+        "showAnalytics": true,
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
         "gridSettings": {
@@ -608,38 +755,82 @@
           }
         }
       },
-      "conditionalVisibility": null
+      "conditionalVisibility": null,
+      "showPin": true,
+      "name": "query - 8"
     },
     {
       "type": 1,
       "content": {
-        "json": "**Counters**\r\n- ServiceMap (VMConnection)"
+        "json": "## Memory"
       },
-      "conditionalVisibility": null
+      "conditionalVisibility": null,
+      "name": "text - 10"
+    },
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "query": "",
+        "crossComponentResources": [],
+        "parameters": [
+          {
+            "id": "471e58b7-da7a-4004-a038-4202025a9c87",
+            "version": "KqlParameterItem/1.0",
+            "name": "ShowHelp",
+            "type": 2,
+            "isRequired": true,
+            "value": "0",
+            "isHiddenWhenLocked": false,
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "jsonData": "[\r\n    { \"value\": \"1\", \"label\": \"Yes\" },\r\n    { \"value\": \"0\", \"label\": \"No\"}\r\n]",
+            "timeContextFromParameter": null
+          },
+          {
+            "id": "121af5d2-4d7a-45d3-a75f-de677366240e",
+            "version": "KqlParameterItem/1.0",
+            "name": "RunQuery",
+            "type": 2,
+            "isRequired": true,
+            "value": "0",
+            "isHiddenWhenLocked": false,
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "jsonData": "[\r\n    { \"value\": \"1\", \"label\": \"Yes\" },\r\n    { \"value\": \"0\", \"label\": \"No\"}\r\n]",
+            "timeContextFromParameter": null
+          }
+        ],
+        "style": "pills",
+        "queryType": 0,
+        "resourceType": "microsoft.operationalinsights/workspaces"
+      },
+      "conditionalVisibility": null,
+      "name": "parameters - 15"
     },
     {
       "type": 1,
       "content": {
-        "json": "## Memory\r\n\r\n⚠ *Computer stats aggregated over processes, not per computer*"
+        "json": "⚠ *Computer stats aggregated over processes, not per computer*\r\n\r\n**Counters**\r\n- PerfMon Windows (Process/Private Bytes)\r\n- PerfMon Linux (Process/Used Mmeory)"
       },
-      "conditionalVisibility": null
+      "conditionalVisibility": {
+        "parameterName": "ShowHelp",
+        "comparison": "isEqualTo",
+        "value": "1"
+      },
+      "name": "text - 16"
     },
     {
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let mem = Perf {ComputerFilter} | where TimeGenerated {TimeRange} | where ObjectName == 'Process' and CounterName == 'Private Bytes' or CounterName == 'Used Memory' and InstanceName != '_Total' and InstanceName != 'Idle';\r\nlet memc = mem | summarize Memory=sum(CounterValue) by Computer;\r\nlet memp = mem | summarize Memory=avg(CounterValue) by Computer, InstanceName;\r\nlet comp = memc | project Name=strcat('💻 ', Computer), Key=Computer, Memory;\r\nlet proc = memp | project Name=strcat('🎫 ', InstanceName), Key=strcat(Computer, '-', InstanceName), ParentKey=Computer, Memory;\r\ncomp\r\n| union proc\r\n| order by Memory desc",
-        "showQuery": false,
+        "query": "let mem = Perf {ComputerFilter} | where \"{RunQuery:value}\" == \"1\" | where TimeGenerated {TimeRange} | where ObjectName == 'Process' and CounterName == 'Private Bytes' or CounterName == 'Used Memory' and InstanceName != '_Total' and InstanceName != 'Idle';\r\nlet memc = mem | summarize Memory=sum(CounterValue) by Computer;\r\nlet memp = mem | summarize Memory=avg(CounterValue) by Computer, InstanceName;\r\nlet comp = memc | project Name=strcat('💻 ', Computer), Key=Computer, Memory;\r\nlet proc = memp | project Name=strcat('🎫 ', InstanceName), Key=strcat(Computer, '-', InstanceName), ParentKey=Computer, Memory;\r\ncomp\r\n| union proc\r\n| order by Memory desc",
         "size": 0,
-        "aggregation": 0,
-        "showAnnotations": false,
-        "showAnalytics": false,
-        "timeContextFromParameter": null,
+        "showAnalytics": true,
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
-        "crossComponentResources": [
-          "{Workspace}"
-        ],
         "gridSettings": {
           "formatters": [
             {
@@ -681,14 +872,9 @@
           }
         }
       },
-      "conditionalVisibility": null
-    },
-    {
-      "type": 1,
-      "content": {
-        "json": "**Counters**\r\n- PerfMon Windows (Process/Private Bytes)\r\n- PerfMon Linux (Process/Used Mmeory)"
-      },
-      "conditionalVisibility": null
+      "conditionalVisibility": null,
+      "showPin": true,
+      "name": "query - 11"
     }
   ],
   "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"


### PR DESCRIPTION
Add dropdowns to show or hide help text for each metric and enable or
disable running their respective queries. All but one query is disabled
by default for workbook performance reasons.

![image](https://user-images.githubusercontent.com/43890980/57997686-dc304980-7a82-11e9-8d2b-122d621d45e3.png)
