### PR TITLE
fix cosmosdb template

### DIFF
--- a/Workbooks/CosmosDb/Overview/Overview.workbook
+++ b/Workbooks/CosmosDb/Overview/Overview.workbook
@@ -21,7 +21,7 @@
             "multiSelect": true,
             "quote": "'",
             "delimiter": ",",
-            "query": "where type =~ 'Microsoft.DocumentDB/databaseAccounts'\r\n| summarize by subscriptionId\r\n| order by subscriptionId\r\n| summarize SelectedSub = makelist(subscriptionId, 1), Sub = makelist(subscriptionId, 100000)\r\n| mvexpand Sub limit 100000\r\n| mvexpand SelectedSub\r\n| project value = strcat(\"/subscriptions/\", Sub), label = Sub, selected = iff(tostring(Sub) == tostring(SelectedSub), true, false)\r\n",
+            "query": "where type =~ 'Microsoft.DocumentDB/databaseAccounts'\r\n| summarize Count = count() by subscriptionId\r\n| order by Count desc\r\n| summarize SelectedSub = makelist(subscriptionId, 1), Sub = makelist(subscriptionId, 100000)\r\n| mvexpand Sub limit 100000\r\n| mvexpand SelectedSub\r\n| project value = strcat(\"/subscriptions/\", Sub), label = Sub, selected = iff(tostring(Sub) == tostring(SelectedSub), true, false)\r\n",
             "crossComponentResources": [
               "value::selected"
             ],
@@ -41,7 +41,7 @@
             "multiSelect": true,
             "quote": "'",
             "delimiter": ",",
-            "query": "where type =~ 'Microsoft.DocumentDB/databaseAccounts'\r\n| summarize Count = count() by subscriptionId\r\n| order by Count desc\r\n| summarize SelectedSub = makelist(subscriptionId, 1), Sub = makelist(subscriptionId, 100000)\r\n| mvexpand Sub limit 100000\r\n| mvexpand SelectedSub\r\n| project value = strcat(\"/subscriptions/\", Sub), label = Sub, selected = iff(tostring(Sub) == tostring(SelectedSub), true, false)\r\n",
+            "query": "where type =~ 'Microsoft.DocumentDB/databaseAccounts'\r\n| order by name asc\r\n| summarize Selected = makelist(id, 10), All = makelist(id, 1000)\r\n| mvexpand All limit 10000\r\n| project value = tostring(All), label = tostring(All), selected = iff(Selected contains All, true, false)\r\n",
             "crossComponentResources": [
               "{Subscription}"
             ],


### PR DESCRIPTION
the previous commit to the template changed the cosmosdb query to also return subs instead of changing the subs query

moved the subs query to the subs param, restored the previous query for cosmosdb param