### PR TITLE
Add workspace regions

### DIFF
--- a/Workbooks/Virtual Machines - Performance Analysis/Performance Analysis for a Group of VMs (Dev)/Performance Analysis for a Group of VMs (Dev).workbook
+++ b/Workbooks/Virtual Machines - Performance Analysis/Performance Analysis for a Group of VMs (Dev)/Performance Analysis for a Group of VMs (Dev).workbook
@@ -12,9 +12,6 @@
       "type": 9,
       "content": {
         "version": "KqlParameterItem/1.0",
-        "crossComponentResources": [
-          "{Subscriptions}"
-        ],
         "parameters": [
           {
             "id": "7d3239b1-19a0-44fd-a771-df82340e0d88",
@@ -50,12 +47,9 @@
             "type": 1,
             "query": "take 1\r\n| extend x = split ({DefaultResource:value}, '/')\r\n| project value = tostring(pack('sub', x[2], 'rg', case(x[4] != 'null', x[4], ''), 'vm', case(x[8] != 'null', x[8], '')))",
             "crossComponentResources": [
-              "value::selected"
+              "value::all"
             ],
             "isHiddenWhenLocked": true,
-            "timeContext": {
-              "durationMs": 0
-            },
             "timeContextFromParameter": "TimeRange",
             "queryType": 1,
             "resourceType": "microsoft.resourcegraph/resources"
@@ -71,19 +65,15 @@
             "delimiter": ",",
             "query": "where type in~('microsoft.compute/virtualmachines', 'microsoft.compute/virtualmachinescalesets')\r\n| summarize Count = count() by subscriptionId\r\n| order by Count desc\r\n| extend Rank = row_number()\r\n| project value = subscriptionId, label = subscriptionId, selected = iff(subscriptionId =~ todynamic('{Selection}').sub, true, false)",
             "crossComponentResources": [
-              "value::selected"
+              "value::all"
             ],
             "typeSettings": {
-              "additionalResourceOptions": [
-                "value::1"
-              ],
+              "additionalResourceOptions": [],
               "showDefault": false
             },
+            "timeContextFromParameter": "TimeRange",
             "queryType": 1,
-            "resourceType": "microsoft.resourcegraph/resources",
-            "value": [
-              "value::1"
-            ]
+            "resourceType": "microsoft.resourcegraph/resources"
           },
           {
             "id": "efc388e8-ac7b-4e72-8573-e97cfe370f16",
@@ -111,21 +101,38 @@
             "resourceType": "microsoft.resourcegraph/resources"
           },
           {
-            "id": "ff31cd1b-224e-42bd-8d65-f803ca13ce13",
+            "id": "b829835f-1161-457d-96c5-72fc444db73a",
             "version": "KqlParameterItem/1.0",
-            "name": "Resources",
-            "label": "Virtual machines",
+            "name": "Location",
+            "label": "Workspace Regions",
+            "type": 8,
+            "isRequired": true,
+            "multiSelect": true,
+            "quote": "'",
+            "delimiter": ",",
+            "value": [
+              "value::3"
+            ],
+            "typeSettings": {
+              "limitSelectTo": 20,
+              "additionalResourceOptions": [
+                "value::3"
+              ],
+              "includeAll": true
+            }
+          },
+          {
+            "id": "0b488656-655a-4716-9438-bb3137c98055",
+            "version": "KqlParameterItem/1.0",
+            "name": "Workspaces",
             "type": 5,
             "isRequired": true,
             "multiSelect": true,
             "quote": "'",
             "delimiter": ",",
-            "query": "Resources \r\n| where resourceGroup in~({ResourceGroup}) and type in~('microsoft.compute/virtualmachines', 'microsoft.compute/virtualmachinescalesets')\r\n| project id, name, selected=false, group=iff(type =~ \"microsoft.compute/virtualmachines\", \"Virtual machines\", \"Virtual machine scale sets\")",
+            "query": "where type =~ \"microsoft.operationalinsights/workspaces\"\r\n| where location in~ ({Location})",
             "crossComponentResources": [
               "{Subscriptions}"
-            ],
-            "value": [
-              "value::all"
             ],
             "typeSettings": {
               "additionalResourceOptions": [
@@ -181,24 +188,34 @@
             }
           },
           {
-            "id": "d643672d-1bc2-497d-a5ce-20f631ee9399",
+            "id": "d38751bd-cb5d-4ad7-a2b2-dac377be99f5",
             "version": "KqlParameterItem/1.0",
-            "name": "ResourceScope",
-            "type": 7,
+            "name": "Resources",
+            "label": "Virtual Machines",
+            "type": 5,
             "isRequired": true,
             "multiSelect": true,
             "quote": "'",
             "delimiter": ",",
-            "query": "Resources\r\n| take 1\r\n| project x = dynamic([\"microsoft.compute/virtualmachines\", \"microsoft.compute/virtualmachinescalesets\", \"microsoft.resources/resourcegroups\", \"microsoft.resources/subscriptions\"])\r\n| mvexpand x to typeof(string)\r\n| extend jkey = 1\r\n| join kind = inner (Resources \r\n| where id in~ ({Resources})\r\n| summarize Subs = dcount(subscriptionId), resourceGroups = dcount(resourceGroup), resourceCount = count()\r\n| extend jkey = 1) on jkey\r\n| project x, label = 'x', selected = case(x in ('microsoft.compute/virtualmachinescalesets', 'microsoft.compute/virtualmachines') and resourceCount <= 5, true, x == 'microsoft.resources/resourcegroups' and resourceGroups <= 3 and resourceCount > 5, true, x == 'microsoft.resources/subscriptions' and resourceGroups > 3 and resourceCount > 5, true, false)\r\n",
+            "query": "InsightsMetrics\r\n| distinct _ResourceId",
             "crossComponentResources": [
-              "{Subscriptions}"
+              "{Workspaces}"
             ],
-            "isHiddenWhenLocked": true,
+            "value": [
+              "value::all"
+            ],
             "typeSettings": {
-              "additionalResourceOptions": []
+              "additionalResourceOptions": [
+                "value::all"
+              ],
+              "selectAllValue": "all"
             },
-            "queryType": 1,
-            "resourceType": "microsoft.resourcegraph/resources"
+            "timeContext": {
+              "durationMs": 0
+            },
+            "timeContextFromParameter": "TimeRange",
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces"
           },
           {
             "id": "e36a2c69-a3c1-4b0c-b758-b37bc16b4669",
@@ -207,7 +224,7 @@
             "type": 1,
             "query": "let perf = InsightsMetrics\r\n| where TimeGenerated {TimeRange}\r\n| take 1;\r\nlet servicemap = ServiceMapComputer_CL\r\n| where TimeGenerated {TimeRange}\r\n| take 1;\r\nperf\r\n| union servicemap",
             "crossComponentResources": [
-              "{Resources}"
+              "{Workspaces}"
             ],
             "isHiddenWhenLocked": true,
             "timeContext": {
@@ -215,26 +232,87 @@
             },
             "timeContextFromParameter": "TimeRange",
             "queryType": 0,
-            "resourceType": "microsoft.resources/subscriptions"
+            "resourceType": "microsoft.operationalinsights/workspaces",
+            "label": "Not Onboarded"
+          },
+          {
+            "id": "ea980bb9-09d6-4966-bdd3-dc54b2246226",
+            "version": "KqlParameterItem/1.0",
+            "name": "resourcesValueSnippet",
+            "type": 1,
+            "description": "query snippet when user selects from Resources dropdown",
+            "query": "{\"version\":\"1.0.0\",\"content\":\"\\\"| where _ResourceId in ({Resources})\\\"\",\"transformers\":null}",
+            "isHiddenWhenLocked": true,
+            "timeContext": {
+              "durationMs": 0
+            },
+            "timeContextFromParameter": "TimeRange",
+            "queryType": 8,
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          },
+          {
+            "id": "ce1f0e30-7383-4dc2-826f-b9ea83e11851",
+            "version": "KqlParameterItem/1.0",
+            "name": "resourcesValue",
+            "type": 1,
+            "query": "{\"version\":\"1.0.0\",\"content\":\"\\\"{Resources}\\\"\",\"transformers\":null}",
+            "isHiddenWhenLocked": true,
+            "timeContext": {
+              "durationMs": 0
+            },
+            "timeContextFromParameter": "TimeRange",
+            "queryType": 8
+          },
+          {
+            "id": "bc05c31b-9919-41da-94a8-a9f58dfbc5ed",
+            "version": "KqlParameterItem/1.0",
+            "name": "emptyParam",
+            "type": 1,
+            "isHiddenWhenLocked": true,
+            "timeContext": {
+              "durationMs": 0
+            },
+            "timeContextFromParameter": "TimeRange"
+          },
+          {
+            "id": "6f523dd4-292d-468c-b058-a76f628347d6",
+            "version": "KqlParameterItem/1.0",
+            "name": "vmSnippet",
+            "type": 1,
+            "isHiddenWhenLocked": true,
+            "criteriaData": [
+              {
+                "condition": "if (resourcesValue != ''all''), result = resourcesValueSnippet",
+                "criteriaContext": {
+                  "leftOperand": "resourcesValue",
+                  "operator": "!=",
+                  "rightValType": "static",
+                  "rightVal": "'all'",
+                  "resultValType": "param",
+                  "resultVal": "resourcesValueSnippet"
+                }
+              },
+              {
+                "condition": "else result = emptyParam",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "param",
+                  "resultVal": "emptyParam"
+                }
+              }
+            ],
+            "timeContext": {
+              "durationMs": 0
+            },
+            "timeContextFromParameter": "TimeRange"
           }
         ],
         "style": "above",
-        "queryType": 1,
-        "resourceType": "microsoft.resourcegraph/resources"
+        "queryType": 0,
+        "resourceType": "microsoft.operationalinsights/workspaces"
       },
       "name": "top-level parameters"
