### PR TITLE
Remove unused parameters

### DIFF
--- a/Workbooks/Virtual Machines - Performance Analysis/Performance Counters/Performance Counters.workbook
+++ b/Workbooks/Virtual Machines - Performance Analysis/Performance Counters/Performance Counters.workbook
@@ -2040,6 +2040,5 @@
   ],
   "fallbackResourceIds": [],
   "styleSettings": {},
-  "fromTemplateId": "Workbooks/Virtual Machines - Performance Analysis/Performance Counters",
   "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
 }

--- a/Workbooks/Virtual Machines - Performance Analysis/Performance Counters/Performance Counters.workbook
+++ b/Workbooks/Virtual Machines - Performance Analysis/Performance Counters/Performance Counters.workbook
@@ -6,7 +6,9 @@
       "content": {
         "version": "KqlParameterItem/1.0",
         "query": "",
-        "crossComponentResources": [],
+        "crossComponentResources": [
+          "{Workspaces}"
+        ],
         "parameters": [
           {
             "id": "e41c2177-932a-4c58-ba24-03ef070eb197",
@@ -28,19 +30,16 @@
               "additionalResourceOptions": [
                 "value::1"
               ]
-            },
-            "timeContextFromParameter": null
+            }
           },
           {
             "id": "5f8cce4b-9c4c-47da-8683-7e5ccc9faed3",
             "version": "KqlParameterItem/1.0",
             "name": "TimeRange",
             "type": 4,
-            "isRequired": false,
             "value": {
               "durationMs": 14400000
             },
-            "isHiddenWhenLocked": false,
             "typeSettings": {
               "selectableValues": [
                 {
@@ -152,25 +151,21 @@
             "type": 2,
             "isRequired": true,
             "value": "15m",
-            "isHiddenWhenLocked": false,
             "typeSettings": {
               "additionalResourceOptions": []
             },
-            "jsonData": "[\r\n    {\r\n        \"label\": \"1 minute\",\r\n        \"value\": \"1m\"\r\n    },\r\n    {\r\n        \"label\": \"5 minutes\",\r\n        \"value\": \"5m\"\r\n    },\r\n    {\r\n        \"label\": \"15 minutes\",\r\n        \"value\": \"15m\"\r\n    },\r\n    {\r\n        \"label\": \"30 minutes\",\r\n        \"value\": \"30m\"\r\n    },\r\n    {\r\n        \"label\": \"1 hour\",\r\n        \"value\": \"1h\"\r\n    }\r\n]",
-            "timeContextFromParameter": null
+            "jsonData": "[\r\n    {\r\n        \"label\": \"1 minute\",\r\n        \"value\": \"1m\"\r\n    },\r\n    {\r\n        \"label\": \"5 minutes\",\r\n        \"value\": \"5m\"\r\n    },\r\n    {\r\n        \"label\": \"15 minutes\",\r\n        \"value\": \"15m\"\r\n    },\r\n    {\r\n        \"label\": \"30 minutes\",\r\n        \"value\": \"30m\"\r\n    },\r\n    {\r\n        \"label\": \"1 hour\",\r\n        \"value\": \"1h\"\r\n    }\r\n]"
           },
           {
             "id": "112823d7-bf58-4604-a299-78ccc5899516",
             "version": "KqlParameterItem/1.0",
             "name": "LineChartQuerySnippet",
             "type": 1,
-            "isRequired": false,
             "query": "print(\"bin(TimeGenerated, {TimeGrain}), ResourceName | render linechart\")",
             "crossComponentResources": [
               "{Workspaces}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
           {
@@ -178,68 +173,27 @@
             "version": "KqlParameterItem/1.0",
             "name": "GridQuerySnippet",
             "type": 1,
-            "isRequired": false,
             "value": "ResourceName",
-            "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null
+            "isHiddenWhenLocked": true
           },
           {
             "id": "0b83d1f7-f49b-4dea-8727-ac6d03f51b2a",
             "version": "KqlParameterItem/1.0",
             "name": "ComputerNameContains",
             "type": 1,
-            "isRequired": false,
-            "value": "",
-            "isHiddenWhenLocked": false,
-            "timeContextFromParameter": null
-          },
-          {
-            "id": "7fdd3365-6ae2-48d7-b305-7b9fcead73f2",
-            "version": "KqlParameterItem/1.0",
-            "name": "CustomComputerGroup",
-            "type": 2,
-            "isRequired": false,
-            "value": null,
-            "isHiddenWhenLocked": true,
-            "typeSettings": {
-              "additionalResourceOptions": []
-            },
-            "jsonData": "[\r\n    {\r\n        \"label\": \"My Custom Group - Perf\",\r\n        \"value\": \"Perf | distinct Computer\"\r\n    },\r\n    {\r\n        \"label\": \"My Custom Group - ServiceMap\",\r\n        \"value\": \"ServiceMapComputer_CL | distinct Computer\"\r\n    }\r\n]",
-            "timeContextFromParameter": null
-          },
-          {
-            "id": "d7cf3b2d-bbd9-4c40-a7c9-d1d0ed110ca2",
-            "version": "KqlParameterItem/1.0",
-            "name": "CustomComputerGroupResult",
-            "type": 2,
-            "isRequired": false,
-            "multiSelect": true,
-            "quote": "'",
-            "delimiter": ",",
-            "query": "{CustomComputerGroup:value}\r\n| project Value = Computer, Display = Computer, isSelected = true",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
-            "isHiddenWhenLocked": true,
-            "typeSettings": {
-              "additionalResourceOptions": []
-            },
-            "timeContextFromParameter": null,
-            "resourceType": "microsoft.operationalinsights/workspaces",
-            "value": null
+            "value": ""
           },
           {
             "id": "8e436ee8-ba56-4fe5-8a2b-46f77ad405ee",
             "version": "KqlParameterItem/1.0",
             "name": "CustomComputerQuery",
             "type": 1,
-            "isRequired": false,
-            "query": "let computerFilter = iff('{ComputerNameContains}' != '', \"| where Computer contains '{ComputerNameContains}'\", iff('{CustomComputerGroupResult:value}' != '', \"| where Computer in ({CustomComputerGroupResult})\", ''));\r\nprint(computerFilter)",
+            "query": "let computerFilter = iff('{ComputerNameContains}' != '', \"| where Computer contains '{ComputerNameContains}'\", \"\");\r\nprint(computerFilter)",
             "crossComponentResources": [
               "{Workspaces}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
+            "queryType": 0,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
           {
@@ -255,11 +209,9 @@
             "crossComponentResources": [
               "{Workspaces}"
             ],
-            "isHiddenWhenLocked": false,
             "typeSettings": {
               "additionalResourceOptions": []
             },
-            "timeContextFromParameter": null,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
           {
@@ -267,13 +219,11 @@
             "version": "KqlParameterItem/1.0",
             "name": "ComputerFilter",
             "type": 1,
-            "isRequired": false,
             "query": "let computerFilter = iff('*' in ({Computers}), \"{CustomComputerQuery}\", \"| where Computer in ({Computers})\");\r\nprint(computerFilter)",
             "crossComponentResources": [
               "{Workspaces}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
           {
@@ -286,8 +236,6 @@
             "crossComponentResources": [
               "{Workspaces}"
             ],
-            "isHiddenWhenLocked": false,
-            "timeContextFromParameter": null,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
           {
@@ -297,26 +245,24 @@
             "type": 2,
             "isRequired": true,
             "value": "1",
-            "isHiddenWhenLocked": false,
             "typeSettings": {
               "additionalResourceOptions": []
             },
-            "jsonData": "[\r\n    {\r\n        \"label\": \"Locked\",\r\n        \"value\": \"1\"\r\n    },\r\n    {\r\n        \"label\": \"Unlocked\",\r\n        \"value\": \"0\"\r\n    }\r\n]",
-            "timeContextFromParameter": null
+            "jsonData": "[\r\n    {\r\n        \"label\": \"Locked\",\r\n        \"value\": \"1\"\r\n    },\r\n    {\r\n        \"label\": \"Unlocked\",\r\n        \"value\": \"0\"\r\n    }\r\n]"
           }
         ],
         "style": "above",
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces"
       },
-      "conditionalVisibility": null
+      "name": "parameters - 0"
     },
     {
       "type": 1,
       "content": {
         "json": "<hr style=\"height: 2px;\" />"
       },
-      "conditionalVisibility": null
+      "name": "text - 1"
     },
     {
       "type": 9,
@@ -337,11 +283,9 @@
             "crossComponentResources": [
               "{Workspaces}"
             ],
-            "isHiddenWhenLocked": false,
             "typeSettings": {
               "additionalResourceOptions": []
             },
-            "timeContextFromParameter": null,
             "resourceType": "microsoft.operationalinsights/workspaces",
             "value": "{\"counter\":\"% Processor Time\",\"object\":\"Process\"}"
           },
@@ -351,25 +295,21 @@
             "name": "TrendAggregator",
             "type": 2,
             "isRequired": true,
-            "isHiddenWhenLocked": false,
             "typeSettings": {
               "additionalResourceOptions": []
             },
-            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\", \"selected\":false},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\", \"selected\":false},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P80th = round(percentile(CounterValue, 80), 2)\", \"label\":\"P80th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\", \"selected\":true}    \r\n]",
-            "timeContextFromParameter": null
+            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\", \"selected\":false},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\", \"selected\":false},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P80th = round(percentile(CounterValue, 80), 2)\", \"label\":\"P80th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\", \"selected\":true}    \r\n]"
           },
           {
             "id": "0327f26e-cdde-4b48-b512-6c35f06ad1d0",
             "version": "KqlParameterItem/1.0",
             "name": "TrendAggregatorOrder1",
             "type": 1,
-            "isRequired": false,
             "query": "print(iff('{TrendAggregator:label}' == 'P5th'  or '{TrendAggregator:label}' == 'P10th', 'asc', 'desc'))",
             "crossComponentResources": [
               "{Workspaces}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
           {
@@ -382,11 +322,9 @@
             "crossComponentResources": [
               "{Workspaces}"
             ],
-            "isHiddenWhenLocked": false,
             "typeSettings": {
               "additionalResourceOptions": []
             },
-            "timeContextFromParameter": null,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
           {
@@ -400,7 +338,6 @@
               "{Workspaces}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
           {
@@ -408,13 +345,11 @@
             "version": "KqlParameterItem/1.0",
             "name": "Counter1",
             "type": 1,
-            "isRequired": false,
             "query": "print '{Counter}'",
             "crossComponentResources": [
               "{Workspaces}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
           {
@@ -422,13 +357,11 @@
             "version": "KqlParameterItem/1.0",
             "name": "CounterLabel1",
             "type": 1,
-            "isRequired": false,
             "query": "print '{Counter:label}'",
             "crossComponentResources": [
               "{Workspaces}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
           {
@@ -436,13 +369,11 @@
             "version": "KqlParameterItem/1.0",
             "name": "TrendAggregatorValue1",
             "type": 1,
-            "isRequired": false,
             "query": "print '{TrendAggregator}'",
             "crossComponentResources": [
               "{Workspaces}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
           {
@@ -450,13 +381,11 @@
             "version": "KqlParameterItem/1.0",
             "name": "TrendAggregatorLabel1",
             "type": 1,
-            "isRequired": false,
             "query": "print '{TrendAggregator:label}'",
             "crossComponentResources": [
               "{Workspaces}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
           {
@@ -464,14 +393,11 @@
             "version": "KqlParameterItem/1.0",
             "name": "Unit",
             "type": 2,
-            "isRequired": false,
             "value": null,
-            "isHiddenWhenLocked": false,
             "typeSettings": {
               "additionalResourceOptions": []
             },
-            "jsonData": "[\r\n    {\r\n        \"label\": \"B -> MB\",\r\n        \"value\": \"/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"B -> GB\",\r\n        \"value\": \"/1024/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"MB -> GB\",\r\n        \"value\": \"/1024\"\r\n    },\r\n    {\r\n        \"label\": \"MB -> TB\",\r\n        \"value\": \"/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"b -> Mb\",\r\n        \"value\": \"/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"b -> Gb\",\r\n        \"value\": \"/1000/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"Mb -> Gb\",\r\n        \"value\": \"/1000\"\r\n    },\r\n    {\r\n        \"label\": \"Mb -> Tb\",\r\n        \"value\": \"/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"s -> ms\",\r\n        \"value\": \"*1000\"\r\n    },\r\n    {\r\n        \"label\": \"ms -> s\",\r\n        \"value\": \"/1000\"\r\n    }\r\n]",
-            "timeContextFromParameter": null
+            "jsonData": "[\r\n    {\r\n        \"label\": \"B -> MB\",\r\n        \"value\": \"/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"B -> GB\",\r\n        \"value\": \"/1024/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"MB -> GB\",\r\n        \"value\": \"/1024\"\r\n    },\r\n    {\r\n        \"label\": \"MB -> TB\",\r\n        \"value\": \"/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"b -> Mb\",\r\n        \"value\": \"/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"b -> Gb\",\r\n        \"value\": \"/1000/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"Mb -> Gb\",\r\n        \"value\": \"/1000\"\r\n    },\r\n    {\r\n        \"label\": \"Mb -> Tb\",\r\n        \"value\": \"/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"s -> ms\",\r\n        \"value\": \"*1000\"\r\n    },\r\n    {\r\n        \"label\": \"ms -> s\",\r\n        \"value\": \"/1000\"\r\n    }\r\n]"
           }
         ],
         "style": "above",
@@ -483,7 +409,8 @@
         "comparison": "isEqualTo",
         "value": "0"
       },
-      "customWidth": "25"
+      "customWidth": "25",
+      "name": "parameters - 2"
     },
     {
       "type": 9,
@@ -502,11 +429,9 @@
             "crossComponentResources": [
               "{Workspaces}"
             ],
-            "isHiddenWhenLocked": false,
             "typeSettings": {
               "additionalResourceOptions": []
             },
-            "timeContextFromParameter": null,
             "resourceType": "microsoft.operationalinsights/workspaces",
             "value": "{\"counter\":\"% Available Memory\",\"object\":\"Memory\"}"
           },
@@ -516,22 +441,18 @@
             "name": "TrendAggregator2",
             "type": 2,
             "isRequired": true,
-            "isHiddenWhenLocked": false,
-            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\", \"selected\":false},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\", \"selected\":false},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P80th = round(percentile(CounterValue, 80), 2)\", \"label\":\"P80th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\", \"selected\":true}    \r\n]",
-            "timeContextFromParameter": null
+            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\", \"selected\":false},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\", \"selected\":false},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P80th = round(percentile(CounterValue, 80), 2)\", \"label\":\"P80th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\", \"selected\":true}    \r\n]"
           },
           {
             "id": "0327f26e-cdde-4b48-b512-6c35f06ad1d0",
             "version": "KqlParameterItem/1.0",
             "name": "TrendAggregatorOrder2",
             "type": 1,
-            "isRequired": false,
             "query": "print(iff('{TrendAggregator2:label}' == 'P5th'  or '{TrendAggregator2:label}' == 'P10th', 'asc', 'desc'))",
             "crossComponentResources": [
               "{Workspaces}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
           {
@@ -544,11 +465,9 @@
             "crossComponentResources": [
               "{Workspaces}"
             ],
-            "isHiddenWhenLocked": false,
             "typeSettings": {
               "additionalResourceOptions": []
             },
-            "timeContextFromParameter": null,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
           {
@@ -562,7 +481,6 @@
               "{Workspaces}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
           {
@@ -570,14 +488,11 @@
             "version": "KqlParameterItem/1.0",
             "name": "Unit2",
             "type": 2,
-            "isRequired": false,
             "value": null,
-            "isHiddenWhenLocked": false,
             "typeSettings": {
               "additionalResourceOptions": []
             },
-            "jsonData": "[\r\n    {\r\n        \"label\": \"B -> MB\",\r\n        \"value\": \"/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"B -> GB\",\r\n        \"value\": \"/1024/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"MB -> GB\",\r\n        \"value\": \"/1024\"\r\n    },\r\n    {\r\n        \"label\": \"MB -> TB\",\r\n        \"value\": \"/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"b -> Mb\",\r\n        \"value\": \"/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"b -> Gb\",\r\n        \"value\": \"/1000/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"Mb -> Gb\",\r\n        \"value\": \"/1000\"\r\n    },\r\n    {\r\n        \"label\": \"Mb -> Tb\",\r\n        \"value\": \"/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"s -> ms\",\r\n        \"value\": \"*1000\"\r\n    },\r\n    {\r\n        \"label\": \"ms -> s\",\r\n        \"value\": \"/1000\"\r\n    }\r\n]",
-            "timeContextFromParameter": null
+            "jsonData": "[\r\n    {\r\n        \"label\": \"B -> MB\",\r\n        \"value\": \"/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"B -> GB\",\r\n        \"value\": \"/1024/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"MB -> GB\",\r\n        \"value\": \"/1024\"\r\n    },\r\n    {\r\n        \"label\": \"MB -> TB\",\r\n        \"value\": \"/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"b -> Mb\",\r\n        \"value\": \"/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"b -> Gb\",\r\n        \"value\": \"/1000/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"Mb -> Gb\",\r\n        \"value\": \"/1000\"\r\n    },\r\n    {\r\n        \"label\": \"Mb -> Tb\",\r\n        \"value\": \"/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"s -> ms\",\r\n        \"value\": \"*1000\"\r\n    },\r\n    {\r\n        \"label\": \"ms -> s\",\r\n        \"value\": \"/1000\"\r\n    }\r\n]"
           }
         ],
         "style": "above",
@@ -589,14 +504,14 @@
         "comparison": "isEqualTo",
         "value": "0"
       },
-      "customWidth": "25"
+      "customWidth": "25",
+      "name": "parameters - 3"
     },
     {
       "type": 9,
       "content": {
         "version": "KqlParameterItem/1.0",
         "query": "",
-        "crossComponentResources": [],
         "parameters": [
           {
             "id": "aa2368fc-ad30-4608-b96a-72abf7b1e1af",
@@ -608,13 +523,11 @@
             "crossComponentResources": [
               "{Workspaces}"
             ],
-            "isHiddenWhenLocked": false,
             "typeSettings": {
               "additionalResourceOptions": [
                 "value::1"
               ]
             },
-            "timeContextFromParameter": null,
             "resourceType": "microsoft.operationalinsights/workspaces",
             "value": "{\"counter\":\"Total Bytes Received\",\"object\":\"Network\"}"
           },
@@ -624,22 +537,18 @@
             "name": "TrendAggregator3",
             "type": 2,
             "isRequired": true,
-            "isHiddenWhenLocked": false,
-            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\", \"selected\":false},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\", \"selected\":false},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P80th = round(percentile(CounterValue, 80), 2)\", \"label\":\"P80th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\", \"selected\":true}    \r\n]",
-            "timeContextFromParameter": null
+            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\", \"selected\":false},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\", \"selected\":false},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P80th = round(percentile(CounterValue, 80), 2)\", \"label\":\"P80th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\", \"selected\":true}    \r\n]"
           },
           {
             "id": "0327f26e-cdde-4b48-b512-6c35f06ad1d0",
             "version": "KqlParameterItem/1.0",
             "name": "TrendAggregatorOrder3",
             "type": 1,
-            "isRequired": false,
             "query": "print(iff('{TrendAggregator3:label}' == 'P5th'  or '{TrendAggregator3:label}' == 'P10th', 'asc', 'desc'))",
             "crossComponentResources": [
               "{Workspaces}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
           {
@@ -652,11 +561,9 @@
             "crossComponentResources": [
               "{Workspaces}"
             ],
-            "isHiddenWhenLocked": false,
             "typeSettings": {
               "additionalResourceOptions": []
             },
-            "timeContextFromParameter": null,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
           {
@@ -670,7 +577,6 @@
               "{Workspaces}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
           {
@@ -678,14 +584,11 @@
             "version": "KqlParameterItem/1.0",
             "name": "Unit3",
             "type": 2,
-            "isRequired": false,
             "value": null,
-            "isHiddenWhenLocked": false,
             "typeSettings": {
               "additionalResourceOptions": []
             },
-            "jsonData": "[\r\n    {\r\n        \"label\": \"B -> MB\",\r\n        \"value\": \"/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"B -> GB\",\r\n        \"value\": \"/1024/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"MB -> GB\",\r\n        \"value\": \"/1024\"\r\n    },\r\n    {\r\n        \"label\": \"MB -> TB\",\r\n        \"value\": \"/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"b -> Mb\",\r\n        \"value\": \"/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"b -> Gb\",\r\n        \"value\": \"/1000/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"Mb -> Gb\",\r\n        \"value\": \"/1000\"\r\n    },\r\n    {\r\n        \"label\": \"Mb -> Tb\",\r\n        \"value\": \"/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"s -> ms\",\r\n        \"value\": \"*1000\"\r\n    },\r\n    {\r\n        \"label\": \"ms -> s\",\r\n        \"value\": \"/1000\"\r\n    }\r\n]",
-            "timeContextFromParameter": null
+            "jsonData": "[\r\n    {\r\n        \"label\": \"B -> MB\",\r\n        \"value\": \"/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"B -> GB\",\r\n        \"value\": \"/1024/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"MB -> GB\",\r\n        \"value\": \"/1024\"\r\n    },\r\n    {\r\n        \"label\": \"MB -> TB\",\r\n        \"value\": \"/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"b -> Mb\",\r\n        \"value\": \"/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"b -> Gb\",\r\n        \"value\": \"/1000/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"Mb -> Gb\",\r\n        \"value\": \"/1000\"\r\n    },\r\n    {\r\n        \"label\": \"Mb -> Tb\",\r\n        \"value\": \"/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"s -> ms\",\r\n        \"value\": \"*1000\"\r\n    },\r\n    {\r\n        \"label\": \"ms -> s\",\r\n        \"value\": \"/1000\"\r\n    }\r\n]"
           }
         ],
         "style": "above",
@@ -697,14 +600,14 @@
         "comparison": "isEqualTo",
         "value": "0"
       },
-      "customWidth": "25"
+      "customWidth": "25",
+      "name": "parameters - 4"
     },
     {
       "type": 9,
       "content": {
         "version": "KqlParameterItem/1.0",
         "query": "",
-        "crossComponentResources": [],
         "parameters": [
           {
             "id": "aa2368fc-ad30-4608-b96a-72abf7b1e1af",
@@ -716,11 +619,9 @@
             "crossComponentResources": [
               "{Workspaces}"
             ],
-            "isHiddenWhenLocked": false,
             "typeSettings": {
               "additionalResourceOptions": []
             },
-            "timeContextFromParameter": null,
             "resourceType": "microsoft.operationalinsights/workspaces",
             "value": "{\"counter\":\"Total Bytes Transmitted\",\"object\":\"Network\"}"
           },
@@ -730,22 +631,18 @@
             "name": "TrendAggregator4",
             "type": 2,
             "isRequired": true,
-            "isHiddenWhenLocked": false,
-            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\", \"selected\":false},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\", \"selected\":false},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P80th = round(percentile(CounterValue, 80), 2)\", \"label\":\"P80th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\", \"selected\":true}    \r\n]",
-            "timeContextFromParameter": null
+            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\", \"selected\":false},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\", \"selected\":false},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P80th = round(percentile(CounterValue, 80), 2)\", \"label\":\"P80th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\", \"selected\":true}    \r\n]"
           },
           {
             "id": "0327f26e-cdde-4b48-b512-6c35f06ad1d0",
             "version": "KqlParameterItem/1.0",
             "name": "TrendAggregatorOrder4",
             "type": 1,
-            "isRequired": false,
             "query": "print(iff('{TrendAggregator4:label}' == 'P5th'  or '{TrendAggregator4:label}' == 'P10th', 'asc', 'desc'))",
             "crossComponentResources": [
               "{Workspaces}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
           {
@@ -758,11 +655,9 @@
             "crossComponentResources": [
               "{Workspaces}"
             ],
-            "isHiddenWhenLocked": false,
             "typeSettings": {
               "additionalResourceOptions": []
             },
-            "timeContextFromParameter": null,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
           {
@@ -776,7 +671,6 @@
               "{Workspaces}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
           {
@@ -784,14 +678,11 @@
             "version": "KqlParameterItem/1.0",
             "name": "Unit4",
             "type": 2,
-            "isRequired": false,
             "value": null,
-            "isHiddenWhenLocked": false,
             "typeSettings": {
               "additionalResourceOptions": []
             },
-            "jsonData": "[\r\n    {\r\n        \"label\": \"B -> MB\",\r\n        \"value\": \"/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"B -> GB\",\r\n        \"value\": \"/1024/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"MB -> GB\",\r\n        \"value\": \"/1024\"\r\n    },\r\n    {\r\n        \"label\": \"MB -> TB\",\r\n        \"value\": \"/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"b -> Mb\",\r\n        \"value\": \"/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"b -> Gb\",\r\n        \"value\": \"/1000/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"Mb -> Gb\",\r\n        \"value\": \"/1000\"\r\n    },\r\n    {\r\n        \"label\": \"Mb -> Tb\",\r\n        \"value\": \"/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"s -> ms\",\r\n        \"value\": \"*1000\"\r\n    },\r\n    {\r\n        \"label\": \"ms -> s\",\r\n        \"value\": \"/1000\"\r\n    }\r\n]",
-            "timeContextFromParameter": null
+            "jsonData": "[\r\n    {\r\n        \"label\": \"B -> MB\",\r\n        \"value\": \"/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"B -> GB\",\r\n        \"value\": \"/1024/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"MB -> GB\",\r\n        \"value\": \"/1024\"\r\n    },\r\n    {\r\n        \"label\": \"MB -> TB\",\r\n        \"value\": \"/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"b -> Mb\",\r\n        \"value\": \"/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"b -> Gb\",\r\n        \"value\": \"/1000/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"Mb -> Gb\",\r\n        \"value\": \"/1000\"\r\n    },\r\n    {\r\n        \"label\": \"Mb -> Tb\",\r\n        \"value\": \"/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"s -> ms\",\r\n        \"value\": \"*1000\"\r\n    },\r\n    {\r\n        \"label\": \"ms -> s\",\r\n        \"value\": \"/1000\"\r\n    }\r\n]"
           }
         ],
         "style": "above",
@@ -803,52 +694,50 @@
         "comparison": "isEqualTo",
         "value": "0"
       },
-      "customWidth": "25"
+      "customWidth": "25",
+      "name": "parameters - 5"
     },
     {
       "type": 1,
       "content": {
         "json": "<h3 style=\"margin-bottom:0;\">{CounterLabel1}</h3><h4 style=\"margin-top:0;font-weight:normal;color:#777;\">{TrendAggregatorLabel1} {TrendAggregatorOrder1} {Unit:label}</h4>"
       },
-      "conditionalVisibility": null,
-      "customWidth": "25"
+      "customWidth": "25",
+      "name": "text - 6"
     },
     {
       "type": 1,
       "content": {
         "json": "<h3 style=\"margin-bottom:0;\">{Counter2:label}</h3><h4 style=\"margin-top:0;font-weight:normal;color:#777;\">{TrendAggregator2:label} {TrendAggregatorOrder2} {Unit2:label}</h4>"
       },
-      "conditionalVisibility": null,
-      "customWidth": "25"
+      "customWidth": "25",
+      "name": "text - 7"
     },
     {
       "type": 1,
       "content": {
         "json": "<h3 style=\"margin-bottom:0;\">{Counter3:label}</h3><h4 style=\"margin-top:0;font-weight:normal;color:#777;\">{TrendAggregator3:label} {TrendAggregatorOrder3} {Unit3:label}</h4>"
       },
-      "conditionalVisibility": null,
-      "customWidth": "25"
+      "customWidth": "25",
+      "name": "text - 8"
     },
     {
       "type": 1,
       "content": {
         "json": "<h3 style=\"margin-bottom:0;\">{Counter4:label}</h3><h4 style=\"margin-top:0;font-weight:normal;color:#777;\">{TrendAggregator4:label} {TrendAggregatorOrder4} {Unit4:label}</h4>"
       },
-      "conditionalVisibility": null,
-      "customWidth": "25"
+      "customWidth": "25",
+      "name": "text - 9"
     },
     {
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
         "query": "let metric = dynamic({Counter1});\r\nlet cpuSummary=totable(Perf\r\n    {ComputerFilter}\r\n    | where TimeGenerated {TimeRange} \r\n    | where ObjectName == metric.object and CounterName == metric.counter\r\n    | summarize hint.shufflekey=Computer {TrendAggregatorValue1} by Computer, CounterName\r\n    | top {TopN} by {TrendAggregatorLabel1} {TrendAggregatorOrder1});\r\nlet computerList=(cpuSummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nPerf\r\n    | where TimeGenerated {TimeRange}\r\n    | where ObjectName == metric.object and CounterName == metric.counter\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {TrendAggregatorValue1}{Unit} by {Snippet1}\r\n\t\r\n",
-        "showQuery": false,
         "size": 0,
         "aggregation": 3,
         "showAnnotations": true,
-        "showAnalytics": false,
         "noDataMessage": "No computers are emitting data for this performance counter.",
-        "timeContextFromParameter": null,
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
         "crossComponentResources": [
@@ -876,21 +765,18 @@
           }
         }
       },
-      "conditionalVisibility": null,
-      "customWidth": "25"
+      "customWidth": "25",
+      "name": "query - 10"
     },
     {
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
         "query": "let metric = dynamic({Counter2});\r\nlet cpuSummary=totable(Perf\r\n    {ComputerFilter}\r\n    | where TimeGenerated {TimeRange} \r\n    | where ObjectName == metric.object and CounterName == metric.counter\r\n    | summarize hint.shufflekey=Computer {TrendAggregator2} by Computer, CounterName\r\n    | top {TopN} by {TrendAggregator2:label} {TrendAggregatorOrder2});\r\nlet computerList=(cpuSummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nPerf\r\n    | where TimeGenerated {TimeRange}\r\n    | where ObjectName == metric.object and CounterName == metric.counter\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {TrendAggregator2}{Unit2} by {Snippet2}",
-        "showQuery": false,
         "size": 0,
         "aggregation": 3,
         "showAnnotations": true,
-        "showAnalytics": false,
         "noDataMessage": "No computers are emitting data for this performance counter.",
-        "timeContextFromParameter": null,
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
         "crossComponentResources": [
@@ -918,21 +804,18 @@
           }
         }
       },
-      "conditionalVisibility": null,
-      "customWidth": "25"
+      "customWidth": "25",
+      "name": "query - 11"
     },
     {
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
         "query": "let metric = dynamic({Counter3});\r\nlet cpuSummary=totable(Perf\r\n    {ComputerFilter}\r\n    | where TimeGenerated {TimeRange} \r\n    | where ObjectName == metric.object and CounterName == metric.counter\r\n    | summarize hint.shufflekey=Computer {TrendAggregator3} by Computer, CounterName\r\n    | top {TopN} by {TrendAggregator3:label} {TrendAggregatorOrder3});\r\nlet computerList=(cpuSummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nPerf\r\n    | where TimeGenerated {TimeRange}\r\n    | where ObjectName == metric.object and CounterName == metric.counter\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {TrendAggregator3}{Unit3} by {Snippet3}",
-        "showQuery": false,
         "size": 0,
         "aggregation": 3,
         "showAnnotations": true,
-        "showAnalytics": false,
         "noDataMessage": "No computers are emitting data for this performance counter.",
-        "timeContextFromParameter": null,
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
         "crossComponentResources": [
@@ -960,21 +843,18 @@
           }
         }
       },
-      "conditionalVisibility": null,
-      "customWidth": "25"
+      "customWidth": "25",
+      "name": "query - 12"
     },
     {
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
         "query": "let metric = dynamic({Counter4});\r\nlet cpuSummary=totable(Perf\r\n    {ComputerFilter}\r\n    | where TimeGenerated {TimeRange} \r\n    | where ObjectName == metric.object and CounterName == metric.counter\r\n    | summarize hint.shufflekey=Computer {TrendAggregator4} by Computer, CounterName\r\n    | top {TopN} by {TrendAggregator4:label} {TrendAggregatorOrder4});\r\nlet computerList=(cpuSummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nPerf\r\n    | where TimeGenerated {TimeRange}\r\n    | where ObjectName == metric.object and CounterName == metric.counter\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {TrendAggregator4}{Unit4} by {Snippet4}",
-        "showQuery": false,
         "size": 0,
         "aggregation": 3,
         "showAnnotations": true,
-        "showAnalytics": false,
         "noDataMessage": "No computers are emitting data for this performance counter.",
-        "timeContextFromParameter": null,
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
         "crossComponentResources": [
@@ -1002,8 +882,8 @@
           }
         }
       },
-      "conditionalVisibility": null,
-      "customWidth": "25"
+      "customWidth": "25",
+      "name": "query - 13"
     },
     {
       "type": 9,
@@ -1022,13 +902,11 @@
             "crossComponentResources": [
               "{Workspaces}"
             ],
-            "isHiddenWhenLocked": false,
             "typeSettings": {
               "additionalResourceOptions": [
                 "value::1"
               ]
             },
-            "timeContextFromParameter": null,
             "resourceType": "microsoft.operationalinsights/workspaces",
             "value": "{\"counter\":\"Disk Reads/sec\",\"object\":\"Logical Disk\"}"
           },
@@ -1038,22 +916,18 @@
             "name": "TrendAggregator5",
             "type": 2,
             "isRequired": true,
-            "isHiddenWhenLocked": false,
-            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\", \"selected\":false},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\", \"selected\":false},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P80th = round(percentile(CounterValue, 80), 2)\", \"label\":\"P80th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\", \"selected\":true}    \r\n]",
-            "timeContextFromParameter": null
+            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\", \"selected\":false},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\", \"selected\":false},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P80th = round(percentile(CounterValue, 80), 2)\", \"label\":\"P80th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\", \"selected\":true}    \r\n]"
           },
           {
             "id": "0327f26e-cdde-4b48-b512-6c35f06ad1d0",
             "version": "KqlParameterItem/1.0",
             "name": "TrendAggregatorOrder5",
             "type": 1,
-            "isRequired": false,
             "query": "print(iff('{TrendAggregator5:label}' == 'P5th'  or '{TrendAggregator5:label}' == 'P10th', 'asc', 'desc'))",
             "crossComponentResources": [
               "{Workspaces}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
           {
@@ -1066,11 +940,9 @@
             "crossComponentResources": [
               "{Workspaces}"
             ],
-            "isHiddenWhenLocked": false,
             "typeSettings": {
               "additionalResourceOptions": []
             },
-            "timeContextFromParameter": null,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
           {
@@ -1084,7 +956,6 @@
               "{Workspaces}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
           {
@@ -1092,14 +963,11 @@
             "version": "KqlParameterItem/1.0",
             "name": "Unit5",
             "type": 2,
-            "isRequired": false,
             "value": null,
-            "isHiddenWhenLocked": false,
             "typeSettings": {
               "additionalResourceOptions": []
             },
-            "jsonData": "[\r\n    {\r\n        \"label\": \"B -> MB\",\r\n        \"value\": \"/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"B -> GB\",\r\n        \"value\": \"/1024/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"MB -> GB\",\r\n        \"value\": \"/1024\"\r\n    },\r\n    {\r\n        \"label\": \"MB -> TB\",\r\n        \"value\": \"/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"b -> Mb\",\r\n        \"value\": \"/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"b -> Gb\",\r\n        \"value\": \"/1000/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"Mb -> Gb\",\r\n        \"value\": \"/1000\"\r\n    },\r\n    {\r\n        \"label\": \"Mb -> Tb\",\r\n        \"value\": \"/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"s -> ms\",\r\n        \"value\": \"*1000\"\r\n    },\r\n    {\r\n        \"label\": \"ms -> s\",\r\n        \"value\": \"/1000\"\r\n    }\r\n]",
-            "timeContextFromParameter": null
+            "jsonData": "[\r\n    {\r\n        \"label\": \"B -> MB\",\r\n        \"value\": \"/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"B -> GB\",\r\n        \"value\": \"/1024/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"MB -> GB\",\r\n        \"value\": \"/1024\"\r\n    },\r\n    {\r\n        \"label\": \"MB -> TB\",\r\n        \"value\": \"/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"b -> Mb\",\r\n        \"value\": \"/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"b -> Gb\",\r\n        \"value\": \"/1000/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"Mb -> Gb\",\r\n        \"value\": \"/1000\"\r\n    },\r\n    {\r\n        \"label\": \"Mb -> Tb\",\r\n        \"value\": \"/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"s -> ms\",\r\n        \"value\": \"*1000\"\r\n    },\r\n    {\r\n        \"label\": \"ms -> s\",\r\n        \"value\": \"/1000\"\r\n    }\r\n]"
           }
         ],
         "style": "above",
@@ -1111,7 +979,8 @@
         "comparison": "isEqualTo",
         "value": "0"
       },
-      "customWidth": "25"
+      "customWidth": "25",
+      "name": "parameters - 14"
     },
     {
       "type": 9,
@@ -1130,13 +999,11 @@
             "crossComponentResources": [
               "{Workspaces}"
             ],
-            "isHiddenWhenLocked": false,
             "typeSettings": {
               "additionalResourceOptions": [
                 "value::1"
               ]
             },
-            "timeContextFromParameter": null,
             "resourceType": "microsoft.operationalinsights/workspaces",
             "value": "{\"counter\":\"Disk Read Bytes/sec\",\"object\":\"Logical Disk\"}"
           },
@@ -1146,22 +1013,18 @@
             "name": "TrendAggregator6",
             "type": 2,
             "isRequired": true,
-            "isHiddenWhenLocked": false,
-            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\", \"selected\":false},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\", \"selected\":false},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P80th = round(percentile(CounterValue, 80), 2)\", \"label\":\"P80th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\", \"selected\":true}    \r\n]",
-            "timeContextFromParameter": null
+            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\", \"selected\":false},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\", \"selected\":false},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P80th = round(percentile(CounterValue, 80), 2)\", \"label\":\"P80th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\", \"selected\":true}    \r\n]"
           },
           {
             "id": "0327f26e-cdde-4b48-b512-6c35f06ad1d0",
             "version": "KqlParameterItem/1.0",
             "name": "TrendAggregatorOrder6",
             "type": 1,
-            "isRequired": false,
             "query": "print(iff('{TrendAggregator6:label}' == 'P5th'  or '{TrendAggregator6:label}' == 'P10th', 'asc', 'desc'))",
             "crossComponentResources": [
               "{Workspaces}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
           {
@@ -1174,11 +1037,9 @@
             "crossComponentResources": [
               "{Workspaces}"
             ],
-            "isHiddenWhenLocked": false,
             "typeSettings": {
               "additionalResourceOptions": []
             },
-            "timeContextFromParameter": null,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
           {
@@ -1192,7 +1053,6 @@
               "{Workspaces}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
           {
@@ -1200,14 +1060,11 @@
             "version": "KqlParameterItem/1.0",
             "name": "Unit6",
             "type": 2,
-            "isRequired": false,
             "value": null,
-            "isHiddenWhenLocked": false,
             "typeSettings": {
               "additionalResourceOptions": []
             },
-            "jsonData": "[\r\n    {\r\n        \"label\": \"B -> MB\",\r\n        \"value\": \"/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"B -> GB\",\r\n        \"value\": \"/1024/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"MB -> GB\",\r\n        \"value\": \"/1024\"\r\n    },\r\n    {\r\n        \"label\": \"MB -> TB\",\r\n        \"value\": \"/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"b -> Mb\",\r\n        \"value\": \"/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"b -> Gb\",\r\n        \"value\": \"/1000/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"Mb -> Gb\",\r\n        \"value\": \"/1000\"\r\n    },\r\n    {\r\n        \"label\": \"Mb -> Tb\",\r\n        \"value\": \"/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"s -> ms\",\r\n        \"value\": \"*1000\"\r\n    },\r\n    {\r\n        \"label\": \"ms -> s\",\r\n        \"value\": \"/1000\"\r\n    }\r\n]",
-            "timeContextFromParameter": null
+            "jsonData": "[\r\n    {\r\n        \"label\": \"B -> MB\",\r\n        \"value\": \"/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"B -> GB\",\r\n        \"value\": \"/1024/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"MB -> GB\",\r\n        \"value\": \"/1024\"\r\n    },\r\n    {\r\n        \"label\": \"MB -> TB\",\r\n        \"value\": \"/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"b -> Mb\",\r\n        \"value\": \"/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"b -> Gb\",\r\n        \"value\": \"/1000/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"Mb -> Gb\",\r\n        \"value\": \"/1000\"\r\n    },\r\n    {\r\n        \"label\": \"Mb -> Tb\",\r\n        \"value\": \"/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"s -> ms\",\r\n        \"value\": \"*1000\"\r\n    },\r\n    {\r\n        \"label\": \"ms -> s\",\r\n        \"value\": \"/1000\"\r\n    }\r\n]"
           }
         ],
         "style": "above",
@@ -1219,7 +1076,8 @@
         "comparison": "isEqualTo",
         "value": "0"
       },
-      "customWidth": "25"
+      "customWidth": "25",
+      "name": "parameters - 15"
     },
     {
       "type": 9,
@@ -1238,13 +1096,11 @@
             "crossComponentResources": [
               "{Workspaces}"
             ],
-            "isHiddenWhenLocked": false,
             "typeSettings": {
               "additionalResourceOptions": [
                 "value::1"
               ]
             },
-            "timeContextFromParameter": null,
             "resourceType": "microsoft.operationalinsights/workspaces",
             "value": "{\"counter\":\"Disk Writes/sec\",\"object\":\"Logical Disk\"}"
           },
@@ -1254,22 +1110,18 @@
             "name": "TrendAggregator7",
             "type": 2,
             "isRequired": true,
-            "isHiddenWhenLocked": false,
-            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\", \"selected\":false},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\", \"selected\":false},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P80th = round(percentile(CounterValue, 80), 2)\", \"label\":\"P80th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\", \"selected\":true}    \r\n]",
-            "timeContextFromParameter": null
+            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\", \"selected\":false},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\", \"selected\":false},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P80th = round(percentile(CounterValue, 80), 2)\", \"label\":\"P80th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\", \"selected\":true}    \r\n]"
           },
           {
             "id": "0327f26e-cdde-4b48-b512-6c35f06ad1d0",
             "version": "KqlParameterItem/1.0",
             "name": "TrendAggregatorOrder7",
             "type": 1,
-            "isRequired": false,
             "query": "print(iff('{TrendAggregator7:label}' == 'P5th'  or '{TrendAggregator7:label}' == 'P10th', 'asc', 'desc'))",
             "crossComponentResources": [
               "{Workspaces}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
           {
@@ -1282,11 +1134,9 @@
             "crossComponentResources": [
               "{Workspaces}"
             ],
-            "isHiddenWhenLocked": false,
             "typeSettings": {
               "additionalResourceOptions": []
             },
-            "timeContextFromParameter": null,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
           {
@@ -1300,7 +1150,6 @@
               "{Workspaces}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
           {
@@ -1308,14 +1157,11 @@
             "version": "KqlParameterItem/1.0",
             "name": "Unit7",
             "type": 2,
-            "isRequired": false,
             "value": null,
-            "isHiddenWhenLocked": false,
             "typeSettings": {
               "additionalResourceOptions": []
             },
-            "jsonData": "[\r\n    {\r\n        \"label\": \"B -> MB\",\r\n        \"value\": \"/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"B -> GB\",\r\n        \"value\": \"/1024/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"MB -> GB\",\r\n        \"value\": \"/1024\"\r\n    },\r\n    {\r\n        \"label\": \"MB -> TB\",\r\n        \"value\": \"/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"b -> Mb\",\r\n        \"value\": \"/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"b -> Gb\",\r\n        \"value\": \"/1000/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"Mb -> Gb\",\r\n        \"value\": \"/1000\"\r\n    },\r\n    {\r\n        \"label\": \"Mb -> Tb\",\r\n        \"value\": \"/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"s -> ms\",\r\n        \"value\": \"*1000\"\r\n    },\r\n    {\r\n        \"label\": \"ms -> s\",\r\n        \"value\": \"/1000\"\r\n    }\r\n]",
-            "timeContextFromParameter": null
+            "jsonData": "[\r\n    {\r\n        \"label\": \"B -> MB\",\r\n        \"value\": \"/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"B -> GB\",\r\n        \"value\": \"/1024/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"MB -> GB\",\r\n        \"value\": \"/1024\"\r\n    },\r\n    {\r\n        \"label\": \"MB -> TB\",\r\n        \"value\": \"/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"b -> Mb\",\r\n        \"value\": \"/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"b -> Gb\",\r\n        \"value\": \"/1000/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"Mb -> Gb\",\r\n        \"value\": \"/1000\"\r\n    },\r\n    {\r\n        \"label\": \"Mb -> Tb\",\r\n        \"value\": \"/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"s -> ms\",\r\n        \"value\": \"*1000\"\r\n    },\r\n    {\r\n        \"label\": \"ms -> s\",\r\n        \"value\": \"/1000\"\r\n    }\r\n]"
           }
         ],
         "style": "above",
@@ -1327,7 +1173,8 @@
         "comparison": "isEqualTo",
         "value": "0"
       },
-      "customWidth": "25"
+      "customWidth": "25",
+      "name": "parameters - 16"
     },
     {
       "type": 9,
@@ -1346,13 +1193,11 @@
             "crossComponentResources": [
               "{Workspaces}"
             ],
-            "isHiddenWhenLocked": false,
             "typeSettings": {
               "additionalResourceOptions": [
                 "value::1"
               ]
             },
-            "timeContextFromParameter": null,
             "resourceType": "microsoft.operationalinsights/workspaces",
             "value": "{\"counter\":\"Disk Write Bytes/sec\",\"object\":\"Logical Disk\"}"
           },
@@ -1362,22 +1207,18 @@
             "name": "TrendAggregator8",
             "type": 2,
             "isRequired": true,
-            "isHiddenWhenLocked": false,
-            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\", \"selected\":false},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\", \"selected\":false},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P80th = round(percentile(CounterValue, 80), 2)\", \"label\":\"P80th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\", \"selected\":true}    \r\n]",
-            "timeContextFromParameter": null
+            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\", \"selected\":false},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\", \"selected\":false},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P80th = round(percentile(CounterValue, 80), 2)\", \"label\":\"P80th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\", \"selected\":true}    \r\n]"
           },
           {
             "id": "0327f26e-cdde-4b48-b512-6c35f06ad1d0",
             "version": "KqlParameterItem/1.0",
             "name": "TrendAggregatorOrder8",
             "type": 1,
-            "isRequired": false,
             "query": "print(iff('{TrendAggregator8:label}' == 'P5th'  or '{TrendAggregator8:label}' == 'P10th', 'asc', 'desc'))",
             "crossComponentResources": [
               "{Workspaces}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
           {
@@ -1390,11 +1231,9 @@
             "crossComponentResources": [
               "{Workspaces}"
             ],
-            "isHiddenWhenLocked": false,
             "typeSettings": {
               "additionalResourceOptions": []
             },
-            "timeContextFromParameter": null,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
           {
@@ -1408,7 +1247,6 @@
               "{Workspaces}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
           {
@@ -1416,14 +1254,11 @@
             "version": "KqlParameterItem/1.0",
             "name": "Unit8",
             "type": 2,
-            "isRequired": false,
             "value": null,
-            "isHiddenWhenLocked": false,
             "typeSettings": {
               "additionalResourceOptions": []
             },
-            "jsonData": "[\r\n    {\r\n        \"label\": \"B -> MB\",\r\n        \"value\": \"/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"B -> GB\",\r\n        \"value\": \"/1024/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"MB -> GB\",\r\n        \"value\": \"/1024\"\r\n    },\r\n    {\r\n        \"label\": \"MB -> TB\",\r\n        \"value\": \"/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"b -> Mb\",\r\n        \"value\": \"/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"b -> Gb\",\r\n        \"value\": \"/1000/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"Mb -> Gb\",\r\n        \"value\": \"/1000\"\r\n    },\r\n    {\r\n        \"label\": \"Mb -> Tb\",\r\n        \"value\": \"/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"s -> ms\",\r\n        \"value\": \"*1000\"\r\n    },\r\n    {\r\n        \"label\": \"ms -> s\",\r\n        \"value\": \"/1000\"\r\n    }\r\n]",
-            "timeContextFromParameter": null
+            "jsonData": "[\r\n    {\r\n        \"label\": \"B -> MB\",\r\n        \"value\": \"/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"B -> GB\",\r\n        \"value\": \"/1024/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"MB -> GB\",\r\n        \"value\": \"/1024\"\r\n    },\r\n    {\r\n        \"label\": \"MB -> TB\",\r\n        \"value\": \"/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"b -> Mb\",\r\n        \"value\": \"/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"b -> Gb\",\r\n        \"value\": \"/1000/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"Mb -> Gb\",\r\n        \"value\": \"/1000\"\r\n    },\r\n    {\r\n        \"label\": \"Mb -> Tb\",\r\n        \"value\": \"/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"s -> ms\",\r\n        \"value\": \"*1000\"\r\n    },\r\n    {\r\n        \"label\": \"ms -> s\",\r\n        \"value\": \"/1000\"\r\n    }\r\n]"
           }
         ],
         "style": "above",
@@ -1435,52 +1270,50 @@
         "comparison": "isEqualTo",
         "value": "0"
       },
-      "customWidth": "25"
+      "customWidth": "25",
+      "name": "parameters - 17"
     },
     {
       "type": 1,
       "content": {
         "json": "<h3 style=\"margin-bottom:0;\">{Counter5:label}</h3><h4 style=\"margin-top:0;font-weight:normal;color:#777;\">{TrendAggregator5:label} {TrendAggregatorOrder5} {Unit5:label}</h4>"
       },
-      "conditionalVisibility": null,
-      "customWidth": "25"
+      "customWidth": "25",
+      "name": "text - 18"
     },
     {
       "type": 1,
       "content": {
         "json": "<h3 style=\"margin-bottom:0;\">{Counter6:label}</h3><h4 style=\"margin-top:0;font-weight:normal;color:#777;\">{TrendAggregator6:label} {TrendAggregatorOrder6} {Unit6:label}</h4>"
       },
-      "conditionalVisibility": null,
-      "customWidth": "25"
+      "customWidth": "25",
+      "name": "text - 19"
     },
     {
       "type": 1,
       "content": {
         "json": "<h3 style=\"margin-bottom:0;\">{Counter7:label}</h3><h4 style=\"margin-top:0;font-weight:normal;color:#777;\">{TrendAggregator7:label} {TrendAggregatorOrder7} {Unit7:label}</h4>"
       },
-      "conditionalVisibility": null,
-      "customWidth": "25"
+      "customWidth": "25",
+      "name": "text - 20"
     },
     {
       "type": 1,
       "content": {
         "json": "<h3 style=\"margin-bottom:0;\">{Counter8:label}</h3><h4 style=\"margin-top:0;font-weight:normal;color:#777;\">{TrendAggregator8:label} {TrendAggregatorOrder8} {Unit8:label}</h4>"
       },
-      "conditionalVisibility": null,
-      "customWidth": "25"
+      "customWidth": "25",
+      "name": "text - 21"
     },
     {
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
         "query": "let metric = dynamic({Counter5});\r\nlet cpuSummary=totable(Perf\r\n    {ComputerFilter}\r\n    | where TimeGenerated {TimeRange} \r\n    | where ObjectName == metric.object and CounterName == metric.counter\r\n    | summarize hint.shufflekey=Computer {TrendAggregator5} by Computer, CounterName\r\n    | top {TopN} by {TrendAggregator5:label} {TrendAggregatorOrder5});\r\nlet computerList=(cpuSummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nPerf\r\n    | where TimeGenerated {TimeRange}\r\n    | where ObjectName == metric.object and CounterName == metric.counter\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {TrendAggregator5}{Unit5} by {Snippet5}",
-        "showQuery": false,
         "size": 0,
         "aggregation": 3,
         "showAnnotations": true,
-        "showAnalytics": false,
         "noDataMessage": "No computers are emitting data for this performance counter.",
-        "timeContextFromParameter": null,
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
         "crossComponentResources": [
@@ -1508,21 +1341,18 @@
           }
         }
       },
-      "conditionalVisibility": null,
-      "customWidth": "25"
+      "customWidth": "25",
+      "name": "query - 22"
     },
     {
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
         "query": "let metric = dynamic({Counter6});\r\nlet cpuSummary=totable(Perf\r\n    {ComputerFilter}\r\n    | where TimeGenerated {TimeRange} \r\n    | where ObjectName == metric.object and CounterName == metric.counter\r\n    | summarize hint.shufflekey=Computer {TrendAggregator6} by Computer, CounterName\r\n    | top {TopN} by {TrendAggregator6:label} {TrendAggregatorOrder6});\r\nlet computerList=(cpuSummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nPerf\r\n    | where TimeGenerated {TimeRange}\r\n    | where ObjectName == metric.object and CounterName == metric.counter\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {TrendAggregator6}{Unit6} by {Snippet6}",
-        "showQuery": false,
         "size": 0,
         "aggregation": 3,
         "showAnnotations": true,
-        "showAnalytics": false,
         "noDataMessage": "No computers are emitting data for this performance counter.",
-        "timeContextFromParameter": null,
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
         "crossComponentResources": [
@@ -1550,21 +1380,18 @@
           }
         }
       },
-      "conditionalVisibility": null,
-      "customWidth": "25"
+      "customWidth": "25",
+      "name": "query - 23"
     },
     {
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
         "query": "let metric = dynamic({Counter7});\r\nlet cpuSummary=totable(Perf\r\n    {ComputerFilter}\r\n    | where TimeGenerated {TimeRange} \r\n    | where ObjectName == metric.object and CounterName == metric.counter\r\n    | summarize hint.shufflekey=Computer {TrendAggregator7} by Computer, CounterName\r\n    | top {TopN} by {TrendAggregator7:label} {TrendAggregatorOrder7});\r\nlet computerList=(cpuSummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nPerf\r\n    | where TimeGenerated {TimeRange}\r\n    | where ObjectName == metric.object and CounterName == metric.counter\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {TrendAggregator7}{Unit7} by {Snippet7}",
-        "showQuery": false,
         "size": 0,
         "aggregation": 3,
         "showAnnotations": true,
-        "showAnalytics": false,
         "noDataMessage": "No computers are emitting data for this performance counter.",
-        "timeContextFromParameter": null,
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
         "crossComponentResources": [
@@ -1592,21 +1419,18 @@
           }
         }
       },
-      "conditionalVisibility": null,
-      "customWidth": "25"
+      "customWidth": "25",
+      "name": "query - 24"
     },
     {
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
         "query": "let metric = dynamic({Counter8});\r\nlet cpuSummary=totable(Perf\r\n    {ComputerFilter}\r\n    | where TimeGenerated {TimeRange} \r\n    | where ObjectName == metric.object and CounterName == metric.counter\r\n    | summarize hint.shufflekey=Computer {TrendAggregator8} by Computer, CounterName\r\n    | top {TopN} by {TrendAggregator8:label} {TrendAggregatorOrder8});\r\nlet computerList=(cpuSummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nPerf\r\n    | where TimeGenerated {TimeRange}\r\n    | where ObjectName == metric.object and CounterName == metric.counter\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {TrendAggregator8}{Unit8} by {Snippet8}",
-        "showQuery": false,
         "size": 0,
         "aggregation": 3,
         "showAnnotations": true,
-        "showAnalytics": false,
         "noDataMessage": "No computers are emitting data for this performance counter.",
-        "timeContextFromParameter": null,
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
         "crossComponentResources": [
@@ -1634,8 +1458,8 @@
           }
         }
       },
-      "conditionalVisibility": null,
-      "customWidth": "25"
+      "customWidth": "25",
+      "name": "query - 25"
     },
     {
       "type": 9,
@@ -1654,13 +1478,11 @@
             "crossComponentResources": [
               "{Workspaces}"
             ],
-            "isHiddenWhenLocked": false,
             "typeSettings": {
               "additionalResourceOptions": [
                 "value::1"
               ]
             },
-            "timeContextFromParameter": null,
             "resourceType": "microsoft.operationalinsights/workspaces",
             "value": "{\"counter\":\"% IO Wait Time\",\"object\":\"Processor\"}"
           },
@@ -1670,22 +1492,18 @@
             "name": "TrendAggregator9",
             "type": 2,
             "isRequired": true,
-            "isHiddenWhenLocked": false,
-            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\", \"selected\":false},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\", \"selected\":false},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P80th = round(percentile(CounterValue, 80), 2)\", \"label\":\"P80th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\", \"selected\":true}    \r\n]",
-            "timeContextFromParameter": null
+            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\", \"selected\":false},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\", \"selected\":false},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P80th = round(percentile(CounterValue, 80), 2)\", \"label\":\"P80th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\", \"selected\":true}    \r\n]"
           },
           {
             "id": "01a4cf96-e12f-4d2a-9cf3-25da44a6ebe4",
             "version": "KqlParameterItem/1.0",
             "name": "TrendAggregatorOrder9",
             "type": 1,
-            "isRequired": false,
             "query": "print(iff('{TrendAggregator9:label}' == 'P5th'  or '{TrendAggregator9:label}' == 'P10th', 'asc', 'desc'))",
             "crossComponentResources": [
               "{Workspaces}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
           {
@@ -1698,11 +1516,9 @@
             "crossComponentResources": [
               "{Workspaces}"
             ],
-            "isHiddenWhenLocked": false,
             "typeSettings": {
               "additionalResourceOptions": []
             },
-            "timeContextFromParameter": null,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
           {
@@ -1716,7 +1532,6 @@
               "{Workspaces}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
           {
@@ -1724,14 +1539,11 @@
             "version": "KqlParameterItem/1.0",
             "name": "Unit9",
             "type": 2,
-            "isRequired": false,
             "value": null,
-            "isHiddenWhenLocked": false,
             "typeSettings": {
               "additionalResourceOptions": []
             },
-            "jsonData": "[\r\n    {\r\n        \"label\": \"B -> MB\",\r\n        \"value\": \"/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"B -> GB\",\r\n        \"value\": \"/1024/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"MB -> GB\",\r\n        \"value\": \"/1024\"\r\n    },\r\n    {\r\n        \"label\": \"MB -> TB\",\r\n        \"value\": \"/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"b -> Mb\",\r\n        \"value\": \"/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"b -> Gb\",\r\n        \"value\": \"/1000/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"Mb -> Gb\",\r\n        \"value\": \"/1000\"\r\n    },\r\n    {\r\n        \"label\": \"Mb -> Tb\",\r\n        \"value\": \"/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"s -> ms\",\r\n        \"value\": \"*1000\"\r\n    },\r\n    {\r\n        \"label\": \"ms -> s\",\r\n        \"value\": \"/1000\"\r\n    }\r\n]",
-            "timeContextFromParameter": null
+            "jsonData": "[\r\n    {\r\n        \"label\": \"B -> MB\",\r\n        \"value\": \"/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"B -> GB\",\r\n        \"value\": \"/1024/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"MB -> GB\",\r\n        \"value\": \"/1024\"\r\n    },\r\n    {\r\n        \"label\": \"MB -> TB\",\r\n        \"value\": \"/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"b -> Mb\",\r\n        \"value\": \"/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"b -> Gb\",\r\n        \"value\": \"/1000/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"Mb -> Gb\",\r\n        \"value\": \"/1000\"\r\n    },\r\n    {\r\n        \"label\": \"Mb -> Tb\",\r\n        \"value\": \"/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"s -> ms\",\r\n        \"value\": \"*1000\"\r\n    },\r\n    {\r\n        \"label\": \"ms -> s\",\r\n        \"value\": \"/1000\"\r\n    }\r\n]"
           }
         ],
         "style": "above",
@@ -1743,7 +1555,8 @@
         "comparison": "isEqualTo",
         "value": "0"
       },
-      "customWidth": "25"
+      "customWidth": "25",
+      "name": "parameters - 26"
     },
     {
       "type": 9,
@@ -1762,13 +1575,11 @@
             "crossComponentResources": [
               "{Workspaces}"
             ],
-            "isHiddenWhenLocked": false,
             "typeSettings": {
               "additionalResourceOptions": [
                 "value::1"
               ]
             },
-            "timeContextFromParameter": null,
             "resourceType": "microsoft.operationalinsights/workspaces",
             "value": "{\"counter\":\"% Idle Time\",\"object\":\"Processor\"}"
           },
@@ -1778,22 +1589,18 @@
             "name": "TrendAggregator10",
             "type": 2,
             "isRequired": true,
-            "isHiddenWhenLocked": false,
-            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\", \"selected\":false},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\", \"selected\":false},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P80th = round(percentile(CounterValue, 80), 2)\", \"label\":\"P80th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\", \"selected\":true}    \r\n]",
-            "timeContextFromParameter": null
+            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\", \"selected\":false},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\", \"selected\":false},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P80th = round(percentile(CounterValue, 80), 2)\", \"label\":\"P80th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\", \"selected\":true}    \r\n]"
           },
           {
             "id": "0327f26e-cdde-4b48-b512-6c35f06ad1dd",
             "version": "KqlParameterItem/1.0",
             "name": "TrendAggregatorOrder10",
             "type": 1,
-            "isRequired": false,
             "query": "print(iff('{TrendAggregator10:label}' == 'P5th'  or '{TrendAggregator10:label}' == 'P10th', 'asc', 'desc'))",
             "crossComponentResources": [
               "{Workspaces}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
           {
@@ -1806,11 +1613,9 @@
             "crossComponentResources": [
               "{Workspaces}"
             ],
-            "isHiddenWhenLocked": false,
             "typeSettings": {
               "additionalResourceOptions": []
             },
-            "timeContextFromParameter": null,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
           {
@@ -1824,7 +1629,6 @@
               "{Workspaces}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
           {
@@ -1832,14 +1636,11 @@
             "version": "KqlParameterItem/1.0",
             "name": "Unit10",
             "type": 2,
-            "isRequired": false,
             "value": null,
-            "isHiddenWhenLocked": false,
             "typeSettings": {
               "additionalResourceOptions": []
             },
-            "jsonData": "[\r\n    {\r\n        \"label\": \"B -> MB\",\r\n        \"value\": \"/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"B -> GB\",\r\n        \"value\": \"/1024/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"MB -> GB\",\r\n        \"value\": \"/1024\"\r\n    },\r\n    {\r\n        \"label\": \"MB -> TB\",\r\n        \"value\": \"/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"b -> Mb\",\r\n        \"value\": \"/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"b -> Gb\",\r\n        \"value\": \"/1000/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"Mb -> Gb\",\r\n        \"value\": \"/1000\"\r\n    },\r\n    {\r\n        \"label\": \"Mb -> Tb\",\r\n        \"value\": \"/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"s -> ms\",\r\n        \"value\": \"*1000\"\r\n    },\r\n    {\r\n        \"label\": \"ms -> s\",\r\n        \"value\": \"/1000\"\r\n    }\r\n]",
-            "timeContextFromParameter": null
+            "jsonData": "[\r\n    {\r\n        \"label\": \"B -> MB\",\r\n        \"value\": \"/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"B -> GB\",\r\n        \"value\": \"/1024/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"MB -> GB\",\r\n        \"value\": \"/1024\"\r\n    },\r\n    {\r\n        \"label\": \"MB -> TB\",\r\n        \"value\": \"/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"b -> Mb\",\r\n        \"value\": \"/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"b -> Gb\",\r\n        \"value\": \"/1000/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"Mb -> Gb\",\r\n        \"value\": \"/1000\"\r\n    },\r\n    {\r\n        \"label\": \"Mb -> Tb\",\r\n        \"value\": \"/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"s -> ms\",\r\n        \"value\": \"*1000\"\r\n    },\r\n    {\r\n        \"label\": \"ms -> s\",\r\n        \"value\": \"/1000\"\r\n    }\r\n]"
           }
         ],
         "style": "above",
@@ -1851,7 +1652,8 @@
         "comparison": "isEqualTo",
         "value": "0"
       },
-      "customWidth": "25"
+      "customWidth": "25",
+      "name": "parameters - 27"
     },
     {
       "type": 9,
@@ -1870,13 +1672,11 @@
             "crossComponentResources": [
               "{Workspaces}"
             ],
-            "isHiddenWhenLocked": false,
             "typeSettings": {
               "additionalResourceOptions": [
                 "value::1"
               ]
             },
-            "timeContextFromParameter": null,
             "resourceType": "microsoft.operationalinsights/workspaces",
             "value": "{\"counter\":\"% Interrupt Time\",\"object\":\"Processor\"}"
           },
@@ -1886,22 +1686,18 @@
             "name": "TrendAggregator11",
             "type": 2,
             "isRequired": true,
-            "isHiddenWhenLocked": false,
-            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\", \"selected\":false},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\", \"selected\":false},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P80th = round(percentile(CounterValue, 80), 2)\", \"label\":\"P80th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\", \"selected\":true}    \r\n]",
-            "timeContextFromParameter": null
+            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\", \"selected\":false},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\", \"selected\":false},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P80th = round(percentile(CounterValue, 80), 2)\", \"label\":\"P80th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\", \"selected\":true}    \r\n]"
           },
           {
             "id": "0327f26e-cdde-4b48-b512-6c35f06ad1dd",
             "version": "KqlParameterItem/1.0",
             "name": "TrendAggregatorOrder11",
             "type": 1,
-            "isRequired": false,
             "query": "print(iff('{TrendAggregator11:label}' == 'P5th'  or '{TrendAggregator11:label}' == 'P10th', 'asc', 'desc'))",
             "crossComponentResources": [
               "{Workspaces}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
           {
@@ -1914,11 +1710,9 @@
             "crossComponentResources": [
               "{Workspaces}"
             ],
-            "isHiddenWhenLocked": false,
             "typeSettings": {
               "additionalResourceOptions": []
             },
-            "timeContextFromParameter": null,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
           {
@@ -1932,7 +1726,6 @@
               "{Workspaces}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
           {
@@ -1940,14 +1733,11 @@
             "version": "KqlParameterItem/1.0",
             "name": "Unit11",
             "type": 2,
-            "isRequired": false,
             "value": null,
-            "isHiddenWhenLocked": false,
             "typeSettings": {
               "additionalResourceOptions": []
             },
-            "jsonData": "[\r\n    {\r\n        \"label\": \"B -> MB\",\r\n        \"value\": \"/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"B -> GB\",\r\n        \"value\": \"/1024/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"MB -> GB\",\r\n        \"value\": \"/1024\"\r\n    },\r\n    {\r\n        \"label\": \"MB -> TB\",\r\n        \"value\": \"/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"b -> Mb\",\r\n        \"value\": \"/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"b -> Gb\",\r\n        \"value\": \"/1000/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"Mb -> Gb\",\r\n        \"value\": \"/1000\"\r\n    },\r\n    {\r\n        \"label\": \"Mb -> Tb\",\r\n        \"value\": \"/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"s -> ms\",\r\n        \"value\": \"*1000\"\r\n    },\r\n    {\r\n        \"label\": \"ms -> s\",\r\n        \"value\": \"/1000\"\r\n    }\r\n]",
-            "timeContextFromParameter": null
+            "jsonData": "[\r\n    {\r\n        \"label\": \"B -> MB\",\r\n        \"value\": \"/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"B -> GB\",\r\n        \"value\": \"/1024/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"MB -> GB\",\r\n        \"value\": \"/1024\"\r\n    },\r\n    {\r\n        \"label\": \"MB -> TB\",\r\n        \"value\": \"/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"b -> Mb\",\r\n        \"value\": \"/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"b -> Gb\",\r\n        \"value\": \"/1000/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"Mb -> Gb\",\r\n        \"value\": \"/1000\"\r\n    },\r\n    {\r\n        \"label\": \"Mb -> Tb\",\r\n        \"value\": \"/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"s -> ms\",\r\n        \"value\": \"*1000\"\r\n    },\r\n    {\r\n        \"label\": \"ms -> s\",\r\n        \"value\": \"/1000\"\r\n    }\r\n]"
           }
         ],
         "style": "above",
@@ -1959,7 +1749,8 @@
         "comparison": "isEqualTo",
         "value": "0"
       },
-      "customWidth": "25"
+      "customWidth": "25",
+      "name": "parameters - 28"
     },
     {
       "type": 9,
@@ -1978,13 +1769,11 @@
             "crossComponentResources": [
               "{Workspaces}"
             ],
-            "isHiddenWhenLocked": false,
             "typeSettings": {
               "additionalResourceOptions": [
                 "value::1"
               ]
             },
-            "timeContextFromParameter": null,
             "resourceType": "microsoft.operationalinsights/workspaces",
             "value": "{\"counter\":\"% User Time\",\"object\":\"Processor\"}"
           },
@@ -1994,22 +1783,18 @@
             "name": "TrendAggregator12",
             "type": 2,
             "isRequired": true,
-            "isHiddenWhenLocked": false,
-            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\", \"selected\":false},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\", \"selected\":false},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P80th = round(percentile(CounterValue, 80), 2)\", \"label\":\"P80th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\", \"selected\":true}    \r\n]",
-            "timeContextFromParameter": null
+            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\", \"selected\":false},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\", \"selected\":false},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P80th = round(percentile(CounterValue, 80), 2)\", \"label\":\"P80th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\", \"selected\":true}    \r\n]"
           },
           {
             "id": "0327f26e-cdde-4b48-b512-6c35f06ad1dd",
             "version": "KqlParameterItem/1.0",
             "name": "TrendAggregatorOrder12",
             "type": 1,
-            "isRequired": false,
             "query": "print(iff('{TrendAggregator12:label}' == 'P5th'  or '{TrendAggregator12:label}' == 'P10th', 'asc', 'desc'))",
             "crossComponentResources": [
               "{Workspaces}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
           {
@@ -2022,11 +1807,9 @@
             "crossComponentResources": [
               "{Workspaces}"
             ],
-            "isHiddenWhenLocked": false,
             "typeSettings": {
               "additionalResourceOptions": []
             },
-            "timeContextFromParameter": null,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
           {
@@ -2040,7 +1823,6 @@
               "{Workspaces}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
           {
@@ -2048,14 +1830,11 @@
             "version": "KqlParameterItem/1.0",
             "name": "Unit12",
             "type": 2,
-            "isRequired": false,
             "value": null,
-            "isHiddenWhenLocked": false,
             "typeSettings": {
               "additionalResourceOptions": []
             },
-            "jsonData": "[\r\n    {\r\n        \"label\": \"B -> MB\",\r\n        \"value\": \"/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"B -> GB\",\r\n        \"value\": \"/1024/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"MB -> GB\",\r\n        \"value\": \"/1024\"\r\n    },\r\n    {\r\n        \"label\": \"MB -> TB\",\r\n        \"value\": \"/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"b -> Mb\",\r\n        \"value\": \"/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"b -> Gb\",\r\n        \"value\": \"/1000/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"Mb -> Gb\",\r\n        \"value\": \"/1000\"\r\n    },\r\n    {\r\n        \"label\": \"Mb -> Tb\",\r\n        \"value\": \"/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"s -> ms\",\r\n        \"value\": \"*1000\"\r\n    },\r\n    {\r\n        \"label\": \"ms -> s\",\r\n        \"value\": \"/1000\"\r\n    }\r\n]",
-            "timeContextFromParameter": null
+            "jsonData": "[\r\n    {\r\n        \"label\": \"B -> MB\",\r\n        \"value\": \"/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"B -> GB\",\r\n        \"value\": \"/1024/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"MB -> GB\",\r\n        \"value\": \"/1024\"\r\n    },\r\n    {\r\n        \"label\": \"MB -> TB\",\r\n        \"value\": \"/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"b -> Mb\",\r\n        \"value\": \"/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"b -> Gb\",\r\n        \"value\": \"/1000/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"Mb -> Gb\",\r\n        \"value\": \"/1000\"\r\n    },\r\n    {\r\n        \"label\": \"Mb -> Tb\",\r\n        \"value\": \"/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"s -> ms\",\r\n        \"value\": \"*1000\"\r\n    },\r\n    {\r\n        \"label\": \"ms -> s\",\r\n        \"value\": \"/1000\"\r\n    }\r\n]"
           }
         ],
         "style": "above",
@@ -2067,52 +1846,50 @@
         "comparison": "isEqualTo",
         "value": "0"
       },
-      "customWidth": "25"
+      "customWidth": "25",
+      "name": "parameters - 29"
     },
     {
       "type": 1,
       "content": {
         "json": "<h3 style=\"margin-bottom:0;\">{Counter9:label}</h3><h4 style=\"margin-top:0;font-weight:normal;color:#777;\">{TrendAggregator9:label} {TrendAggregatorOrder9} {Unit9:label}</h4>"
       },
-      "conditionalVisibility": null,
-      "customWidth": "25"
+      "customWidth": "25",
+      "name": "text - 30"
     },
     {
       "type": 1,
       "content": {
         "json": "<h3 style=\"margin-bottom:0;\">{Counter10:label}</h3><h4 style=\"margin-top:0;font-weight:normal;color:#777;\">{TrendAggregator10:label} {TrendAggregatorOrder10} {Unit10:label}</h4>"
       },
-      "conditionalVisibility": null,
-      "customWidth": "25"
+      "customWidth": "25",
+      "name": "text - 31"
     },
     {
       "type": 1,
       "content": {
         "json": "<h3 style=\"margin-bottom:0;\">{Counter11:label}</h3><h4 style=\"margin-top:0;font-weight:normal;color:#777;\">{TrendAggregator11:label} {TrendAggregatorOrder11} {Unit11:label}</h4>"
       },
-      "conditionalVisibility": null,
-      "customWidth": "25"
+      "customWidth": "25",
+      "name": "text - 32"
     },
     {
       "type": 1,
       "content": {
         "json": "<h3 style=\"margin-bottom:0;\">{Counter12:label}</h3><h4 style=\"margin-top:0;font-weight:normal;color:#777;\">{TrendAggregator12:label} {TrendAggregatorOrder12} {Unit12:label}</h4>"
       },
-      "conditionalVisibility": null,
-      "customWidth": "25"
+      "customWidth": "25",
+      "name": "text - 33"
     },
     {
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
         "query": "let metric = dynamic({Counter9});\r\nlet cpuSummary=totable(Perf\r\n    {ComputerFilter}\r\n    | where TimeGenerated {TimeRange} \r\n    | where ObjectName == metric.object and CounterName == metric.counter\r\n    | summarize hint.shufflekey=Computer {TrendAggregator9} by Computer, CounterName\r\n    | top {TopN} by {TrendAggregator9:label} {TrendAggregatorOrder9});\r\nlet computerList=(cpuSummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nPerf\r\n    | where TimeGenerated {TimeRange}\r\n    | where ObjectName == metric.object and CounterName == metric.counter\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {TrendAggregator9}{Unit9} by {Snippet9}",
-        "showQuery": false,
         "size": 0,
         "aggregation": 3,
         "showAnnotations": true,
-        "showAnalytics": false,
         "noDataMessage": "No computers are emitting data for this performance counter.",
-        "timeContextFromParameter": null,
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
         "crossComponentResources": [
@@ -2140,21 +1917,18 @@
           }
         }
       },
-      "conditionalVisibility": null,
-      "customWidth": "25"
+      "customWidth": "25",
+      "name": "query - 34"
     },
     {
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
         "query": "let metric = dynamic({Counter10});\r\nlet cpuSummary=totable(Perf\r\n    {ComputerFilter}\r\n    | where TimeGenerated {TimeRange} \r\n    | where ObjectName == metric.object and CounterName == metric.counter\r\n    | summarize hint.shufflekey=Computer {TrendAggregator10} by Computer, CounterName\r\n    | top {TopN} by {TrendAggregator10:label} {TrendAggregatorOrder10});\r\nlet computerList=(cpuSummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nPerf\r\n    | where TimeGenerated {TimeRange}\r\n    | where ObjectName == metric.object and CounterName == metric.counter\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {TrendAggregator10}{Unit10} by {Snippet10}",
-        "showQuery": false,
         "size": 0,
         "aggregation": 3,
         "showAnnotations": true,
-        "showAnalytics": false,
         "noDataMessage": "No computers are emitting data for this performance counter.",
-        "timeContextFromParameter": null,
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
         "crossComponentResources": [
@@ -2182,21 +1956,18 @@
           }
         }
       },
-      "conditionalVisibility": null,
-      "customWidth": "25"
+      "customWidth": "25",
+      "name": "query - 35"
     },
     {
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
         "query": "let metric = dynamic({Counter11});\r\nlet cpuSummary=totable(Perf\r\n    {ComputerFilter}\r\n    | where TimeGenerated {TimeRange} \r\n    | where ObjectName == metric.object and CounterName == metric.counter\r\n    | summarize hint.shufflekey=Computer {TrendAggregator11} by Computer, CounterName\r\n    | top {TopN} by {TrendAggregator11:label} {TrendAggregatorOrder11});\r\nlet computerList=(cpuSummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nPerf\r\n    | where TimeGenerated {TimeRange}\r\n    | where ObjectName == metric.object and CounterName == metric.counter\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {TrendAggregator11}{Unit11} by {Snippet11}",
-        "showQuery": false,
         "size": 0,
         "aggregation": 3,
         "showAnnotations": true,
-        "showAnalytics": false,
         "noDataMessage": "No computers are emitting data for this performance counter.",
-        "timeContextFromParameter": null,
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
         "crossComponentResources": [
@@ -2224,21 +1995,18 @@
           }
         }
       },
-      "conditionalVisibility": null,
-      "customWidth": "25"
+      "customWidth": "25",
+      "name": "query - 36"
     },
     {
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
         "query": "let metric = dynamic({Counter12});\r\nlet cpuSummary=totable(Perf\r\n    {ComputerFilter}\r\n    | where TimeGenerated {TimeRange} \r\n    | where ObjectName == metric.object and CounterName == metric.counter\r\n    | summarize hint.shufflekey=Computer {TrendAggregator12} by Computer, CounterName\r\n    | top {TopN} by {TrendAggregator12:label} {TrendAggregatorOrder12});\r\nlet computerList=(cpuSummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nPerf\r\n    | where TimeGenerated {TimeRange}\r\n    | where ObjectName == metric.object and CounterName == metric.counter\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {TrendAggregator12}{Unit12} by {Snippet12}",
-        "showQuery": false,
         "size": 0,
         "aggregation": 3,
         "showAnnotations": true,
-        "showAnalytics": false,
         "noDataMessage": "No computers are emitting data for this performance counter.",
-        "timeContextFromParameter": null,
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
         "crossComponentResources": [
@@ -2266,9 +2034,12 @@
           }
         }
       },
-      "conditionalVisibility": null,
-      "customWidth": "25"
+      "customWidth": "25",
+      "name": "query - 37"
     }
   ],
+  "fallbackResourceIds": [],
+  "styleSettings": {},
+  "fromTemplateId": "Workbooks/Virtual Machines - Performance Analysis/Performance Counters",
   "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
 }


### PR DESCRIPTION
Minor cosmetic fix to Performance Counters workbook by removing an unused parameter. The parameters were probably introduced as part of a feature enhancement to the workbook, but was never implemented and utilized in our Ibiza extension. Important changes are between lines `183` and `192`. The rest of the diffs are due to template update from the workbooks extension.

Overview:
![image](https://user-images.githubusercontent.com/43890980/64736602-dc27df80-d49f-11e9-9c91-f89883563c16.png)

Before with broken parameter
![image](https://user-images.githubusercontent.com/43890980/64736609-e4801a80-d49f-11e9-9387-e85412a9296a.png)
