### PR TITLE
Retrieve workspaces and VMs via Service Map API

### DIFF
--- a/Workbooks/Virtual Machines - Performance Analysis/Performance Analysis for a Group of VMs (Dev)/Performance Analysis for a Group of VMs (Dev).workbook
+++ b/Workbooks/Virtual Machines - Performance Analysis/Performance Analysis for a Group of VMs (Dev)/Performance Analysis for a Group of VMs (Dev).workbook
@@ -12,6 +12,9 @@
       "type": 9,
       "content": {
         "version": "KqlParameterItem/1.0",
+        "crossComponentResources": [
+          "value::all"
+        ],
         "parameters": [
           {
             "id": "7d3239b1-19a0-44fd-a771-df82340e0d88",
@@ -57,18 +60,18 @@
           {
             "id": "604f6d89-c6f9-4bdb-b4ca-483f56a8946c",
             "version": "KqlParameterItem/1.0",
-            "name": "Subscriptions",
+            "name": "Subscription",
             "type": 6,
             "isRequired": true,
-            "multiSelect": true,
-            "quote": "'",
-            "delimiter": ",",
             "query": "where type in~('microsoft.compute/virtualmachines', 'microsoft.compute/virtualmachinescalesets')\r\n| summarize Count = count() by subscriptionId\r\n| order by Count desc\r\n| extend Rank = row_number()\r\n| project value = subscriptionId, label = subscriptionId, selected = iff(subscriptionId =~ todynamic('{Selection}').sub, true, false)",
             "crossComponentResources": [
               "value::all"
             ],
+            "value": "value::1",
             "typeSettings": {
-              "additionalResourceOptions": [],
+              "additionalResourceOptions": [
+                "value::1"
+              ],
               "showDefault": false
             },
             "timeContextFromParameter": "TimeRange",
@@ -79,7 +82,7 @@
             "id": "efc388e8-ac7b-4e72-8573-e97cfe370f16",
             "version": "KqlParameterItem/1.0",
             "name": "ResourceGroup",
-            "label": "Resource groups",
+            "label": "Resource group",
             "type": 2,
             "isRequired": true,
             "multiSelect": true,
@@ -87,18 +90,76 @@
             "delimiter": ",",
             "query": "where type in~('microsoft.compute/virtualmachines', 'microsoft.compute/virtualmachinescalesets')\r\n| summarize Count = count() by resourceGroup\r\n| order by Count desc\r\n| extend Rank = row_number()\r\n| project value = resourceGroup, label = resourceGroup, selected = iff(resourceGroup =~ todynamic('{Selection}').rg, true, false)\r\n| order by value asc",
             "crossComponentResources": [
-              "{Subscriptions}"
+              "{Subscription}"
             ],
             "value": [
               "value::all"
             ],
             "typeSettings": {
+              "limitSelectTo": 1,
               "additionalResourceOptions": [
+                "value::1",
                 "value::all"
-              ]
+              ],
+              "selectAllValue": "all"
             },
+            "timeContextFromParameter": "TimeRange",
             "queryType": 1,
             "resourceType": "microsoft.resourcegraph/resources"
+          },
+          {
+            "id": "7e3ee42f-fa46-47fe-ae7e-1fecdecc094a",
+            "version": "KqlParameterItem/1.0",
+            "name": "armPrefix",
+            "type": 1,
+            "isHiddenWhenLocked": true,
+            "criteriaData": [
+              {
+                "condition": "if (ResourceGroup != 'all'), result = '{Subscription}/resourcegroups/{ResourceGroup:unformatted}'",
+                "criteriaContext": {
+                  "leftOperand": "ResourceGroup",
+                  "operator": "!=",
+                  "rightValType": "static",
+                  "rightVal": "all",
+                  "resultValType": "static",
+                  "resultVal": "{Subscription}/resourcegroups/{ResourceGroup:unformatted}"
+                }
+              },
+              {
+                "condition": "else result = '{Subscription}'",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "static",
+                  "resultVal": "{Subscription}"
+                }
+              }
+            ]
+          },
+          {
+            "id": "8cfecad8-d483-42de-abb3-9cb558a00acd",
+            "version": "KqlParameterItem/1.0",
+            "name": "Resources",
+            "label": "Virtual Machines",
+            "type": 5,
+            "description": "Onboarded Virtual Machines",
+            "multiSelect": true,
+            "quote": "'",
+            "delimiter": ",",
+            "query": "{\"version\":\"ARMEndpoint/1.0\",\"data\":null,\"headers\":[],\"method\":\"GET\",\"path\":\"{armPrefix}/providers/Microsoft.Insights/vmInsightsOnboardingStatuses?api-version=2018-11-27-preview\",\"urlParams\":[],\"batchDisabled\":false,\"transformers\":[{\"type\":\"jsonpath\",\"settings\":{\"tablePath\":\"$.value\",\"columns\":[{\"path\":\"$.properties.resourceId\",\"columnid\":\"resourceId\"}]}}]}",
+            "value": [
+              "value::all"
+            ],
+            "typeSettings": {
+              "additionalResourceOptions": [
+                "value::1",
+                "value::all"
+              ],
+              "selectAllValue": "all"
+            },
+            "timeContextFromParameter": "TimeRange",
+            "queryType": 12,
+            "resourceType": "microsoft.operationalinsights/workspaces"
           },
           {
             "id": "b829835f-1161-457d-96c5-72fc444db73a",
@@ -120,10 +181,33 @@
                 "value::3"
               ],
               "includeAll": true
-            }
+            },
+            "timeContextFromParameter": "TimeRange"
           },
           {
             "id": "0b488656-655a-4716-9438-bb3137c98055",
+            "version": "KqlParameterItem/1.0",
+            "name": "allWorkspaces",
+            "type": 5,
+            "multiSelect": true,
+            "quote": "'",
+            "delimiter": ",",
+            "query": "{\"version\":\"ARMEndpoint/1.0\",\"data\":null,\"headers\":[],\"method\":\"GET\",\"path\":\"{armPrefix}/providers/Microsoft.Insights/vmInsightsOnboardingStatuses?api-version=2018-11-27-preview\",\"urlParams\":[],\"batchDisabled\":false,\"transformers\":[{\"type\":\"jsonpath\",\"settings\":{\"tablePath\":\"$.value..workspace\",\"columns\":[{\"path\":\"$.id\",\"columnid\":\"workspaceId\"}]}}]}",
+            "value": [
+              "value::all"
+            ],
+            "isHiddenWhenLocked": true,
+            "typeSettings": {
+              "additionalResourceOptions": [
+                "value::all"
+              ]
+            },
+            "timeContextFromParameter": "TimeRange",
+            "queryType": 12,
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          },
+          {
+            "id": "598a32fb-b4b3-4f0e-adcf-4357a9cd53c3",
             "version": "KqlParameterItem/1.0",
             "name": "Workspaces",
             "type": 5,
@@ -131,15 +215,17 @@
             "multiSelect": true,
             "quote": "'",
             "delimiter": ",",
-            "query": "where type =~ \"microsoft.operationalinsights/workspaces\"\r\n| where location in~ ({Location})",
+            "query": "where type =~ \"microsoft.operationalinsights/workspaces\"\r\n| where id in~ ({allWorkspaces})\r\n| where location in~ ({Location})",
             "crossComponentResources": [
-              "{Subscriptions}"
+              "value::all"
             ],
             "typeSettings": {
               "additionalResourceOptions": [
                 "value::all"
-              ]
+              ],
+              "showDefault": false
             },
