### PR TITLE
Remove unnecessary KQL comments

### DIFF
--- a/Workbooks/Virtual Machines - Network Dependencies/Connections Overview - Single VM/Connections Overview.workbook
+++ b/Workbooks/Virtual Machines - Network Dependencies/Connections Overview - Single VM/Connections Overview.workbook
@@ -6,7 +6,6 @@
       "content": {
         "json": "<h1>Connections Overview</h1>"
       },
-      "conditionalVisibility": null,
       "name": "text - 0"
     },
     {
@@ -33,21 +32,18 @@
               "additionalResourceOptions": [
                 "value::1"
               ]
-            },
-            "timeContextFromParameter": null
+            }
           },
           {
             "id": "a9393837-8ef0-40e5-b223-4df1208a691e",
             "version": "KqlParameterItem/1.0",
             "name": "Test",
             "type": 1,
-            "isRequired": false,
             "query": "VMConnection\r\n| take 1\r\n| summarize count()",
             "crossComponentResources": [
               "{Computer}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
             "resourceType": "microsoft.compute/virtualmachines"
           },
           {
@@ -55,13 +51,11 @@
             "version": "KqlParameterItem/1.0",
             "name": "DisclaimerText",
             "type": 1,
-            "isRequired": false,
             "query": "print iff('{Test}' == '' , 'This workbook requires [Azure Monitor for VMs (preview)](https://docs.microsoft.com/en-us/azure/azure-monitor/insights/vminsights-overview) enabled', iff('{Test}' == '0', '⚠ There is currently no `VMConnection` data for this virtual machine', ''))",
             "crossComponentResources": [
               "{Computer}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
             "resourceType": "microsoft.compute/virtualmachines"
           }
         ],
@@ -81,7 +75,6 @@
       "content": {
         "json": "{DisclaimerText}\r\n\r\n---"
       },
-      "conditionalVisibility": null,
       "name": "text - 2"
     },
     {
@@ -89,7 +82,9 @@
       "content": {
         "version": "KqlParameterItem/1.0",
         "query": "",
-        "crossComponentResources": [],
+        "crossComponentResources": [
+          "{Computer}"
+        ],
         "parameters": [
           {
             "id": "addcec31-b7ac-4715-a78d-9b803f86af8a",
@@ -100,7 +95,6 @@
             "value": {
               "durationMs": 3600000
             },
-            "isHiddenWhenLocked": false,
             "typeSettings": {
               "selectableValues": [
                 {
@@ -203,8 +197,7 @@
                 }
               ],
               "allowCustom": true
-            },
-            "timeContextFromParameter": null
+            }
           },
           {
             "id": "db9b2f1d-188a-4dda-af4a-b39deeb34da3",
@@ -214,12 +207,10 @@
             "description": "Direction of the network connection from the VMs",
             "isRequired": true,
             "value": "outbound",
-            "isHiddenWhenLocked": false,
             "typeSettings": {
               "additionalResourceOptions": []
             },
-            "jsonData": "[\r\n    { \"value\":\"inbound\", \"label\":\"Inbound\" },\r\n    { \"value\":\"outbound\", \"label\":\"Outbound\" }\r\n]",
-            "timeContextFromParameter": null
+            "jsonData": "[\r\n    { \"value\":\"inbound\", \"label\":\"Inbound\" },\r\n    { \"value\":\"outbound\", \"label\":\"Outbound\" }\r\n]"
           },
           {
             "id": "488d1f86-cabc-4fcc-8dc9-9a2e5803fb20",
@@ -232,7 +223,6 @@
               "{Computer}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
             "resourceType": "microsoft.compute/virtualmachines"
           },
           {
@@ -247,11 +237,9 @@
               "{Computer}"
             ],
             "value": "0",
-            "isHiddenWhenLocked": false,
             "typeSettings": {
               "additionalResourceOptions": []
             },
-            "timeContextFromParameter": null,
             "resourceType": "microsoft.compute/virtualmachines"
           },
           {
@@ -260,24 +248,20 @@
             "name": "TableFilter",
             "type": 2,
             "description": "Filter table based on presence of malicious connections or at least one link failing",
-            "isRequired": false,
             "multiSelect": true,
             "quote": "",
             "delimiter": "",
             "value": [],
-            "isHiddenWhenLocked": false,
             "typeSettings": {
               "additionalResourceOptions": []
             },
-            "jsonData": "[\r\n    {\r\n        \"label\": \"Only Malicious Connections\",\r\n        \"value\": \" | where MaliciousConnectionsCount >= 1\"\r\n    },\r\n    {\r\n        \"label\": \"Only Links Failed\",\r\n        \"value\": \" | where LinksFailed >= 1\"\r\n    }\r\n]",
-            "timeContextFromParameter": null
+            "jsonData": "[\r\n    {\r\n        \"label\": \"Only Malicious Connections\",\r\n        \"value\": \" | where MaliciousConnectionsCount >= 1\"\r\n    },\r\n    {\r\n        \"label\": \"Only Links Failed\",\r\n        \"value\": \" | where LinksFailed >= 1\"\r\n    }\r\n]"
           }
         ],
         "style": "above",
         "queryType": 0,
         "resourceType": "microsoft.compute/virtualmachines"
       },
