### PR TITLE
Update storage at-scale template

### DIFF
--- a/Workbooks/Storage/Overview/Overview.workbook
+++ b/Workbooks/Storage/Overview/Overview.workbook
@@ -11,44 +11,31 @@
         ],
         "parameters": [
           {
-            "id": "ccd5adcd-8d59-4cfe-99ec-98075de2e253",
-            "version": "KqlParameterItem/1.0",
-            "name": "DefaultSubscription_Internal",
-            "type": 1,
-            "isRequired": true,
-            "query": "extend Rank = iff(type =~ 'microsoft.storage/storageaccounts', 1, 2)\r\n| order by Rank asc, subscriptionId asc\r\n| take 1\r\n| project subscriptionId",
-            "crossComponentResources": [
-              "value::all"
-            ],
-            "isHiddenWhenLocked": true,
-            "queryType": 1,
-            "resourceType": "microsoft.resourcegraph/resources"
-          },
-          {
-            "id": "1ca69445-60fc-4806-b43d-ac7e6aad630a",
+            "id": "1f74ed9a-e3ed-498d-bd5b-f68f3836a117",
             "version": "KqlParameterItem/1.0",
             "name": "Subscription",
+            "label": "Subscriptions",
             "type": 6,
+            "description": "All subscriptions with storage accounts",
             "isRequired": true,
             "multiSelect": true,
             "quote": "'",
             "delimiter": ",",
-            "query": "summarize Count = countif(type =~ 'microsoft.storage/storageaccounts') by subscriptionId\r\n| project value = strcat(\"/subscriptions/\", subscriptionId), label = subscriptionId, selected = iff(subscriptionId =~ '{DefaultSubscription_Internal}', true, false), group = iff(Count == 0, 'Subscriptions without storage accounts', 'Subscriptions with storage accounts')\r\n| order by group asc\r\n",
+            "query": "where type =~ 'microsoft.storage/storageaccounts'\r\n| summarize by subscriptionId\r\n| order by subscriptionId\r\n| summarize SelectedSub = makelist(subscriptionId, 1), Sub = makelist(subscriptionId, 100000)\r\n| mvexpand Sub limit 100000\r\n| mvexpand SelectedSub\r\n| project value = strcat(\"/subscriptions/\", Sub), label = Sub, selected = iff(tostring(Sub) == tostring(SelectedSub), true, false)\r\n",
             "crossComponentResources": [
               "value::all"
             ],
             "typeSettings": {
-              "limitSelectTo": 10,
               "additionalResourceOptions": []
             },
             "queryType": 1,
-            "resourceType": "microsoft.resourcegraph/resources",
-            "label": "Subscriptions"
+            "resourceType": "microsoft.resourcegraph/resources"
           },
           {
             "id": "e94aafa3-c5d9-4523-89f0-4e87aa754511",
             "version": "KqlParameterItem/1.0",
             "name": "StorageAccounts",
+            "label": "Storage Accounts",
             "type": 5,
             "isRequired": true,
             "multiSelect": true,
@@ -66,14 +53,12 @@
                 "microsoft.storage/storageaccounts": true
               },
               "additionalResourceOptions": [
-                "value::3",
                 "value::10",
                 "value::all"
               ]
             },
             "queryType": 1,
