### PR TITLE
skip copy workbook in loc if exist

### DIFF
--- a/scripts/ProcessTemplates.ps1
+++ b/scripts/ProcessTemplates.ps1
@@ -256,6 +256,14 @@ Function CopyFromEnuIfNotExist() {
         $fileName = $enuFile.Name
         $destinationFile = "$fullName\$fileName"
         if (!(Test-Path $destinationFile)) {
+            if ($fileName -like "*.workbook") {
+                $existingWorkbooks = Get-ChildItem -Path "$fullName\*" -Include *.workbook
+                if ($existingWorkbooks.Count -ne 0) {
+                    Write-Host ">>>>>> Skipping .workbook in $existingWorkbooks <<<<<<<<"
+                    continue
+                }    
+            }
+
             $fullPath = $enuFile.FullName
             Write-Host "[#WARNING: missing File]: copying file $fullPath to $fullName"
             # copy file from enu to localized folder


### PR DESCRIPTION
sometimes loc branches are missing some .json and .workbook files so the script copies them from master to loc branches when processing the templates. however, when the .workbook filename changes, this process could copy and have multiple .workbook in a directory and the tool will fail. this fix will check if .workbook already exist in the loc branches and skip copying another .workbook file over