### PR TITLE
Fix SAP Monitor v2 (modify TimeRange)

### DIFF
--- a/Workbooks/SapMonitor/SapHanaInfrastructure/SapHanaInfrastructure.workbook
+++ b/Workbooks/SapMonitor/SapHanaInfrastructure/SapHanaInfrastructure.workbook
@@ -13,12 +13,11 @@
             "version": "KqlParameterItem/1.0",
             "name": "testDataExist",
             "type": 1,
-            "query": "SapHana_LoadHistory_CL\r\n| where TimeGenerated  {TimeRange}\r\n|project HOST_s\r\n| take 1",
+            "query": "SapHana_LoadHistory_CL\r\n| project HOST_s\r\n| take 1",
             "isHiddenWhenLocked": true,
             "timeContext": {
-              "durationMs": 0
+              "durationMs": 1800000
             },
-            "timeContextFromParameter": "TimeRange",
             "queryType": 0,
             "resourceType": "microsoft.operationalinsights/workspaces"
           }


### PR DESCRIPTION
Starting from the previous PR #375, there is a parameter (`testDataExist`) that will probe if the ingested custom logs have already "arrived" to Log Analytics. This was originally (wrongly) used in the user parameters, and then moved to the top of the workbook template. However, it referenced `TimeRange`, which was not set at the moment.
For the purpose of checking if data already exists, I've "hard-coded" a 30 minutes threshold which resolves this issue. Going forward, a more elaborate method can be used. 