-            "resourceType": "microsoft.resourcegraph/resources",
-            "label": "Storage Accounts"
+            "resourceType": "microsoft.resourcegraph/resources"
           },
           {
             "id": "c4b69c01-2263-4ada-8d9c-43433b739ff3",
@@ -161,12 +146,12 @@
             "label": "Time Range"
           },
           {
-            "id": "39d40a09-cd54-4acc-a6d1-7e3b50d0dce4",
+            "id": "9b48988f-dcd2-48cc-b233-5999ed32149f",
             "version": "KqlParameterItem/1.0",
-            "name": "ShowDetails",
+            "name": "Message",
             "type": 1,
             "isRequired": true,
-            "query": "where type =~ 'microsoft.storage/storageaccounts'\n| summarize Count = count()\n| project Value = iff(Count == 0, 'No', 'Yes')",
+            "query": "where type == 'microsoft.storage/storageaccounts' \n| summarize Selected = countif(id in ({StorageAccounts:value})), Total = count()\n| project Message = case(Selected < Total, strcat('Showing ', Selected, ' of ', Total, ' storage accounts in the selected subscriptions. Change the `Storage Accounts` drop down to see more.'), 'Click on links in the table to see more information about a specific storage account.')",
             "crossComponentResources": [
               "{Subscription}"
             ],
@@ -182,65 +167,11 @@
       "name": "parameters - 1"
     },
     {
-      "type": 3,
-      "content": {
-        "version": "KqlItem/1.0",
-        "query": "where type == 'microsoft.storage/storageaccounts' \r\n| extend Title = iff(id in ({StorageAccounts:value}), '✔️ Shown', '✖️ Not shown'), Rank = iff(id in ({StorageAccounts:value}), 1, 2)\r\n| summarize Count = count() by type, Title, Rank\r\n//| extend XC = array_length(dynamic([{StorageAccounts:value}]))\r\n| extend expand = iff(Count > 100, dynamic(['✔️ Shown', '✖️ Not shown']), dynamic(['✔️ Shown']))\r\n| mvexpand expand\r\n| extend Count = iff(tostring(expand) == '✔️ Shown' and Title == '✔️ Shown' and Count > 100, 100, Count)\r\n| extend Count = iff(tostring(expand) == '✖️ Not shown' and Title == '✔️ Shown' and Count > 100, Count - 100, Count)\r\n| extend Title = iff(tostring(expand) == '✖️ Not shown' and Title == '✔️ Shown', '✖️ Not shown', Title)\r\n| summarize by type, Title, Rank, Count\r\n| order by Rank asc\r\n\r\n\r\n\r\n",
-        "size": 4,
-        "queryType": 1,
-        "resourceType": "microsoft.resourcegraph/resources",
-        "crossComponentResources": [
-          "{Subscription}"
-        ],
-        "visualization": "tiles",
-        "tileSettings": {
-          "titleContent": {
-            "columnMatch": "type",
-            "formatter": 16,
-            "formatOptions": {
-              "showIcon": true
-            }
-          },
-          "leftContent": {
-            "columnMatch": "Count",
-            "formatter": 12,
-            "formatOptions": {
-              "min": 0,
-              "showIcon": true
-            },
-            "numberFormat": {
-              "unit": 17,
-              "options": {
-                "style": "decimal",
-                "maximumFractionDigits": 2,
-                "maximumSignificantDigits": 3
-              }
-            }
-          },
-          "secondaryContent": {
-            "columnMatch": "Title",
-            "formatter": 16,
-            "formatOptions": {
-              "showIcon": false
-            }
-          },
-          "showBorder": false
-        }
-      },
-      "conditionalVisibility": {
-        "parameterName": "ShowDetails",
-        "comparison": "isEqualTo",
-        "value": "Yes"
-      },
-      "customWidth": "60",
-      "name": "Storage count"
-    },
-    {
       "type": 10,
       "content": {
         "chartId": "workbookdb19a8d8-91af-44ea-951d-5ffa133b2ebe",
         "version": "MetricsItem/2.0",
-        "size": 4,
+        "size": 3,
         "chartType": 0,
         "resourceIds": [
           "{StorageAccounts}"
@@ -260,14 +191,6 @@
           },
           {
             "namespace": "microsoft.storage/storageaccounts",
-            "metric": "microsoft.storage/storageaccounts-Transaction-Transactions",
-            "aggregation": 1,
-            "splitBy": "ResponseType",
-            "splitBySortOrder": -1,
-            "splitByLimit": 4
-          },
-          {
-            "namespace": "microsoft.storage/storageaccounts",
             "metric": "microsoft.storage/storageaccounts-Transaction-Availability",
             "aggregation": 4
           },
@@ -282,117 +205,17 @@
             "metric": "microsoft.storage/storageaccounts-Transaction-SuccessServerLatency",
             "aggregation": 4,
             "columnName": "Server Latency"
+          },
+          {
+            "namespace": "microsoft.storage/storageaccounts",
+            "metric": "microsoft.storage/storageaccounts-Transaction-Transactions",
+            "aggregation": 1,
+            "splitBy": "ResponseType",
+            "splitBySortOrder": -1,
+            "splitByLimit": 4
           }
         ],
