### PR TITLE
replace spaces in codeowners file with stars

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,43 +5,40 @@
 # Order is important. The last matching pattern has the most precedence.
 
 # everything at the root, or inside docs, schema, scripts, cohorts requires workbooks team review
-*  @microsoft/applicationinsights-devtools
-/Documentation/**   @microsoft/applicationinsights-devtools
-/_assets/**  @microsoft/applicationinsights-devtools
-/schema/**  @microsoft/applicationinsights-devtools
+* @microsoft/applicationinsights-devtools
+/Documentation/** @microsoft/applicationinsights-devtools
+/_assets/** @microsoft/applicationinsights-devtools
+/schema/** @microsoft/applicationinsights-devtools
 /scripts/** @microsoft/applicationinsights-devtools
-/test/**    @microsoft/applicationinsights-devtools
-/.pipelines/**  @microsoft/applicationinsights-devtools
+/test/** @microsoft/applicationinsights-devtools
+/.pipelines/** @microsoft/applicationinsights-devtools
 /Cohorts/** @microsoft/applicationinsights-devtools
 /Workbooks/** @microsoft/applicationinsights-devtools
 
 # teams that want to lock down their templates would insert rows here with the path to their template and the users/teams they want to own the items
 # anything not specified will default to requiring review by the workbooks team
+# it also appears that spaces in directory names are not well handled or are handled differently on different platforms. so here * is used instead of spaces.
 
 /Workbooks/AKS/** @BLuEScioN @microsoft/applicationinsights-devtools
 
-/Workbooks/Azure Active Directory Conditional Access/** @danielwood95 @KranthiKiranerusu @jssmomo
-/Workbooks/Azure Active Directory Domain Services/** @MikeStephens-MikeStephens
-/Workbooks/Azure Active Directory TroubleShooting/** @danielwood95 @KranthiKiranerusu
-/Workbooks/Azure Active Directory/** @danielwood95 @KranthiKiranerusu @sukhong
+/Workbooks/Azure*Active*Directory*Conditional*Access/** @danielwood95 @KranthiKiranerusu @jssmomo
+/Workbooks/Azure*Active*Directory*Domain*Services/** @MikeStephens-MikeStephens
+/Workbooks/Azure*Active*Directory*TroubleShooting/** @danielwood95 @KranthiKiranerusu
+/Workbooks/Azure*Active*Directory/** @danielwood95 @KranthiKiranerusu @sukhong
 
-/Workbooks/Azure Backup/** @VinothJeyaraman @pikumarmsft 
+/Workbooks/Azure*Backup/** @VinothJeyaraman @pikumarmsft 
 
-/Workbooks/Azure Blockchain/** @keikumata @microsoft/applicationinsights-devtools
+/Workbooks/Azure*Blockchain/** @keikumata @microsoft/applicationinsights-devtools
 
 /Workbooks/HDInsight/** @tylerfox @microsoft/applicationinsights-devtools
 
-/Workbooks/Intune Audit/** @kumarvaranasi @microsoft/applicationinsights-devtools
-/Workbooks/Intune Compliance/** @kumarvaranasi @microsoft/applicationinsights-devtools
-/Workbooks/Intune Enrollment/** @kumarvaranasi @microsoft/applicationinsights-devtools
-/Workbooks/Intune Reports/** @RoyceMou @adamlandmsft @anquachmsft
+/Workbooks/Intune*Audit/** @kumarvaranasi @microsoft/applicationinsights-devtools
+/Workbooks/Intune*Compliance/** @kumarvaranasi @microsoft/applicationinsights-devtools
+/Workbooks/Intune*Enrollment/** @kumarvaranasi @microsoft/applicationinsights-devtools
+/Workbooks/Intune*Reports/** @RoyceMou @adamlandmsft @anquachmsft
 
-/Workbooks/Network Insights/** @sayghosh @microsoft/applicationinsights-devtools
+/Workbooks/Network*Insights/** @sayghosh @microsoft/applicationinsights-devtools
  
 /Workbooks/SapMonitor/** @tniek @microsoft/applicationinsights-devtools
 
-/Workbooks/Virtual Machine Scale Sets - Network Dependencies/** @andrewki-msft @nasundar
-/Workbooks/Virtual Machine Scale Sets - Performance Analysis/** @andrewki-msft @nasundar
-/Workbooks/Virtual Machines - Network Dependencies/** @andrewki-msft @nasundar
-/Workbooks/Virtual Machines - Performance Analysis/** @andrewki-msft @nasundar
-/Workbooks/Virtual Machines/** @andrewki-msft @nasundar @microsoft/applicationinsights-devtools
+/Workbooks/Virtual*Machine*/** @andrewki-msft @nasundar


### PR DESCRIPTION
it doesn't look like GitHub/whatever codeowners parsing likes spaces in filenames, so it is basically falling back to everything owned by us.  it looks like spaces for stars was the best thing that worked "cross platform", we'll see what GitHub says after it gets completed?