-    },
-    {
-      "type": 1,
-      "content": {
-        "json": "⚠ No counters were detected. Try the following:\r\n\r\n* Select a different time range\r\n* Try different scope selections\r\n* Onboard to Azure Monitor for VMs ([Azure Monitor for VMs GA FAQ](https://docs.microsoft.com/en-us/azure/azure-monitor/insights/vminsights-ga-release-faq))."
-      },
-      "conditionalVisibility": {
-        "parameterName": "Test",
-        "comparison": "isEqualTo",
-        "value": null
-      },
-      "name": "onboarding prompt"
     },
     {
       "type": 11,
@@ -261,11 +339,23 @@
       "name": "top-level tabs"
     },
     {
+      "type": 1,
+      "content": {
+        "json": "⚠ No counters were detected. Try the following:\r\n\r\n* Select a different time range\r\n* Try different scope selections\r\n* Onboard to Azure Monitor for VMs ([Azure Monitor for VMs GA FAQ](https://docs.microsoft.com/en-us/azure/azure-monitor/insights/vminsights-ga-release-faq))."
+      },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isEqualTo",
+        "value": null
+      },
+      "name": "onboarding prompt"
+    },
+    {
       "type": 9,
       "content": {
         "version": "KqlParameterItem/1.0",
         "crossComponentResources": [
-          "{DefaultResource}"
+          "{Workspaces}"
         ],
         "parameters": [
           {
@@ -274,17 +364,16 @@
             "name": "Counter",
             "type": 2,
             "description": "Select a VM performance counter for the table below",
-            "isRequired": true,
-            "query": "InsightsMetrics\r\n| where TimeGenerated {TimeRange}\r\n| summarize by Namespace, Name, CounterText = Name\r\n| order by Name asc, Namespace asc\r\n| project Counter = pack('counter', Name, 'object', Namespace), CounterText, group = Namespace",
+            "query": "InsightsMetrics\r\n{vmSnippet}\r\n| where TimeGenerated {TimeRange}\r\n| summarize by Namespace, Name, CounterText = Name\r\n| order by Name asc, Namespace asc\r\n| project Counter = pack('counter', Name, 'object', Namespace), CounterText, group = Namespace",
             "crossComponentResources": [
-              "{Resources}"
+              "{Workspaces}"
             ],
-            "value": "{\"counter\":\"BytesPerSecond\",\"object\":\"LogicalDisk\"}",
             "typeSettings": {
               "additionalResourceOptions": []
             },
             "queryType": 0,
-            "resourceType": "microsoft.resources/subscriptions"
+            "resourceType": "microsoft.operationalinsights/workspaces",
+            "value": "{\"counter\":\"UtilizationPercentage\",\"object\":\"Processor\"}"
           },
           {
             "id": "9ad8858d-8ef3-4144-94b1-66a8bf9fa9c9",
@@ -311,7 +400,8 @@
             "typeSettings": {
               "additionalResourceOptions": []
             },
-            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(Val), 2)\", \"label\":\"Average\", \"selected\": true },\r\n    { \"value\":\"P5th = round(percentile(Val, 5), 2)\", \"label\":\"P5th\", \"selected\": false },\r\n    { \"value\":\"P10th = round(percentile(Val, 10), 2)\", \"label\":\"P10th\", \"selected\": false },\r\n    { \"value\":\"P50th = round(percentile(Val, 50), 2)\", \"label\":\"P50th\", \"selected\": false },\r\n    { \"value\":\"P80th = round(percentile(Val, 80), 2)\", \"label\":\"P80th\", \"selected\": false },\r\n    { \"value\":\"P90th = round(percentile(Val, 90), 2)\", \"label\":\"P90th\", \"selected\": false },\r\n    { \"value\":\"P95th = round(percentile(Val, 95), 2)\", \"label\":\"P95th\", \"selected\": false }\r\n]"
+            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(Val), 2)\", \"label\":\"Average\", \"selected\": true },\r\n    { \"value\":\"P5th = round(percentile(Val, 5), 2)\", \"label\":\"P5th\", \"selected\": false },\r\n    { \"value\":\"P10th = round(percentile(Val, 10), 2)\", \"label\":\"P10th\", \"selected\": false },\r\n    { \"value\":\"P50th = round(percentile(Val, 50), 2)\", \"label\":\"P50th\", \"selected\": false },\r\n    { \"value\":\"P80th = round(percentile(Val, 80), 2)\", \"label\":\"P80th\", \"selected\": false },\r\n    { \"value\":\"P90th = round(percentile(Val, 90), 2)\", \"label\":\"P90th\", \"selected\": false },\r\n    { \"value\":\"P95th = round(percentile(Val, 95), 2)\", \"label\":\"P95th\", \"selected\": false }\r\n]",
+            "label": "Table Trend"
           },
           {
             "id": "a31e3a83-360d-49a2-9fbd-928dd8e3ff35",
@@ -398,7 +488,7 @@
         ],
         "style": "above",
         "queryType": 0,
-        "resourceType": "{ResourceScope}"
+        "resourceType": "microsoft.operationalinsights/workspaces"
       },
       "conditionalVisibilities": [
         {
@@ -420,16 +510,47 @@
       "name": "top-100 parameters"
     },
     {
+      "type": 1,
+      "content": {
+        "json": "⚠ Select a `Counter`"
+      },
+      "conditionalVisibilities": [
+        {
+          "parameterName": "tab",
+          "comparison": "isEqualTo",
+          "value": "top100"
+        },
+        {
+          "parameterName": "Counter",
+          "comparison": "isEqualTo"
+        },
+        {
+          "parameterName": "Test",
+          "comparison": "isNotEqualTo"
+        }
+      ],
+      "conditionalVisibility": {
+        "parameterName": "tab",
+        "comparison": "isEqualTo",
+        "value": "top100"
+      },
+      "name": "text - 23"
+    },
+    {
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let metric = dynamic({Counter}); \r\nlet timeRangeStart = {TimeRange:start};\r\nlet timeRangeEnd = {TimeRange:end};\r\nlet timeRangeGrain = {TimeRange:grain};\r\nlet maxResultCount = 100;\r\nlet summaryPerComputer = totable(InsightsMetrics       | where TimeGenerated {TimeRange}  | where Namespace == metric.object and Name == metric.counter      | summarize hint.shufflekey = Computer Average = avg(Val), Max = max(Val), Min = min(Val), percentiles(Val, 5, 10, 50, 80, 90, 95) by Computer       | project Computer, Average, Max, Min, P5th = percentile_Val_5, P10th = percentile_Val_10, P50th = percentile_Val_50, P80th = percentile_Val_80, P90th = percentile_Val_90, P95th = percentile_Val_95       | order by {TableTrend:label} {tableTrendOrder}, Computer       | limit maxResultCount); let computerList = summaryPerComputer       | project Computer; let MachineSummary = ServiceMapComputer_CL      | where TimeGenerated {TimeRange}      | where Computer in (computerList)      | summarize arg_max(TimeGenerated, *) by Computer      | project Computer, MachineSummary = pack('Fully Qualified Domain Name', Computer, 'OS Type', OperatingSystemFamily_s, 'Operating System', OperatingSystemFullName_s, 'Ipv4 Addresses', Ipv4Addresses_s,         'Ipv6 Addresses', Ipv6Addresses_s, 'Mac Addresses', MacAddresses_s, 'DNS Names', DnsNames_s, 'CPUs', strcat(Cpus_d, ' @ ', CpuSpeed_d, ' MHz'), 'Bitness', Bitness_s,         'Physcial Memory', strcat(PhysicalMemory_d, ' MB'), 'Virtualization State', VirtualizationState_s, 'VM Type', VirtualMachineType_s, 'OMS Agent', split(ResourceName_s, 'm-')[1]);let EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];let OmsNodeIdentityAndProps = computerList      | extend NodeId = Computer      | extend Priority = 1      | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);let ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL      | where TimeGenerated {TimeRange}      | where Computer in (computerList)      | summarize arg_max(TimeGenerated, *) by Computer      | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), ' |',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), ' |',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId) | project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;let NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                                  | summarize arg_max(Priority, *) by Computer; let NodeIdentityAndPropsMin = NodeIdentityAndProps      | extend Type = iff(NodeProps.type == 'StandAloneNode', iff(NodeProps.azureResourceId == '', 'Non-Azure Virtual Machine', 'Azure Virtual Machine'), NodeProps.type),      ResourceId = iff(NodeProps.type == 'AzureScaleSetNode', NodeProps.vmScaleSetResourceId,          iff(NodeProps.type == 'AzureCloudServiceNode', NodeProps.cloudServiceDeploymentId, Computer)),     ResourceName = iff(NodeProps.type == 'AzureScaleSetNode', strcat(NodeProps.vmScaleSetName, '  | ', NodeProps.scaleSetInstanceId),          iff(NodeProps.type == 'AzureCloudServiceNode', strcat(NodeProps.cloudServiceRoleName, '  | ', NodeProps.cloudServiceInstanceId), Computer))      | project Computer, Type, ResourceId, ResourceName;let trend = InsightsMetrics           | where TimeGenerated {TimeRange}          | where Computer in (computerList)           | where Namespace == metric.object and Name == metric.counter         | make-series {TableTrend} default = 0 on TimeGenerated in range(timeRangeStart, timeRangeEnd, timeRangeGrain) by Computer      | project Computer, ['Trend ({TableTrend:label})'] = {TableTrend:label}; summaryPerComputer      | join kind=leftouter (trend) on Computer      | join kind=leftouter (NodeIdentityAndProps) on Computer      | join kind=leftouter (NodeIdentityAndPropsMin) on Computer      | join kind=leftouter (MachineSummary) on Computer      | project ResourceName, Type, {mergedAggregators}, ['Trend ({TableTrend:label})'], Properties = MachineSummary      | sort by {TableTrend:label} {tableTrendOrder}",
+        "query": "let metric = dynamic({Counter}); \r\nlet timeRangeStart = {TimeRange:start};\r\nlet timeRangeEnd = {TimeRange:end};\r\nlet timeRangeGrain = {TimeRange:grain};\r\nlet maxResultCount = 100;\r\nlet summaryPerComputer = totable(InsightsMetrics {vmSnippet}       | where TimeGenerated {TimeRange}  | where Namespace == metric.object and Name == metric.counter      | summarize hint.shufflekey = Computer Average = avg(Val), Max = max(Val), Min = min(Val), percentiles(Val, 5, 10, 50, 80, 90, 95) by Computer       | project Computer, Average, Max, Min, P5th = percentile_Val_5, P10th = percentile_Val_10, P50th = percentile_Val_50, P80th = percentile_Val_80, P90th = percentile_Val_90, P95th = percentile_Val_95       | order by {TableTrend:label} {tableTrendOrder}, Computer       | limit maxResultCount); let computerList = summaryPerComputer       | project Computer; let MachineSummary = ServiceMapComputer_CL      | where TimeGenerated {TimeRange}      | where Computer in (computerList)      | summarize arg_max(TimeGenerated, *) by Computer      | project Computer, MachineSummary = pack('Fully Qualified Domain Name', Computer, 'OS Type', OperatingSystemFamily_s, 'Operating System', OperatingSystemFullName_s, 'Ipv4 Addresses', Ipv4Addresses_s,         'Ipv6 Addresses', Ipv6Addresses_s, 'Mac Addresses', MacAddresses_s, 'DNS Names', DnsNames_s, 'CPUs', strcat(Cpus_d, ' @ ', CpuSpeed_d, ' MHz'), 'Bitness', Bitness_s,         'Physcial Memory', strcat(PhysicalMemory_d, ' MB'), 'Virtualization State', VirtualizationState_s, 'VM Type', VirtualMachineType_s, 'OMS Agent', split(ResourceName_s, 'm-')[1]);let EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];let OmsNodeIdentityAndProps = computerList      | extend NodeId = Computer      | extend Priority = 1      | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);let ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL      | where TimeGenerated {TimeRange}      | where Computer in (computerList)      | summarize arg_max(TimeGenerated, *) by Computer      | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), ' |',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), ' |',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId) | project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;let NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                                  | summarize arg_max(Priority, *) by Computer; let NodeIdentityAndPropsMin = NodeIdentityAndProps      | extend Type = iff(NodeProps.type == 'StandAloneNode', iff(NodeProps.azureResourceId == '', 'Non-Azure Virtual Machine', 'Azure Virtual Machine'), NodeProps.type),      ResourceId = iff(NodeProps.type == 'AzureScaleSetNode', NodeProps.vmScaleSetResourceId,          iff(NodeProps.type == 'AzureCloudServiceNode', NodeProps.cloudServiceDeploymentId, Computer)),     ResourceName = iff(NodeProps.type == 'AzureScaleSetNode', strcat(NodeProps.vmScaleSetName, '  | ', NodeProps.scaleSetInstanceId),          iff(NodeProps.type == 'AzureCloudServiceNode', strcat(NodeProps.cloudServiceRoleName, '  | ', NodeProps.cloudServiceInstanceId), Computer))      | project Computer, Type, ResourceId, ResourceName;let trend = InsightsMetrics   {vmSnippet}       | where TimeGenerated {TimeRange}          | where Computer in (computerList)           | where Namespace == metric.object and Name == metric.counter         | make-series {TableTrend} default = 0 on TimeGenerated in range(timeRangeStart, timeRangeEnd, timeRangeGrain) by Computer      | project Computer, ['Trend ({TableTrend:label})'] = {TableTrend:label}; summaryPerComputer      | join kind=leftouter (trend) on Computer      | join kind=leftouter (NodeIdentityAndProps) on Computer      | join kind=leftouter (NodeIdentityAndPropsMin) on Computer      | join kind=leftouter (MachineSummary) on Computer      | project ResourceName, Type, {mergedAggregators}, ['Trend ({TableTrend:label})'], Properties = MachineSummary      | sort by {TableTrend:label} {tableTrendOrder}",
         "size": 3,
         "noDataMessage": "There is no data for this counter, either enable the counter or onboard machines to this workspace",