-        "gridSettings": {
-          "formatters": [
-            {
-              "columnMatch": "Subscription",
-              "formatter": 0,
-              "formatOptions": {
-                "showIcon": true
-              }
-            },
-            {
-              "columnMatch": "Name",
-              "formatter": 0,
-              "formatOptions": {
-                "showIcon": true
-              }
-            },
-            {
-              "columnMatch": "Transactions Timeline",
-              "formatter": 0,
-              "formatOptions": {
-                "showIcon": true
-              }
-            },
-            {
-              "columnMatch": "Transactions (Sum)",
-              "formatter": 0,
-              "formatOptions": {
-                "showIcon": true
-              }
-            },
-            {
-              "columnMatch": "Success/Transactions",
-              "formatter": 0,
-              "formatOptions": {
-                "showIcon": true
-              }
-            },
-            {
-              "columnMatch": "ClientOtherError/Transactions",
-              "formatter": 0,
-              "formatOptions": {
-                "showIcon": true
-              }
-            },
-            {
-              "columnMatch": ".*\\/Transactions$",
-              "formatter": 1
-            },
-            {
-              "columnMatch": "Availability Timeline",
-              "formatter": 0,
-              "formatOptions": {
-                "showIcon": true
-              }
-            },
-            {
-              "columnMatch": "Availability (Average)",
-              "formatter": 0,
-              "formatOptions": {
-                "showIcon": true
-              }
-            },
-            {
-              "columnMatch": "E2E Latency Timeline",
-              "formatter": 0,
-              "formatOptions": {
-                "showIcon": true
-              }
-            },
-            {
-              "columnMatch": "E2E Latency",
-              "formatter": 0,
-              "formatOptions": {
-                "showIcon": true
-              }
-            },
-            {
-              "columnMatch": "Server Latency Timeline",
-              "formatter": 0,
-              "formatOptions": {
-                "showIcon": true
-              }
-            },
-            {
-              "columnMatch": "Server Latency",
-              "formatter": 0,
-              "formatOptions": {
-                "showIcon": true
-              }
-            }
-          ]
-        },
-        "sortBy": []
-      },
-      "conditionalVisibility": {
-        "parameterName": "1",
-        "comparison": "isEqualTo",
-        "value": "1"
-      },
-      "customWidth": "40",
-      "name": "storage account metrics"
-    },
-    {
-      "type": 3,
-      "content": {
-        "version": "KqlItem/1.0",
-        "query": "{\"version\":\"Merge/1.0\",\"merges\":[{\"id\":\"25434bff-19cb-4ae6-a1d5-7d3f530f703b\",\"mergeType\":\"table\",\"leftTable\":\"storage account metrics\"}],\"projectRename\":[{\"originalName\":\"[storage account metrics].Name\",\"mergedName\":\"Name\"},{\"originalName\":\"[storage account metrics].Subscription\",\"mergedName\":\"Subscription\"},{\"originalName\":\"[storage account metrics].Transactions (Sum)\",\"mergedName\":\"Transactions (Sum)\"},{\"originalName\":\"[storage account metrics].Transactions Timeline\",\"mergedName\":\"Transactions Timeline\"},{\"originalName\":\"[storage account metrics].Success/Transactions\",\"mergedName\":\"Success/Transactions\"},{\"originalName\":\"[storage account metrics].Availability (Average)\",\"mergedName\":\"Availability (Average)\"},{\"originalName\":\"[storage account metrics].E2E Latency\",\"mergedName\":\"E2E Latency\"},{\"originalName\":\"[storage account metrics].Server Latency\",\"mergedName\":\"Server Latency\"},{\"originalName\":\"[storage account metrics].ClientOtherError/Transactions\",\"mergedName\":\"ClientOtherError/Transactions\"},{\"originalName\":\"[Added column]\",\"mergedName\":\"...\",\"fromId\":null,\"isNewItem\":true,\"newItemData\":[{\"condition\":\"Default\",\"newColumnContext\":{\"operator\":\"Default\",\"rightValType\":\"column\",\"resultValType\":\"static\",\"resultVal\":\"☰ Details\"}}]},{\"originalName\":\"[storage account metrics].NetworkError/Transactions\",\"mergedName\":\"NetworkError/Transactions\",\"fromId\":\"unknown\"},{\"originalName\":\"[storage account metrics].ServerTimeoutError/Transactions\",\"mergedName\":\"ServerTimeoutError/Transactions\",\"fromId\":\"unknown\"},{\"originalName\":\"[storage account metrics].AuthorizationError/Transactions\",\"mergedName\":\"AuthorizationError/Transactions\",\"fromId\":\"unknown\"},{\"originalName\":\"[storage account metrics].AuthenticationError/Transactions\",\"mergedName\":\"AuthenticationError/Transactions\",\"fromId\":\"unknown\"},{\"originalName\":\"[storage account metrics].ClientThrottlingError/Transactions\",\"mergedName\":\"ClientThrottlingError/Transactions\",\"fromId\":\"unknown\"},{\"originalName\":\"[storage account metrics].Other/Transactions\",\"mergedName\":\"Other/Transactions\",\"fromId\":\"unknown\"},{\"originalName\":\"[storage account metrics].Server Latency Timeline\"},{\"originalName\":\"[storage account metrics].Server Latency\"},{\"originalName\":\"[storage account metrics].E2E Latency Timeline\"},{\"originalName\":\"[storage account metrics].E2E Latency\"},{\"originalName\":\"[storage account metrics].Availability Timeline\"},{\"originalName\":\"[storage account metrics].Availability (Average)\"},{\"originalName\":\"[storage account metrics].ClientOtherError/Transactions\"},{\"originalName\":\"[storage account metrics].Success/Transactions\"},{\"originalName\":\"[storage account metrics].Transactions Timeline\"},{\"originalName\":\"[storage account metrics].Transactions (Sum)\"},{\"originalName\":\"[storage account metrics].Name\"}]}",
-        "size": 0,
-        "queryType": 7,
+        "title": "Storage account summary",
         "gridSettings": {
           "formatters": [
             {
@@ -404,18 +227,16 @@
               }
             },
             {
-              "columnMatch": "Name",
+              "columnMatch": "Subscription",
               "formatter": 5,
               "formatOptions": {
-                "linkTarget": "Resource",
                 "showIcon": true
               }
             },
             {
-              "columnMatch": "Subscription",
+              "columnMatch": "Name",
               "formatter": 5,
               "formatOptions": {
-                "linkTarget": "Resource",
                 "showIcon": true
               }
             },
@@ -446,13 +267,6 @@
               }
             },
             {
-              "columnMatch": "Success/Transactions",
-              "formatter": 5,
-              "formatOptions": {
-                "showIcon": true
-              }
-            },
-            {
               "columnMatch": "Availability (Average)",
               "formatter": 18,
               "formatOptions": {
@@ -462,8 +276,7 @@
                 "thresholdsGrid": [
                   {
                     "operator": "is Empty",
-                    "representation": "Blank",
-                    "text": "-"
+                    "text": ""
                   },
                   {
                     "operator": "<",
@@ -506,7 +319,14 @@
               }
             },
             {
-              "columnMatch": "Latency",
+              "columnMatch": "Availability Timeline",
+              "formatter": 5,
+              "formatOptions": {
+                "showIcon": true
+              }
+            },
+            {
+              "columnMatch": "E2E Latency|Server Latency",
               "formatter": 8,
               "formatOptions": {
                 "min": 0,
@@ -535,10 +355,30 @@
               }
             },
             {
-              "columnMatch": ".*/Transactions$",
+              "columnMatch": "E2E Latency Timeline",
+              "formatter": 5,
+              "formatOptions": {
+                "showIcon": true
+              }
+            },
+            {
+              "columnMatch": "Server Latency Timeline",
+              "formatter": 5,
+              "formatOptions": {
+                "showIcon": true
+              }
+            },
+            {
+              "columnMatch": "Success/Transactions",
+              "formatter": 5,
+              "formatOptions": {
+                "showIcon": true
+              }
+            },
+            {
+              "columnMatch": ".*\\/Transactions$",
               "formatter": 18,
               "formatOptions": {
-                "palette": "purple",
                 "linkTarget": "WorkbookTemplate",
                 "showIcon": true,
                 "thresholdsOptions": "icons",
@@ -553,7 +393,7 @@
                     "operator": "Default",
                     "thresholdValue": null,
                     "representation": "Blank",
-                    "text": "-"
+                    "text": ""
                   }
                 ],
                 "workbookContext": {
@@ -576,26 +416,6 @@
                   "maximumFractionDigits": 1
                 }
               }
-            },
-            {
-              "columnMatch": "\\.\\.\\.",
-              "formatter": 7,
-              "formatOptions": {
-                "linkTarget": "WorkbookTemplate",
-                "showIcon": true,
-                "workbookContext": {
-                  "componentIdSource": "column",
-                  "componentId": "Name",
-                  "resourceIdsSource": "column",
-                  "resourceIds": "Name",
-                  "templateIdSource": "static",
-                  "templateId": "Community-Workbooks/Individual Storage/Overview",
-                  "typeSource": "static",
-                  "type": "workbook",
-                  "gallerySource": "static",
-                  "gallery": "microsoft.storage/storageaccounts"
-                }
-              }
             }
           ],
           "filter": true,
