### PR TITLE
add codeowners file which will automatically add reviewers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,17 @@
+# Lines starting with '#' are comments.
+# Each line is a file pattern followed by one or more owners.
+# see https://help.github.com/en/articles/about-code-owners
+
+# Order is important. The last matching pattern has the most precedence.
+
+# teams that want to lock down their templates would insert rows here with the path to their template and the users/teams they want to own the items
+
+# everything at the root, or inside docs, schema, scripts, cohorts requires workbooks team review
+/*  applicationinsights-devtools
+/Documentation/**   applicationinsights-devtools
+/schema/**  applicationinsights-devtools
+/scripts/** applicationinsights-devtools
+/test/**    applicationinsights-devtools
+/.pipelines/**  applicationinsights-devtools
+/Cohorts/** applicationinsights-devtools
+

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,11 +7,11 @@
 # teams that want to lock down their templates would insert rows here with the path to their template and the users/teams they want to own the items
 
 # everything at the root, or inside docs, schema, scripts, cohorts requires workbooks team review
-/*  applicationinsights-devtools
-/Documentation/**   applicationinsights-devtools
-/schema/**  applicationinsights-devtools
-/scripts/** applicationinsights-devtools
-/test/**    applicationinsights-devtools
-/.pipelines/**  applicationinsights-devtools
-/Cohorts/** applicationinsights-devtools
+/*  @microsoft/applicationinsights-devtools
+/Documentation/**   @microsoft/applicationinsights-devtools
+/schema/**  @microsoft/applicationinsights-devtools
+/scripts/** @microsoft/applicationinsights-devtools
+/test/**    @microsoft/applicationinsights-devtools
+/.pipelines/**  @microsoft/applicationinsights-devtools
+/Cohorts/** @microsoft/applicationinsights-devtools
 


### PR DESCRIPTION
This should enable automatic reviewers on various paths in the repo, and teams that want to add their own teams as owners on paths for their templates can.

see https://help.github.com/en/articles/about-code-owners

I don't think this will start working until it is checked in though, so i'm not positive all the paths and syntax are correct until people start creating prs after that?