### PR TITLE
treat workbook, cohort files as json in github

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+*.workbook linguist-detectable
+*.workbook linguist-language=JSON
+*.cohort linguist-detectable
+*.cohort linguist-language=JSON

--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,9 @@
+# Microsoft Open Source Code of Conduct
+
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
+
+Resources:
+
+- [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/)
+- [Microsoft Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/)
+- Contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with questions or concerns


### PR DESCRIPTION
## PR Checklist

* Adds .gitattributes that should ([according to this](https://github.com/github/linguist#using-gitattributes)) make `.workbooks` and `.cohorts` files treated as json files in github for compares, etc

* also adds the standard microsoft open source code of conduct markdown file as well.