-      "conditionalVisibility": null,
       "name": "parameters - 3"
     },
     {
@@ -300,7 +284,6 @@
               "{Computer}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
             "resourceType": "microsoft.compute/virtualmachines"
           },
           {
@@ -308,13 +291,11 @@
             "version": "KqlParameterItem/1.0",
             "name": "MaliciousIpData",
             "type": 1,
-            "isRequired": false,
             "query": "print(\"let maliciousIpData = VMConnection | where TimeGenerated {TimeRange} | where Direction == '{Direction}' {ComputerFilter} | where MaliciousIp != '' | summarize by Computer, ProcessName, MaliciousIp, DestinationPort, RemoteIp, IsActive, IndicatorThreatType, RemoteCountry, RemoteLongitude, RemoteLatitude, Confidence, Severity, FirstReportedDateTime, LastReportedDateTime | project MaliciousIp = strcat(Computer, '-', ProcessName, '-', MaliciousIp), MaliciousPort = strcat(Computer, '-', ProcessName, '-', DestinationPort), MaliciousPortIp = strcat(Computer, '-', ProcessName, '-', DestinationPort, '-', RemoteIp), Computer = Computer, Process = strcat(Computer, '-', ProcessName), MaliciousIpInfo = pack('Malicious IP', MaliciousIp, 'Is Active', IsActive, 'Indicator Threat Type', IndicatorThreatType, 'Remote Country', RemoteCountry, 'Longitude', RemoteLongitude, 'Latitude', RemoteLatitude, 'Confidence', Confidence, 'Severity', Severity, 'First Reported DateTime', FirstReportedDateTime, 'Last Reported DateTime', LastReportedDateTime, 'Destination Port', DestinationPort, 'Remote IP', RemoteIp);\");",
             "crossComponentResources": [
               "{Computer}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
             "resourceType": "microsoft.compute/virtualmachines"
           },
           {
@@ -322,13 +303,11 @@
             "version": "KqlParameterItem/1.0",
             "name": "ComputerData",
             "type": 1,
-            "isRequired": false,
             "query": "print(\"let computerData = VMConnection | where TimeGenerated {TimeRange} | where Direction == '{Direction}' {ComputerFilter} | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 * sum(ResponseTimeSum) / sum(Responses) by Name = strcat('🖥️ ', Computer), ComputerName = Computer, Type = 'Computer', TypeKey = 1, Key = Computer, ParentKey = '---' | join kind=leftouter (maliciousIpData | summarize MaliciousIpInfo = tostring(count()) by Computer) on $left.Key == $right.Computer | project-away Computer | order by Name asc;\");",
             "crossComponentResources": [
               "{Computer}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
             "resourceType": "microsoft.compute/virtualmachines"
           },
           {
@@ -336,13 +315,11 @@
             "version": "KqlParameterItem/1.0",
             "name": "RemoteIpDataInbound",
             "type": 1,
-            "isRequired": false,
             "query": "print(\"let remoteIpDataInbound = VMConnection | where TimeGenerated {TimeRange} | where Direction == 'inbound' | where 'inbound' == 'inbound' {ComputerFilter} | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) by Computer, ProcessName, RemoteIp, Type = 'Remote Computer', TypeKey = 3, Key = strcat(Computer, '-', ProcessName, '-', tostring(DestinationPort), '-', RemoteIp), ParentKey = strcat(Computer, '-', ProcessName, '-', tostring(DestinationPort)), Id = strcat(Computer, '-', ProcessName, '-', RemoteIp), ComputerName = Computer | join kind=inner     sourcePortData on $left.ParentKey == $right.Key | project-away AverageResponseTime1, Computer1, Key1, LinksFailed1, MaxLinksLive1, ParentKey1, ProcessName1, Responses1, TotalBytesReceived1, TotalBytesSent1, Type1, TypeKey1 | order by Name asc | join kind=leftouter     ipComputerMapping on $left.RemoteIp == $right.Ipv4 | extend Name = iff(RemoteIp == '', 'Unknown',  strcat('🌐 External (', RemoteIp, ')')) | project-away Computer, Ipv4 | order by Name desc | join kind=leftouter     maliciousIpData on $left.Key == $right.MaliciousPortIp | extend MaliciousIpInfo = tostring(MaliciousIpInfo1) | project-away MaliciousIp, Computer, Process, Computer1, MaliciousIpInfo1, Id;\");",
             "crossComponentResources": [
               "{Computer}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
             "resourceType": "microsoft.compute/virtualmachines"
           },
           {
@@ -350,13 +327,11 @@
             "version": "KqlParameterItem/1.0",
             "name": "ProcessName",
             "type": 1,
-            "isRequired": false,
             "query": "print(\"let processData = VMConnection | where TimeGenerated {TimeRange} | where Direction == '{Direction}' {ComputerFilter} | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) by Computer, ProcessName, Name = strcat('🎫 ', ProcessName), Type = 'Process', TypeKey = 2, Key = strcat(Computer, '-', ProcessName), ParentKey = Computer, ComputerName = Computer | join kind=inner computerData on $left.ParentKey == $right.Key | project-away Name1, Responses1, LinksFailed1, MaxLinksLive1, TotalBytesSent1, TotalBytesReceived1, AverageResponseTime1, Type1, Key1, ParentKey1 | join kind=leftouter (maliciousIpData | summarize MaliciousIpInfo = tostring(count()) by Process) on $left.Key == $right.Process | project-away Process, MaliciousIpInfo | extend MaliciousIpInfo = tostring(MaliciousIpInfo1) | project-away MaliciousIpInfo1 | order by Name asc;\");",
             "crossComponentResources": [
               "{Computer}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
             "resourceType": "microsoft.compute/virtualmachines"
           },
           {
@@ -370,7 +345,6 @@
               "{Computer}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
             "resourceType": "microsoft.compute/virtualmachines"
           },
           {
@@ -378,13 +352,11 @@
             "version": "KqlParameterItem/1.0",
             "name": "SourcePortData",
             "type": 1,
-            "isRequired": false,
             "query": "print(\"let sourcePortData = VMConnection | where TimeGenerated {TimeRange} | where Direction == '{Direction}' | where '{Direction}' == 'inbound' {ComputerFilter} | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) by Computer, ProcessName, DestinationIp, DestinationPort, Name = strcat('🔶 ', DestinationPort), Type = 'Remote Port', TypeKey = 4, Key = strcat(Computer, '-', ProcessName, '-', tostring(DestinationPort)), ParentKey = strcat(Computer, '-', ProcessName), ComputerName = Computer | join kind=leftouter maliciousIpData on $left.Key == $right.MaliciousPort | extend MaliciousIpInfo = tostring(MaliciousIpInfo) | project-away Computer1, MaliciousIp, MaliciousPort, MaliciousPortIp, Process; {RemoteIpDataInbound}\");",
             "crossComponentResources": [
               "{Computer}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
             "resourceType": "microsoft.compute/virtualmachines"
           },
           {
@@ -392,13 +364,11 @@
             "version": "KqlParameterItem/1.0",
             "name": "DestinationPortData",
             "type": 1,
-            "isRequired": false,
             "query": "print(\"let destinationPortData = VMConnection | where TimeGenerated {TimeRange} | where Direction == '{Direction}' | where '{Direction}' == 'outbound' {ComputerFilter} | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) by Computer, ProcessName, DestinationIp, DestinationPort, Name = strcat('🔶 ', DestinationPort), Type = 'Remote Port', TypeKey = 4, Key = strcat(Computer, '-', ProcessName, '-', DestinationIp, '-', tostring(DestinationPort)), ParentKey = strcat(Computer, '-', ProcessName, '-', DestinationIp), ComputerName = Computer | join kind=inner remoteIpData on $left.ParentKey == $right.Key | project-away Name1, Responses1, Type1, Key1, ParentKey1 | order by Name asc;\");",
             "crossComponentResources": [
               "{Computer}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
             "resourceType": "microsoft.compute/virtualmachines"
           },
           {
@@ -406,13 +376,11 @@
             "version": "KqlParameterItem/1.0",
             "name": "QueryProject",
             "type": 1,
-            "isRequired": false,
             "query": "print(\"| where Type != 'Overall' | extend MaliciousConnectionsCount = iff(MaliciousIpInfo == '', 0, iff(Type == 'Computer' or Type == 'Process' or Type == 'Overall', tolong(MaliciousIpInfo), 1)) | project ComputerName, ProcessName, RemoteIp, DestinationPort, Name = iff(Name == '🎫 ', '🎫 <Unknown>', Name), Type, MaliciousConnections = iff(MaliciousIpInfo == '', '✅ No Malicious Connections', iff(Type == 'Computer' or Type == 'Process' or Type == 'Overall', iff(MaliciousConnectionsCount > 1, strcat('❌ ', MaliciousIpInfo, ' Malicious Connections'), strcat('❌ ', MaliciousIpInfo, ' Malicious Connection')), '❌ Malicious Connection')), Responses, MaxLinksLive, LinksFailed, AverageResponseTime, TotalBytesSent, TotalBytesReceived, Info = iff(MaliciousIpInfo != '', MaliciousIpInfo, ''), Key, ParentKey, TypeKey, MaliciousConnectionsCount | order by TypeKey asc, MaliciousConnectionsCount desc, LinksFailed desc, AverageResponseTime desc, Responses desc, MaxLinksLive desc, Name asc | project-away TypeKey\");",
             "crossComponentResources": [
               "{Computer}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
             "resourceType": "microsoft.compute/virtualmachines"
           },
           {
@@ -420,13 +388,11 @@
             "version": "KqlParameterItem/1.0",
             "name": "Computer_Process_IP_Port",
             "type": 1,
-            "isRequired": false,
             "query": "print(strcat(\"{ServiceMapComputers}\", \" let ipComputerMapping = computers | project Computer, Ipv4 = todynamic(tostring(Properties.Ipv4Addresses_s)) | mvexpand Ipv4 to typeof(string); \", \"{MaliciousIpData}\", \" let totalMaliciousConnectionsCount = maliciousIpData | summarize MaliciousIpInfo = count() | extend Type = 'Overall'; \", \"{ComputerData}\", \"{ProcessName}\", \"{RemoteIpData}\", \"{DestinationPortData}\", \"{SourcePortData}\", \" let overalldata = VMConnection | where TimeGenerated {TimeRange} | where Direction == '{Direction}' {ComputerFilter} | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) | extend Name = '🔵 Overall', Type = 'Overall', TypeKey = 0, Key = '--Overall--', ParentKey = '----' | join kind=leftouter totalMaliciousConnectionsCount on Type | extend MaliciousIpInfo = iff(MaliciousIpInfo == '0', '', tostring(MaliciousIpInfo)) | project-away Type1; computerData | union processData | union remoteIpData | union destinationPortData | union remoteIpDataInbound | union sourcePortData | union overalldata\t\", \"{QueryProject}\"));",
             "crossComponentResources": [
               "{Computer}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
             "resourceType": "microsoft.compute/virtualmachines"
           },
           {
@@ -434,13 +400,11 @@
             "version": "KqlParameterItem/1.0",
             "name": "Computer_Process_IP",
             "type": 1,
-            "isRequired": false,
             "query": "print(strcat(\"{ServiceMapComputers}\", \" let ipComputerMapping = computers | project Computer, Ipv4 = todynamic(tostring(Properties.Ipv4Addresses_s)) | mvexpand Ipv4 to typeof(string); \", \"{MaliciousIpData}\", \" let totalMaliciousConnectionsCount = maliciousIpData | summarize MaliciousIpInfo = count() | extend Type = 'Overall'; \", \"{ComputerData}\", \"{ProcessName}\", \"{RemoteIpData}\", \"{SourcePortData}\", \" let overalldata = VMConnection | where TimeGenerated {TimeRange} | where Direction == '{Direction}' {ComputerFilter} | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) | extend Name = '🔵 Overall', Type = 'Overall', TypeKey = 0, Key = '--Overall--', ParentKey = '----' | join kind=leftouter totalMaliciousConnectionsCount on Type | extend MaliciousIpInfo = iff(MaliciousIpInfo == '0', '', tostring(MaliciousIpInfo)) | project-away Type1;\" ,\" computerData | union processData | union remoteIpData | union sourcePortData | union overalldata \", \"{QueryProject}\"));",
             "crossComponentResources": [
               "{Computer}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
             "resourceType": "microsoft.compute/virtualmachines"
           },
           {
@@ -449,12 +413,12 @@
             "name": "QueryPadDestinationPortTable",
             "type": 1,
             "isRequired": true,
-            "query": "// {Computer:label}\r\nprint(\"let destinationPortPadding = datatable (DestinationPort: string) [];\");",
+            "query": "print(\"let destinationPortPadding = datatable (DestinationPort: string) [];\");",
             "crossComponentResources": [
               "{Computer}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
+            "queryType": 0,
             "resourceType": "microsoft.compute/virtualmachines"
           },
           {
@@ -463,12 +427,12 @@
             "name": "QueryPadRemoteIpTable",
             "type": 1,
             "isRequired": true,
-            "query": "// {Computer:label}\r\nprint(\"let remoteIpPadding = datatable (RemoteIp: string) [];\");",
+            "query": "print(\"let remoteIpPadding = datatable (RemoteIp: string) [];\");",
             "crossComponentResources": [
               "{Computer}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
+            "queryType": 0,
             "resourceType": "microsoft.compute/virtualmachines"
           },
           {
@@ -476,13 +440,11 @@
             "version": "KqlParameterItem/1.0",
             "name": "Computer_Process",
             "type": 1,
-            "isRequired": false,
             "query": "print(strcat(\"{ServiceMapComputers}\", \" let ipComputerMapping = computers | project Computer, Ipv4 = todynamic(tostring(Properties.Ipv4Addresses_s)) | mvexpand Ipv4 to typeof(string); \", \"{MaliciousIpData}\", \" let totalMaliciousConnectionsCount = maliciousIpData | summarize MaliciousIpInfo = count() | extend Type = 'Overall'; \", \"{ComputerData}\", \"{ProcessName}\", \" let overalldata = VMConnection | where TimeGenerated {TimeRange} | where Direction == '{Direction}' {ComputerFilter} | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) | extend Name = '🔵 Overall', Type = 'Overall', TypeKey = 0, Key = '--Overall--', ParentKey = '----' | join kind=leftouter totalMaliciousConnectionsCount on Type | extend MaliciousIpInfo = iff(MaliciousIpInfo == '0', '', tostring(MaliciousIpInfo)) | project-away Type1;\", \"{QueryPadDestinationPortTable}\", \"{QueryPadRemoteIpTable}\",\" computerData | union remoteIpPadding | union destinationPortPadding | union processData | union overalldata \", \"{QueryProject}\"));",
             "crossComponentResources": [
               "{Computer}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
             "resourceType": "microsoft.compute/virtualmachines"
           },
           {
@@ -491,12 +453,12 @@
             "name": "QueryPadProcessNameTable",
             "type": 1,
             "isRequired": true,
-            "query": "// {Computer:label}\r\nprint(\"let processNamePadding = datatable (ProcessName: string) [];\");",
+            "query": "print(\"let processNamePadding = datatable (ProcessName: string) [];\");",
             "crossComponentResources": [
               "{Computer}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
+            "queryType": 0,
             "resourceType": "microsoft.compute/virtualmachines"
           },
           {
@@ -504,13 +466,11 @@
             "version": "KqlParameterItem/1.0",
             "name": "Computer_Query",
             "type": 1,
-            "isRequired": false,
             "query": "print(strcat(\"{ServiceMapComputers}\", \" let ipComputerMapping = computers | project Computer, Ipv4 = todynamic(tostring(Properties.Ipv4Addresses_s)) | mvexpand Ipv4 to typeof(string); \", \"{MaliciousIpData}\", \" let totalMaliciousConnectionsCount = maliciousIpData | summarize MaliciousIpInfo = count() | extend Type = 'Overall'; \", \"{ComputerData}\", \" let overalldata = VMConnection | where TimeGenerated {TimeRange} | where Direction == '{Direction}' {ComputerFilter} | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) | extend Name = '🔵 Overall', Type = 'Overall', TypeKey = 0, Key = '--Overall--', ParentKey = '----' | join kind=leftouter totalMaliciousConnectionsCount on Type | extend MaliciousIpInfo = iff(MaliciousIpInfo == '0', '', tostring(MaliciousIpInfo)) | project-away Type1;\", \"{QueryPadDestinationPortTable}\", \"{QueryPadRemoteIpTable}\", \"{QueryPadProcessNameTable}\",\" computerData | union remoteIpPadding | union processNamePadding | union destinationPortPadding | union overalldata \", \"{QueryProject}\"));",
             "crossComponentResources": [
               "{Computer}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
             "resourceType": "microsoft.compute/virtualmachines"
           },
           {
@@ -518,13 +478,11 @@
             "version": "KqlParameterItem/1.0",
             "name": "FinalQuery",
             "type": 1,
-            "isRequired": false,
             "query": "print(strcat(\r\niff({Hierarchy} == 0, \"{Computer_Process_IP_Port}\", \r\niff({Hierarchy} == 1, \"{Computer_Process_IP}\",\r\niff({Hierarchy} == 2, \"{Computer_Process}\",\r\niff({Hierarchy} == 3, \"{Computer}\", \"{Computer}\")))),'{TableFilter:value}'));",
             "crossComponentResources": [
               "{Computer}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
             "resourceType": "microsoft.compute/virtualmachines"
           },
           {
@@ -532,17 +490,14 @@
             "version": "KqlParameterItem/1.0",
             "name": "ConnectionGrid",
             "type": 1,
-            "isRequired": false,
             "value": "{}",
-            "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null
+            "isHiddenWhenLocked": true
           }
         ],
         "style": "above",
         "queryType": 0,
         "resourceType": "microsoft.compute/virtualmachines"
       },
-      "conditionalVisibility": null,
       "name": "parameters - 4"
     },
     {
@@ -550,17 +505,17 @@
       "content": {
         "json": "💡 <em>Select a row from the table below to view connection details for that entry.</em>"
       },
-      "conditionalVisibility": null,
       "name": "text - 5"
     },
     {
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "// {Computer} {Test} {TimeRange} {Direction} {ComputerFilter} {Hierarchy} {TableFilter} {ServiceMapComputers} {MaliciousIpData} {ComputerData} {RemoteIpDataInbound} {ProcessName} {RemoteIpData} {SourcePortData} {DestinationPortData} {QueryProject} {Computer_Process_IP_Port} {Computer_Process_IP} {Computer_Process} {Computer_Query} {FinalQuery}\r\n{FinalQuery:value}",
+        "query": "{FinalQuery:value}",
         "size": 0,
         "exportParameterName": "ConnectionGrid",
         "showAnalytics": true,
+        "exportToExcelOptions": "visible",
         "noDataMessage": "No data to be shown for this particular scope combination, please adjust the time range, table filters, etc.",
         "queryType": 0,
         "resourceType": "microsoft.compute/virtualmachines",
@@ -727,7 +682,77 @@
             "treeType": 0,
             "expanderColumn": "Name",
             "expandTopLevel": true
-          }
+          },
+          "labelSettings": [
+            {
+              "columnId": "ComputerName",
+              "label": "ComputerName"
+            },
+            {
+              "columnId": "ProcessName",
+              "label": "ProcessName"
+            },
+            {
+              "columnId": "RemoteIp",
+              "label": "RemoteIp"
+            },
+            {
+              "columnId": "DestinationPort",
+              "label": "DestinationPort"
+            },
+            {
+              "columnId": "Name",
+              "label": "Name"
+            },
+            {
+              "columnId": "Type",
+              "label": "Type"
+            },
+            {
+              "columnId": "MaliciousConnections",
+              "label": "MaliciousConnections"
+            },
+            {
+              "columnId": "Responses",
+              "label": "Responses"
+            },
+            {
+              "columnId": "MaxLinksLive",
+              "label": "MaxLinksLive"
+            },
+            {
+              "columnId": "LinksFailed",
+              "label": "LinksFailed"
+            },
+            {
+              "columnId": "AverageResponseTime",
+              "label": "AverageResponseTime"
+            },
+            {
+              "columnId": "TotalBytesSent",
+              "label": "TotalBytesSent"
+            },
+            {
+              "columnId": "TotalBytesReceived",
+              "label": "TotalBytesReceived"
+            },
+            {
+              "columnId": "Info",
+              "label": "Info"
+            },
+            {
+              "columnId": "Key",
+              "label": "Key"
+            },
+            {
+              "columnId": "ParentKey",
+              "label": "ParentKey"
+            },
+            {
+              "columnId": "MaliciousConnectionsCount",
+              "label": "MaliciousConnectionsCount"
+            }
+          ]
         },
         "tileSettings": {
           "showBorder": false,
@@ -751,7 +776,6 @@
           }
         }
       },
-      "conditionalVisibility": null,
       "showPin": true,
       "name": "query - 6"
     },
@@ -769,13 +793,12 @@
             "version": "KqlParameterItem/1.0",
             "name": "ComputerName",
             "type": 1,
-            "isRequired": false,
-            "query": "// {Computer:label}\r\nlet row = dynamic({ConnectionGrid});\r\nlet computerName = row.ComputerName;\r\nprint computerName",
+            "query": "let row = dynamic({ConnectionGrid});\r\nlet computerName = row.ComputerName;\r\nprint computerName",
             "crossComponentResources": [
               "{Computer}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
+            "queryType": 0,
             "resourceType": "microsoft.compute/virtualmachines"
           },
           {
@@ -783,13 +806,12 @@
             "version": "KqlParameterItem/1.0",
             "name": "ProcessName",
             "type": 1,
-            "isRequired": false,
-            "query": "// {Computer:label}\r\nlet row = dynamic({ConnectionGrid});\r\nlet ProcessName = row.ProcessName;\r\nprint ProcessName",
+            "query": "let row = dynamic({ConnectionGrid});\r\nlet ProcessName = row.ProcessName;\r\nprint ProcessName",
             "crossComponentResources": [
               "{Computer}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
+            "queryType": 0,
             "resourceType": "microsoft.compute/virtualmachines"
           },
           {
@@ -797,13 +819,12 @@
             "version": "KqlParameterItem/1.0",
             "name": "RemoteIp",
             "type": 1,
-            "isRequired": false,
-            "query": "// {Computer:label}\r\nlet row = dynamic({ConnectionGrid});\r\nlet RemoteIp = row.RemoteIp;\r\nprint RemoteIp",
+            "query": "let row = dynamic({ConnectionGrid});\r\nlet RemoteIp = row.RemoteIp;\r\nprint RemoteIp",
             "crossComponentResources": [
               "{Computer}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
+            "queryType": 0,
             "resourceType": "microsoft.compute/virtualmachines"
           },
           {
@@ -811,13 +832,12 @@
             "version": "KqlParameterItem/1.0",
             "name": "DestinationPort",
             "type": 1,
-            "isRequired": false,
-            "query": "// {Computer:label}\r\nlet row = dynamic({ConnectionGrid});\r\nlet destinationPort = row.DestinationPort;\r\nprint destinationPort",
+            "query": "let row = dynamic({ConnectionGrid});\r\nlet destinationPort = row.DestinationPort;\r\nprint destinationPort",
             "crossComponentResources": [
               "{Computer}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
+            "queryType": 0,
             "resourceType": "microsoft.compute/virtualmachines"
           },
           {
@@ -828,7 +848,6 @@
             "isRequired": true,
             "query": "print(strcat('{ComputerName}{ProcessName}{RemoteIp}{DestinationPort}' != ''))",
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
             "resourceType": "microsoft.compute/virtualmachines"
           },
           {
@@ -836,13 +855,12 @@
             "version": "KqlParameterItem/1.0",
             "name": "Heading",
             "type": 1,
-            "isRequired": false,
-            "query": "// {Computer:label}\r\nprint(strcat('💻 {ComputerName}',iff('{ProcessName}' != '',' > 🎫 {ProcessName}',''),iff('{Direction}' == 'outbound',strcat(iff('{RemoteIp}' != '',' > 🌐 {RemoteIp}',''),iff('{DestinationPort}' != '',' > 🔸 {DestinationPort}','')),strcat(iff('{DestinationPort}' != '',' > 🔸 {DestinationPort}',''),iff('{RemoteIp}' != '',' > 🌐 {RemoteIp}','')))))",
+            "query": "print(strcat('💻 {ComputerName}',iff('{ProcessName}' != '',' > 🎫 {ProcessName}',''),iff('{Direction}' == 'outbound',strcat(iff('{RemoteIp}' != '',' > 🌐 {RemoteIp}',''),iff('{DestinationPort}' != '',' > 🔸 {DestinationPort}','')),strcat(iff('{DestinationPort}' != '',' > 🔸 {DestinationPort}',''),iff('{RemoteIp}' != '',' > 🌐 {RemoteIp}','')))))",
             "crossComponentResources": [
               "{Computer}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
+            "queryType": 0,
             "resourceType": "microsoft.compute/virtualmachines"
           },
           {
@@ -850,13 +868,12 @@
             "version": "KqlParameterItem/1.0",
             "name": "QueryFilter",
             "type": 1,
-            "isRequired": false,
-            "query": "// {Computer:label}\r\nprint(strcat(' where Computer == \"{ComputerName}\"',iff('{ProcessName}' != '', ' | where ProcessName == \"{ProcessName}\"', ''),iff('{RemoteIp}' != '',' | where RemoteIp == \"{RemoteIp}\"',''),iff('{DestinationPort}' != '',' | where DestinationPort == \"{DestinationPort}\"','')));",
+            "query": "print(strcat(' where Computer == \"{ComputerName}\"',iff('{ProcessName}' != '', ' | where ProcessName == \"{ProcessName}\"', ''),iff('{RemoteIp}' != '',' | where RemoteIp == \"{RemoteIp}\"',''),iff('{DestinationPort}' != '',' | where DestinationPort == \"{DestinationPort}\"','')));",
             "crossComponentResources": [
               "{Computer}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
+            "queryType": 0,
             "resourceType": "microsoft.compute/virtualmachines"
           }
         ],
@@ -864,7 +881,6 @@
         "queryType": 0,
         "resourceType": "microsoft.compute/virtualmachines"
       },
-      "conditionalVisibility": null,
       "name": "parameters - 7"
     },
     {
@@ -935,8 +951,9 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "// {Computer:label}\r\nlet SourceMachineData = VMConnection\r\n| where TimeGenerated {TimeRange}\r\n| {QueryFilter}\r\n| where Direction == '{Direction}'\r\n| summarize Responses = sum(Responses) by bin(TimeGenerated, time('{TimeRange:grain}'));\r\nSourceMachineData",
+        "query": "let SourceMachineData = VMConnection\r\n| where TimeGenerated {TimeRange}\r\n| {QueryFilter}\r\n| where Direction == '{Direction}'\r\n| summarize Responses = sum(Responses) by bin(TimeGenerated, time('{TimeRange:grain}'));\r\nSourceMachineData",
         "size": 1,
+        "exportToExcelOptions": "visible",
         "queryType": 0,
         "resourceType": "microsoft.compute/virtualmachines",
         "crossComponentResources": [
@@ -956,9 +973,10 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "// {Computer:label}\r\nlet SourceMachineData = VMConnection\r\n| where TimeGenerated {TimeRange}\r\n| {QueryFilter}\r\n| where Direction == '{Direction}'\r\n| summarize P50 = percentiles(ResponseTimeSum, 50), P90 = percentiles(ResponseTimeSum, 90), P95 = percentiles(ResponseTimeSum, 95) by bin(TimeGenerated, time('{TimeRange:grain}'));\r\nSourceMachineData",
+        "query": "let SourceMachineData = VMConnection\r\n| where TimeGenerated {TimeRange}\r\n| {QueryFilter}\r\n| where Direction == '{Direction}'\r\n| summarize P50 = percentiles(ResponseTimeSum, 50), P90 = percentiles(ResponseTimeSum, 90), P95 = percentiles(ResponseTimeSum, 95) by bin(TimeGenerated, time('{TimeRange:grain}'));\r\nSourceMachineData",
         "size": 1,
         "aggregation": 3,
+        "exportToExcelOptions": "visible",
         "queryType": 0,
         "resourceType": "microsoft.compute/virtualmachines",
         "crossComponentResources": [
@@ -978,8 +996,9 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "// {Computer:label}\r\nlet SourceMachineData = VMConnection\r\n| where TimeGenerated {TimeRange}\r\n| {QueryFilter}\r\n| where Direction == '{Direction}'\r\n| summarize Sent = sum(BytesSent), Received = sum(BytesReceived) by bin(TimeGenerated, time('{TimeRange:grain}'));\r\nSourceMachineData",
+        "query": "let SourceMachineData = VMConnection\r\n| where TimeGenerated {TimeRange}\r\n| {QueryFilter}\r\n| where Direction == '{Direction}'\r\n| summarize Sent = sum(BytesSent), Received = sum(BytesReceived) by bin(TimeGenerated, time('{TimeRange:grain}'));\r\nSourceMachineData",
         "size": 1,
+        "exportToExcelOptions": "visible",
         "queryType": 0,
         "resourceType": "microsoft.compute/virtualmachines",
         "crossComponentResources": [
@@ -999,9 +1018,10 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "// {Computer:label}\r\nlet SourceMachineData = VMConnection\r\n| where TimeGenerated {TimeRange}\r\n| {QueryFilter}\r\n| where Direction == '{Direction}'\r\n| summarize MaxOpenPorts = max(LinksLive), SumFailed = sum(LinksFailed) by bin(TimeGenerated, time('{TimeRange:grain}'));\r\nSourceMachineData",
+        "query": "let SourceMachineData = VMConnection\r\n| where TimeGenerated {TimeRange}\r\n| {QueryFilter}\r\n| where Direction == '{Direction}'\r\n| summarize MaxOpenPorts = max(LinksLive), SumFailed = sum(LinksFailed) by bin(TimeGenerated, time('{TimeRange:grain}'));\r\nSourceMachineData",
         "size": 1,
         "aggregation": 3,
+        "exportToExcelOptions": "visible",
         "queryType": 0,
         "resourceType": "microsoft.compute/virtualmachines",
         "crossComponentResources": [
@@ -1018,5 +1038,6 @@
       "name": "query - 16"
     }
   ],
+  "styleSettings": {},
   "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
 }

--- a/Workbooks/Virtual Machines - Network Dependencies/Connections Overview - Single VM/Connections Overview.workbook
+++ b/Workbooks/Virtual Machines - Network Dependencies/Connections Overview - Single VM/Connections Overview.workbook
@@ -12,7 +12,6 @@
       "type": 9,
       "content": {
         "version": "KqlParameterItem/1.0",
-        "query": "",
         "crossComponentResources": [
           "{Computer}"
         ],
@@ -81,7 +80,6 @@
       "type": 9,
       "content": {
         "version": "KqlParameterItem/1.0",
-        "query": "",
         "crossComponentResources": [
           "{Computer}"
         ],
@@ -197,7 +195,8 @@
                 }
               ],
               "allowCustom": true
-            }
+            },
+            "label": "Time Range"
           },
           {
             "id": "db9b2f1d-188a-4dda-af4a-b39deeb34da3",
@@ -255,7 +254,8 @@
             "typeSettings": {
               "additionalResourceOptions": []
             },
-            "jsonData": "[\r\n    {\r\n        \"label\": \"Only Malicious Connections\",\r\n        \"value\": \" | where MaliciousConnectionsCount >= 1\"\r\n    },\r\n    {\r\n        \"label\": \"Only Links Failed\",\r\n        \"value\": \" | where LinksFailed >= 1\"\r\n    }\r\n]"
+            "jsonData": "[\r\n    {\r\n        \"label\": \"Only Malicious Connections\",\r\n        \"value\": \" | where MaliciousConnectionsCount >= 1\"\r\n    },\r\n    {\r\n        \"label\": \"Only Links Failed\",\r\n        \"value\": \" | where LinksFailed >= 1\"\r\n    }\r\n]",
+            "label": "Table Filter"
           }
         ],
         "style": "above",
@@ -268,7 +268,6 @@
       "type": 9,
       "content": {
         "version": "KqlParameterItem/1.0",
-        "query": "",
         "crossComponentResources": [
           "{Computer}"
         ],
@@ -413,13 +412,8 @@
             "name": "QueryPadDestinationPortTable",
             "type": 1,
             "isRequired": true,
-            "query": "print(\"let destinationPortPadding = datatable (DestinationPort: string) [];\");",
-            "crossComponentResources": [
-              "{Computer}"
-            ],
-            "isHiddenWhenLocked": true,
-            "queryType": 0,
-            "resourceType": "microsoft.compute/virtualmachines"
+            "value": "let destinationPortPadding = datatable (DestinationPort: string) [];",
+            "isHiddenWhenLocked": true
           },
           {
             "id": "df8a6322-511e-40e0-a258-fe717099a072",
@@ -427,13 +421,8 @@
             "name": "QueryPadRemoteIpTable",
             "type": 1,
             "isRequired": true,
-            "query": "print(\"let remoteIpPadding = datatable (RemoteIp: string) [];\");",
-            "crossComponentResources": [
-              "{Computer}"
-            ],
-            "isHiddenWhenLocked": true,
-            "queryType": 0,
-            "resourceType": "microsoft.compute/virtualmachines"
+            "value": "let remoteIpPadding = datatable (RemoteIp: string) [];",
+            "isHiddenWhenLocked": true
           },
           {
             "id": "e8f2c394-18e8-4d6d-8f5e-8453cb67128c",
@@ -453,13 +442,8 @@
             "name": "QueryPadProcessNameTable",
             "type": 1,
             "isRequired": true,
-            "query": "print(\"let processNamePadding = datatable (ProcessName: string) [];\");",
-            "crossComponentResources": [
-              "{Computer}"
-            ],
-            "isHiddenWhenLocked": true,
-            "queryType": 0,
-            "resourceType": "microsoft.compute/virtualmachines"
+            "value": "let processNamePadding = datatable (ProcessName: string) [];",
+            "isHiddenWhenLocked": true
           },
           {
             "id": "a4b0e146-7c89-40bb-ade2-ed2e392e9311",
@@ -783,7 +767,6 @@
       "type": 9,
       "content": {
         "version": "KqlParameterItem/1.0",
-        "query": "",
         "crossComponentResources": [
           "{Computer}"
         ],

--- a/Workbooks/Virtual Machines - Network Dependencies/Connections Overview/Connections Overview.workbook
+++ b/Workbooks/Virtual Machines - Network Dependencies/Connections Overview/Connections Overview.workbook
@@ -5,7 +5,6 @@
       "type": 9,
       "content": {
         "version": "KqlParameterItem/1.0",
-        "query": "",
         "crossComponentResources": [
           "{Workspace}"
         ],
@@ -38,8 +37,7 @@
             ],
             "isHiddenWhenLocked": true,
             "queryType": 0,
-            "resourceType": "microsoft.operationalinsights/workspaces",
-            "value": null
+            "resourceType": "microsoft.operationalinsights/workspaces"
           },
           {
             "id": "648ac90d-4be5-4c08-ac13-bcff7f8ddbf9",
@@ -77,7 +75,6 @@
       "type": 9,
       "content": {
         "version": "KqlParameterItem/1.0",
-        "query": "",
         "crossComponentResources": [
           "{Workspace}"
         ],
@@ -193,7 +190,8 @@
                 }
               ],
               "allowCustom": true
-            }
+            },
+            "label": "Time Range"
           },
           {
             "id": "db9b2f1d-188a-4dda-af4a-b39deeb34da3",
@@ -212,7 +210,8 @@
             "id": "8744c427-f060-4725-95af-850af2fa08b1",
             "version": "KqlParameterItem/1.0",
             "name": "ComputerNameContains",
-            "type": 1
+            "type": 1,
+            "label": "Computer Name Contains"
           },
           {
             "id": "b141bd6c-cd8d-488e-a5f6-83ab00d31161",
@@ -234,8 +233,7 @@
             },
             "timeContextFromParameter": "TimeRange",
             "queryType": 0,
-            "resourceType": "microsoft.operationalinsights/workspaces",
-            "value": null
+            "resourceType": "microsoft.operationalinsights/workspaces"
           },
           {
             "id": "488d1f86-cabc-4fcc-8dc9-9a2e5803fb20",
@@ -247,7 +245,6 @@
             "crossComponentResources": [
               "{Workspace}"
             ],
-            "value": null,
             "isHiddenWhenLocked": true,
             "queryType": 0,
             "resourceType": "microsoft.operationalinsights/workspaces"
@@ -282,7 +279,8 @@
             "typeSettings": {
               "additionalResourceOptions": []
             },
-            "jsonData": "[\r\n    {\r\n        \"label\": \"Only Malicious Connections\",\r\n        \"value\": \" | where MaliciousConnectionsCount >= 1\"\r\n    },\r\n    {\r\n        \"label\": \"Only Links Failed\",\r\n        \"value\": \" | where LinksFailed >= 1\"\r\n    }\r\n]"
+            "jsonData": "[\r\n    {\r\n        \"label\": \"Only Malicious Connections\",\r\n        \"value\": \" | where MaliciousConnectionsCount >= 1\"\r\n    },\r\n    {\r\n        \"label\": \"Only Links Failed\",\r\n        \"value\": \" | where LinksFailed >= 1\"\r\n    }\r\n]",
+            "label": "Table Filter"
           }
         ],
         "style": "above",
@@ -295,7 +293,6 @@
       "type": 9,
       "content": {
         "version": "KqlParameterItem/1.0",
-        "query": "",
         "crossComponentResources": [
           "{Workspace}"
         ],
@@ -704,7 +701,77 @@
             "treeType": 0,
             "expanderColumn": "Name",
             "expandTopLevel": false
-          }
+          },
+          "labelSettings": [
+            {
+              "columnId": "ComputerName",
+              "label": "ComputerName"
+            },
+            {
+              "columnId": "ProcessName",
+              "label": "ProcessName"
+            },
+            {
+              "columnId": "RemoteIp",
+              "label": "RemoteIp"
+            },
+            {
+              "columnId": "DestinationPort",
+              "label": "DestinationPort"
+            },
+            {
+              "columnId": "Name",
+              "label": "Name"
+            },
+            {
+              "columnId": "Type",
+              "label": "Type"
+            },
+            {
+              "columnId": "MaliciousConnections",
+              "label": "MaliciousConnections"
+            },
+            {
+              "columnId": "Responses",
+              "label": "Responses"
+            },
+            {
+              "columnId": "MaxLinksLive",
+              "label": "MaxLinksLive"
+            },
+            {
+              "columnId": "LinksFailed",
+              "label": "LinksFailed"
+            },
+            {
+              "columnId": "AverageResponseTime",
+              "label": "AverageResponseTime"
+            },
+            {
+              "columnId": "TotalBytesSent",
+              "label": "TotalBytesSent"
+            },
+            {
+              "columnId": "TotalBytesReceived",
+              "label": "TotalBytesReceived"
+            },
+            {
+              "columnId": "Info",
+              "label": "Info"
+            },
+            {
+              "columnId": "Key",
+              "label": "Key"
+            },
+            {
+              "columnId": "ParentKey",
+              "label": "ParentKey"
+            },
+            {
+              "columnId": "MaliciousConnectionsCount",
+              "label": "MaliciousConnectionsCount"
+            }
+          ]
         },
         "tileSettings": {
           "showBorder": false,
@@ -735,7 +802,6 @@
       "type": 9,
       "content": {
         "version": "KqlParameterItem/1.0",
-        "query": "",
         "crossComponentResources": [
           "{Workspace}"
         ],

--- a/Workbooks/Virtual Machines - Network Dependencies/Connections Overview/Connections Overview.workbook
+++ b/Workbooks/Virtual Machines - Network Dependencies/Connections Overview/Connections Overview.workbook
@@ -6,7 +6,9 @@
       "content": {
         "version": "KqlParameterItem/1.0",
         "query": "",
-        "crossComponentResources": [],
+        "crossComponentResources": [
+          "{Workspace}"
+        ],
         "parameters": [
           {
             "id": "e41c2177-932a-4c58-ba24-03ef070eb197",
@@ -23,36 +25,32 @@
               "additionalResourceOptions": [
                 "value::1"
               ]
-            },
-            "timeContextFromParameter": null
+            }
           },
           {
             "id": "a9393837-8ef0-40e5-b223-4df1208a691e",
             "version": "KqlParameterItem/1.0",
             "name": "Test",
             "type": 1,
-            "isRequired": false,
             "query": "VMConnection\r\n| take 1\r\n| summarize count()",
             "crossComponentResources": [
               "{Workspace}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
             "queryType": 0,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "resourceType": "microsoft.operationalinsights/workspaces",
+            "value": null
           },
           {
             "id": "648ac90d-4be5-4c08-ac13-bcff7f8ddbf9",
             "version": "KqlParameterItem/1.0",
             "name": "DisclaimerText",
             "type": 1,
-            "isRequired": false,
             "query": "print iff('{Test}' == '' , 'This workbook requires [Azure Monitor for VMs (preview)](https://docs.microsoft.com/en-us/azure/azure-monitor/insights/vminsights-overview) enabled', iff('{Test}' == '0', '⚠ There is currently no `VMConnection` data in this workspace', 'The following table presents the connection statistics for computers in your workspace (max `10,000` rows). Use the <em>Hierarchy</em> dropdown for more detailed information for each computer but fewer computers will be shown if the total number of rows rendered exceeds `10,000`.'))",
             "crossComponentResources": [
               "{Workspace}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
             "queryType": 0,
             "resourceType": "microsoft.operationalinsights/workspaces"
           }
@@ -73,7 +71,6 @@
       "content": {
         "json": "{DisclaimerText}\r\n\r\n---"
       },
-      "conditionalVisibility": null,
       "name": "text - 1"
     },
     {
@@ -94,7 +91,6 @@
             "value": {
               "durationMs": 3600000
             },
-            "isHiddenWhenLocked": false,
             "typeSettings": {
               "selectableValues": [
                 {
@@ -197,8 +193,7 @@
                 }
               ],
               "allowCustom": true
-            },
-            "timeContextFromParameter": null
+            }
           },
           {
             "id": "db9b2f1d-188a-4dda-af4a-b39deeb34da3",
@@ -208,28 +203,22 @@
             "description": "Direction of the network connection from the VMs",
             "isRequired": true,
             "value": "outbound",
-            "isHiddenWhenLocked": false,
             "typeSettings": {
               "additionalResourceOptions": []
             },
-            "jsonData": "[\r\n    { \"value\":\"inbound\", \"label\":\"Inbound\" },\r\n    { \"value\":\"outbound\", \"label\":\"Outbound\" }\r\n]",
-            "timeContextFromParameter": null
+            "jsonData": "[\r\n    { \"value\":\"inbound\", \"label\":\"Inbound\" },\r\n    { \"value\":\"outbound\", \"label\":\"Outbound\" }\r\n]"
           },
           {
             "id": "8744c427-f060-4725-95af-850af2fa08b1",
             "version": "KqlParameterItem/1.0",
             "name": "ComputerNameContains",
-            "type": 1,
-            "isRequired": false,
-            "isHiddenWhenLocked": false,
-            "timeContextFromParameter": null
+            "type": 1
           },
           {
             "id": "b141bd6c-cd8d-488e-a5f6-83ab00d31161",
             "version": "KqlParameterItem/1.0",
             "name": "Computers",
             "type": 2,
-            "isRequired": false,
             "multiSelect": true,
             "quote": "'",
             "delimiter": ",",
@@ -237,7 +226,6 @@
             "crossComponentResources": [
               "{Workspace}"
             ],
-            "isHiddenWhenLocked": false,
             "typeSettings": {
               "additionalResourceOptions": []
             },
@@ -246,7 +234,8 @@
             },
             "timeContextFromParameter": "TimeRange",
             "queryType": 0,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "resourceType": "microsoft.operationalinsights/workspaces",
+            "value": null
           },
           {
             "id": "488d1f86-cabc-4fcc-8dc9-9a2e5803fb20",
@@ -254,12 +243,12 @@
             "name": "ComputerFilter",
             "type": 1,
             "isRequired": true,
-            "query": "// {Workspace} {Test} {DisclaimerText} {ComputerNameContains} {Computers}\r\nlet computerFilter = iff('*' in ({Computers}), \"| where Computer contains '{ComputerNameContains}'\", \"| where Computer in ({Computers})\");\r\nprint(computerFilter)",
+            "query": "let computerFilter = iff('*' in ({Computers}), \"| where Computer contains '{ComputerNameContains}'\", \"| where Computer in ({Computers})\");\r\nprint(computerFilter)",
             "crossComponentResources": [
               "{Workspace}"
             ],
+            "value": null,
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
             "queryType": 0,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
@@ -275,11 +264,9 @@
               "{Workspace}"
             ],
             "value": "2",
-            "isHiddenWhenLocked": false,
             "typeSettings": {
               "additionalResourceOptions": []
             },
-            "timeContextFromParameter": null,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
           {
@@ -288,24 +275,20 @@
             "name": "TableFilter",
             "type": 2,
             "description": "Filter table based on presence of malicious connections or at least one link failing",
-            "isRequired": false,
             "multiSelect": true,
             "quote": "",
             "delimiter": "",
             "value": [],
-            "isHiddenWhenLocked": false,
             "typeSettings": {
               "additionalResourceOptions": []
             },
-            "jsonData": "[\r\n    {\r\n        \"label\": \"Only Malicious Connections\",\r\n        \"value\": \" | where MaliciousConnectionsCount >= 1\"\r\n    },\r\n    {\r\n        \"label\": \"Only Links Failed\",\r\n        \"value\": \" | where LinksFailed >= 1\"\r\n    }\r\n]",
-            "timeContextFromParameter": null
+            "jsonData": "[\r\n    {\r\n        \"label\": \"Only Malicious Connections\",\r\n        \"value\": \" | where MaliciousConnectionsCount >= 1\"\r\n    },\r\n    {\r\n        \"label\": \"Only Links Failed\",\r\n        \"value\": \" | where LinksFailed >= 1\"\r\n    }\r\n]"
           }
         ],
         "style": "above",
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces"
       },
