### PR TITLE
cosmosdb, operations tab and other cosmetic changes

### DIFF
--- a/Workbooks/CosmosDb/Overview/Overview.workbook
+++ b/Workbooks/CosmosDb/Overview/Overview.workbook
@@ -187,10 +187,20 @@
             "linkLabel": "Capacity",
             "subTarget": "Capacity",
             "style": "link"
+          },
+          {
+            "cellValue": "selectedTab",
+            "linkTarget": "parameter",
+            "linkLabel": "Operation",
+            "subTarget": "Operation",
+            "style": "link"
           }
         ]
       },
-      "name": "links-tabs"
+      "name": "links-tabs",
+      "styleSettings": {
+        "margin": "-15px 0px -15px 0px"
+      }
     },
     {
       "type": 1,
@@ -613,7 +623,42 @@
               "sortOrder": 2
             }
           ],
-          "labelSettings": []
+          "labelSettings": [
+            {
+              "columnId": "Subscription"
+            },
+            {
+              "columnId": "Name"
+            },
+            {
+              "columnId": "Namespace"
+            },
+            {
+              "columnId": "Metric"
+            },
+            {
+              "columnId": "Metric ID"
+            },
+            {
+              "columnId": "Aggregation"
+            },
+            {
+              "columnId": "Segment Field"
+            },
+            {
+              "columnId": "Segment"
+            },
+            {
+              "columnId": "Value",
+              "label": "Data Usage",
+              "comment": "Current column name is Value. which doesn't tell anythiing about the data in the column"
+            },
+            {
+              "columnId": "Timeline",
+              "label": "Data Usage Timeline",
+              "comment": "Current column Timeline is Value. which doesn't tell anythiing about the data in the column"
+            }
+          ]
         },
         "sortBy": [
           {
@@ -644,6 +689,202 @@
         "value": "blah"
       },
       "name": "CapacitySectionEditEnds"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "# Start editing Operation section from here\r\n\r\n <br />"
+      },
+      "conditionalVisibility": {
+        "parameterName": "dummy",
+        "comparison": "isEqualTo",
+        "value": "blah"
+      },
+      "name": "OperationSectionEditStarts"
+    },
+    {
+      "type": 10,
+      "content": {
+        "chartId": "workbookdb19a8d8-91af-44ea-951d-5ffa133b2ebe",
+        "version": "MetricsItem/2.0",
+        "size": 0,
+        "chartType": 0,
+        "resourceIds": [
+          "{CosmosDB}"
+        ],
+        "timeContext": {
+          "durationMs": 0
+        },
+        "timeContextFromParameter": "TimeRange",
+        "resourceType": "microsoft.documentdb/databaseaccounts",
+        "resourceParameter": "CosmosDB",
+        "metrics": [
+          {
+            "namespace": "microsoft.documentdb/databaseaccounts",
+            "metric": "microsoft.documentdb/databaseaccounts-Requests-TotalRequests",
+            "aggregation": 7,
+            "splitBy": "OperationType",
+            "splitBySortOrder": -1,
+            "splitByLimit": 10
+          },
+          {
+            "namespace": "microsoft.documentdb/databaseaccounts",
+            "metric": "microsoft.documentdb/databaseaccounts-Requests-TotalRequests",
+            "aggregation": 7,
+            "splitBy": null
+          }
+        ],
+        "gridSettings": {
+          "formatters": [
+            {
+              "columnMatch": "$gen_group",
+              "formatter": 13,
+              "formatOptions": {
+                "linkTarget": null,
+                "showIcon": true
+              }
+            },
+            {
+              "columnMatch": "Subscription",
+              "formatter": 5,
+              "formatOptions": {
+                "showIcon": true
+              }
+            },
+            {
+              "columnMatch": "Name",
+              "formatter": 5,
+              "formatOptions": {
+                "showIcon": true
+              }
+            },
+            {
+              "columnMatch": ".*\\/Total Requests$",
+              "formatter": 8,
+              "formatOptions": {
+                "showIcon": true
+              },
+              "numberFormat": {
+                "unit": 17,
+                "options": {
+                  "style": "decimal",
+                  "maximumFractionDigits": 1
+                }
+              }
+            },
+            {
+              "columnMatch": "microsoft.documentdb/databaseaccounts-Requests-TotalRequests",
+              "formatter": 8,
+              "formatOptions": {
+                "showIcon": true
+              },
+              "numberFormat": {
+                "unit": 17,
+                "options": {
+                  "style": "decimal",
+                  "maximumFractionDigits": 1
+                }
+              }
+            },
+            {
+              "columnMatch": "Timeline",
+              "formatter": 9,
+              "formatOptions": {
+                "showIcon": true
+              }
+            },
+            {
+              "columnMatch": "Namespace",
+              "formatter": 5,
+              "formatOptions": {
+                "showIcon": true
+              }
+            },
+            {
+              "columnMatch": "Metric",
+              "formatter": 5,
+              "formatOptions": {
+                "showIcon": true
+              }
+            },
+            {
+              "columnMatch": "Metric ID",
+              "formatter": 5,
+              "formatOptions": {
+                "showIcon": true
+              }
+            },
+            {
+              "columnMatch": "Aggregation",
+              "formatter": 5,
+              "formatOptions": {
+                "showIcon": true
+              }
+            },
+            {
+              "columnMatch": "Segment Field",
+              "formatter": 5,
+              "formatOptions": {
+                "showIcon": true
+              }
+            },
+            {
+              "columnMatch": "Segment",
+              "formatter": 5,
+              "formatOptions": {
+                "showIcon": true
+              }
+            },
+            {
+              "columnMatch": "Value",
+              "formatter": 8,
+              "formatOptions": {
+                "showIcon": true,
+                "aggregation": "Sum"
+              },
+              "numberFormat": {
+                "unit": 17,
+                "options": {
+                  "style": "decimal",
+                  "maximumFractionDigits": 1
+                }
+              }
+            }
+          ],
+          "rowLimit": 10000,
+          "filter": true,
+          "hierarchySettings": {
+            "treeType": 1,
+            "groupBy": [
+              "Subscription"
+            ],
+            "expandTopLevel": true,
+            "finalBy": "Name"
+          },
+          "labelSettings": []
+        },
+        "sortBy": [],
+        "exportToExcelOptions": "visible"
+      },
+      "conditionalVisibility": {
+        "parameterName": "selectedTab",
+        "comparison": "isEqualTo",
+        "value": "Operation"
+      },
+      "showPin": true,
+      "name": "cosmosDB account metrics"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "# Operation section ends here\r\n"
+      },
+      "conditionalVisibility": {
+        "parameterName": "dummy",
+        "comparison": "isEqualTo",
+        "value": "blah"
+      },
+      "name": "OperationSectionEditEnds"
     }
   ],
   "styleSettings": {},

--- a/Workbooks/CosmosDb/Overview/Overview.workbook
+++ b/Workbooks/CosmosDb/Overview/Overview.workbook
@@ -651,12 +651,12 @@
             {
               "columnId": "Value",
               "label": "Data Usage",
-              "comment": "Current column name is Value. which doesn't tell anythiing about the data in the column"
+              "comment": "Current column name is Value. It doesn't tell anything about the type of data in the column"
             },
             {
               "columnId": "Timeline",
               "label": "Data Usage Timeline",
-              "comment": "Current column Timeline is Value. which doesn't tell anythiing about the data in the column"
+              "comment": "Current column name is Timeline. It doesn't tell anything about the type of data in the column"
             }
           ]
         },


### PR DESCRIPTION
Add operation tab
Margin between the tabs control and the metric grid
Use custom column name for Capacity tab columns

![ci1](https://user-images.githubusercontent.com/47616490/66006289-08ad9680-e463-11e9-9493-f5bab7c57cdf.PNG)

![ci2](https://user-images.githubusercontent.com/47616490/66006302-13682b80-e463-11e9-9b75-a9417f391a0a.PNG)
