### PR TITLE
add top level contributing docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,39 @@
+## How to contribute
+We follow the [GitHub shared repository model](https://help.github.com/articles/about-collaborative-development-models).
+
+
+Please note that this project is released with a [Contributor Code of Conduct][code-of-conduct]. By participating in this project you agree to abide by its terms.
+- [Creating issues](#creating-issues)
+- [Recommended setup for contributing](#recommended-setup-for-contributing)
+- [Commit messages](#commit-messages)
+- [Pull requests](#pull-requests)
+
+
+## Creating issues
+- You can [create an issue][new-issue], but before doing that please read the bullets below and include as many details as possible.
+- Perform a [cursory search][issue-search] to see if a similar issue has already been submitted.
+
+### Related repositories
+This is the repository for Azure Monitor Workbook Templates used in the Azure Portal. Please ensure that you are opening issues in the right repository.
+
+Other repos you might be looking for:
+* [Log Analytics Query Examples](https://github.com/MicrosoftDocs/LogAnalyticsExamples) repo - contains example log analytics queries
+* [Azure Sentinel](https://github.com/azure/azure-sentinel) repo - contains queries, dashboards, templates used by Azure Sentinel
+
+## Recommended setup for contributing
+- Get contributor access
+
+  In order to contribute, you'll need contributor access to the repo in order to push your branch and create a PR. If you are a Microsoft employee, mail `azmonworkbooks`  to be added as a contributor. If you are not a Microsoft employee, the quickest way is to [create a new issue][new-issue] and ask for contributor access.
+
+- To contribute your own examples, clone the repo, [create a new branch](#topic-branch), make your changes or additions, and then [submit a pull request](https://help.github.com/articles/about-pull-requests/). When creating a pull request, please create a good title, fill the description with content, and ideally, paste a screenshot of what your template looks like when used as a workbook.
+
+- If you submit a pull request with new or significant changes, and you are not an employee of Microsoft, we'll add a comment to the pull request asking you to submit an online [CLA](https://cla.microsoft.com) (Contribution License Agreement). We'll need you to complete the online form before we can accept your pull request.
+
+For details of how to contribute templates, see the [template contribution](Documentation/Contributing.md) documentation
+
+
+[code-of-conduct]: https://opensource.microsoft.com/codeofconduct/
+[new-issue]: https://github.com/microsoft/Application-Insights-Workbooks/issues/new
+[issue-search]: https://github.com/microsoft/Application-Insights-Workbooks/issues
+[white-house-api-guidelines]: https://github.com/WhiteHouse/api-standards/blob/master/README.md
+[topic-branch]: http://www.git-scm.com/book/en/v2/Git-Branching-Branching-Workflows#Topic-Branches

--- a/Documentation/Contributing.md
+++ b/Documentation/Contributing.md
@@ -1,5 +1,7 @@
 # Contributing to the Template Gallery
 
+If you haven't already read the top level [Contributing](../CONTRIBUTING.md) docs, read that first to find out how to get contributor access to the repo.
+
 ## Template Format
 Workbook templates follow a certain folder structure.
 ```

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 ## Contributing
 
-This project welcomes contributions and suggestions.  Most contributions require you to agree to a 
+This project welcomes contributions and suggestions. Most contributions require you to agree to a 
 Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us 
 the rights to use your contribution. For details, visit https://cla.microsoft.com.
 
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
 For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
-contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
+contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments. 
 
 ## What is this repository for?
 This repository contains the templates shown in the workbook galleries of [Azure Monitor Workbooks](https://docs.microsoft.com/azure/application-insights/app-insights-usage-workbooks). Templates added to this repository will show up in the various Workbook Galleries for users of Azure Monitor Workbooks. By contributing templates, you can help others solve interesting problems using the workbooks you've found helpful on your own team.
@@ -40,13 +40,14 @@ Use these links to learn more about workbooks:
 ![Image of a sample workbook](Documentation/Images/WorkbookExample.png)
 
 ## How to contribute?
-The template contribution process is as simple creating a PR against this repo. The templates need to be in a specific format that is documented here: [Contributing](Documentation/Contributing.md). 
+
+For more details about getting started, see the [Contributing guidelines](CONTRIBUTING.md).
 
 Note that templates in this repo will show up for all users of Azure who open the specified gallery. For this reason, the templates gallery is curated by Microsoft. If the submitted template is useful to the community and it does not place undue stress on the underlying infrastructure, it will be accepted to be part of the gallery.
 
 ## Status
 This repo is [supported by Microsoft](https://docs.microsoft.com/en-us/azure/azure-monitor).
-* File an issue or submit a pull request on GitHub
+* [File an issue](new-issue) or submit a pull request on GitHub
 * Request or upvote features on [UserVoice](https://feedback.azure.com/forums/913690-azure-monitor)
 * File a [support](https://docs.microsoft.com/en-us/azure/azure-supportability/how-to-create-azure-support-request) ticket with Azure
 


### PR DESCRIPTION
added a top level contributing doc about getting contributor access, etc, instead of having that point to details about contributing templates.

links from the main readme go to the new page, which also has a link to the template details docs