### PR TITLE
SAI: Add number formatting to tiles, add missing column match in overview

### DIFF
--- a/Documentation/Visualizations/Graph.md
+++ b/Documentation/Visualizations/Graph.md
@@ -6,7 +6,7 @@ The graph below show data flowing in/out of a computer via various port to/from 
 
 ![Image showing an example of a graph visualization in workbooks](../Images/Graph-Example2.png)
 
-## Adding a Tile
+## Adding a Graph
 1. Switch the workbook to edit mode by clicking on the _Edit_ toolbar item.
 2. Use the _Add query_ link to add a log query control to the workbook. 
 3. Select the query type as _Log_, resource type (e.g. Application Insights) and the resources to target.

--- a/Workbooks/Individual Storage/Overview/Overview.workbook
+++ b/Workbooks/Individual Storage/Overview/Overview.workbook
@@ -316,6 +316,13 @@
             "formatter": 12,
             "formatOptions": {
               "showIcon": true
+            },
+            "numberFormat": {
+              "unit": 0,
+              "options": {
+                "style": "decimal",
+                "maximumFractionDigits": 2
+              }
             }
           },
           "secondaryContent": {

--- a/Workbooks/Storage/Overview/Overview.workbook
+++ b/Workbooks/Storage/Overview/Overview.workbook
@@ -442,6 +442,13 @@
               }
             },
             {
+              "columnMatch": "success/Errors",
+              "formatter": 5,
+              "formatOptions": {
+                "showIcon": true
+              }
+            },
+            {
               "columnMatch": ".*\\/Errors",
               "formatter": 8,
               "formatOptions": {


### PR DESCRIPTION
Limit the formatting of tiles to 2 decimal places

Sometimes metrics returns split by error as lower case success. Add a regex to handle lower case success