### PR TITLE
Update CODEOWNERS with defaults for each folder

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,14 +4,44 @@
 
 # Order is important. The last matching pattern has the most precedence.
 
-# teams that want to lock down their templates would insert rows here with the path to their template and the users/teams they want to own the items
-
 # everything at the root, or inside docs, schema, scripts, cohorts requires workbooks team review
-/*  @microsoft/applicationinsights-devtools
+*  @microsoft/applicationinsights-devtools
 /Documentation/**   @microsoft/applicationinsights-devtools
+/_assets/**  @microsoft/applicationinsights-devtools
 /schema/**  @microsoft/applicationinsights-devtools
 /scripts/** @microsoft/applicationinsights-devtools
 /test/**    @microsoft/applicationinsights-devtools
 /.pipelines/**  @microsoft/applicationinsights-devtools
 /Cohorts/** @microsoft/applicationinsights-devtools
+/Workbooks/** @microsoft/applicationinsights-devtools
 
+# teams that want to lock down their templates would insert rows here with the path to their template and the users/teams they want to own the items
+# anything not specified will default to requiring review by the workbooks team
+
+/Workbooks/AKS/** @BLuEScioN @microsoft/applicationinsights-devtools
+
+/Workbooks/Azure Active Directory Conditional Access/** @danielwood95 @KranthiKiranerusu @jssmomo
+/Workbooks/Azure Active Directory Domain Services/** @MikeStephens-MikeStephens
+/Workbooks/Azure Active Directory TroubleShooting/** @danielwood95 @KranthiKiranerusu
+/Workbooks/Azure Active Directory/** @danielwood95 @KranthiKiranerusu @sukhong
+
+/Workbooks/Azure Backup/** @VinothJeyaraman @pikumarmsft 
+
+/Workbooks/Azure Blockchain/** @keikumata @microsoft/applicationinsights-devtools
+
+/Workbooks/HDInsight/** @tylerfox @microsoft/applicationinsights-devtools
+
+/Workbooks/Intune Audit/** @kumarvaranasi @microsoft/applicationinsights-devtools
+/Workbooks/Intune Compliance/** @kumarvaranasi @microsoft/applicationinsights-devtools
+/Workbooks/Intune Enrollment/** @kumarvaranasi @microsoft/applicationinsights-devtools
+/Workbooks/Intune Reports/** @RoyceMou @adamlandmsft @anquachmsft
+
+/Workbooks/Network Insights/** @sayghosh @microsoft/applicationinsights-devtools
+ 
+/Workbooks/SapMonitor/** @tniek @microsoft/applicationinsights-devtools
+
+/Workbooks/Virtual Machine Scale Sets - Network Dependencies/** @andrewki-msft @nasundar
+/Workbooks/Virtual Machine Scale Sets - Performance Analysis/** @andrewki-msft @nasundar
+/Workbooks/Virtual Machines - Network Dependencies/** @andrewki-msft @nasundar
+/Workbooks/Virtual Machines - Performance Analysis/** @andrewki-msft @nasundar
+/Workbooks/Virtual Machines/** @andrewki-msft @nasundar @microsoft/applicationinsights-devtools

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,12 +25,22 @@ Other repos you might be looking for:
 
   In order to contribute, you'll need contributor access to the repo in order to push your branch and create a PR. If you are a Microsoft employee, mail `azmonworkbooks`  to be added as a contributor. If you are not a Microsoft employee, the quickest way is to [create a new issue][new-issue] and ask for contributor access.
 
-- To contribute your own examples, clone the repo, [create a new branch](#topic-branch), make your changes or additions, and then [submit a pull request](https://help.github.com/articles/about-pull-requests/). When creating a pull request, please create a good title, fill the description with content, and ideally, paste a screenshot of what your template looks like when used as a workbook.
+- To contribute your own examples, clone the repo, [create a new branch](#topic-branch), make your changes or additions, and then [submit a pull request](https://help.github.com/articles/about-pull-requests/). 
 
 - If you submit a pull request with new or significant changes, and you are not an employee of Microsoft, we'll add a comment to the pull request asking you to submit an online [CLA](https://cla.microsoft.com) (Contribution License Agreement). We'll need you to complete the online form before we can accept your pull request.
 
+- If you are adding new folders to the top level Workbooks folder, you should also update the CODEOWNERS file to assign people from your team as owners of content in that folder. This will allow github to automatically require review from people in your team in order to update your templates.
+
 For details of how to contribute templates, see the [template contribution](Documentation/Contributing.md) documentation
 
+## Commit messages
+When creating commits, always try to create useful commit messages explaining what that commit contains. Avoid commit messages like "fix" or "commit". If you're fixing something that's been reported as an issue in the repo, refer to the issue number in commit messages.
+
+## Pull Requests
+When creating a pull request, please create a good title, fill the description with content, and ideally, paste a screenshot of what your template looks like when used as a workbook. Not everyone may have access to the type of data you have in your workbook, so seeing a screenshot of what is expected is often helpful, especially for complicated workbooks.
+
+In general, the workbooks team will *not* complete or merge PRs for other teams unless explicitly told to do so.
+After your pull request is approved and merged, please delete your branch.
 
 [code-of-conduct]: https://opensource.microsoft.com/codeofconduct/
 [new-issue]: https://github.com/microsoft/Application-Insights-Workbooks/issues/new

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,15 @@ When creating a pull request, please create a good title, fill the description w
 In general, the workbooks team will *not* complete or merge PRs for other teams unless explicitly told to do so.
 After your pull request is approved and merged, please delete your branch.
 
+The github pull request will verify you've signed the CLA agreement, and that your code passes a set of CI build tests.
+
+## Build and Deployment
+After a PR is completed to the `master` branch, an [official build is queued](https://github-private.visualstudio.com/microsoft/_build?definitionId=48) (you might not have access to this), which packages all the templates up into a cacheable format for deployment. This build generally takes ~15 minutes.
+
+After the official build completes, [a staged release deployment takes place to ](https://github-private.visualstudio.com/microsoft/_release?_a=releases&definitionId=1) (again, you might not have access to this), which takes ~15 minutes to work its way through all the stages.
+
+So in the usual case, after successful completion of a PR and deployment, template changes become available in ~30 minutes.
+
 [code-of-conduct]: https://opensource.microsoft.com/codeofconduct/
 [new-issue]: https://github.com/microsoft/Application-Insights-Workbooks/issues/new
 [issue-search]: https://github.com/microsoft/Application-Insights-Workbooks/issues


### PR DESCRIPTION
Added default owners from recent history. 
If a folder ended up with only one owner, I added our team again so that it isn't just one owner.

From how I read https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners, it implies to me that the last entry that applies wins, so it could end up with one person being required, but you can't approve your own PRs so without that people would be stuck?

i'm sure there will be some growing pains with this, so bear with us!