-      "conditionalVisibility": null,
       "name": "parameters - 2"
     },
     {
@@ -328,7 +311,6 @@
               "{Workspace}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
             "queryType": 0,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
@@ -337,13 +319,11 @@
             "version": "KqlParameterItem/1.0",
             "name": "MaliciousIpData",
             "type": 1,
-            "isRequired": false,
             "query": "print(\"let maliciousIpData = VMConnection  | where Direction == '{Direction}' {ComputerFilter} | where MaliciousIp != '' | summarize by Computer, ProcessName, MaliciousIp, DestinationPort, RemoteIp, IsActive, IndicatorThreatType, RemoteCountry, RemoteLongitude, RemoteLatitude, Confidence, Severity, FirstReportedDateTime, LastReportedDateTime | project MaliciousIp = strcat(Computer, '-', ProcessName, '-', MaliciousIp), MaliciousPort = strcat(Computer, '-', ProcessName, '-', DestinationPort), MaliciousPortIp = strcat(Computer, '-', ProcessName, '-', DestinationPort, '-', RemoteIp), Computer = Computer, Process = strcat(Computer, '-', ProcessName), MaliciousIpInfo = pack('Malicious IP', MaliciousIp, 'Is Active', IsActive, 'Indicator Threat Type', IndicatorThreatType, 'Remote Country', RemoteCountry, 'Longitude', RemoteLongitude, 'Latitude', RemoteLatitude, 'Confidence', Confidence, 'Severity', Severity, 'First Reported DateTime', FirstReportedDateTime, 'Last Reported DateTime', LastReportedDateTime, 'Destination Port', DestinationPort, 'Remote IP', RemoteIp);\");",
             "crossComponentResources": [
               "{Workspace}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
             "queryType": 0,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
@@ -352,13 +332,11 @@
             "version": "KqlParameterItem/1.0",
             "name": "ComputerData",
             "type": 1,
-            "isRequired": false,
             "query": "print(\"let computerData = VMConnection | where Direction == '{Direction}' {ComputerFilter} | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 * sum(ResponseTimeSum) / sum(Responses) by Name = strcat('🖥️ ', Computer), ComputerName = Computer, Type = 'Computer', TypeKey = 1, Key = Computer, ParentKey = '---' | join kind=leftouter (maliciousIpData | summarize MaliciousIpInfo = tostring(count()) by Computer) on $left.Key == $right.Computer | project-away Computer | order by Name asc;\");",
             "crossComponentResources": [
               "{Workspace}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
             "queryType": 0,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
@@ -367,13 +345,11 @@
             "version": "KqlParameterItem/1.0",
             "name": "RemoteIpDataInbound",
             "type": 1,
-            "isRequired": false,
             "query": "print(\"let remoteIpDataInbound = VMConnection | where Direction == 'inbound' | where 'inbound' == 'inbound' {ComputerFilter} | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) by Computer, ProcessName, RemoteIp, Type = 'Remote Computer', TypeKey = 3, Key = strcat(Computer, '-', ProcessName, '-', tostring(DestinationPort), '-', RemoteIp), ParentKey = strcat(Computer, '-', ProcessName, '-', tostring(DestinationPort)), Id = strcat(Computer, '-', ProcessName, '-', RemoteIp), ComputerName = Computer | join kind=inner     sourcePortData on $left.ParentKey == $right.Key | project-away AverageResponseTime1, Computer1, Key1, LinksFailed1, MaxLinksLive1, ParentKey1, ProcessName1, Responses1, TotalBytesReceived1, TotalBytesSent1, Type1, TypeKey1 | order by Name asc | join kind=leftouter     ipComputerMapping on $left.RemoteIp == $right.Ipv4 | extend Name = iff(RemoteIp == '', 'Unknown',  strcat('🌐 External (', RemoteIp, ')')) | project-away Computer, Ipv4 | order by Name desc | join kind=leftouter     maliciousIpData on $left.Key == $right.MaliciousPortIp | extend MaliciousIpInfo = tostring(MaliciousIpInfo1) | project-away MaliciousIp, Computer, Process, Computer1, MaliciousIpInfo1, Id;\");",
             "crossComponentResources": [
               "{Workspace}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
             "queryType": 0,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
@@ -382,13 +358,11 @@
             "version": "KqlParameterItem/1.0",
             "name": "ProcessName",
             "type": 1,
-            "isRequired": false,
             "query": "print(\"let processData = VMConnection | where Direction == '{Direction}' {ComputerFilter} | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) by Computer, ProcessName, Name = strcat('🎫 ', ProcessName), Type = 'Process', TypeKey = 2, Key = strcat(Computer, '-', ProcessName), ParentKey = Computer, ComputerName = Computer | join kind=inner computerData on $left.ParentKey == $right.Key | project-away Name1, Responses1, LinksFailed1, MaxLinksLive1, TotalBytesSent1, TotalBytesReceived1, AverageResponseTime1, Type1, Key1, ParentKey1 | join kind=leftouter (maliciousIpData | summarize MaliciousIpInfo = tostring(count()) by Process) on $left.Key == $right.Process | project-away Process, MaliciousIpInfo | extend MaliciousIpInfo = tostring(MaliciousIpInfo1) | project-away MaliciousIpInfo1 | order by Name asc;\");",
             "crossComponentResources": [
               "{Workspace}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
             "queryType": 0,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
@@ -403,7 +377,6 @@
               "{Workspace}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
             "queryType": 0,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
@@ -412,13 +385,11 @@
             "version": "KqlParameterItem/1.0",
             "name": "SourcePortData",
             "type": 1,
-            "isRequired": false,
             "query": "print(\"let sourcePortData = VMConnection | where Direction == '{Direction}' | where '{Direction}' == 'inbound' {ComputerFilter} | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) by Computer, ProcessName, DestinationIp, DestinationPort, Name = strcat('🔶 ', DestinationPort), Type = 'Remote Port', TypeKey = 4, Key = strcat(Computer, '-', ProcessName, '-', tostring(DestinationPort)), ParentKey = strcat(Computer, '-', ProcessName), ComputerName = Computer | join kind=leftouter maliciousIpData on $left.Key == $right.MaliciousPort | extend MaliciousIpInfo = tostring(MaliciousIpInfo) | project-away Computer1, MaliciousIp, MaliciousPort, MaliciousPortIp, Process; {RemoteIpDataInbound}\");",
             "crossComponentResources": [
               "{Workspace}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
             "queryType": 0,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
@@ -427,13 +398,11 @@
             "version": "KqlParameterItem/1.0",
             "name": "DestinationPortData",
             "type": 1,
-            "isRequired": false,
             "query": "print(\"let destinationPortData = VMConnection | where Direction == '{Direction}' | where '{Direction}' == 'outbound' {ComputerFilter} | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) by Computer, ProcessName, DestinationIp, DestinationPort, Name = strcat('🔶 ', DestinationPort), Type = 'Remote Port', TypeKey = 4, Key = strcat(Computer, '-', ProcessName, '-', DestinationIp, '-', tostring(DestinationPort)), ParentKey = strcat(Computer, '-', ProcessName, '-', DestinationIp), ComputerName = Computer | join kind=inner remoteIpData on $left.ParentKey == $right.Key | project-away Name1, Responses1, Type1, Key1, ParentKey1 | order by Name asc;\");",
             "crossComponentResources": [
               "{Workspace}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
             "queryType": 0,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
@@ -442,13 +411,11 @@
             "version": "KqlParameterItem/1.0",
             "name": "QueryProject",
             "type": 1,
-            "isRequired": false,
             "query": "print(\"| extend MaliciousConnectionsCount = iff(MaliciousIpInfo == '', 0, iff(Type == 'Computer' or Type == 'Process' or Type == 'Overall', tolong(MaliciousIpInfo), 1)) | project ComputerName, ProcessName, RemoteIp, DestinationPort, Name = iff(Name == '🎫 ', '🎫 <Unknown>', Name), Type, MaliciousConnections = iff(MaliciousIpInfo == '', '✅ No Malicious Connections', iff(Type == 'Computer' or Type == 'Process' or Type == 'Overall', iff(MaliciousConnectionsCount > 1, strcat('❌ ', MaliciousIpInfo, ' Malicious Connections'), strcat('❌ ', MaliciousIpInfo, ' Malicious Connection')), '❌ Malicious Connection')), Responses, MaxLinksLive, LinksFailed, AverageResponseTime, TotalBytesSent, TotalBytesReceived, Info = iff(MaliciousIpInfo != '', MaliciousIpInfo, ''), Key, ParentKey, TypeKey, MaliciousConnectionsCount | order by TypeKey asc, MaliciousConnectionsCount desc, LinksFailed desc, AverageResponseTime desc, Responses desc, MaxLinksLive desc, Name asc | project-away TypeKey\");",
             "crossComponentResources": [
               "{Workspace}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
           {
@@ -456,13 +423,11 @@
             "version": "KqlParameterItem/1.0",
             "name": "Computer_Process_IP_Port",
             "type": 1,
-            "isRequired": false,
             "query": "print(strcat(\"{ServiceMapComputers}\", \" let ipComputerMapping = computers | project Computer, Ipv4 = todynamic(tostring(Properties.Ipv4Addresses_s)) | mvexpand Ipv4 to typeof(string); \", \"{MaliciousIpData}\", \" let totalMaliciousConnectionsCount = maliciousIpData | summarize MaliciousIpInfo = count() | extend Type = 'Overall'; \", \"{ComputerData}\", \"{ProcessName}\", \"{RemoteIpData}\", \"{DestinationPortData}\", \"{SourcePortData}\", \" let overalldata = VMConnection | where Direction == '{Direction}' {ComputerFilter} | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) | extend Name = '🔵 Overall', Type = 'Overall', TypeKey = 0, Key = '--Overall--', ParentKey = '----' | join kind=leftouter totalMaliciousConnectionsCount on Type | extend MaliciousIpInfo = iff(MaliciousIpInfo == '0', '', tostring(MaliciousIpInfo)) | project-away Type1; computerData | union processData | union remoteIpData | union destinationPortData | union remoteIpDataInbound | union sourcePortData | union overalldata\t\", \"{QueryProject}\"));",
             "crossComponentResources": [
               "{Workspace}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
             "queryType": 0,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
@@ -471,13 +436,11 @@
             "version": "KqlParameterItem/1.0",
             "name": "Computer_Process_IP",
             "type": 1,
-            "isRequired": false,
             "query": "print(strcat(\"{ServiceMapComputers}\", \" let ipComputerMapping = computers | project Computer, Ipv4 = todynamic(tostring(Properties.Ipv4Addresses_s)) | mvexpand Ipv4 to typeof(string); \", \"{MaliciousIpData}\", \" let totalMaliciousConnectionsCount = maliciousIpData | summarize MaliciousIpInfo = count() | extend Type = 'Overall'; \", \"{ComputerData}\", \"{ProcessName}\", \"{RemoteIpData}\", \"{SourcePortData}\", \" let overalldata = VMConnection | where Direction == '{Direction}' {ComputerFilter} | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) | extend Name = '🔵 Overall', Type = 'Overall', TypeKey = 0, Key = '--Overall--', ParentKey = '----' | join kind=leftouter totalMaliciousConnectionsCount on Type | extend MaliciousIpInfo = iff(MaliciousIpInfo == '0', '', tostring(MaliciousIpInfo)) | project-away Type1;\" ,\" computerData | union processData | union remoteIpData | union sourcePortData | union overalldata \", \"{QueryProject}\"));",
             "crossComponentResources": [
               "{Workspace}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
             "queryType": 0,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
@@ -487,12 +450,12 @@
             "name": "QueryPadDestinationPortTable",
             "type": 1,
             "isRequired": true,
-            "query": "// {Workspace:label}\r\nprint(\"let destinationPortPadding = datatable (DestinationPort: string) [];\");",
+            "query": "print(\"let destinationPortPadding = datatable (DestinationPort: string) [];\");",
             "crossComponentResources": [
               "{Workspace}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
+            "queryType": 0,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
           {
@@ -501,12 +464,12 @@
             "name": "QueryPadRemoteIpTable",
             "type": 1,
             "isRequired": true,
-            "query": "// {Workspace:label}\r\nprint(\"let remoteIpPadding = datatable (RemoteIp: string) [];\");",
+            "query": "print(\"let remoteIpPadding = datatable (RemoteIp: string) [];\");",
             "crossComponentResources": [
               "{Workspace}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
+            "queryType": 0,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
           {
@@ -514,13 +477,11 @@
             "version": "KqlParameterItem/1.0",
             "name": "Computer_Process",
             "type": 1,
-            "isRequired": false,
             "query": "print(strcat(\"{ServiceMapComputers}\", \" let ipComputerMapping = computers | project Computer, Ipv4 = todynamic(tostring(Properties.Ipv4Addresses_s)) | mvexpand Ipv4 to typeof(string); \", \"{MaliciousIpData}\", \" let totalMaliciousConnectionsCount = maliciousIpData | summarize MaliciousIpInfo = count() | extend Type = 'Overall'; \", \"{ComputerData}\", \"{ProcessName}\", \" let overalldata = VMConnection | where Direction == '{Direction}' {ComputerFilter} | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) | extend Name = '🔵 Overall', Type = 'Overall', TypeKey = 0, Key = '--Overall--', ParentKey = '----' | join kind=leftouter totalMaliciousConnectionsCount on Type | extend MaliciousIpInfo = iff(MaliciousIpInfo == '0', '', tostring(MaliciousIpInfo)) | project-away Type1;\", \"{QueryPadDestinationPortTable}\", \"{QueryPadRemoteIpTable}\",\" computerData | union remoteIpPadding | union destinationPortPadding | union processData | union overalldata \", \"{QueryProject}\"));",
             "crossComponentResources": [
               "{Workspace}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
             "queryType": 0,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
@@ -530,12 +491,12 @@
             "name": "QueryPadProcessNameTable",
             "type": 1,
             "isRequired": true,
-            "query": "// {Workspace:label}\r\nprint(\"let processNamePadding = datatable (ProcessName: string) [];\");",
+            "query": "print(\"let processNamePadding = datatable (ProcessName: string) [];\");",
             "crossComponentResources": [
               "{Workspace}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
+            "queryType": 0,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
           {
@@ -543,13 +504,11 @@
             "version": "KqlParameterItem/1.0",
             "name": "Computer",
             "type": 1,
-            "isRequired": false,
             "query": "print(strcat(\"{ServiceMapComputers}\", \" let ipComputerMapping = computers | project Computer, Ipv4 = todynamic(tostring(Properties.Ipv4Addresses_s)) | mvexpand Ipv4 to typeof(string); \", \"{MaliciousIpData}\", \" let totalMaliciousConnectionsCount = maliciousIpData | summarize MaliciousIpInfo = count() | extend Type = 'Overall'; \", \"{ComputerData}\", \" let overalldata = VMConnection | where Direction == '{Direction}' {ComputerFilter} | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) | extend Name = '🔵 Overall', Type = 'Overall', TypeKey = 0, Key = '--Overall--', ParentKey = '----' | join kind=leftouter totalMaliciousConnectionsCount on Type | extend MaliciousIpInfo = iff(MaliciousIpInfo == '0', '', tostring(MaliciousIpInfo)) | project-away Type1;\", \"{QueryPadDestinationPortTable}\", \"{QueryPadRemoteIpTable}\", \"{QueryPadProcessNameTable}\",\" computerData | union remoteIpPadding | union processNamePadding | union destinationPortPadding | union overalldata \", \"{QueryProject}\"));",
             "crossComponentResources": [
               "{Workspace}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
             "queryType": 0,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
@@ -558,13 +517,11 @@
             "version": "KqlParameterItem/1.0",
             "name": "FinalQuery",
             "type": 1,
-            "isRequired": false,
             "query": "print(strcat(\r\niff({Hierarchy} == 0, \"{Computer_Process_IP_Port}\", \r\niff({Hierarchy} == 1, \"{Computer_Process_IP}\",\r\niff({Hierarchy} == 2, \"{Computer_Process}\",\r\niff({Hierarchy} == 3, \"{Computer}\", \"{Computer}\")))),'{TableFilter:value}'));",
             "crossComponentResources": [
               "{Workspace}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
           {
@@ -572,17 +529,14 @@
             "version": "KqlParameterItem/1.0",
             "name": "ConnectionGrid",
             "type": 1,
-            "isRequired": false,
             "value": "{}",
-            "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null
+            "isHiddenWhenLocked": true
           }
         ],
         "style": "above",
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces"
       },
-      "conditionalVisibility": null,
       "name": "parameters - 3"
     },
     {
@@ -590,17 +544,17 @@
       "content": {
         "json": "💡 <em>Select a row from the table below to view connection details for that entry.</em>"
       },
-      "conditionalVisibility": null,
       "name": "text - 4"
     },
     {
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "// {Workspace} {Test} {TimeRange} {Direction} {ComputerNameContains} {Computers} {ComputerFilter} {Hierarchy} {TableFilter} {ServiceMapComputers} {MaliciousIpData} {ComputerData} {RemoteIpDataInbound} {ProcessName} {RemoteIpData} {SourcePortData} {DestinationPortData} {QueryProject} {Computer_Process_IP_Port} {Computer_Process_IP} {Computer_Process} {Computer} {FinalQuery}\r\n{FinalQuery:value}",
+        "query": "{FinalQuery:value}",
         "size": 0,
         "exportParameterName": "ConnectionGrid",
         "showAnalytics": true,
+        "exportToExcelOptions": "visible",
         "noDataMessage": "No data to be shown for this particular scope combination, please adjust the time range, table filters, etc.",
         "timeContext": {
           "durationMs": 0
@@ -774,7 +728,6 @@
           }
         }
       },
-      "conditionalVisibility": null,
       "showPin": true,
       "name": "query - 5"
     },
@@ -792,13 +745,12 @@
             "version": "KqlParameterItem/1.0",
             "name": "ComputerName",
             "type": 1,
-            "isRequired": false,
-            "query": "// {Workspace:label}\r\nlet row = dynamic({ConnectionGrid});\r\nlet computerName = row.ComputerName;\r\nprint computerName",
+            "query": "let row = dynamic({ConnectionGrid});\r\nlet computerName = row.ComputerName;\r\nprint computerName",
             "crossComponentResources": [
               "{Workspace}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
+            "queryType": 0,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
           {
@@ -806,13 +758,12 @@
             "version": "KqlParameterItem/1.0",
             "name": "ProcessName",
             "type": 1,
-            "isRequired": false,
-            "query": "// {Workspace:label}\r\nlet row = dynamic({ConnectionGrid});\r\nlet ProcessName = row.ProcessName;\r\nprint ProcessName",
+            "query": "let row = dynamic({ConnectionGrid});\r\nlet ProcessName = row.ProcessName;\r\nprint ProcessName",
             "crossComponentResources": [
               "{Workspace}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
+            "queryType": 0,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
           {
@@ -820,13 +771,12 @@
             "version": "KqlParameterItem/1.0",
             "name": "RemoteIp",
             "type": 1,
-            "isRequired": false,
-            "query": "// {Workspace:label}\r\nlet row = dynamic({ConnectionGrid});\r\nlet RemoteIp = row.RemoteIp;\r\nprint RemoteIp",
+            "query": "let row = dynamic({ConnectionGrid});\r\nlet RemoteIp = row.RemoteIp;\r\nprint RemoteIp",
             "crossComponentResources": [
               "{Workspace}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
+            "queryType": 0,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
           {
@@ -834,13 +784,12 @@
             "version": "KqlParameterItem/1.0",
             "name": "DestinationPort",
             "type": 1,
-            "isRequired": false,
-            "query": "// {Workspace:label}\r\nlet row = dynamic({ConnectionGrid});\r\nlet destinationPort = row.DestinationPort;\r\nprint destinationPort",
+            "query": "let row = dynamic({ConnectionGrid});\r\nlet destinationPort = row.DestinationPort;\r\nprint destinationPort",
             "crossComponentResources": [
               "{Workspace}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
+            "queryType": 0,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
           {
@@ -854,7 +803,6 @@
               "{Workspace}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
           {
@@ -862,13 +810,12 @@
             "version": "KqlParameterItem/1.0",
             "name": "Heading",
             "type": 1,
-            "isRequired": false,
-            "query": "// {Workspace:label}\r\nprint(strcat('💻 {ComputerName}',iff('{ProcessName}' != '',' > 🎫 {ProcessName}',''),iff('{Direction}' == 'outbound',strcat(iff('{RemoteIp}' != '',' > 🌐 {RemoteIp}',''),iff('{DestinationPort}' != '',' > 🔸 {DestinationPort}','')),strcat(iff('{DestinationPort}' != '',' > 🔸 {DestinationPort}',''),iff('{RemoteIp}' != '',' > 🌐 {RemoteIp}','')))))",
+            "query": "print(strcat('💻 {ComputerName}',iff('{ProcessName}' != '',' > 🎫 {ProcessName}',''),iff('{Direction}' == 'outbound',strcat(iff('{RemoteIp}' != '',' > 🌐 {RemoteIp}',''),iff('{DestinationPort}' != '',' > 🔸 {DestinationPort}','')),strcat(iff('{DestinationPort}' != '',' > 🔸 {DestinationPort}',''),iff('{RemoteIp}' != '',' > 🌐 {RemoteIp}','')))))",
             "crossComponentResources": [
               "{Workspace}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
+            "queryType": 0,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
           {
@@ -876,13 +823,12 @@
             "version": "KqlParameterItem/1.0",
             "name": "QueryFilter",
             "type": 1,
-            "isRequired": false,
-            "query": "// {Workspace:label}\r\nprint(strcat(' where Computer == \"{ComputerName}\"',iff('{ProcessName}' != '', ' | where ProcessName == \"{ProcessName}\"', ''),iff('{RemoteIp}' != '',' | where RemoteIp == \"{RemoteIp}\"',''),iff('{DestinationPort}' != '',' | where DestinationPort == \"{DestinationPort}\"','')));",
+            "query": "print(strcat(' where Computer == \"{ComputerName}\"',iff('{ProcessName}' != '', ' | where ProcessName == \"{ProcessName}\"', ''),iff('{RemoteIp}' != '',' | where RemoteIp == \"{RemoteIp}\"',''),iff('{DestinationPort}' != '',' | where DestinationPort == \"{DestinationPort}\"','')));",
             "crossComponentResources": [
               "{Workspace}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
+            "queryType": 0,
             "resourceType": "microsoft.operationalinsights/workspaces"
           }
         ],
@@ -890,7 +836,6 @@
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces"
       },
-      "conditionalVisibility": null,
       "name": "parameters - 6"
     },
     {
@@ -961,8 +906,9 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "// {Workspace:label}\r\nlet SourceMachineData = VMConnection\r\n| where TimeGenerated {TimeRange}\r\n| {QueryFilter}\r\n| where Direction == '{Direction}'\r\n| summarize Responses = sum(Responses) by bin(TimeGenerated, time('{TimeRange:grain}'));\r\nSourceMachineData",
+        "query": "let SourceMachineData = VMConnection\r\n| where TimeGenerated {TimeRange}\r\n| {QueryFilter}\r\n| where Direction == '{Direction}'\r\n| summarize Responses = sum(Responses) by bin(TimeGenerated, time('{TimeRange:grain}'));\r\nSourceMachineData",
         "size": 1,
+        "exportToExcelOptions": "visible",
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
         "crossComponentResources": [
@@ -982,9 +928,10 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "// {Workspace:label}\r\nlet SourceMachineData = VMConnection\r\n| where TimeGenerated {TimeRange}\r\n| {QueryFilter}\r\n| where Direction == '{Direction}'\r\n| summarize P50 = percentiles(ResponseTimeSum, 50), P90 = percentiles(ResponseTimeSum, 90), P95 = percentiles(ResponseTimeSum, 95) by bin(TimeGenerated, time('{TimeRange:grain}'));\r\nSourceMachineData",
+        "query": "let SourceMachineData = VMConnection\r\n| where TimeGenerated {TimeRange}\r\n| {QueryFilter}\r\n| where Direction == '{Direction}'\r\n| summarize P50 = percentiles(ResponseTimeSum, 50), P90 = percentiles(ResponseTimeSum, 90), P95 = percentiles(ResponseTimeSum, 95) by bin(TimeGenerated, time('{TimeRange:grain}'));\r\nSourceMachineData",
         "size": 1,
         "aggregation": 3,
+        "exportToExcelOptions": "visible",
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
         "crossComponentResources": [
@@ -1004,8 +951,9 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "// {Workspace:label}\r\nlet SourceMachineData = VMConnection\r\n| where TimeGenerated {TimeRange}\r\n| {QueryFilter}\r\n| where Direction == '{Direction}'\r\n| summarize Sent = sum(BytesSent), Received = sum(BytesReceived) by bin(TimeGenerated, time('{TimeRange:grain}'));\r\nSourceMachineData",
+        "query": "let SourceMachineData = VMConnection\r\n| where TimeGenerated {TimeRange}\r\n| {QueryFilter}\r\n| where Direction == '{Direction}'\r\n| summarize Sent = sum(BytesSent), Received = sum(BytesReceived) by bin(TimeGenerated, time('{TimeRange:grain}'));\r\nSourceMachineData",
         "size": 1,
+        "exportToExcelOptions": "visible",
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
         "crossComponentResources": [
@@ -1025,9 +973,10 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "// {Workspace:label}\r\nlet SourceMachineData = VMConnection\r\n| where TimeGenerated {TimeRange}\r\n| {QueryFilter}\r\n| where Direction == '{Direction}'\r\n| summarize MaxOpenPorts = max(LinksLive), SumFailed = sum(LinksFailed) by bin(TimeGenerated, time('{TimeRange:grain}'));\r\nSourceMachineData",
+        "query": "let SourceMachineData = VMConnection\r\n| where TimeGenerated {TimeRange}\r\n| {QueryFilter}\r\n| where Direction == '{Direction}'\r\n| summarize MaxOpenPorts = max(LinksLive), SumFailed = sum(LinksFailed) by bin(TimeGenerated, time('{TimeRange:grain}'));\r\nSourceMachineData",
         "size": 1,
         "aggregation": 3,
+        "exportToExcelOptions": "visible",
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
         "crossComponentResources": [
@@ -1044,5 +993,6 @@
       "name": "query - 15"
     }
   ],
+  "styleSettings": {},
   "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
 }


### PR DESCRIPTION
KQL comments were originally introduced for better loading user experience. Recent updates in workbooks makes adding such KQL comments unnecessary. Also KQL queries were causing problems when the query strings were getting too long.

AtScale
![image](https://user-images.githubusercontent.com/43890980/66282340-dee5dc80-e873-11e9-838d-111b3f53f214.png)

SingleVM
![image](https://user-images.githubusercontent.com/43890980/66282406-1d7b9700-e874-11e9-9c9b-7736cee3f844.png)