@@ -613,26 +433,23 @@
               "sortOrder": 2
             }
           ]
-        }
+        },
+        "sortBy": [
+          {
+            "itemKey": "$gen_heatmap_Transactions (Sum)_3",
+            "sortOrder": 2
+          }
+        ]
       },
-      "conditionalVisibility": {
-        "parameterName": "ShowDetails",
-        "comparison": "isEqualTo",
-        "value": "Yes"
-      },
-      "name": "query - 6"
+      "showPin": true,
+      "name": "storage account metrics"
     },
     {
       "type": 1,
       "content": {
-        "json": "<br />\r\n<br />\r\n⚠️ Please select storage accounts to analyze"
+        "json": "💡 _{Message}_"
       },
-      "conditionalVisibility": {
-        "parameterName": "ShowDetails",
-        "comparison": "isEqualTo",
-        "value": "No"
-      },
-      "name": "No storage account message"
+      "name": "Message"
     }
   ],
   "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"


### PR DESCRIPTION
Simplifies the edit experience:
1. Use only the metric control (no merge control).
2. Simplifies parameters (removed default sub and visibility param)
3. Removed the storage account counts and replaced with a banner at the bottom.

<img width="1350" alt="image" src="https://user-images.githubusercontent.com/9730127/59968401-31320600-94ee-11e9-8406-b5d618a2491b.png">

<img width="1350" alt="image" src="https://user-images.githubusercontent.com/9730127/59968410-4dce3e00-94ee-11e9-9bbe-de98157d5130.png">