### PR TITLE
Remove VM Insights workbooks from workspace gallery

### DIFF
--- a/Workbooks/Virtual Machines - Network Dependencies/Active Ports/settings.json
+++ b/Workbooks/Virtual Machines - Network Dependencies/Active Ports/settings.json
@@ -3,7 +3,6 @@
     "name":"Active Ports",
     "author": "Microsoft",
     "galleries": [
-        { "type": "workbook", "resourceType": "microsoft.operationalinsights/workspaces", "order": 175 },
         { "type": "vm-insights", "resourceType": "Azure Monitor", "order": 175 }
     ]
 }

--- a/Workbooks/Virtual Machines - Network Dependencies/Connection Records/settings.json
+++ b/Workbooks/Virtual Machines - Network Dependencies/Connection Records/settings.json
@@ -4,7 +4,6 @@
     "author": "Microsoft",
     "isPreview": true,
     "galleries": [
-        { "type": "workbook", "resourceType": "microsoft.operationalinsights/workspaces", "order": 300 },
         { "type": "vm-insights", "resourceType": "Azure Monitor", "order": 300 }
     ]
 }

--- a/Workbooks/Virtual Machines - Network Dependencies/Connections Overview/settings.json
+++ b/Workbooks/Virtual Machines - Network Dependencies/Connections Overview/settings.json
@@ -3,7 +3,6 @@
     "name":"Connections Overview",
     "author": "Microsoft",
     "galleries": [
-        { "type": "workbook", "resourceType": "microsoft.operationalinsights/workspaces", "order": 100 },
         { "type": "vm-insights", "resourceType": "Azure Monitor", "order": 100 }
     ]
 }

--- a/Workbooks/Virtual Machines - Network Dependencies/Failed Connections/settings.json
+++ b/Workbooks/Virtual Machines - Network Dependencies/Failed Connections/settings.json
@@ -3,7 +3,6 @@
     "name":"Failed Connections",
     "author": "Microsoft",
     "galleries": [
-        { "type": "workbook", "resourceType": "microsoft.operationalinsights/workspaces", "order": 200 },
         { "type": "vm-insights", "resourceType": "Azure Monitor", "order": 200 }
     ]
 }

--- a/Workbooks/Virtual Machines - Network Dependencies/Open Ports/settings.json
+++ b/Workbooks/Virtual Machines - Network Dependencies/Open Ports/settings.json
@@ -3,7 +3,6 @@
     "name": "Open Ports",
     "author": "Microsoft",
     "galleries": [
-        { "type": "workbook", "resourceType": "microsoft.operationalinsights/workspaces", "order": 175 },
         { "type": "vm-insights", "resourceType": "Azure Monitor", "order": 175 }
     ]
 }

--- a/Workbooks/Virtual Machines - Network Dependencies/Security and Audit/settings.json
+++ b/Workbooks/Virtual Machines - Network Dependencies/Security and Audit/settings.json
@@ -3,7 +3,6 @@
     "name": "Security and Audit",
     "author": "Microsoft",
     "galleries": [
-        { "type": "workbook", "resourceType": "microsoft.operationalinsights/workspaces", "order": 300 },
         { "type": "vm-insights", "resourceType": "Azure Monitor", "order": 300 }
     ]
 }

--- a/Workbooks/Virtual Machines - Network Dependencies/TCP Traffic/settings.json
+++ b/Workbooks/Virtual Machines - Network Dependencies/TCP Traffic/settings.json
@@ -3,7 +3,6 @@
     "name":"TCP Traffic",
     "author": "Microsoft",
     "galleries": [
-        { "type": "workbook", "resourceType": "microsoft.operationalinsights/workspaces", "order": 200 },
         { "type": "vm-insights", "resourceType": "Azure Monitor", "order": 200 }
     ]
 }

--- a/Workbooks/Virtual Machines - Network Dependencies/Traffic Comparison/settings.json
+++ b/Workbooks/Virtual Machines - Network Dependencies/Traffic Comparison/settings.json
@@ -3,7 +3,6 @@
     "name": "Traffic Comparison",
     "author": "Microsoft",
     "galleries": [
-        { "type": "workbook", "resourceType": "microsoft.operationalinsights/workspaces", "order": 200 },
         { "type": "vm-insights", "resourceType": "Azure Monitor", "order": 200 }
     ]
 }

--- a/Workbooks/Virtual Machines - Network Dependencies/VM Events/settings.json
+++ b/Workbooks/Virtual Machines - Network Dependencies/VM Events/settings.json
@@ -4,7 +4,6 @@
     "author": "Microsoft",
     "isPreview": true,
     "galleries": [
-        { "type": "workbook", "resourceType": "microsoft.operationalinsights/workspaces", "order": 300 },
         { "type": "vm-insights", "resourceType": "Azure Monitor", "order": 300 }
     ]
 }

--- a/Workbooks/Virtual Machines - Performance Analysis/Performance Analysis for a Group of VMs/settings.json
+++ b/Workbooks/Virtual Machines - Performance Analysis/Performance Analysis for a Group of VMs/settings.json
@@ -3,7 +3,6 @@
     "name":"Performance",
     "author": "Microsoft",
     "galleries": [
-        { "type": "workbook", "resourceType": "microsoft.operationalinsights/workspaces", "order": 200 },
         { "type": "workbook", "resourceType": "Azure Monitor", "categoryKey": "azureMonitorVirtualMachines", "order": 100 },
         { "type": "vm-insights", "resourceType": "Azure Monitor", "order": 200 }
     ]

--- a/Workbooks/Virtual Machines - Performance Analysis/Performance Counters/settings.json
+++ b/Workbooks/Virtual Machines - Performance Analysis/Performance Counters/settings.json
@@ -3,7 +3,6 @@
     "name":"Performance Counters",
     "author": "Microsoft",
     "galleries": [
-        { "type": "workbook", "resourceType": "microsoft.operationalinsights/workspaces", "order": 200 },
         { "type": "vm-insights", "resourceType": "Azure Monitor", "order": 200 }
     ]
 }

--- a/Workbooks/Virtual Machines - Performance Analysis/Resource Monitor/settings.json
+++ b/Workbooks/Virtual Machines - Performance Analysis/Resource Monitor/settings.json
@@ -4,7 +4,6 @@
     "author": "Microsoft",
     "isPreview": true,
     "galleries": [
-        { "type": "workbook", "resourceType": "microsoft.operationalinsights/workspaces", "order": 200 },
         { "type": "vm-insights", "resourceType": "Azure Monitor", "order": 200 }
     ]
 }


### PR DESCRIPTION
I pushed these same changes to https://github.com/ericc1103/Application-Insights-Templates-Dev but for some reason the Log Analytics workbook gallery is still showing VM Insights templates. Will take a look again tomorrow.

![image](https://user-images.githubusercontent.com/43890980/65302201-40494400-db2f-11e9-94f6-a7314e577d54.png)
