### PR TITLE
Storage Insights: Use column labels

### DIFF
--- a/Workbooks/Storage/Capacity/Capacity.workbook
+++ b/Workbooks/Storage/Capacity/Capacity.workbook
@@ -246,46 +246,31 @@
             "namespace": "microsoft.storage/storageaccounts",
             "metric": "microsoft.storage/storageaccounts-Capacity-UsedCapacity",
             "aggregation": 4,
-            "splitBy": null,
-            "splitBySortOrder": -1,
-            "splitByLimit": 4,
-            "columnName": "Account used capacity"
+            "splitBy": null
           },
           {
             "namespace": "microsoft.storage/storageaccounts/blobservices",
             "metric": "microsoft.storage/storageaccounts/blobservices-Capacity-BlobCapacity",
             "aggregation": 4,
-            "splitBy": null,
-            "splitBySortOrder": -1,
-            "splitByLimit": 5,
-            "columnName": "Blob capacity"
+            "splitBy": null
           },
           {
             "namespace": "microsoft.storage/storageaccounts/fileservices",
             "metric": "microsoft.storage/storageaccounts/fileservices-Capacity-FileCapacity",
             "aggregation": 4,
-            "splitBy": null,
-            "splitBySortOrder": -1,
-            "splitByLimit": 5,
-            "columnName": "File capacity"
+            "splitBy": null
           },
           {
             "namespace": "microsoft.storage/storageaccounts/queueservices",
             "metric": "microsoft.storage/storageaccounts/queueservices-Capacity-QueueCapacity",
             "aggregation": 4,
-            "splitBy": null,
-            "splitBySortOrder": -1,
-            "splitByLimit": 5,
-            "columnName": "Queue capacity"
+            "splitBy": null
           },
           {
             "namespace": "microsoft.storage/storageaccounts/tableservices",
             "metric": "microsoft.storage/storageaccounts/tableservices-Capacity-TableCapacity",
             "aggregation": 4,
-            "splitBy": null,
-            "splitBySortOrder": -1,
-            "splitByLimit": 5,
-            "columnName": "Table capacity"
+            "splitBy": null
           }
         ],
         "gridSettings": {
@@ -395,7 +380,54 @@
               "sortOrder": 2
             }
           ],
-          "labelSettings": []
+          "labelSettings": [
+            {
+              "columnId": "Subscription"
+            },
+            {
+              "columnId": "Name"
+            },
+            {
+              "columnId": "microsoft.storage/storageaccounts-Capacity-UsedCapacity",
+              "label": "Account used capacity"
+            },
+            {
+              "columnId": "microsoft.storage/storageaccounts-Capacity-UsedCapacity Timeline",
+              "label": "Account used capacity Timeline"
+            },
+            {
+              "columnId": "microsoft.storage/storageaccounts/blobservices-Capacity-BlobCapacity",
+              "label": "Blob capacity"
+            },
+            {
+              "columnId": "microsoft.storage/storageaccounts/blobservices-Capacity-BlobCapacity Timeline",
+              "label": "Blob capacity Timeline"
+            },
+            {
+              "columnId": "microsoft.storage/storageaccounts/fileservices-Capacity-FileCapacity",
+              "label": "File capacity"
+            },
+            {
+              "columnId": "microsoft.storage/storageaccounts/fileservices-Capacity-FileCapacity Timeline",
+              "label": "File capacity Timeline"
+            },
+            {
+              "columnId": "microsoft.storage/storageaccounts/queueservices-Capacity-QueueCapacity",
+              "label": "Queue capacity"
+            },
+            {
+              "columnId": "microsoft.storage/storageaccounts/queueservices-Capacity-QueueCapacity Timeline",
+              "label": "Queue capacity Timeline"
+            },
+            {
+              "columnId": "microsoft.storage/storageaccounts/tableservices-Capacity-TableCapacity",
+              "label": "Table capacity"
+            },
+            {
+              "columnId": "microsoft.storage/storageaccounts/tableservices-Capacity-TableCapacity Timeline",
+              "label": "Table capacity Timeline"
+            }
+          ]
         },
         "sortBy": [
           {

--- a/Workbooks/Storage/Overview/Overview.workbook
+++ b/Workbooks/Storage/Overview/Overview.workbook
@@ -246,29 +246,25 @@
             "metric": "microsoft.storage/storageaccounts-Transaction-Transactions",
             "aggregation": 1,
             "splitBy": null,
-            "splitByLimit": null,
-            "columnName": "Transactions"
+            "splitByLimit": null
           },
           {
             "namespace": "microsoft.storage/storageaccounts",
             "metric": "microsoft.storage/storageaccounts-Transaction-Availability",
             "aggregation": 4,
-            "splitByLimit": null,
-            "columnName": "Availability"
+            "splitByLimit": null
           },
           {
             "namespace": "microsoft.storage/storageaccounts",
             "metric": "microsoft.storage/storageaccounts-Transaction-SuccessE2ELatency",
             "aggregation": 4,
-            "splitByLimit": null,
-            "columnName": "E2E Latency"
+            "splitByLimit": null
           },
           {
             "namespace": "microsoft.storage/storageaccounts",
             "metric": "microsoft.storage/storageaccounts-Transaction-SuccessServerLatency",
             "aggregation": 4,
-            "splitByLimit": null,
-            "columnName": "Server Latency"
+            "splitByLimit": null
           },
           {
             "namespace": "microsoft.storage/storageaccounts",
@@ -500,7 +496,53 @@
               "sortOrder": 2
             }
           ],
-          "labelSettings": []
+          "labelSettings": [
+            {
+              "columnId": "Subscription"
+            },
+            {
+              "columnId": "Name",
+              "label": ""
+            },
+            {
+              "columnId": "microsoft.storage/storageaccounts-Transaction-Transactions",
+              "label": "Transactions"
+            },
+            {
+              "columnId": "microsoft.storage/storageaccounts-Transaction-Transactions Timeline",
+              "label": "Transactions Timeline"
+            },
+            {
+              "columnId": "microsoft.storage/storageaccounts-Transaction-Availability",
+              "label": "Availability"
+            },
+            {
+              "columnId": "microsoft.storage/storageaccounts-Transaction-Availability Timeline",
+              "label": "Availability Timeline"
+            },
+            {
+              "columnId": "microsoft.storage/storageaccounts-Transaction-SuccessE2ELatency",
+              "label": "E2E Latency"
+            },
+            {
+              "columnId": "microsoft.storage/storageaccounts-Transaction-SuccessE2ELatency Timeline",
+              "label": "E2E Latency Timeline"
+            },
+            {
+              "columnId": "microsoft.storage/storageaccounts-Transaction-SuccessServerLatency",
+              "label": "Server Latency"
+            },
+            {
+              "columnId": "microsoft.storage/storageaccounts-Transaction-SuccessServerLatency Timeline",
+              "label": "Server Latency Timeline"
+            },
+            {
+              "columnId": "Success/Errors"
+            },
+            {
+              "columnId": "ClientOtherError/Errors"
+            }
+          ]
         },
         "sortBy": [
           {


### PR DESCRIPTION
Column name option has been removed from metric pills and moved to column label options in settings blade. Remove column name from each metric setting and move it to column label settings.

Removes the confusion where someone tries to change Availability metric  to say Egress metric but the column name still says Availability. 