### PR TITLE
Add y-scaling for % charts, fix scale-out support

### DIFF
--- a/Workbooks/SapMonitor/SapHanaInfrastructure/SapHanaInfrastructure.workbook
+++ b/Workbooks/SapMonitor/SapHanaInfrastructure/SapHanaInfrastructure.workbook
@@ -435,6 +435,7 @@
         "query": "let nodata = datatable(HOST:string, ACTIVE:string,HOST_STATUS_s:string,INDEXSERVERROLE:string,NAMESERVERROLE:string)\r\n[\r\n\"N\\\\A\", \"YES\",\"OK\",\"MASTER\",\"MASTER\"\r\n];\r\nSapHana_HostConfig_CL\r\n| where TimeGenerated > ago(30d)\r\n| summarize arg_max(TimeGenerated, *) by HOST_s \r\n| project HOST=HOST_s , ACTIVE=HOST_ACTIVE_s , HOST_STATUS_s , INDEXSERVERROLE=INDEXSERVER_ACTUAL_ROLE_s , NAMESERVERROLE=NAMESERVER_ACTUAL_ROLE_s\r\n| union   isfuzzy=true nodata  | where HOST <> \"N\\\\A\" ",
         "size": 4,
         "title": "HANA IndexServer Role",
+        "exportToExcelOptions": "visible",
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
         "visualization": "tiles",
@@ -446,151 +447,21 @@
               "formatOptions": {
                 "showIcon": true
               }
-            },
-            {
-              "columnMatch": "CPU",
-              "formatter": 18,
-              "formatOptions": {
-                "min": 0,
-                "max": 100,
-                "palette": "redDark",
-                "showIcon": true,
-                "thresholdsOptions": "icons",
-                "thresholdsGrid": [
-                  {
-                    "operator": "<",
-                    "thresholdValue": "70",
-                    "representation": "success",
-                    "text": "{0}{1}"
-                  },
-                  {
-                    "operator": ">=",
-                    "text": "{0}{1}"
-                  },
-                  {
-                    "thresholdValue": "70",
-                    "representation": "warning",
-                    "text": "{0}{1}"
-                  },
-                  {
-                    "operator": ">=",
-                    "text": "{0}{1}"
-                  },
-                  {
-                    "thresholdValue": "85",
-                    "representation": "4",
-                    "text": "{0}{1}"
-                  },
-                  {
-                    "operator": "Default",
-                    "thresholdValue": null,
-                    "representation": "success",
-                    "text": "{0}{1}"
-                  }
-                ]
-              }
-            },
-            {
-              "columnMatch": "MEM",
-              "formatter": 18,
-              "formatOptions": {
-                "showIcon": true,
-                "thresholdsOptions": "icons",
-                "thresholdsGrid": [
-                  {
-                    "operator": "<=",
-                    "thresholdValue": "70",
-                    "representation": "success",
-                    "text": "{0}{1}"
-                  },
-                  {
-                    "operator": ">",
-                    "thresholdValue": "70",
-                    "representation": "2",
-                    "text": "{0}{1}"
-                  },
-                  {
-                    "operator": ">=",
-                    "thresholdValue": "85",
-                    "representation": "critical",
-                    "text": "{0}{1}"
-                  },
-                  {
-                    "operator": "Default",
-                    "thresholdValue": null,
-                    "representation": "success",
-                    "text": "{0}{1}"
-                  }
-                ]
-              }
-            },
-            {
-              "columnMatch": "Disk_Used",
-              "formatter": 18,
-              "formatOptions": {
-                "min": 0,
-                "max": 100,
-                "palette": "red",
-                "showIcon": true,
-                "thresholdsOptions": "icons",
-                "thresholdsGrid": [
-                  {
-                    "operator": "<=",
-                    "thresholdValue": "70",
-                    "representation": "success",
-                    "text": "{0}{1}"
-                  },
-                  {
-                    "operator": ">",
-                    "thresholdValue": "70",
-                    "representation": "2",
-                    "text": "{0}{1}"
-                  },
-                  {
-                    "operator": ">",
-                    "thresholdValue": "80",
-                    "representation": "4",
-                    "text": "{0}{1}"
-                  },
-                  {
-                    "operator": "Default",
-                    "thresholdValue": null,
-                    "representation": "success",
-                    "text": "{0}{1}"
-                  }
-                ]
-              }
-            },
-            {
-              "columnMatch": "NW_IN",
-              "formatter": 4,
-              "formatOptions": {
-                "palette": "orange",
-                "showIcon": true
-              }
-            },
-            {
-              "columnMatch": "NW_OUT",
-              "formatter": 4,
-              "formatOptions": {
-                "showIcon": true
-              }
             }
