### PR TITLE
SQL DB Resource Group Insights Fix

### DIFF
--- a/Workbooks/Resource Groups/Sql databases/Sql databases.workbook
+++ b/Workbooks/Resource Groups/Sql databases/Sql databases.workbook
@@ -130,33 +130,19 @@
             "namespace": "microsoft.sql/servers/databases",
             "metric": "microsoft.sql/servers/databases-Basic-cpu_percent",
             "aggregation": 4,
-            "splitBy": null,
-            "splitBySortOrder": -1,
-            "splitByLimit": 5
-          },
-          {
-            "namespace": "microsoft.sql/servers/databases",
-            "metric": "microsoft.sql/servers/databases-Basic-storage_percent",
-            "aggregation": 3,
-            "splitBy": null,
-            "splitBySortOrder": -1,
-            "splitByLimit": 5
+            "splitBy": null
           },
           {
             "namespace": "microsoft.sql/servers/databases",
             "metric": "microsoft.sql/servers/databases-Basic-physical_data_read_percent",
             "aggregation": 4,
-            "splitBy": null,
-            "splitBySortOrder": -1,
-            "splitByLimit": 5
+            "splitBy": null
           },
           {
             "namespace": "microsoft.sql/servers/databases",
-            "metric": "microsoft.sql/servers/databases-Basic-log_write_percent",
-            "aggregation": 4,
-            "splitBy": null,
-            "splitBySortOrder": -1,
-            "splitByLimit": 5
+            "metric": "microsoft.sql/servers/databases-Basic-connection_failed",
+            "aggregation": 1,
+            "splitBy": null
           }
         ],
         "gridSettings": {
@@ -200,30 +186,7 @@
               }
             },
             {
-              "columnMatch": "microsoft.sql/servers/databases-Basic-storage_percent",
-              "formatter": 8,
-              "formatOptions": {
-                "min": 0,
-                "palette": "red",
-                "showIcon": true
-              },
-              "numberFormat": {
-                "unit": 1,
-                "options": {
-                  "style": "decimal",
-                  "maximumFractionDigits": 2
-                }
-              }
-            },
-            {
-              "columnMatch": "microsoft.sql/servers/databases-Basic-storage_percent Timeline",
-              "formatter": 5,
-              "formatOptions": {
-                "showIcon": true
-              }
-            },
-            {
-              "columnMatch": "microsoft.sql/servers/databases-Basic-physical_data_read_percent|microsoft.sql/servers/databases-Basic-log_write_percent",
+              "columnMatch": "microsoft.sql/servers/databases-Basic-physical_data_read_percent",
               "formatter": 8,
               "formatOptions": {
                 "min": 0,
@@ -246,18 +209,34 @@
               }
             },
             {
-              "columnMatch": "microsoft.sql/servers/databases-Basic-log_write_percent Timeline",
+              "columnMatch": "microsoft.sql/servers/databases-Basic-connection_failed",
+              "formatter": 8,
+              "formatOptions": {
+                "min": 0,
+                "palette": "red",
+                "showIcon": true
+              },
+              "numberFormat": {
+                "unit": 0,
+                "options": {
+                  "style": "decimal",
+                  "maximumFractionDigits": 2
+                }
+              }
+            },
+            {
+              "columnMatch": "microsoft.sql/servers/databases-Basic-connection_failed Timeline",
               "formatter": 5,
               "formatOptions": {
                 "showIcon": true
               }
             }
           ],
+          "rowLimit": 10000,
           "filter": true,
           "labelSettings": []
         },
         "sortBy": [],
-        "filters": [],
         "showExportToExcel": true
       },
       "conditionalVisibility": {
@@ -281,6 +260,5 @@
       "name": "No resource message"
     }
   ],
-  "styleSettings": {},
   "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
 }


### PR DESCRIPTION
Second and hopefully last fix for SQB DB resource group template. Previously I removed one metric due to failing metrics call. Turns out there are many restrictions on which metrics are enabled. 
https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported#microsoftsqlserversdatabases

Changing the template to only use metrics that are enabled for all sql types
