### PR TITLE
SQL database Workbook: Remove DTU % Metric

### DIFF
--- a/Workbooks/Resource Groups/Sql databases/Sql databases.workbook
+++ b/Workbooks/Resource Groups/Sql databases/Sql databases.workbook
@@ -128,14 +128,6 @@
         "metrics": [
           {
             "namespace": "microsoft.sql/servers/databases",
-            "metric": "microsoft.sql/servers/databases-Basic-dtu_consumption_percent",
-            "aggregation": 4,
-            "splitBy": null,
-            "splitBySortOrder": -1,
-            "splitByLimit": 5
-          },
-          {
-            "namespace": "microsoft.sql/servers/databases",
             "metric": "microsoft.sql/servers/databases-Basic-cpu_percent",
             "aggregation": 4,
             "splitBy": null,
@@ -181,31 +173,6 @@
               "formatter": 13,
               "formatOptions": {
                 "linkTarget": "Resource",
-                "showIcon": true
-              }
-            },
-            {
-              "columnMatch": "microsoft.sql/servers/databases-Basic-dtu_consumption_percent",
-              "formatter": 8,
-              "formatOptions": {
-                "min": 0,
-                "palette": "blue",
-                "showIcon": true
-              },
-              "numberFormat": {
-                "unit": 1,
-                "options": {
-                  "style": "decimal",
-                  "maximumFractionDigits": 1
-                }
-              }
-            },
-            {
-              "columnMatch": "microsoft.sql/servers/databases-Basic-dtu_consumption_percent Timeline",
-              "formatter": 9,
-              "formatOptions": {
-                "min": 0,
-                "palette": "blue",
                 "showIcon": true
               }
             },


### PR DESCRIPTION
Telemetry is showing many failures in this workbook. After further investigation, metrics provider is returning 400s for the DTU percentage metric due to the fact that data warehouses do not support this metric. https://docs.microsoft.com/en-us/azure/sql-data-warehouse/sql-data-warehouse-concept-resource-utilization-query-activity

 Removing DTU % from the template