### PR TITLE
Add Preview Single VM Perf workbook using InsightsMetrics

### DIFF
--- a/Workbooks/Virtual Machines - Performance Analysis/Performance Analysis for a Single VM (Preview)/Performance Analysis for a Single VM.workbook
+++ b/Workbooks/Virtual Machines - Performance Analysis/Performance Analysis for a Single VM (Preview)/Performance Analysis for a Single VM.workbook
@@ -1,0 +1,734 @@
+{
+  "version": "Notebook/1.0",
+  "items": [
+    {
+      "type": 1,
+      "content": {
+        "json": "# Performance Analysis"
+      },
+      "name": "text - 0"
+    },
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "query": "",
+        "crossComponentResources": [
+          "{Computer}"
+        ],
+        "parameters": [
+          {
+            "id": "4f883c2c-8e3d-4d52-8f71-30fd86a0f827",
+            "version": "KqlParameterItem/1.0",
+            "name": "Computer",
+            "type": 5,
+            "isRequired": true,
+            "value": "value::1",
+            "isHiddenWhenLocked": true,
+            "typeSettings": {
+              "resourceTypeFilter": {
+                "microsoft.compute/virtualmachines": true
+              },
+              "additionalResourceOptions": [
+                "value::1"
+              ]
+            }
+          },
+          {
+            "id": "cb7fdad2-dd9c-4c53-b2cb-572351dbbb3d",
+            "version": "KqlParameterItem/1.0",
+            "name": "TimeRange",
+            "type": 4,
+            "isRequired": true,
+            "value": {
+              "durationMs": 86400000
+            },
+            "typeSettings": {
+              "selectableValues": [
+                {
+                  "durationMs": 300000,
+                  "createdTime": "2019-01-15T00:55:43.346Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 900000,
+                  "createdTime": "2019-01-15T00:55:43.346Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 1800000,
+                  "createdTime": "2019-01-15T00:55:43.346Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 3600000,
+                  "createdTime": "2019-01-15T00:55:43.346Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 14400000,
+                  "createdTime": "2019-01-15T00:55:43.346Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 43200000,
+                  "createdTime": "2019-01-15T00:55:43.346Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 86400000,
+                  "createdTime": "2019-01-15T00:55:43.346Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 172800000,
+                  "createdTime": "2019-01-15T00:55:43.346Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 259200000,
+                  "createdTime": "2019-01-15T00:55:43.346Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 604800000,
+                  "createdTime": "2019-01-15T00:55:43.347Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 1209600000,
+                  "createdTime": "2019-01-15T00:55:43.347Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 2592000000,
+                  "createdTime": "2019-01-15T00:55:43.347Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 5184000000,
+                  "createdTime": "2019-01-15T00:55:43.347Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 7776000000,
+                  "createdTime": "2019-01-15T00:55:43.347Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                }
+              ],
+              "allowCustom": true
+            }
+          }
+        ],
+        "style": "above",
+        "queryType": 0,
+        "resourceType": "microsoft.compute/virtualmachines"
+      },
+      "name": "parameters - 1"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "---\n## Trend\n💡 In the graph below a default counter (`Counter`) has been selected, select the dropdown to choose a different counter."
+      },
+      "name": "text - 2"
+    },
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "query": "",
+        "crossComponentResources": [
+          "{Computer}"
+        ],
+        "parameters": [
+          {
+            "id": "d495f8c1-c6b2-490e-8eb6-43d151bc20c0",
+            "version": "KqlParameterItem/1.0",
+            "name": "Counter",
+            "type": 2,
+            "description": "Select a virtual machine performance counter to display in the chart below",
+            "isRequired": true,
+            "query": "InsightsMetrics\r\n| where TimeGenerated {TimeRange}\r\n| summarize by Namespace, Name\r\n| order by Namespace asc, Name asc\r\n| project Counter = pack('counter', Name, 'object', Namespace), Name, group = Name",
+            "crossComponentResources": [
+              "{Computer}"
+            ],
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "queryType": 0,
+            "resourceType": "microsoft.compute/virtualmachines"
+          },
+          {
+            "id": "31b68fb4-3740-406d-b8eb-ac29cb461c3f",
+            "version": "KqlParameterItem/1.0",
+            "name": "CounterText",
+            "type": 1,
+            "query": "let metric = dynamic({Counter});\r\nrange Steps from 1 to 1 step 1\r\n| project strcat(metric.object, \" > \", metric.counter)",
+            "crossComponentResources": [
+              "{Computer}"
+            ],
+            "isHiddenWhenLocked": true,
+            "queryType": 0,
+            "resourceType": "microsoft.compute/virtualmachines"
+          },
+          {
+            "id": "4bf4bd96-531d-4d30-b1ba-1aef067fbc6e",
+            "version": "KqlParameterItem/1.0",
+            "name": "grain",
+            "type": 1,
+            "isRequired": true,
+            "query": "print ({TimeRange:end} - {TimeRange:start})/100",
+            "isHiddenWhenLocked": true,
+            "resourceType": "microsoft.compute/virtualmachines"
+          },
+          {
+            "id": "dff91367-8a90-4d46-8a43-8595972eacc8",
+            "version": "KqlParameterItem/1.0",
+            "name": "Aggregates",
+            "type": 2,
+            "description": "Select one or more aggregates for the performance counter to display in the chart below",
+            "isRequired": true,
+            "multiSelect": true,
+            "quote": "",
+            "delimiter": ",",
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(Val), 2)\", \"label\":\"Average\", \"selected\":true },\r\n    { \"value\":\"P1st = round(percentile(Val, 1), 2)\", \"label\":\"P1st\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(Val, 5), 2)\", \"label\":\"P5th\", \"selected\":false},\r\n    { \"value\":\"P10th = round(percentile(Val, 10), 2)\", \"label\":\"P10th\", \"selected\":false},\r\n    { \"value\":\"P50th = round(percentile(Val, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(Val, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(Val, 95), 2)\", \"label\":\"P95th\", \"selected\":false},\r\n    { \"value\":\"P99th = round(percentile(Val, 99), 2)\", \"label\":\"P99th\", \"selected\":false},\r\n    { \"value\":\"Min = round(min(Val), 2)\", \"label\":\"Min\", \"selected\":false},\r\n    { \"value\":\"Max = round(max(Val), 2)\", \"label\":\"Max\", \"selected\":false}    \r\n]"
+          }
+        ],
+        "style": "above",
+        "queryType": 0,
+        "resourceType": "microsoft.compute/virtualmachines"
+      },
+      "name": "parameters - 3"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "let metric = dynamic({Counter});\r\nInsightsMetrics\r\n| where TimeGenerated {TimeRange}\r\n| where Namespace == metric.object and Name == metric.counter\r\n| summarize {Aggregates} by bin(TimeGenerated, totimespan('{grain}'))",
+        "size": 0,
+        "aggregation": 3,
+        "exportToExcelOptions": "visible",
+        "noDataMessage": "Current machine is not emitting data for this performance counter.",
+        "queryType": 0,
+        "resourceType": "microsoft.compute/virtualmachines",
+        "crossComponentResources": [
+          "{Computer}"
+        ],
+        "visualization": "timechart"
+      },
+      "name": "query - 4"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "---\n## Performance Charts\n💡 *Customize or add your own charts below in edit mode or by using the advanced editor*"
+      },
+      "name": "text - 5"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "### CPU Utilization %"
+      },
+      "customWidth": "50",
+      "name": "text - 6"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "### Available Memory MB"
+      },
+      "customWidth": "50",
+      "name": "text - 7"
+    },
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "query": "",
+        "crossComponentResources": [
+          "{Computer}"
+        ],
+        "parameters": [
+          {
+            "id": "f4ab7159-2f3a-4720-96b2-2365a3e93617",
+            "version": "KqlParameterItem/1.0",
+            "name": "Aggregates",
+            "type": 2,
+            "multiSelect": true,
+            "quote": "",
+            "delimiter": ",",
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(Val), 2)\", \"label\":\"Average\", \"selected\":true },\r\n    { \"value\":\"P1st = round(percentile(Val, 1), 2)\", \"label\":\"P1st\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(Val, 5), 2)\", \"label\":\"P5th\", \"selected\":false},\r\n    { \"value\":\"P10th = round(percentile(Val, 10), 2)\", \"label\":\"P10th\", \"selected\":false},\r\n    { \"value\":\"P50th = round(percentile(Val, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(Val, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(Val, 95), 2)\", \"label\":\"P95th\", \"selected\":true},\r\n    { \"value\":\"P99th = round(percentile(Val, 99), 2)\", \"label\":\"P99th\", \"selected\":false},\r\n    { \"value\":\"Min = round(min(Val), 2)\", \"label\":\"Min\", \"selected\":false},\r\n    { \"value\":\"Max = round(max(Val), 2)\", \"label\":\"Max\", \"selected\":false}    \r\n]"
+          },
+          {
+            "id": "069034ca-ed62-48e7-b6ae-d90d1d6d7aaf",
+            "version": "KqlParameterItem/1.0",
+            "name": "AggregatesLeft",
+            "type": 1,
+            "query": "print \"{Aggregates}\"",
+            "isHiddenWhenLocked": true,
+            "resourceType": "microsoft.compute/virtualmachines"
+          }
+        ],
+        "style": "above",
+        "queryType": 0,
+        "resourceType": "microsoft.compute/virtualmachines"
+      },
+      "customWidth": "50",
+      "name": "parameters - 8"
+    },
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "query": "",
+        "crossComponentResources": [
+          "{Computer}"
+        ],
+        "parameters": [
+          {
+            "id": "a1d2a8b9-9c5b-4d1f-b709-49dbd0fe94bd",
+            "version": "KqlParameterItem/1.0",
+            "name": "Aggregates",
+            "type": 2,
+            "multiSelect": true,
+            "quote": "",
+            "delimiter": ",",
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(Val), 2)\", \"label\":\"Average\", \"selected\":true },\r\n    { \"value\":\"P1st = round(percentile(Val, 1), 2)\", \"label\":\"P1st\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(Val, 5), 2)\", \"label\":\"P5th\", \"selected\":true},\r\n    { \"value\":\"P10th = round(percentile(Val, 10), 2)\", \"label\":\"P10th\", \"selected\":true},\r\n    { \"value\":\"P50th = round(percentile(Val, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(Val, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(Val, 95), 2)\", \"label\":\"P95th\", \"selected\":false},\r\n    { \"value\":\"P99th = round(percentile(Val, 99), 2)\", \"label\":\"P99th\", \"selected\":false},\r\n    { \"value\":\"Min = round(min(Val), 2)\", \"label\":\"Min\", \"selected\":false},\r\n    { \"value\":\"Max = round(max(Val), 2)\", \"label\":\"Max\", \"selected\":false}    \r\n]"
+          },
+          {
+            "id": "1f360103-df10-41c7-8f82-13edd11461aa",
+            "version": "KqlParameterItem/1.0",
+            "name": "AggregatesRight",
+            "type": 1,
+            "query": "print \"{Aggregates}\"",
+            "isHiddenWhenLocked": true,
+            "resourceType": "microsoft.compute/virtualmachines"
+          }
+        ],
+        "style": "above",
+        "queryType": 0,
+        "resourceType": "microsoft.compute/virtualmachines"
+      },
+      "customWidth": "50",
+      "name": "parameters - 9"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "InsightsMetrics\n| where TimeGenerated {TimeRange}\n| where Namespace == 'Processor' and Name == 'UtilizationPercentage'\n| summarize {AggregatesLeft} by bin(TimeGenerated, totimespan('{grain}'))",
+        "size": 0,
+        "aggregation": 3,
+        "showAnnotations": true,
+        "exportToExcelOptions": "visible",
+        "noDataMessage": "Current machine is not emitting data for this performance counter.",
+        "queryType": 0,
+        "resourceType": "microsoft.compute/virtualmachines",
+        "crossComponentResources": [
+          "{Computer}"
+        ],
+        "visualization": "timechart"
+      },
+      "customWidth": "50",
+      "name": "query - 10"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "InsightsMetrics\r\n| where TimeGenerated {TimeRange}\r\n| where Namespace == 'Memory' and Name == 'AvailableMB'\r\n| summarize {AggregatesRight} by bin(TimeGenerated, totimespan('{grain}'))",
+        "size": 0,
+        "aggregation": 3,
+        "showAnnotations": true,
+        "exportToExcelOptions": "visible",
+        "noDataMessage": "Current machine is not emitting data for this performance counter.",
+        "queryType": 0,
+        "resourceType": "microsoft.compute/virtualmachines",
+        "crossComponentResources": [
+          "{Computer}"
+        ],
+        "visualization": "linechart"
+      },
+      "customWidth": "50",
+      "name": "query - 11"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "### Logical Disk IOPS"
+      },
+      "customWidth": "50",
+      "name": "text - 12"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "### Logical Disk MB/s"
+      },
+      "customWidth": "50",
+      "name": "text - 13"
+    },
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "query": "",
+        "crossComponentResources": [
+          "{Computer}"
+        ],
+        "parameters": [
+          {
+            "id": "547dae05-22bf-47a5-ad44-043a23995759",
+            "version": "KqlParameterItem/1.0",
+            "name": "Aggregates",
+            "type": 2,
+            "multiSelect": true,
+            "quote": "",
+            "delimiter": ",",
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(Val), 2)\", \"label\":\"Average\", \"selected\":true },\r\n    { \"value\":\"P1st = round(percentile(Val, 1), 2)\", \"label\":\"P1st\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(Val, 5), 2)\", \"label\":\"P5th\", \"selected\":false},\r\n    { \"value\":\"P10th = round(percentile(Val, 10), 2)\", \"label\":\"P10th\", \"selected\":false},\r\n    { \"value\":\"P50th = round(percentile(Val, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(Val, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(Val, 95), 2)\", \"label\":\"P95th\", \"selected\":true},\r\n    { \"value\":\"P99th = round(percentile(Val, 99), 2)\", \"label\":\"P99th\", \"selected\":false},\r\n    { \"value\":\"Min = round(min(Val), 2)\", \"label\":\"Min\", \"selected\":false},\r\n    { \"value\":\"Max = round(max(Val), 2)\", \"label\":\"Max\", \"selected\":false}    \r\n]"
+          },
+          {
+            "id": "1af979b2-3131-4771-bf02-30193138c565",
+            "version": "KqlParameterItem/1.0",
+            "name": "AggregatesLeft",
+            "type": 1,
+            "query": "print \"{Aggregates}\"",
+            "isHiddenWhenLocked": true,
+            "resourceType": "microsoft.compute/virtualmachines"
+          }
+        ],
+        "style": "above",
+        "queryType": 0,
+        "resourceType": "microsoft.compute/virtualmachines"
+      },
+      "customWidth": "50",
+      "name": "parameters - 14"
+    },
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "query": "",
+        "crossComponentResources": [
+          "{Computer}"
+        ],
+        "parameters": [
+          {
+            "id": "8aaa181d-7182-4d9d-b74e-22f37e3acbce",
+            "version": "KqlParameterItem/1.0",
+            "name": "Aggregates",
+            "type": 2,
+            "multiSelect": true,
+            "quote": "",
+            "delimiter": ",",
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(Val), 2)\", \"label\":\"Average\", \"selected\":true },\r\n    { \"value\":\"P1st = round(percentile(Val, 1), 2)\", \"label\":\"P1st\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(Val, 5), 2)\", \"label\":\"P5th\", \"selected\":false},\r\n    { \"value\":\"P10th = round(percentile(Val, 10), 2)\", \"label\":\"P10th\", \"selected\":false},\r\n    { \"value\":\"P50th = round(percentile(Val, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(Val, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(Val, 95), 2)\", \"label\":\"P95th\", \"selected\":true},\r\n    { \"value\":\"P99th = round(percentile(Val, 99), 2)\", \"label\":\"P99th\", \"selected\":false},\r\n    { \"value\":\"Min = round(min(Val), 2)\", \"label\":\"Min\", \"selected\":false},\r\n    { \"value\":\"Max = round(max(Val), 2)\", \"label\":\"Max\", \"selected\":false}    \r\n]"
+          },
+          {
+            "id": "c021b342-6bc8-4870-a88b-8ddf0b8b9cfa",
+            "version": "KqlParameterItem/1.0",
+            "name": "AggregatesRight",
+            "type": 1,
+            "query": "print \"{Aggregates}\"",
+            "isHiddenWhenLocked": true,
+            "resourceType": "microsoft.compute/virtualmachines"
+          }
+        ],
+        "style": "above",
+        "queryType": 0,
+        "resourceType": "microsoft.compute/virtualmachines"
+      },
+      "customWidth": "50",
+      "name": "parameters - 15"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "InsightsMetrics\r\n| where TimeGenerated {TimeRange}\r\n| where Namespace == 'LogicalDisk' and Name == 'TransfersPerSecond'\r\n| summarize {AggregatesLeft} by bin(TimeGenerated, totimespan('{grain}'))",
+        "size": 0,
+        "aggregation": 3,
+        "showAnnotations": true,
+        "exportToExcelOptions": "visible",
+        "noDataMessage": "Current machine is not emitting data for this performance counter.",
+        "queryType": 0,
+        "resourceType": "microsoft.compute/virtualmachines",
+        "crossComponentResources": [
+          "{Computer}"
+        ],
+        "visualization": "timechart"
+      },
+      "customWidth": "50",
+      "name": "query - 16"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "InsightsMetrics\r\n| where TimeGenerated {TimeRange}\r\n| where Namespace == 'LogicalDisk' and Name == 'BytesPerSecond'\r\n| summarize {AggregatesRight} by bin(TimeGenerated, totimespan('{grain}'))",
+        "size": 0,
+        "aggregation": 3,
+        "showAnnotations": true,
+        "exportToExcelOptions": "visible",
+        "noDataMessage": "Current machine is not emitting data for this performance counter.",
+        "queryType": 0,
+        "resourceType": "microsoft.compute/virtualmachines",
+        "crossComponentResources": [
+          "{Computer}"
+        ],
+        "visualization": "linechart"
+      },
+      "customWidth": "50",
+      "name": "query - 17"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "### Max Logical Disk Used %"
+      },
+      "customWidth": "50",
+      "name": "text - 18"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "### Bytes Sent Rate B/s"
+      },
+      "customWidth": "50",
+      "name": "text - 19"
+    },
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "query": "",
+        "crossComponentResources": [
+          "{Computer}"
+        ],
+        "parameters": [],
+        "style": "pills",
+        "queryType": 0,
+        "resourceType": "microsoft.compute/virtualmachines"
+      },
+      "customWidth": "50",
+      "name": "parameters - 20"
+    },
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "query": "",
+        "crossComponentResources": [
+          "{Computer}"
+        ],
+        "parameters": [
+          {
+            "id": "f963e52a-2099-4cd3-a3ad-0fdf78f38238",
+            "version": "KqlParameterItem/1.0",
+            "name": "Aggregates",
+            "type": 2,
+            "multiSelect": true,
+            "quote": "",
+            "delimiter": ",",
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(Val), 2)\", \"label\":\"Average\", \"selected\":true },\r\n    { \"value\":\"P1st = round(percentile(Val, 1), 2)\", \"label\":\"P1st\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(Val, 5), 2)\", \"label\":\"P5th\", \"selected\":false},\r\n    { \"value\":\"P10th = round(percentile(Val, 10), 2)\", \"label\":\"P10th\", \"selected\":false},\r\n    { \"value\":\"P50th = round(percentile(Val, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(Val, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(Val, 95), 2)\", \"label\":\"P95th\", \"selected\":false},\r\n    { \"value\":\"P99th = round(percentile(Val, 99), 2)\", \"label\":\"P99th\", \"selected\":false},\r\n    { \"value\":\"Min = round(min(Val), 2)\", \"label\":\"Min\", \"selected\":false},\r\n    { \"value\":\"Max = round(max(Val), 2)\", \"label\":\"Max\", \"selected\":false}    \r\n]"
+          },
+          {
+            "id": "6c5d9373-5403-44e5-b496-7155c338f958",
+            "version": "KqlParameterItem/1.0",
+            "name": "AggregatesRight",
+            "type": 1,
+            "query": "print \"{Aggregates}\"",
+            "isHiddenWhenLocked": true,
+            "resourceType": "microsoft.compute/virtualmachines"
+          }
+        ],
+        "style": "above",
+        "queryType": 0,
+        "resourceType": "microsoft.compute/virtualmachines"
+      },
+      "customWidth": "50",
+      "name": "parameters - 21"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "InsightsMetrics\r\n| where TimeGenerated {TimeRange}\r\n| where Namespace == 'LogicalDisk' and Name == 'FreeSpacePercentage'\r\n| summarize {AggregatesLeft} by bin(TimeGenerated, totimespan('{grain}'))",
+        "size": 0,
+        "aggregation": 2,
+        "showAnnotations": true,
+        "exportToExcelOptions": "visible",
+        "noDataMessage": "Current machine is not emitting data for this performance counter.",
+        "queryType": 0,
+        "resourceType": "microsoft.compute/virtualmachines",
+        "crossComponentResources": [
+          "{Computer}"
+        ],
+        "visualization": "timechart"
+      },
+      "customWidth": "50",
+      "name": "query - 22"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "InsightsMetrics\r\n| where TimeGenerated {TimeRange}\r\n| where Namespace == 'Network' and Name == 'WriteBytesPerSecond'\r\n| summarize {AggregatesRight} by bin(TimeGenerated, totimespan('{grain}'))",
+        "size": 0,
+        "aggregation": 3,
+        "showAnnotations": true,
+        "exportToExcelOptions": "visible",
+        "noDataMessage": "Current machine is not emitting data for this performance counter.",
+        "queryType": 0,
+        "resourceType": "microsoft.compute/virtualmachines",
+        "crossComponentResources": [
+          "{Computer}"
+        ],
+        "visualization": "timechart"
+      },
+      "customWidth": "50",
+      "name": "query - 23"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "### Bytes Received Rate B/s"
+      },
+      "customWidth": "50",
+      "name": "text - 24"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": ""
+      },
+      "customWidth": "50",
+      "name": "text - 25"
+    },
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "query": "",
+        "crossComponentResources": [
+          "{Computer}"
+        ],
+        "parameters": [
+          {
+            "id": "c0592d9a-edd4-4a69-86c0-098ac0c72cf2",
+            "version": "KqlParameterItem/1.0",
+            "name": "Aggregates",
+            "type": 2,
+            "multiSelect": true,
+            "quote": "",
+            "delimiter": ",",
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(Val), 2)\", \"label\":\"Average\", \"selected\":true },\r\n    { \"value\":\"P1st = round(percentile(Val, 1), 2)\", \"label\":\"P1st\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(Val, 5), 2)\", \"label\":\"P5th\", \"selected\":false},\r\n    { \"value\":\"P10th = round(percentile(Val, 10), 2)\", \"label\":\"P10th\", \"selected\":false},\r\n    { \"value\":\"P50th = round(percentile(Val, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(Val, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(Val, 95), 2)\", \"label\":\"P95th\", \"selected\":false},\r\n    { \"value\":\"P99th = round(percentile(Val, 99), 2)\", \"label\":\"P99th\", \"selected\":false},\r\n    { \"value\":\"Min = round(min(Val), 2)\", \"label\":\"Min\", \"selected\":false},\r\n    { \"value\":\"Max = round(max(Val), 2)\", \"label\":\"Max\", \"selected\":false}    \r\n]"
+          },
+          {
+            "id": "d4795fc0-c995-4975-8bc6-e515dbad00be",
+            "version": "KqlParameterItem/1.0",
+            "name": "AggregatesLeft",
+            "type": 1,
+            "query": "print \"{Aggregates}\"",
+            "isHiddenWhenLocked": true,
+            "resourceType": "microsoft.compute/virtualmachines"
+          }
+        ],
+        "style": "above",
+        "queryType": 0,
+        "resourceType": "microsoft.compute/virtualmachines"
+      },
+      "customWidth": "50",
+      "name": "parameters - 26"
+    },
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "query": "",
+        "crossComponentResources": [
+          "{Computer}"
+        ],
+        "parameters": [],
+        "style": "pills",
+        "queryType": 0,
+        "resourceType": "microsoft.compute/virtualmachines"
+      },
+      "customWidth": "50",
+      "name": "parameters - 27"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "InsightsMetrics\r\n| where TimeGenerated {TimeRange}\r\n| where Namespace == 'Network' and Name == 'ReadBytesPerSecond'\r\n| summarize {AggregatesLeft} by bin(TimeGenerated, totimespan('{grain}'))",
+        "size": 0,
+        "aggregation": 3,
+        "showAnnotations": true,
+        "exportToExcelOptions": "visible",
+        "noDataMessage": "Current machine is not emitting data for this performance counter.",
+        "queryType": 0,
+        "resourceType": "microsoft.compute/virtualmachines",
+        "crossComponentResources": [
+          "{Computer}"
+        ],
+        "visualization": "timechart"
+      },
+      "customWidth": "50",
+      "name": "query - 28"
+    }
+  ],
+  "fallbackResourceIds": [],
+  "styleSettings": {},
+  "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
+}

--- a/Workbooks/Virtual Machines - Performance Analysis/Performance Analysis for a Single VM (Preview)/settings.json
+++ b/Workbooks/Virtual Machines - Performance Analysis/Performance Analysis for a Single VM (Preview)/settings.json
@@ -1,0 +1,10 @@
+{
+    "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/settings.json",
+    "name":"Performance (Preview)",
+    "author": "Microsoft",
+    "isPreview": true,
+    "galleries": [
+        { "type": "performance-vm", "resourceType": "microsoft.compute/virtualmachines", "order": 200 },
+        { "type": "insights", "resourceType": "microsoft.compute/virtualmachines", "order": 200 }
+    ]
+}


### PR DESCRIPTION
Use the new InsightsMetrics table, workbook is behind preview flag

![image](https://user-images.githubusercontent.com/43890980/66278714-b7394900-e860-11e9-966d-8e87c22291f5.png)

![image](https://user-images.githubusercontent.com/43890980/66278716-c4eece80-e860-11e9-8217-c0036da4a822.png)
