### PR TITLE
Fix malformed ARM URLs

### DIFF
--- a/Workbooks/Virtual Machines - Performance Analysis/Performance Analysis for a Group of VMs (Dev)/Performance Analysis for a Group of VMs (Dev).workbook
+++ b/Workbooks/Virtual Machines - Performance Analysis/Performance Analysis for a Group of VMs (Dev)/Performance Analysis for a Group of VMs (Dev).workbook
@@ -116,7 +116,7 @@
             "version": "KqlParameterItem/1.0",
             "name": "armPrefix",
             "type": 1,
-            "value": "/subscriptions/c1c21d53-ea09-4dcf-9c3d-a86941c960cc",
+            "value": "",
             "isHiddenWhenLocked": true,
             "criteriaData": [
               {
@@ -157,7 +157,7 @@
             "version": "KqlParameterItem/1.0",
             "name": "armUrl",
             "type": 1,
-            "value": "/subscriptions/c1c21d53-ea09-4dcf-9c3d-a86941c960cc/providers/Microsoft.Insights/vmInsightsOnboardingStatuses?api-version=2018-11-27-preview",
+            "value": "",
             "isHiddenWhenLocked": true,
             "criteriaData": [
               {

--- a/Workbooks/Virtual Machines - Performance Analysis/Performance Analysis for a Group of VMs (Dev)/Performance Analysis for a Group of VMs (Dev).workbook
+++ b/Workbooks/Virtual Machines - Performance Analysis/Performance Analysis for a Group of VMs (Dev)/Performance Analysis for a Group of VMs (Dev).workbook
@@ -12,10 +12,14 @@
       "type": 9,
       "content": {
         "version": "KqlParameterItem/1.0",
-        "crossComponentResources": [
-          "value::all"
-        ],
         "parameters": [
+          {
+            "id": "3f34a4f7-9a42-46ed-ac12-7369edbd80a8",
+            "version": "KqlParameterItem/1.0",
+            "name": "blank",
+            "type": 1,
+            "isHiddenWhenLocked": true
+          },
           {
             "id": "7d3239b1-19a0-44fd-a771-df82340e0d88",
             "version": "KqlParameterItem/1.0",
@@ -108,10 +112,11 @@
             "resourceType": "microsoft.resourcegraph/resources"
           },
           {
-            "id": "7e3ee42f-fa46-47fe-ae7e-1fecdecc094a",
+            "id": "f1d9afb3-4e74-4ef7-8e21-e2d0f84534ea",
             "version": "KqlParameterItem/1.0",
             "name": "armPrefix",
             "type": 1,
+            "value": "/subscriptions/c1c21d53-ea09-4dcf-9c3d-a86941c960cc",
             "isHiddenWhenLocked": true,
             "criteriaData": [
               {
@@ -126,12 +131,64 @@
                 }
               },
               {
-                "condition": "else result = '{Subscription}'",
+                "condition": "if (Subscription != blank), result = '{Subscription}'",
+                "criteriaContext": {
+                  "leftOperand": "Subscription",
+                  "operator": "!=",
+                  "rightValType": "param",
+                  "rightVal": "blank",
+                  "resultValType": "static",
+                  "resultVal": "{Subscription}"
+                }
+              },
+              {
+                "condition": "else result = blank",
                 "criteriaContext": {
                   "operator": "Default",
                   "rightValType": "param",
+                  "resultValType": "param",
+                  "resultVal": "blank"
+                }
+              }
+            ]
+          },
+          {
+            "id": "7e3ee42f-fa46-47fe-ae7e-1fecdecc094a",
+            "version": "KqlParameterItem/1.0",
+            "name": "armUrl",
+            "type": 1,
+            "value": "/subscriptions/c1c21d53-ea09-4dcf-9c3d-a86941c960cc/providers/Microsoft.Insights/vmInsightsOnboardingStatuses?api-version=2018-11-27-preview",
+            "isHiddenWhenLocked": true,
+            "criteriaData": [
+              {
+                "condition": "if (ResourceGroup != 'all'), result = '{armPrefix}/providers/Microsoft.Insights/vmInsightsOnboardingStatuses?api-version=2018-11-27-preview'",
+                "criteriaContext": {
+                  "leftOperand": "ResourceGroup",
+                  "operator": "!=",
+                  "rightValType": "static",
+                  "rightVal": "all",
                   "resultValType": "static",
-                  "resultVal": "{Subscription}"
+                  "resultVal": "{armPrefix}/providers/Microsoft.Insights/vmInsightsOnboardingStatuses?api-version=2018-11-27-preview"
+                }
+              },
+              {
+                "condition": "if (Subscription != blank), result = '{armPrefix}/providers/Microsoft.Insights/vmInsightsOnboardingStatuses?api-version=2018-11-27-preview'",
+                "criteriaContext": {
+                  "leftOperand": "Subscription",
+                  "operator": "!=",
+                  "rightValType": "param",
+                  "rightVal": "blank",
+                  "resultValType": "static",
+                  "resultVal": "{armPrefix}/providers/Microsoft.Insights/vmInsightsOnboardingStatuses?api-version=2018-11-27-preview"
+                }
+              },
+              {
+                "condition": "else result = blank",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "param",
+                  "resultVal": "blank"
                 }
               }
             ]
@@ -143,21 +200,20 @@
             "label": "Virtual Machines",
             "type": 5,
             "description": "Onboarded Virtual Machines",
+            "isRequired": true,
             "multiSelect": true,
             "quote": "'",
             "delimiter": ",",
-            "query": "{\"version\":\"ARMEndpoint/1.0\",\"data\":null,\"headers\":[],\"method\":\"GET\",\"path\":\"{armPrefix}/providers/Microsoft.Insights/vmInsightsOnboardingStatuses?api-version=2018-11-27-preview\",\"urlParams\":[],\"batchDisabled\":false,\"transformers\":[{\"type\":\"jsonpath\",\"settings\":{\"tablePath\":\"$.value\",\"columns\":[{\"path\":\"$.properties.resourceId\",\"columnid\":\"resourceId\"}]}}]}",
+            "query": "{\"version\":\"ARMEndpoint/1.0\",\"data\":null,\"headers\":[],\"method\":\"GET\",\"path\":\"{armUrl}\",\"urlParams\":[],\"batchDisabled\":false,\"transformers\":[{\"type\":\"jsonpath\",\"settings\":{\"tablePath\":\"$.value\",\"columns\":[{\"path\":\"$.properties.resourceId\",\"columnid\":\"resourceId\"}]}}]}",
             "value": [
               "value::all"
             ],
             "typeSettings": {
               "additionalResourceOptions": [
-                "value::1",
                 "value::all"
               ],
               "selectAllValue": "all"
             },
-            "timeContextFromParameter": "TimeRange",
             "queryType": 12,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
@@ -189,10 +245,11 @@
             "version": "KqlParameterItem/1.0",
             "name": "allWorkspaces",
             "type": 5,
+            "isRequired": true,
             "multiSelect": true,
             "quote": "'",
             "delimiter": ",",
-            "query": "{\"version\":\"ARMEndpoint/1.0\",\"data\":null,\"headers\":[],\"method\":\"GET\",\"path\":\"{armPrefix}/providers/Microsoft.Insights/vmInsightsOnboardingStatuses?api-version=2018-11-27-preview\",\"urlParams\":[],\"batchDisabled\":false,\"transformers\":[{\"type\":\"jsonpath\",\"settings\":{\"tablePath\":\"$.value..workspace\",\"columns\":[{\"path\":\"$.id\",\"columnid\":\"workspaceId\"}]}}]}",
+            "query": "{\"version\":\"ARMEndpoint/1.0\",\"data\":null,\"headers\":[],\"method\":\"GET\",\"path\":\"{armUrl}\",\"urlParams\":[],\"batchDisabled\":false,\"transformers\":[{\"type\":\"jsonpath\",\"settings\":{\"tablePath\":\"$..workspace\",\"columns\":[{\"path\":\"$.id\",\"columnid\":\"workspaceId\"}]}}]}",
             "value": [
               "value::all"
             ],
@@ -211,12 +268,14 @@
             "version": "KqlParameterItem/1.0",
             "name": "Workspaces",
             "type": 5,
-            "isRequired": true,
             "multiSelect": true,
             "quote": "'",
             "delimiter": ",",
             "query": "where type =~ \"microsoft.operationalinsights/workspaces\"\r\n| where id in~ ({allWorkspaces})\r\n| where location in~ ({Location})",
             "crossComponentResources": [
+              "value::all"
+            ],
+            "value": [
               "value::all"
             ],
             "typeSettings": {
@@ -321,21 +380,11 @@
             "queryType": 8
           },
           {
-            "id": "bc05c31b-9919-41da-94a8-a9f58dfbc5ed",
-            "version": "KqlParameterItem/1.0",
-            "name": "emptyParam",
-            "type": 1,
-            "isHiddenWhenLocked": true,
-            "timeContext": {
-              "durationMs": 0
-            },
-            "timeContextFromParameter": "TimeRange"
-          },
-          {
             "id": "6f523dd4-292d-468c-b058-a76f628347d6",
             "version": "KqlParameterItem/1.0",
             "name": "vmSnippet",
             "type": 1,
+            "value": "",
             "isHiddenWhenLocked": true,
             "criteriaData": [
               {
@@ -350,12 +399,12 @@
                 }
               },
               {
-                "condition": "else result = emptyParam",
+                "condition": "else result = '| where _ResourceId startswith \"{armPrefix}\"'",
                 "criteriaContext": {
                   "operator": "Default",
                   "rightValType": "param",
-                  "resultValType": "param",
-                  "resultVal": "emptyParam"
+                  "resultValType": "static",
+                  "resultVal": "| where _ResourceId startswith \"{armPrefix}\""
                 }
               }
             ],
@@ -366,8 +415,8 @@
           }
         ],
         "style": "above",
-        "queryType": 1,
-        "resourceType": "microsoft.resourcegraph/resources"
+        "queryType": 0,
+        "resourceType": "microsoft.operationalinsights/workspaces"
       },
       "name": "top-level parameters"
     },


### PR DESCRIPTION
Malformed ARM URLs caused the ARM parameter to error out resetting the
"All" default value upon initialization. Also modified the `vmSnippet`
so that it will only show VMs in currently selected sub/RG.

- Change to armUrl
- Make Workspaces dropdown not required
- Fix workspaces ARM parameter
- Filter workspace query to scoped onboarded VMs

![image](https://user-images.githubusercontent.com/43890980/74390061-ffd7b480-4db4-11ea-9ba0-cece493233ea.png)