+        "timeContext": {
+          "durationMs": 0
+        },
+        "timeContextFromParameter": "TimeRange",
         "queryType": 0,
-        "resourceType": "{ResourceScope}",
+        "resourceType": "microsoft.operationalinsights/workspaces",
         "crossComponentResources": [
-          "{Resources}"
+          "{Workspaces}"
         ],
         "visualization": "table",
         "gridSettings": {
@@ -617,6 +738,17 @@
         },
         "sortBy": []
       },
+      "conditionalVisibilities": [
+        {
+          "parameterName": "tab",
+          "comparison": "isEqualTo",
+          "value": "top100"
+        },
+        {
+          "parameterName": "Counter",
+          "comparison": "isNotEqualTo"
+        }
+      ],
       "conditionalVisibility": {
         "parameterName": "tab",
         "comparison": "isEqualTo",
@@ -854,15 +986,19 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let cpuSummary=totable(InsightsMetrics\r\n    | where TimeGenerated {TimeRange}\r\n    | where _ResourceId in~ ({Resources})\r\n    | where (Namespace == 'Processor' and Name == 'UtilizationPercentage')\r\n    | summarize hint.shufflekey=Computer {aggregateLeftValue} by Computer, Name\r\n    | top 10 by {aggregateLeftLabel} {aggregateOrderLeft});\r\nlet computerList=(cpuSummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nInsightsMetrics\r\n    | where TimeGenerated {TimeRange}\r\n    | where _ResourceId in~ ({Resources})\r\n    | where (Namespace == 'Processor' and Name == 'UtilizationPercentage')\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {aggregateLeftValue} by bin(TimeGenerated, ({TimeRange:end} - {TimeRange:start})/100), ResourceName",
+        "query": "let cpuSummary=totable(InsightsMetrics {vmSnippet}\r\n    | where (Namespace == 'Processor' and Name == 'UtilizationPercentage')\r\n    | summarize hint.shufflekey=Computer {aggregateLeftValue} by Computer, Name\r\n    | top 10 by {aggregateLeftLabel} {aggregateOrderLeft});\r\nlet computerList=(cpuSummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nInsightsMetrics {vmSnippet}\r\n    | where (Namespace == 'Processor' and Name == 'UtilizationPercentage')\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {aggregateLeftValue} by bin(TimeGenerated, ({TimeRange:end} - {TimeRange:start})/100), ResourceName",
         "size": 0,
         "aggregation": 3,
         "showAnnotations": true,
         "noDataMessage": "There is no data for this counter, either enable the counter or onboard machines to this workspace",
+        "timeContext": {
+          "durationMs": 0
+        },
+        "timeContextFromParameter": "TimeRange",
         "queryType": 0,
-        "resourceType": "{ResourceScope}",
+        "resourceType": "microsoft.operationalinsights/workspaces",
         "crossComponentResources": [
-          "{Resources}"
+          "{Workspaces}"
         ],
         "visualization": "linechart",
         "tileSettings": {
@@ -906,15 +1042,19 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let memorySummary=totable(InsightsMetrics\r\n    | where TimeGenerated {TimeRange} \r\n    | where _ResourceId in~ ({Resources})\r\n    | where Namespace == 'Memory' and Name == 'AvailableMB'\r\n    | summarize hint.shufflekey=Computer {aggregateRightValue} by Computer, Name\r\n    | top 10 by {aggregateRightLabel} {aggregateOrderRight});\r\nlet computerList=(memorySummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nInsightsMetrics\r\n    | where TimeGenerated {TimeRange}\r\n    | where _ResourceId in~ ({Resources})\r\n    | where Namespace == 'Memory' and Name == 'AvailableMB'\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {aggregateRightValue} by bin(TimeGenerated, ({TimeRange:end} - {TimeRange:start})/100), ResourceName",
+        "query": "let memorySummary=totable(InsightsMetrics {vmSnippet}\r\n    | where Namespace == 'Memory' and Name == 'AvailableMB'\r\n    | summarize hint.shufflekey=Computer {aggregateRightValue} by Computer, Name\r\n    | top 10 by {aggregateRightLabel} {aggregateOrderRight});\r\nlet computerList=(memorySummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nInsightsMetrics {vmSnippet}\r\n    | where Namespace == 'Memory' and Name == 'AvailableMB'\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {aggregateRightValue} by bin(TimeGenerated, ({TimeRange:end} - {TimeRange:start})/100), ResourceName",
         "size": 0,
         "aggregation": 3,
         "showAnnotations": true,
         "noDataMessage": "There is no data for this counter, either enable the counter or onboard machines to this workspace",
+        "timeContext": {
+          "durationMs": 0
+        },
+        "timeContextFromParameter": "TimeRange",
         "queryType": 0,
-        "resourceType": "{ResourceScope}",
+        "resourceType": "microsoft.operationalinsights/workspaces",
         "crossComponentResources": [
-          "{Resources}"
+          "{Workspaces}"
         ],
         "visualization": "linechart",
         "tileSettings": {
@@ -1184,14 +1324,18 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let memorySummary=totable(InsightsMetrics\r\n    | where TimeGenerated {TimeRange}\r\n    | where _ResourceId in~ ({Resources})\r\n    | where Namespace == 'Network' and Name == 'WriteBytesPerSecond'\r\n    | summarize hint.shufflekey=Computer {aggregateLeftValue} by Computer, Name\r\n    | top 10 by {aggregateLeftLabel} {aggregateOrderLeft});\r\nlet computerList=(memorySummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nInsightsMetrics\r\n    | where TimeGenerated {TimeRange}\r\n    | where _ResourceId in~ ({Resources})\r\n    | where Namespace == 'Network' and Name == 'WriteBytesPerSecond'\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {aggregateLeftValue} by bin(TimeGenerated, ({TimeRange:end} - {TimeRange:start})/100), ResourceName",
+        "query": "let memorySummary=totable(InsightsMetrics {vmSnippet}\r\n    | where Namespace == 'Network' and Name == 'WriteBytesPerSecond'\r\n    | summarize hint.shufflekey=Computer {aggregateLeftValue} by Computer, Name\r\n    | top 10 by {aggregateLeftLabel} {aggregateOrderLeft});\r\nlet computerList=(memorySummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nInsightsMetrics {vmSnippet}\r\n    | where Namespace == 'Network' and Name == 'WriteBytesPerSecond'\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {aggregateLeftValue} by bin(TimeGenerated, ({TimeRange:end} - {TimeRange:start})/100), ResourceName",
         "size": 0,
         "showAnnotations": true,
         "noDataMessage": "There is no data for this counter, either enable the counter or onboard machines to this workspace",
+        "timeContext": {
+          "durationMs": 0
+        },
+        "timeContextFromParameter": "TimeRange",
         "queryType": 0,
-        "resourceType": "{ResourceScope}",
+        "resourceType": "microsoft.operationalinsights/workspaces",
         "crossComponentResources": [
-          "{Resources}"
+          "{Workspaces}"
         ],
         "visualization": "linechart",
         "tileSettings": {
@@ -1235,14 +1379,18 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let memorySummary=totable(InsightsMetrics\r\n    | where TimeGenerated {TimeRange}\r\n    | where _ResourceId in~ ({Resources})\r\n    | where Namespace == 'Network' and Name == 'ReadBytesPerSecond'\r\n    | summarize hint.shufflekey=Computer {aggregateRightValue} by Computer, Name\r\n    | top 10 by {aggregateRightLabel} {aggregateOrderRight});\r\nlet computerList=(memorySummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nInsightsMetrics\r\n    | where TimeGenerated {TimeRange}\r\n    | where _ResourceId in~ ({Resources})\r\n    | where Namespace == 'Network' and Name == 'ReadBytesPerSecond'\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {aggregateRightValue} by bin(TimeGenerated, ({TimeRange:end} - {TimeRange:start})/100), ResourceName",
+        "query": "let memorySummary=totable(InsightsMetrics {vmSnippet}\r\n    | where Namespace == 'Network' and Name == 'ReadBytesPerSecond'\r\n    | summarize hint.shufflekey=Computer {aggregateRightValue} by Computer, Name\r\n    | top 10 by {aggregateRightLabel} {aggregateOrderRight});\r\nlet computerList=(memorySummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nInsightsMetrics {vmSnippet}\r\n    | where Namespace == 'Network' and Name == 'ReadBytesPerSecond'\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {aggregateRightValue} by bin(TimeGenerated, ({TimeRange:end} - {TimeRange:start})/100), ResourceName",
         "size": 0,
         "showAnnotations": true,
         "noDataMessage": "There is no data for this counter, either enable the counter or onboard machines to this workspace",
+        "timeContext": {
+          "durationMs": 0
+        },
+        "timeContextFromParameter": "TimeRange",
         "queryType": 0,
-        "resourceType": "{ResourceScope}",
+        "resourceType": "microsoft.operationalinsights/workspaces",
         "crossComponentResources": [
-          "{Resources}"
+          "{Workspaces}"
         ],
         "visualization": "linechart",
         "tileSettings": {
@@ -1399,15 +1547,19 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let memorySummary=totable(InsightsMetrics\r\n    | where TimeGenerated {TimeRange}\r\n    | where _ResourceId in~ ({Resources})\r\n    | where Namespace == 'LogicalDisk' and Name == 'FreeSpacePercentage'\r\n\t| extend Val = 100 - Val\r\n    | summarize hint.shufflekey=Computer {aggregateLeftValue} by Computer, Name\r\n    | top 10 by {aggregateLeftLabel} {aggregateOrderLeft});\r\nlet computerList=(memorySummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nInsightsMetrics\r\n    | where TimeGenerated {TimeRange}\r\n    | where _ResourceId in~ ({Resources})\r\n    | where Namespace == 'LogicalDisk' and Name == 'FreeSpacePercentage'\r\n\t| extend Val = 100 - Val\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {aggregateLeftValue} by bin(TimeGenerated, ({TimeRange:end} - {TimeRange:start})/100), ResourceName",
+        "query": "let memorySummary=totable(InsightsMetrics {vmSnippet}\r\n    | where Namespace == 'LogicalDisk' and Name == 'FreeSpacePercentage'\r\n\t| extend Val = 100 - Val\r\n    | summarize hint.shufflekey=Computer {aggregateLeftValue} by Computer, Name\r\n    | top 10 by {aggregateLeftLabel} {aggregateOrderLeft});\r\nlet computerList=(memorySummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nInsightsMetrics {vmSnippet}\r\n    | where Namespace == 'LogicalDisk' and Name == 'FreeSpacePercentage'\r\n\t| extend Val = 100 - Val\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {aggregateLeftValue} by bin(TimeGenerated, ({TimeRange:end} - {TimeRange:start})/100), ResourceName",
         "size": 0,
         "aggregation": 3,
         "showAnnotations": true,
         "noDataMessage": "There is no data for this counter, either enable the counter or onboard machines to this workspace",
+        "timeContext": {
+          "durationMs": 0
+        },
+        "timeContextFromParameter": "TimeRange",
         "queryType": 0,
-        "resourceType": "{ResourceScope}",
+        "resourceType": "microsoft.operationalinsights/workspaces",
         "crossComponentResources": [
-          "{Resources}"
+          "{Workspaces}"
         ],
         "visualization": "linechart",
         "tileSettings": {

--- a/Workbooks/Virtual Machines - Performance Analysis/Performance Analysis for a Group of VMs (Dev)/Performance Analysis for a Group of VMs (Dev).workbook
+++ b/Workbooks/Virtual Machines - Performance Analysis/Performance Analysis for a Group of VMs (Dev)/Performance Analysis for a Group of VMs (Dev).workbook
@@ -106,6 +106,7 @@
             "name": "Location",
             "label": "Workspace Regions",
             "type": 8,
+            "description": "Queries with workspaces in 5 or more regions may take excessive time to complete",
             "isRequired": true,
             "multiSelect": true,
             "quote": "'",


### PR DESCRIPTION
Moved all queries back to workspace-centric queries. User will first
select appropriate workspace regions based on subscriptions and resource
groups. The Virtual Machines dropdown is now based off of workspace
`InsightsMetrics` with query snippets.

- Update query to read from workspaces
- Expand subscription selection scope
- Attempt to fix default counter and subscription
- Empty counter prompt
- Fix Top 10 charts to workspace-centric queries
- Add virtual machine dropdown based off of workspaces InsightsMetrics
- Add Query filter by virtual machines
- Optimize selecting virtual machines

Top 100
![image](https://user-images.githubusercontent.com/43890980/74283069-207d0d00-4cd6-11ea-86db-6ab64e12c138.png)

Top 10
![image](https://user-images.githubusercontent.com/43890980/74283108-3094ec80-4cd6-11ea-9ed9-5a5074cd7260.png)