-          ],
-          "labelSettings": []
+          ]
         },
         "tileSettings": {
           "titleContent": {
+            "columnMatch": "HOST",
             "formatter": 1,
             "formatOptions": {
               "showIcon": true
             }
           },
-          "leftContent": {
+          "subtitleContent": {
             "columnMatch": "INDEXSERVERROLE",
             "formatter": 1,
             "formatOptions": {
-              "palette": "auto",
               "showIcon": true
             }
           },
@@ -641,6 +512,7 @@
         "query": "let nodata = datatable(HOST:string, ACTIVE:string,HOST_STATUS_s:string,INDEXSERVERROLE:string,NAMESERVERROLE:string)\r\n[\r\n\"N\\\\A\", \"YES\",\"OK\",\"MASTER\",\"MASTER\"\r\n];\r\nSapHana_HostConfig_CL\r\n| where TimeGenerated > ago(30d)\r\n| summarize arg_max(TimeGenerated, *) by HOST_s \r\n| project HOST=HOST_s , ACTIVE=HOST_ACTIVE_s , HOST_STATUS_s , INDEXSERVERROLE=INDEXSERVER_ACTUAL_ROLE_s , NAMESERVERROLE=NAMESERVER_ACTUAL_ROLE_s\r\n| union   isfuzzy=true nodata  | where HOST <> \"N\\\\A\" ",
         "size": 4,
         "title": "HANA NameServer Role",
+        "exportToExcelOptions": "visible",
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
         "visualization": "tiles",
@@ -652,151 +524,21 @@
               "formatOptions": {
                 "showIcon": true
               }
-            },
-            {
-              "columnMatch": "CPU",
-              "formatter": 18,
-              "formatOptions": {
-                "min": 0,
-                "max": 100,
-                "palette": "redDark",
-                "showIcon": true,
-                "thresholdsOptions": "icons",
-                "thresholdsGrid": [
-                  {
-                    "operator": "<",
-                    "thresholdValue": "70",
-                    "representation": "success",
-                    "text": "{0}{1}"
-                  },
-                  {
-                    "operator": ">=",
-                    "text": "{0}{1}"
-                  },
-                  {
-                    "thresholdValue": "70",
-                    "representation": "warning",
-                    "text": "{0}{1}"
-                  },
-                  {
-                    "operator": ">=",
-                    "text": "{0}{1}"
-                  },
-                  {
-                    "thresholdValue": "85",
-                    "representation": "4",
-                    "text": "{0}{1}"
-                  },
-                  {
-                    "operator": "Default",
-                    "thresholdValue": null,
-                    "representation": "success",
-                    "text": "{0}{1}"
-                  }
-                ]
-              }
-            },
-            {
-              "columnMatch": "MEM",
-              "formatter": 18,
-              "formatOptions": {
-                "showIcon": true,
-                "thresholdsOptions": "icons",
-                "thresholdsGrid": [
-                  {
-                    "operator": "<=",
-                    "thresholdValue": "70",
-                    "representation": "success",
-                    "text": "{0}{1}"
-                  },
-                  {
-                    "operator": ">",
-                    "thresholdValue": "70",
-                    "representation": "2",
-                    "text": "{0}{1}"
-                  },
-                  {
-                    "operator": ">=",
-                    "thresholdValue": "85",
-                    "representation": "critical",
-                    "text": "{0}{1}"
-                  },
-                  {
-                    "operator": "Default",
-                    "thresholdValue": null,
-                    "representation": "success",
-                    "text": "{0}{1}"
-                  }
-                ]
-              }
-            },
-            {
-              "columnMatch": "Disk_Used",
-              "formatter": 18,
-              "formatOptions": {
-                "min": 0,
-                "max": 100,
-                "palette": "red",
-                "showIcon": true,
-                "thresholdsOptions": "icons",
-                "thresholdsGrid": [
-                  {
-                    "operator": "<=",
-                    "thresholdValue": "70",
-                    "representation": "success",
-                    "text": "{0}{1}"
-                  },
-                  {
-                    "operator": ">",
-                    "thresholdValue": "70",
-                    "representation": "2",
-                    "text": "{0}{1}"
-                  },
-                  {
-                    "operator": ">",
-                    "thresholdValue": "80",
-                    "representation": "4",
-                    "text": "{0}{1}"
-                  },
-                  {
-                    "operator": "Default",
-                    "thresholdValue": null,
-                    "representation": "success",
-                    "text": "{0}{1}"
-                  }
-                ]
-              }
-            },
-            {
-              "columnMatch": "NW_IN",
-              "formatter": 4,
-              "formatOptions": {
-                "palette": "orange",
-                "showIcon": true
-              }
-            },
-            {
-              "columnMatch": "NW_OUT",
-              "formatter": 4,
-              "formatOptions": {
-                "showIcon": true
-              }
             }
-          ],
-          "labelSettings": []
+          ]
         },
         "tileSettings": {
           "titleContent": {
+            "columnMatch": "HOST",
             "formatter": 1,
             "formatOptions": {
               "showIcon": true
             }
           },
-          "leftContent": {
+          "subtitleContent": {
             "columnMatch": "NAMESERVERROLE",
             "formatter": 1,
             "formatOptions": {
-              "palette": "auto",
               "showIcon": true
             }
           },
@@ -844,7 +586,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let nodata = datatable([\"HANA Host\"]:string, [\"CPU used (%)\"]:real,[\"Memory used (GB)\"]:real,[\"Disk used (GB)\"]:real,[\"Network in (MB/s)\"]:real,[\"Network out (MB/s)\"]:real)\r\n[\r\n\"N\\\\A\", 0,0,0,0,0\r\n];\r\nSapHana_LoadHistory_CL\r\n| where HOST_s in  ({Host}) or '*' in ({Host})\r\n|summarize arg_max(TimeGenerated, *) by HOST_s\r\n|project [\"HANA Host\"]=HOST_s , [\"CPU used (%)\"]=CPU_d ,  [\"Memory used (GB)\"]=round((MEMORY_USED_d/MEMORY_SIZE_d)*100,2),[\"Disk used (GB)\"]=DISK_USED_d  , [\"Network in (MB/s)\"]=NETWORK_IN_d , [\"Network out (MB/s)\"]=NETWORK_OUT_d \r\n| union   isfuzzy=true nodata  | where [\"HANA Host\"] <> \"N\\\\A\" ",
+        "query": "let nodata = datatable([\"HANA Host\"]:string, [\"CPU used (%)\"]:real,[\"Memory used (%)\"]:real,[\"Disk used (GB)\"]:real,[\"Network in (MB/s)\"]:real,[\"Network out (MB/s)\"]:real)\r\n[\r\n\"N\\\\A\", 0,0,0,0,0\r\n];\r\nSapHana_LoadHistory_CL\r\n| where HOST_s in  ({Host}) or '*' in ({Host})\r\n|summarize arg_max(TimeGenerated, *) by HOST_s\r\n|project [\"HANA Host\"]=HOST_s , [\"CPU used (%)\"]=CPU_d ,  [\"Memory used (GB)\"]=round((MEMORY_USED_d/MEMORY_SIZE_d)*100,2),[\"Disk used (GB)\"]=DISK_USED_d  , [\"Network in (MB/s)\"]=NETWORK_IN_d , [\"Network out (MB/s)\"]=NETWORK_OUT_d \r\n| union   isfuzzy=true nodata  | where [\"HANA Host\"] <> \"N\\\\A\" ",
         "size": 4,
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
@@ -866,7 +608,7 @@
               }
             },
             {
-              "columnMatch": "Memory used (GB)",
+              "columnMatch": "Memory used (%)",
               "formatter": 0,
               "formatOptions": {
                 "showIcon": true
@@ -939,7 +681,13 @@
         "timeContextFromParameter": "TimeRange",
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
-        "visualization": "timechart"
+        "visualization": "timechart",
+        "chartSettings": {
+          "ySettings": {
+            "min": 0,
+            "max": 100
+          }
+        }
       },
       "conditionalVisibilities": [
         {
@@ -983,7 +731,13 @@
         "timeContextFromParameter": "TimeRange",
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
-        "visualization": "scatterchart"
+        "visualization": "scatterchart",
+        "chartSettings": {
+          "ySettings": {
+            "min": 0,
+            "max": 100
+          }
+        }
       },
       "conditionalVisibilities": [
         {
@@ -1022,7 +776,13 @@
         "color": "orange",
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
-        "visualization": "timechart"
+        "visualization": "timechart",
+        "chartSettings": {
+          "ySettings": {
+            "min": 0,
+            "max": 100
+          }
+        }
       },
       "conditionalVisibilities": [
         {
@@ -1061,7 +821,13 @@
         "color": "orange",
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
-        "visualization": "scatterchart"
+        "visualization": "scatterchart",
+        "chartSettings": {
+          "ySettings": {
+            "min": 0,
+            "max": 100
+          }
+        }
       },
       "conditionalVisibilities": [
         {
@@ -1180,7 +946,12 @@
         "color": "turquoise",
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
-        "visualization": "timechart"
+        "visualization": "timechart",
+        "chartSettings": {
+          "ySettings": {
+            "min": 0
+          }
+        }
       },
       "conditionalVisibilities": [
         {
@@ -1216,7 +987,12 @@
         "color": "turquoise",
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
-        "visualization": "scatterchart"
+        "visualization": "scatterchart",
+        "chartSettings": {
+          "ySettings": {
+            "min": 0
+          }
+        }
       },
       "conditionalVisibilities": [
         {
@@ -1337,7 +1113,13 @@
         "title": "CPU Anomalies",
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
-        "visualization": "linechart"
+        "visualization": "linechart",
+        "chartSettings": {
+          "ySettings": {
+            "min": 0,
+            "max": 100
+          }
+        }
       },
       "conditionalVisibilities": [
         {
@@ -1367,7 +1149,13 @@
         "title": "Memory Anomalies",
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
-        "visualization": "linechart"
+        "visualization": "linechart",
+        "chartSettings": {
+          "ySettings": {
+            "min": 0,
+            "max": 100
+          }
+        }
       },
       "conditionalVisibilities": [
         {
@@ -1377,7 +1165,7 @@
         },
         {
           "parameterName": "testDataExist",
-          "comparison": "isEqualTo"
+          "comparison": "isNotEqualTo"
         }
       ],
       "conditionalVisibility": {


### PR DESCRIPTION
This PR resolves the following issues:
- Include y-scale support for "CPU %" and "Memory %" charts
- Fix host status for HANA scale-out (now displays host names)
- Fix visibility of "Memory anomalies" chart