+            "timeContextFromParameter": "TimeRange",
             "queryType": 1,
             "resourceType": "microsoft.resourcegraph/resources"
           },
@@ -187,36 +273,6 @@
               ],
               "allowCustom": true
             }
-          },
-          {
-            "id": "d38751bd-cb5d-4ad7-a2b2-dac377be99f5",
-            "version": "KqlParameterItem/1.0",
-            "name": "Resources",
-            "label": "Virtual Machines",
-            "type": 5,
-            "isRequired": true,
-            "multiSelect": true,
-            "quote": "'",
-            "delimiter": ",",
-            "query": "InsightsMetrics\r\n| distinct _ResourceId",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
-            "value": [
-              "value::all"
-            ],
-            "typeSettings": {
-              "additionalResourceOptions": [
-                "value::all"
-              ],
-              "selectAllValue": "all"
-            },
-            "timeContext": {
-              "durationMs": 0
-            },
-            "timeContextFromParameter": "TimeRange",
-            "queryType": 0,
-            "resourceType": "microsoft.operationalinsights/workspaces"
           },
           {
             "id": "e36a2c69-a3c1-4b0c-b758-b37bc16b4669",
@@ -310,8 +366,8 @@
           }
         ],
         "style": "above",
-        "queryType": 0,
-        "resourceType": "microsoft.operationalinsights/workspaces"
+        "queryType": 1,
+        "resourceType": "microsoft.resourcegraph/resources"
       },
       "name": "top-level parameters"
     },
@@ -373,8 +429,7 @@
               "additionalResourceOptions": []
             },
             "queryType": 0,
-            "resourceType": "microsoft.operationalinsights/workspaces",
-            "value": "{\"counter\":\"UtilizationPercentage\",\"object\":\"Processor\"}"
+            "resourceType": "microsoft.operationalinsights/workspaces"
           },
           {
             "id": "9ad8858d-8ef3-4144-94b1-66a8bf9fa9c9",


### PR DESCRIPTION
Previous implementation only fetched workspaces from the respective
sub/rg. This change will instead retrieve workspaces from VMs onboarded
to the respective sub/rg utilizing ARM parameters.

NOTE: there may be a bug where this workbook will be broken upon
initialization.

- Change sub and RG to single-select
- Add armPrefix parameter
- Modify workspaces dropdown to read from ARM
- Filter workspaces through ARG
- Workspaces respect workspace regions

![image](https://user-images.githubusercontent.com/43890980/74381197-dc563f00-4d9f-11ea-9b01-148abdb0d6e9.png)
