### PR TITLE
Storage Insights: Total transactions in Failure tab

### DIFF
--- a/Workbooks/Individual Storage/Failures/Failures.workbook
+++ b/Workbooks/Individual Storage/Failures/Failures.workbook
@@ -213,10 +213,6 @@
             "columnName": "Total Transactions"
           }
         ],
-        "gridSettings": {
-          "rowLimit": 10000,
-          "labelSettings": []
-        },
         "gridFormatType": 1,
         "tileSettings": {
           "titleContent": {
@@ -272,46 +268,6 @@
             "splitBy": "ResponseType"
           }
         ],
-        "gridSettings": {
-          "formatters": [
-            {
-              "columnMatch": "Subscription",
-              "formatter": 5
-            },
-            {
-              "columnMatch": "Metric",
-              "formatter": 1
-            },
-            {
-              "columnMatch": "Aggregation",
-              "formatter": 1
-            },
-            {
-              "columnMatch": "Segment Field",
-              "formatter": 5
-            },
-            {
-              "columnMatch": "Segment",
-              "formatter": 1
-            },
-            {
-              "columnMatch": "Value",
-              "formatter": 1
-            },
-            {
-              "columnMatch": "Timeline",
-              "formatter": 9
-            },
-            {
-              "columnMatch": "Name",
-              "formatter": 13,
-              "formatOptions": {
-                "linkTarget": "Resource"
-              }
-            }
-          ],
-          "labelSettings": []
-        },
         "gridFormatType": 1,
         "tileSettings": {
           "titleContent": {


### PR DESCRIPTION
Addition of a total transactions tile alongside transactions split by result type. Tile is to further clarify total transactions in absence of failures.
![MicrosoftTeams-image (3)](https://user-images.githubusercontent.com/10899839/63724378-6b7c9400-c80c-11e9-82a0-cfc855991d2d.png)
