### PR TITLE
Optimize Connections Overview workbook

### DIFF
--- a/Workbooks/Virtual Machines - Network Dependencies/Connections Overview (Dev)/Connections Overview (Dev).workbook
+++ b/Workbooks/Virtual Machines - Network Dependencies/Connections Overview (Dev)/Connections Overview (Dev).workbook
@@ -1,0 +1,1724 @@
+{
+  "version": "Notebook/1.0",
+  "items": [
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "parameters": [
+          {
+            "id": "3f34a4f7-9a42-46ed-ac12-7369edbd80a8",
+            "version": "KqlParameterItem/1.0",
+            "name": "blank",
+            "type": 1,
+            "isHiddenWhenLocked": true
+          },
+          {
+            "id": "7d3239b1-19a0-44fd-a771-df82340e0d88",
+            "version": "KqlParameterItem/1.0",
+            "name": "DefaultResource",
+            "type": 5,
+            "value": "value::1",
+            "isHiddenWhenLocked": true,
+            "typeSettings": {
+              "resourceTypeFilter": {
+                "microsoft.resources/subscriptions": true,
+                "microsoft.resources/resourcegroups": true
+              },
+              "additionalResourceOptions": [
+                "value::1"
+              ]
+            }
+          },
+          {
+            "id": "0caf61ec-d776-4642-8553-5293060a62c7",
+            "version": "KqlParameterItem/1.0",
+            "name": "ContextFree",
+            "type": 1,
+            "query": "{\"version\":\"1.0.0\",\"content\":\"\\\"{DefaultResource}\\\"\"}",
+            "isHiddenWhenLocked": true,
+            "queryType": 8,
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          },
+          {
+            "id": "6e82c4c1-769e-4549-bd80-b356ef999efa",
+            "version": "KqlParameterItem/1.0",
+            "name": "Selection",
+            "type": 1,
+            "query": "take 1\r\n| extend x = split ({DefaultResource:value}, '/')\r\n| project value = tostring(pack('sub', x[2], 'rg', case(x[4] != 'null', x[4], ''), 'vm', case(x[8] != 'null', x[8], '')))",
+            "crossComponentResources": [
+              "value::all"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": "TimeRange",
+            "queryType": 1,
+            "resourceType": "microsoft.resourcegraph/resources"
+          },
+          {
+            "id": "604f6d89-c6f9-4bdb-b4ca-483f56a8946c",
+            "version": "KqlParameterItem/1.0",
+            "name": "Subscription",
+            "type": 6,
+            "isRequired": true,
+            "query": "where type in~('microsoft.compute/virtualmachines', 'microsoft.compute/virtualmachinescalesets')\r\n| summarize Count = count() by subscriptionId\r\n| order by Count desc\r\n| extend Rank = row_number()\r\n| project value = subscriptionId, label = subscriptionId, selected = iff(subscriptionId =~ todynamic('{Selection}').sub, true, false)",
+            "crossComponentResources": [
+              "value::all"
+            ],
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "timeContextFromParameter": "TimeRange",
+            "queryType": 1,
+            "resourceType": "microsoft.resourcegraph/resources"
+          },
+          {
+            "id": "efc388e8-ac7b-4e72-8573-e97cfe370f16",
+            "version": "KqlParameterItem/1.0",
+            "name": "ResourceGroup",
+            "label": "Resource group",
+            "type": 2,
+            "isRequired": true,
+            "multiSelect": true,
+            "quote": "'",
+            "delimiter": ",",
+            "query": "where type in~('microsoft.compute/virtualmachines', 'microsoft.compute/virtualmachinescalesets')\r\n| summarize Count = count() by resourceGroup\r\n| order by Count desc\r\n| extend Rank = row_number()\r\n| project value = resourceGroup, label = resourceGroup, selected = iff(resourceGroup =~ todynamic('{Selection}').rg, true, false)\r\n| order by value asc",
+            "crossComponentResources": [
+              "{Subscription}"
+            ],
+            "typeSettings": {
+              "limitSelectTo": 1,
+              "additionalResourceOptions": [
+                "value::1",
+                "value::all"
+              ],
+              "selectAllValue": "all"
+            },
+            "timeContextFromParameter": "TimeRange",
+            "queryType": 1,
+            "resourceType": "microsoft.resourcegraph/resources",
+            "value": [
+              "value::all"
+            ]
+          },
+          {
+            "id": "ab4d0200-d7f0-4705-a006-c9f63e4e161e",
+            "version": "KqlParameterItem/1.0",
+            "name": "validResourceGroup",
+            "type": 1,
+            "isHiddenWhenLocked": true,
+            "criteriaData": [
+              {
+                "condition": "if (ResourceGroup == 'all'), result = blank",
+                "criteriaContext": {
+                  "leftOperand": "ResourceGroup",
+                  "operator": "==",
+                  "rightValType": "static",
+                  "rightVal": "all",
+                  "resultValType": "param",
+                  "resultVal": "blank"
+                }
+              },
+              {
+                "condition": "if (ResourceGroup == blank), result = blank",
+                "criteriaContext": {
+                  "leftOperand": "ResourceGroup",
+                  "operator": "==",
+                  "rightValType": "param",
+                  "rightVal": "blank",
+                  "resultValType": "param",
+                  "resultVal": "blank"
+                }
+              },
+              {
+                "condition": "else result = '{ResourceGroup:unformatted}'",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "static",
+                  "resultVal": "{ResourceGroup:unformatted}"
+                }
+              }
+            ],
+            "timeContextFromParameter": "TimeRange"
+          },
+          {
+            "id": "f1d9afb3-4e74-4ef7-8e21-e2d0f84534ea",
+            "version": "KqlParameterItem/1.0",
+            "name": "armPrefix",
+            "type": 1,
+            "value": "",
+            "isHiddenWhenLocked": true,
+            "criteriaData": [
+              {
+                "condition": "if (validResourceGroup != blank), result = '{Subscription}/resourcegroups/{validResourceGroup}'",
+                "criteriaContext": {
+                  "leftOperand": "validResourceGroup",
+                  "operator": "!=",
+                  "rightValType": "param",
+                  "rightVal": "blank",
+                  "resultValType": "static",
+                  "resultVal": "{Subscription}/resourcegroups/{validResourceGroup}"
+                }
+              },
+              {
+                "condition": "if (Subscription != blank), result = '{Subscription}'",
+                "criteriaContext": {
+                  "leftOperand": "Subscription",
+                  "operator": "!=",
+                  "rightValType": "param",
+                  "rightVal": "blank",
+                  "resultValType": "static",
+                  "resultVal": "{Subscription}"
+                }
+              },
+              {
+                "condition": "else result = blank",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "param",
+                  "resultVal": "blank"
+                }
+              }
+            ]
+          },
+          {
+            "id": "7e3ee42f-fa46-47fe-ae7e-1fecdecc094a",
+            "version": "KqlParameterItem/1.0",
+            "name": "armUrl",
+            "type": 1,
+            "value": "",
+            "isHiddenWhenLocked": true,
+            "criteriaData": [
+              {
+                "condition": "if (armPrefix != blank), result = '{armPrefix}/providers/Microsoft.Insights/vmInsightsOnboardingStatuses?api-version=2018-11-27-preview'",
+                "criteriaContext": {
+                  "leftOperand": "armPrefix",
+                  "operator": "!=",
+                  "rightValType": "param",
+                  "rightVal": "blank",
+                  "resultValType": "static",
+                  "resultVal": "{armPrefix}/providers/Microsoft.Insights/vmInsightsOnboardingStatuses?api-version=2018-11-27-preview"
+                }
+              },
+              {
+                "condition": "else result = blank",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "param",
+                  "resultVal": "blank"
+                }
+              }
+            ]
+          },
+          {
+            "id": "8cfecad8-d483-42de-abb3-9cb558a00acd",
+            "version": "KqlParameterItem/1.0",
+            "name": "Resources",
+            "label": "Virtual Machines",
+            "type": 5,
+            "description": "Onboarded Virtual Machines",
+            "isRequired": true,
+            "multiSelect": true,
+            "quote": "'",
+            "delimiter": ",",
+            "query": "{\"version\":\"ARMEndpoint/1.0\",\"data\":null,\"headers\":[],\"method\":\"GET\",\"path\":\"{armUrl}\",\"urlParams\":[],\"batchDisabled\":false,\"transformers\":[{\"type\":\"jsonpath\",\"settings\":{\"tablePath\":\"$.value\",\"columns\":[{\"path\":\"$.properties.resourceId\",\"columnid\":\"resourceId\"}]}}]}",
+            "value": [
+              "value::all"
+            ],
+            "typeSettings": {
+              "additionalResourceOptions": [
+                "value::all"
+              ],
+              "selectAllValue": "all"
+            },
+            "queryType": 12,
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          },
+          {
+            "id": "b829835f-1161-457d-96c5-72fc444db73a",
+            "version": "KqlParameterItem/1.0",
+            "name": "Location",
+            "label": "Workspace Regions",
+            "type": 8,
+            "description": "Queries with workspaces in 5 or more regions may take excessive time to complete",
+            "isRequired": true,
+            "multiSelect": true,
+            "quote": "'",
+            "delimiter": ",",
+            "value": [
+              "value::3"
+            ],
+            "typeSettings": {
+              "limitSelectTo": 20,
+              "additionalResourceOptions": [
+                "value::3"
+              ],
+              "includeAll": true
+            },
+            "timeContextFromParameter": "TimeRange"
+          },
+          {
+            "id": "0b488656-655a-4716-9438-bb3137c98055",
+            "version": "KqlParameterItem/1.0",
+            "name": "allWorkspaces",
+            "type": 5,
+            "isRequired": true,
+            "multiSelect": true,
+            "quote": "'",
+            "delimiter": ",",
+            "query": "{\"version\":\"ARMEndpoint/1.0\",\"data\":null,\"headers\":[],\"method\":\"GET\",\"path\":\"{armUrl}\",\"urlParams\":[],\"batchDisabled\":false,\"transformers\":[{\"type\":\"jsonpath\",\"settings\":{\"tablePath\":\"$..workspace\",\"columns\":[{\"path\":\"$.id\",\"columnid\":\"workspaceId\"}]}}]}",
+            "value": [
+              "value::all"
+            ],
+            "isHiddenWhenLocked": true,
+            "typeSettings": {
+              "additionalResourceOptions": [
+                "value::all"
+              ]
+            },
+            "timeContextFromParameter": "TimeRange",
+            "queryType": 12,
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          },
+          {
+            "id": "598a32fb-b4b3-4f0e-adcf-4357a9cd53c3",
+            "version": "KqlParameterItem/1.0",
+            "name": "Workspaces",
+            "type": 5,
+            "multiSelect": true,
+            "quote": "'",
+            "delimiter": ",",
+            "query": "where type =~ \"microsoft.operationalinsights/workspaces\"\r\n| where id in~ ({allWorkspaces})\r\n| where location in~ ({Location})",
+            "crossComponentResources": [
+              "value::all"
+            ],
+            "value": [
+              "value::all"
+            ],
+            "typeSettings": {
+              "additionalResourceOptions": [
+                "value::all"
+              ],
+              "showDefault": false
+            },
+            "timeContextFromParameter": "TimeRange",
+            "queryType": 1,
+            "resourceType": "microsoft.resourcegraph/resources"
+          },
+          {
+            "id": "feb5ccab-6fe6-4c5f-9161-ca0e412bd637",
+            "version": "KqlParameterItem/1.0",
+            "name": "TimeRange",
+            "label": "Time range",
+            "type": 4,
+            "value": {
+              "durationMs": 3600000
+            },
+            "typeSettings": {
+              "selectableValues": [
+                {
+                  "durationMs": 1800000
+                },
+                {
+                  "durationMs": 3600000
+                },
+                {
+                  "durationMs": 14400000
+                },
+                {
+                  "durationMs": 43200000
+                },
+                {
+                  "durationMs": 86400000
+                },
+                {
+                  "durationMs": 172800000
+                },
+                {
+                  "durationMs": 259200000
+                },
+                {
+                  "durationMs": 604800000
+                },
+                {
+                  "durationMs": 1209600000
+                },
+                {
+                  "durationMs": 2592000000
+                }
+              ],
+              "allowCustom": true
+            }
+          },
+          {
+            "id": "e36a2c69-a3c1-4b0c-b758-b37bc16b4669",
+            "version": "KqlParameterItem/1.0",
+            "name": "Test",
+            "type": 1,
+            "query": "let perf = InsightsMetrics\r\n| where TimeGenerated {TimeRange}\r\n| take 1;\r\nlet servicemap = ServiceMapComputer_CL\r\n| where TimeGenerated {TimeRange}\r\n| take 1;\r\nperf\r\n| union servicemap",
+            "crossComponentResources": [
+              "{Workspaces}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContext": {
+              "durationMs": 0
+            },
+            "timeContextFromParameter": "TimeRange",
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces",
+            "label": "Not Onboarded"
+          },
+          {
+            "id": "ea980bb9-09d6-4966-bdd3-dc54b2246226",
+            "version": "KqlParameterItem/1.0",
+            "name": "resourcesValueSnippet",
+            "type": 1,
+            "description": "query snippet when user selects from Resources dropdown",
+            "query": "{\"version\":\"1.0.0\",\"content\":\"\\\"| where _ResourceId in ({Resources})\\\"\",\"transformers\":null}",
+            "isHiddenWhenLocked": true,
+            "timeContext": {
+              "durationMs": 0
+            },
+            "timeContextFromParameter": "TimeRange",
+            "queryType": 8,
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          },
+          {
+            "id": "ce1f0e30-7383-4dc2-826f-b9ea83e11851",
+            "version": "KqlParameterItem/1.0",
+            "name": "resourcesValue",
+            "type": 1,
+            "query": "{\"version\":\"1.0.0\",\"content\":\"\\\"{Resources}\\\"\",\"transformers\":null}",
+            "isHiddenWhenLocked": true,
+            "timeContext": {
+              "durationMs": 0
+            },
+            "timeContextFromParameter": "TimeRange",
+            "queryType": 8
+          },
+          {
+            "id": "6f523dd4-292d-468c-b058-a76f628347d6",
+            "version": "KqlParameterItem/1.0",
+            "name": "vmSnippet",
+            "type": 1,
+            "value": "",
+            "isHiddenWhenLocked": true,
+            "criteriaData": [
+              {
+                "condition": "if (resourcesValue != ''all''), result = resourcesValueSnippet",
+                "criteriaContext": {
+                  "leftOperand": "resourcesValue",
+                  "operator": "!=",
+                  "rightValType": "static",
+                  "rightVal": "'all'",
+                  "resultValType": "param",
+                  "resultVal": "resourcesValueSnippet"
+                }
+              },
+              {
+                "condition": "else result = '| where _ResourceId startswith \"{armPrefix}\"'",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "static",
+                  "resultVal": "| where _ResourceId startswith \"{armPrefix}\""
+                }
+              }
+            ],
+            "timeContext": {
+              "durationMs": 0
+            },
+            "timeContextFromParameter": "TimeRange"
+          },
+          {
+            "id": "db9b2f1d-188a-4dda-af4a-b39deeb34da3",
+            "version": "KqlParameterItem/1.0",
+            "name": "Direction",
+            "type": 2,
+            "description": "Direction of the network connection from the VMs",
+            "isRequired": true,
+            "value": "outbound",
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "jsonData": "[\r\n    { \"value\":\"inbound\", \"label\":\"Inbound\" },\r\n    { \"value\":\"outbound\", \"label\":\"Outbound\" }\r\n]"
+          },
+          {
+            "id": "56ab6626-c12d-4de1-8a3d-8a6099db3cd3",
+            "version": "KqlParameterItem/1.0",
+            "name": "Hierarchy",
+            "type": 2,
+            "description": "Select the level of detail to be shown in the table below",
+            "isRequired": true,
+            "query": "let outboundTable = datatable (value:string, Display:string)\r\n    [\"0\", \"Computer -> Process -> Remote IP -> Port\",\r\n     \"1\", \"Computer -> Process -> Remote IP\",\r\n     \"2\", \"Computer -> Process\",\r\n     \"3\", \"Computer\"];\r\nlet outbound = outboundTable | extend type = 'outbound';\r\nlet inboundTable = datatable (value:string, Display:string)\r\n    [\"0\", \"Computer -> Process -> Port -> Remote IP\",\r\n     \"1\", \"Computer -> Process -> Port\",\r\n     \"2\", \"Computer -> Process\",\r\n     \"3\", \"Computer\"];\r\nlet inbound = inboundTable | extend type = 'inbound';\r\nlet table = outbound | union inbound;\r\ntable\r\n| where type == iif('{Direction}' == 'outbound', 'outbound', 'inbound')\r\n| project value, Display",
+            "crossComponentResources": [
+              "{Workspaces}"
+            ],
+            "value": "3",
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          },
+          {
+            "id": "5526f711-6d04-469e-8d06-351508f1014e",
+            "version": "KqlParameterItem/1.0",
+            "name": "TableFilter",
+            "type": 2,
+            "description": "Filter table based on presence of malicious connections or at least one link failing",
+            "multiSelect": true,
+            "quote": "",
+            "delimiter": "",
+            "value": [],
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "jsonData": "[\r\n    {\r\n        \"label\": \"Only Malicious Connections\",\r\n        \"value\": \" | where MaliciousConnectionsCount >= 1\"\r\n    },\r\n    {\r\n        \"label\": \"Only Links Failed\",\r\n        \"value\": \" | where LinksFailed >= 1\"\r\n    }\r\n]",
+            "label": "Table Filter"
+          }
+        ],
+        "style": "above",
+        "queryType": 8,
+        "resourceType": "microsoft.operationalinsights/workspaces"
+      },
+      "name": "parameters - 2"
+    },
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "parameters": [
+          {
+            "id": "5e335a1b-7f99-4647-854a-d7b5cb489bb2",
+            "version": "KqlParameterItem/1.0",
+            "name": "ServiceMapComputers",
+            "type": 1,
+            "isRequired": true,
+            "value": "let computers = ServiceMapComputer_CL | summarize (TimeGenerated, Properties) = arg_max(TimeGenerated, pack_all()) by Computer;",
+            "isHiddenWhenLocked": true,
+            "criteriaData": [
+              {
+                "condition": "else result = 'let computers = ServiceMapComputer_CL | summarize (TimeGenerated, Properties) = arg_max(TimeGenerated, pack_all()) by Computer;'",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "static",
+                  "resultVal": "let computers = ServiceMapComputer_CL | summarize (TimeGenerated, Properties) = arg_max(TimeGenerated, pack_all()) by Computer;"
+                }
+              }
+            ]
+          },
+          {
+            "id": "c69fbaae-4fd2-4527-acdd-a2c358eebffa",
+            "version": "KqlParameterItem/1.0",
+            "name": "MaliciousIpData",
+            "type": 1,
+            "value": "",
+            "isHiddenWhenLocked": true,
+            "criteriaData": [
+              {
+                "condition": "else result = 'let maliciousIpData = VMConnection {vmSnippet}  | where Direction == '{Direction}' | where MaliciousIp != '' | summarize by Computer, ProcessName, MaliciousIp, DestinationPort, RemoteIp, IsActive, IndicatorThreatType, RemoteCountry, RemoteLongitude, RemoteLatitude, Confidence, Severity, FirstReportedDateTime, LastReportedDateTime | project MaliciousIp = strcat(Computer, '-', ProcessName, '-', MaliciousIp), MaliciousPort = strcat(Computer, '-', ProcessName, '-', DestinationPort), MaliciousPortIp = strcat(Computer, '-', ProcessName, '-', DestinationPort, '-', RemoteIp), Computer = Computer, Process = strcat(Computer, '-', ProcessName), MaliciousIpInfo = pack('Malicious IP', MaliciousIp, 'Is Active', IsActive, 'Indicator Threat Type', IndicatorThreatType, 'Remote Country', RemoteCountry, 'Longitude', RemoteLongitude, 'Latitude', RemoteLatitude, 'Confidence', Confidence, 'Severity', Severity, 'First Reported DateTime', FirstReportedDateTime, 'Last Reported DateTime', LastReportedDateTime, 'Destination Port', DestinationPort, 'Remote IP', RemoteIp);'",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "static",
+                  "resultVal": "let maliciousIpData = VMConnection {vmSnippet} | where Direction == '{Direction}' | where MaliciousIp != '' | summarize by Computer, ProcessName, MaliciousIp, DestinationPort, RemoteIp, IsActive, IndicatorThreatType, RemoteCountry, RemoteLongitude, RemoteLatitude, Confidence, Severity, FirstReportedDateTime, LastReportedDateTime | project MaliciousIp = strcat(Computer, '-', ProcessName, '-', MaliciousIp), MaliciousPort = strcat(Computer, '-', ProcessName, '-', DestinationPort), MaliciousPortIp = strcat(Computer, '-', ProcessName, '-', DestinationPort, '-', RemoteIp), Computer = Computer, Process = strcat(Computer, '-', ProcessName), MaliciousIpInfo = pack('Malicious IP', MaliciousIp, 'Is Active', IsActive, 'Indicator Threat Type', IndicatorThreatType, 'Remote Country', RemoteCountry, 'Longitude', RemoteLongitude, 'Latitude', RemoteLatitude, 'Confidence', Confidence, 'Severity', Severity, 'First Reported DateTime', FirstReportedDateTime, 'Last Reported DateTime', LastReportedDateTime, 'Destination Port', DestinationPort, 'Remote IP', RemoteIp);"
+                }
+              }
+            ]
+          },
+          {
+            "id": "dd933ac8-1273-48fe-8d09-bd65d857ce83",
+            "version": "KqlParameterItem/1.0",
+            "name": "ComputerData",
+            "type": 1,
+            "value": "",
+            "isHiddenWhenLocked": true,
+            "criteriaData": [
+              {
+                "condition": "else result = 'let computerData = VMConnection {vmSnippet} | where Direction == '{Direction}' | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 * sum(ResponseTimeSum) / sum(Responses) by Name = strcat('🖥️ ', Computer), ComputerName = Computer, Type = 'Computer', TypeKey = 1, Key = Computer, ParentKey = '---' | join kind=leftouter (maliciousIpData | summarize MaliciousIpInfo = tostring(count()) by Computer) on $left.Key == $right.Computer | project-away Computer | order by Name asc;'",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "static",
+                  "resultVal": "let computerData = VMConnection {vmSnippet} | where Direction == '{Direction}' | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 * sum(ResponseTimeSum) / sum(Responses) by Name = strcat('🖥️ ', Computer), ComputerName = Computer, Type = 'Computer', TypeKey = 1, Key = Computer, ParentKey = '---' | join kind=leftouter (maliciousIpData | summarize MaliciousIpInfo = tostring(count()) by Computer) on $left.Key == $right.Computer | project-away Computer | order by Name asc;"
+                }
+              }
+            ]
+          },
+          {
+            "id": "fb879823-c082-4c53-af7e-18d044032f99",
+            "version": "KqlParameterItem/1.0",
+            "name": "RemoteIpDataInbound",
+            "type": 1,
+            "value": "",
+            "isHiddenWhenLocked": true,
+            "criteriaData": [
+              {
+                "condition": "else result = 'let remoteIpDataInbound = VMConnection {vmSnippet} | where Direction == 'inbound' | where 'inbound' == 'inbound' | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) by Computer, ProcessName, RemoteIp, Type = 'Remote Computer', TypeKey = 3, Key = strcat(Computer, '-', ProcessName, '-', tostring(DestinationPort), '-', RemoteIp), ParentKey = strcat(Computer, '-', ProcessName, '-', tostring(DestinationPort)), Id = strcat(Computer, '-', ProcessName, '-', RemoteIp), ComputerName = Computer | join kind=inner     sourcePortData on $left.ParentKey == $right.Key | project-away AverageResponseTime1, Computer1, Key1, LinksFailed1, MaxLinksLive1, ParentKey1, ProcessName1, Responses1, TotalBytesReceived1, TotalBytesSent1, Type1, TypeKey1 | order by Name asc | join kind=leftouter     ipComputerMapping on $left.RemoteIp == $right.Ipv4 | extend Name = iff(RemoteIp == '', 'Unknown',  strcat('🌐 External (', RemoteIp, ')')) | project-away Computer, Ipv4 | order by Name desc | join kind=leftouter     maliciousIpData on $left.Key == $right.MaliciousPortIp | extend MaliciousIpInfo = tostring(MaliciousIpInfo1) | project-away MaliciousIp, Computer, Process, Computer1, MaliciousIpInfo1, Id;'",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "static",
+                  "resultVal": "let remoteIpDataInbound = VMConnection {vmSnippet} | where Direction == 'inbound' | where 'inbound' == 'inbound' | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) by Computer, ProcessName, RemoteIp, Type = 'Remote Computer', TypeKey = 3, Key = strcat(Computer, '-', ProcessName, '-', tostring(DestinationPort), '-', RemoteIp), ParentKey = strcat(Computer, '-', ProcessName, '-', tostring(DestinationPort)), Id = strcat(Computer, '-', ProcessName, '-', RemoteIp), ComputerName = Computer | join kind=inner     sourcePortData on $left.ParentKey == $right.Key | project-away AverageResponseTime1, Computer1, Key1, LinksFailed1, MaxLinksLive1, ParentKey1, ProcessName1, Responses1, TotalBytesReceived1, TotalBytesSent1, Type1, TypeKey1 | order by Name asc | join kind=leftouter     ipComputerMapping on $left.RemoteIp == $right.Ipv4 | extend Name = iff(RemoteIp == '', 'Unknown',  strcat('🌐 External (', RemoteIp, ')')) | project-away Computer, Ipv4 | order by Name desc | join kind=leftouter     maliciousIpData on $left.Key == $right.MaliciousPortIp | extend MaliciousIpInfo = tostring(MaliciousIpInfo1) | project-away MaliciousIp, Computer, Process, Computer1, MaliciousIpInfo1, Id;"
+                }
+              }
+            ]
+          },
+          {
+            "id": "3ad60c70-b530-49c0-a59b-8df690dffbc8",
+            "version": "KqlParameterItem/1.0",
+            "name": "ProcessName",
+            "type": 1,
+            "value": "",
+            "isHiddenWhenLocked": true,
+            "criteriaData": [
+              {
+                "condition": "else result = 'let processData = VMConnection {vmSnippet} | where Direction == '{Direction}' | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) by Computer, ProcessName, Name = strcat('🎫 ', ProcessName), Type = 'Process', TypeKey = 2, Key = strcat(Computer, '-', ProcessName), ParentKey = Computer, ComputerName = Computer | join kind=inner computerData on $left.ParentKey == $right.Key | project-away Name1, Responses1, LinksFailed1, MaxLinksLive1, TotalBytesSent1, TotalBytesReceived1, AverageResponseTime1, Type1, Key1, ParentKey1 | join kind=leftouter (maliciousIpData | summarize MaliciousIpInfo = tostring(count()) by Process) on $left.Key == $right.Process | project-away Process, MaliciousIpInfo | extend MaliciousIpInfo = tostring(MaliciousIpInfo1) | project-away MaliciousIpInfo1 | order by Name asc;'",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "static",
+                  "resultVal": "let processData = VMConnection {vmSnippet} | where Direction == '{Direction}' | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) by Computer, ProcessName, Name = strcat('🎫 ', ProcessName), Type = 'Process', TypeKey = 2, Key = strcat(Computer, '-', ProcessName), ParentKey = Computer, ComputerName = Computer | join kind=inner computerData on $left.ParentKey == $right.Key | project-away Name1, Responses1, LinksFailed1, MaxLinksLive1, TotalBytesSent1, TotalBytesReceived1, AverageResponseTime1, Type1, Key1, ParentKey1 | join kind=leftouter (maliciousIpData | summarize MaliciousIpInfo = tostring(count()) by Process) on $left.Key == $right.Process | project-away Process, MaliciousIpInfo | extend MaliciousIpInfo = tostring(MaliciousIpInfo1) | project-away MaliciousIpInfo1 | order by Name asc;"
+                }
+              }
+            ]
+          },
+          {
+            "id": "c9eea7db-3d14-4fbf-8ae6-b7507ec1d43f",
+            "version": "KqlParameterItem/1.0",
+            "name": "RemoteIpData",
+            "type": 1,
+            "isRequired": true,
+            "value": "",
+            "isHiddenWhenLocked": true,
+            "criteriaData": [
+              {
+                "condition": "else result = 'let remoteIpData = VMConnection {vmSnippet} | where '{Direction}' == 'outbound' | where Direction == '{Direction}' | extend RemoteIp = iff(Direction == 'outbound', DestinationIp, SourceIp) | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) by Computer, ProcessName, RemoteIp, Type = 'Remote Computer', TypeKey = 3, Key = strcat(Computer, '-', ProcessName, '-', RemoteIp), ParentKey = strcat(Computer, '-', ProcessName), ComputerName = Computer | join kind=inner processData on $left.ParentKey == $right.Key | project-away Name, Responses1, LinksFailed1, MaxLinksLive1, TotalBytesSent1, TotalBytesReceived1, AverageResponseTime1, Type1, Key1, ParentKey1 | join kind=leftouter maliciousIpData on $left.Key == $right.MaliciousIp | project-away MaliciousIp, Computer, Process, Computer1, Computer2, MaliciousIpInfo | extend MaliciousIpInfo = tostring(MaliciousIpInfo1) | project-away MaliciousIpInfo1 | join kind = leftouter (ipComputerMapping) on $left.RemoteIp == $right.Ipv4 | extend Name = iff(Computer == '', iff(RemoteIp == '127.0.0.1', '🌐 Localhost',  strcat('🌐 External (', RemoteIp, ')')), strcat('🖥️ ', Computer)) | project-away Computer, Ipv4 | order by Name desc;'",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "static",
+                  "resultVal": "let remoteIpData = VMConnection {vmSnippet} | where '{Direction}' == 'outbound' | where Direction == '{Direction}' | extend RemoteIp = iff(Direction == 'outbound', DestinationIp, SourceIp) | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) by Computer, ProcessName, RemoteIp, Type = 'Remote Computer', TypeKey = 3, Key = strcat(Computer, '-', ProcessName, '-', RemoteIp), ParentKey = strcat(Computer, '-', ProcessName), ComputerName = Computer | join kind=inner processData on $left.ParentKey == $right.Key | project-away Name, Responses1, LinksFailed1, MaxLinksLive1, TotalBytesSent1, TotalBytesReceived1, AverageResponseTime1, Type1, Key1, ParentKey1 | join kind=leftouter maliciousIpData on $left.Key == $right.MaliciousIp | project-away MaliciousIp, Computer, Process, Computer1, Computer2, MaliciousIpInfo | extend MaliciousIpInfo = tostring(MaliciousIpInfo1) | project-away MaliciousIpInfo1 | join kind = leftouter (ipComputerMapping) on $left.RemoteIp == $right.Ipv4 | extend Name = iff(Computer == '', iff(RemoteIp == '127.0.0.1', '🌐 Localhost',  strcat('🌐 External (', RemoteIp, ')')), strcat('🖥️ ', Computer)) | project-away Computer, Ipv4 | order by Name desc;"
+                }
+              }
+            ]
+          },
+          {
+            "id": "4a9ed59b-002e-4c81-b437-8456faeef6a6",
+            "version": "KqlParameterItem/1.0",
+            "name": "SourcePortData",
+            "type": 1,
+            "value": "",
+            "isHiddenWhenLocked": true,
+            "criteriaData": [
+              {
+                "condition": "else result = 'let sourcePortData = VMConnection {vmSnippet} | where Direction == '{Direction}' | where '{Direction}' == 'inbound' | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) by Computer, ProcessName, DestinationIp, DestinationPort, Name = strcat('🔶 ', DestinationPort), Type = 'Remote Port', TypeKey = 4, Key = strcat(Computer, '-', ProcessName, '-', tostring(DestinationPort)), ParentKey = strcat(Computer, '-', ProcessName), ComputerName = Computer | join kind=leftouter maliciousIpData on $left.Key == $right.MaliciousPort | extend MaliciousIpInfo = tostring(MaliciousIpInfo) | project-away Computer1, MaliciousIp, MaliciousPort, MaliciousPortIp, Process; {RemoteIpDataInbound}'",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "static",
+                  "resultVal": "let sourcePortData = VMConnection {vmSnippet} | where Direction == '{Direction}' | where '{Direction}' == 'inbound' | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) by Computer, ProcessName, DestinationIp, DestinationPort, Name = strcat('🔶 ', DestinationPort), Type = 'Remote Port', TypeKey = 4, Key = strcat(Computer, '-', ProcessName, '-', tostring(DestinationPort)), ParentKey = strcat(Computer, '-', ProcessName), ComputerName = Computer | join kind=leftouter maliciousIpData on $left.Key == $right.MaliciousPort | extend MaliciousIpInfo = tostring(MaliciousIpInfo) | project-away Computer1, MaliciousIp, MaliciousPort, MaliciousPortIp, Process; {RemoteIpDataInbound}"
+                }
+              }
+            ]
+          },
+          {
+            "id": "e31a8d21-e24b-45ec-9806-e6c45bca15aa",
+            "version": "KqlParameterItem/1.0",
+            "name": "DestinationPortData",
+            "type": 1,
+            "value": "",
+            "isHiddenWhenLocked": true,
+            "criteriaData": [
+              {
+                "condition": "else result = 'let destinationPortData = VMConnection {vmSnippet} | where Direction == '{Direction}' | where '{Direction}' == 'outbound' | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) by Computer, ProcessName, DestinationIp, DestinationPort, Name = strcat('🔶 ', DestinationPort), Type = 'Remote Port', TypeKey = 4, Key = strcat(Computer, '-', ProcessName, '-', DestinationIp, '-', tostring(DestinationPort)), ParentKey = strcat(Computer, '-', ProcessName, '-', DestinationIp), ComputerName = Computer | join kind=inner remoteIpData on $left.ParentKey == $right.Key | project-away Name1, Responses1, Type1, Key1, ParentKey1 | order by Name asc;'",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "static",
+                  "resultVal": "let destinationPortData = VMConnection {vmSnippet} | where Direction == '{Direction}' | where '{Direction}' == 'outbound' | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) by Computer, ProcessName, DestinationIp, DestinationPort, Name = strcat('🔶 ', DestinationPort), Type = 'Remote Port', TypeKey = 4, Key = strcat(Computer, '-', ProcessName, '-', DestinationIp, '-', tostring(DestinationPort)), ParentKey = strcat(Computer, '-', ProcessName, '-', DestinationIp), ComputerName = Computer | join kind=inner remoteIpData on $left.ParentKey == $right.Key | project-away Name1, Responses1, Type1, Key1, ParentKey1 | order by Name asc;"
+                }
+              }
+            ]
+          },
+          {
+            "id": "a54f3df8-c872-4a19-a280-84b203987ec8",
+            "version": "KqlParameterItem/1.0",
+            "name": "QueryProject",
+            "type": 1,
+            "value": "| extend MaliciousConnectionsCount = iff(MaliciousIpInfo == '', 0, iff(Type == 'Computer' or Type == 'Process' or Type == 'Overall', tolong(MaliciousIpInfo), 1)) | project ComputerName, ProcessName, RemoteIp, DestinationPort, Name = iff(Name == '🎫 ', '🎫 <Unknown>', Name), Type, MaliciousConnections = iff(MaliciousIpInfo == '', '✅ No Malicious Connections', iff(Type == 'Computer' or Type == 'Process' or Type == 'Overall', iff(MaliciousConnectionsCount > 1, strcat('❌ ', MaliciousIpInfo, ' Malicious Connections'), strcat('❌ ', MaliciousIpInfo, ' Malicious Connection')), '❌ Malicious Connection')), Responses, MaxLinksLive, LinksFailed, AverageResponseTime, TotalBytesSent, TotalBytesReceived, Info = iff(MaliciousIpInfo != '', MaliciousIpInfo, ''), Key, ParentKey, TypeKey, MaliciousConnectionsCount | order by TypeKey asc, MaliciousConnectionsCount desc, LinksFailed desc, AverageResponseTime desc, Responses desc, MaxLinksLive desc, Name asc | project-away TypeKey",
+            "isHiddenWhenLocked": true,
+            "criteriaData": [
+              {
+                "condition": "else result = '| extend MaliciousConnectionsCount = iff(MaliciousIpInfo == '', 0, iff(Type == 'Computer' or Type == 'Process' or Type == 'Overall', tolong(MaliciousIpInfo), 1)) | project ComputerName, ProcessName, RemoteIp, DestinationPort, Name = iff(Name == '🎫 ', '🎫 <Unknown>', Name), Type, MaliciousConnections = iff(MaliciousIpInfo == '', '✅ No Malicious Connections', iff(Type == 'Computer' or Type == 'Process' or Type == 'Overall', iff(MaliciousConnectionsCount > 1, strcat('❌ ', MaliciousIpInfo, ' Malicious Connections'), strcat('❌ ', MaliciousIpInfo, ' Malicious Connection')), '❌ Malicious Connection')), Responses, MaxLinksLive, LinksFailed, AverageResponseTime, TotalBytesSent, TotalBytesReceived, Info = iff(MaliciousIpInfo != '', MaliciousIpInfo, ''), Key, ParentKey, TypeKey, MaliciousConnectionsCount | order by TypeKey asc, MaliciousConnectionsCount desc, LinksFailed desc, AverageResponseTime desc, Responses desc, MaxLinksLive desc, Name asc | project-away TypeKey'",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "static",
+                  "resultVal": "| extend MaliciousConnectionsCount = iff(MaliciousIpInfo == '', 0, iff(Type == 'Computer' or Type == 'Process' or Type == 'Overall', tolong(MaliciousIpInfo), 1)) | project ComputerName, ProcessName, RemoteIp, DestinationPort, Name = iff(Name == '🎫 ', '🎫 <Unknown>', Name), Type, MaliciousConnections = iff(MaliciousIpInfo == '', '✅ No Malicious Connections', iff(Type == 'Computer' or Type == 'Process' or Type == 'Overall', iff(MaliciousConnectionsCount > 1, strcat('❌ ', MaliciousIpInfo, ' Malicious Connections'), strcat('❌ ', MaliciousIpInfo, ' Malicious Connection')), '❌ Malicious Connection')), Responses, MaxLinksLive, LinksFailed, AverageResponseTime, TotalBytesSent, TotalBytesReceived, Info = iff(MaliciousIpInfo != '', MaliciousIpInfo, ''), Key, ParentKey, TypeKey, MaliciousConnectionsCount | order by TypeKey asc, MaliciousConnectionsCount desc, LinksFailed desc, AverageResponseTime desc, Responses desc, MaxLinksLive desc, Name asc | project-away TypeKey"
+                }
+              }
+            ]
+          },
+          {
+            "id": "9789ead5-eae5-4f52-86c2-ac197da62f30",
+            "version": "KqlParameterItem/1.0",
+            "name": "Computer_Process_IP_Port",
+            "type": 1,
+            "value": "",
+            "isHiddenWhenLocked": true,
+            "criteriaData": [
+              {
+                "condition": "else result = '{ServiceMapComputers} let ipComputerMapping = computers | project Computer, Ipv4 = todynamic(tostring(Properties.Ipv4Addresses_s)) | mvexpand Ipv4 to typeof(string); {MaliciousIpData} let totalMaliciousConnectionsCount = maliciousIpData | summarize MaliciousIpInfo = count() | extend Type = 'Overall'; {ComputerData} {ProcessName} {RemoteIpData} {DestinationPortData} {SourcePortData} let overalldata = VMConnection {vmSnippet} | where Direction == '{Direction}' | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) | extend Name = '🔵 Overall', Type = 'Overall', TypeKey = 0, Key = '--Overall--', ParentKey = '----' | join kind=leftouter totalMaliciousConnectionsCount on Type | extend MaliciousIpInfo = iff(MaliciousIpInfo == '0', '', tostring(MaliciousIpInfo)) | project-away Type1; computerData | union processData | union remoteIpData | union destinationPortData | union remoteIpDataInbound | union sourcePortData | union overalldata\t{QueryProject}'",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "static",
+                  "resultVal": "{ServiceMapComputers} let ipComputerMapping = computers | project Computer, Ipv4 = todynamic(tostring(Properties.Ipv4Addresses_s)) | mvexpand Ipv4 to typeof(string); {MaliciousIpData} let totalMaliciousConnectionsCount = maliciousIpData | summarize MaliciousIpInfo = count() | extend Type = 'Overall'; {ComputerData} {ProcessName} {RemoteIpData} {DestinationPortData} {SourcePortData} let overalldata = VMConnection {vmSnippet} | where Direction == '{Direction}' | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) | extend Name = '🔵 Overall', Type = 'Overall', TypeKey = 0, Key = '--Overall--', ParentKey = '----' | join kind=leftouter totalMaliciousConnectionsCount on Type | extend MaliciousIpInfo = iff(MaliciousIpInfo == '0', '', tostring(MaliciousIpInfo)) | project-away Type1; computerData | union processData | union remoteIpData | union destinationPortData | union remoteIpDataInbound | union sourcePortData | union overalldata\t{QueryProject}"
+                }
+              }
+            ]
+          },
+          {
+            "id": "0d6a320e-2cef-44fd-ac0b-ad833f8d0c03",
+            "version": "KqlParameterItem/1.0",
+            "name": "Computer_Process_IP",
+            "type": 1,
+            "value": "",
+            "isHiddenWhenLocked": true,
+            "criteriaData": [
+              {
+                "condition": "else result = '{ServiceMapComputers}  let ipComputerMapping = computers | project Computer, Ipv4 = todynamic(tostring(Properties.Ipv4Addresses_s)) | mvexpand Ipv4 to typeof(string);  {MaliciousIpData}  let totalMaliciousConnectionsCount = maliciousIpData | summarize MaliciousIpInfo = count() | extend Type = 'Overall';  {ComputerData} {ProcessName} {RemoteIpData} {SourcePortData}  let overalldata = VMConnection {vmSnippet} | where Direction == '{Direction}' | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) | extend Name = '🔵 Overall', Type = 'Overall', TypeKey = 0, Key = '--Overall--', ParentKey = '----' | join kind=leftouter totalMaliciousConnectionsCount on Type | extend MaliciousIpInfo = iff(MaliciousIpInfo == '0', '', tostring(MaliciousIpInfo)) | project-away Type1;\" ,\" computerData | union processData | union remoteIpData | union sourcePortData | union overalldata  {QueryProject}'",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "static",
+                  "resultVal": "{ServiceMapComputers}  let ipComputerMapping = computers | project Computer, Ipv4 = todynamic(tostring(Properties.Ipv4Addresses_s)) | mvexpand Ipv4 to typeof(string);  {MaliciousIpData}  let totalMaliciousConnectionsCount = maliciousIpData | summarize MaliciousIpInfo = count() | extend Type = 'Overall';  {ComputerData} {ProcessName} {RemoteIpData} {SourcePortData}  let overalldata = VMConnection {vmSnippet} | where Direction == '{Direction}' | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) | extend Name = '🔵 Overall', Type = 'Overall', TypeKey = 0, Key = '--Overall--', ParentKey = '----' | join kind=leftouter totalMaliciousConnectionsCount on Type | extend MaliciousIpInfo = iff(MaliciousIpInfo == '0', '', tostring(MaliciousIpInfo)) | project-away Type1;\" ,\" computerData | union processData | union remoteIpData | union sourcePortData | union overalldata  {QueryProject}"
+                }
+              }
+            ]
+          },
+          {
+            "id": "2de0d685-4382-4822-a8aa-f3583ff11b66",
+            "version": "KqlParameterItem/1.0",
+            "name": "QueryPadDestinationPortTable",
+            "type": 1,
+            "isRequired": true,
+            "value": "let destinationPortPadding = datatable (DestinationPort: string) [];",
+            "isHiddenWhenLocked": true,
+            "criteriaData": [
+              {
+                "condition": "else result = 'let destinationPortPadding = datatable (DestinationPort: string) [];'",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "static",
+                  "resultVal": "let destinationPortPadding = datatable (DestinationPort: string) [];"
+                }
+              }
+            ]
+          },
+          {
+            "id": "df8a6322-511e-40e0-a258-fe717099a072",
+            "version": "KqlParameterItem/1.0",
+            "name": "QueryPadRemoteIpTable",
+            "type": 1,
+            "isRequired": true,
+            "value": "let remoteIpPadding = datatable (RemoteIp: string) [];",
+            "isHiddenWhenLocked": true,
+            "criteriaData": [
+              {
+                "condition": "else result = 'let remoteIpPadding = datatable (RemoteIp: string) [];'",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "static",
+                  "resultVal": "let remoteIpPadding = datatable (RemoteIp: string) [];"
+                }
+              }
+            ]
+          },
+          {
+            "id": "e8f2c394-18e8-4d6d-8f5e-8453cb67128c",
+            "version": "KqlParameterItem/1.0",
+            "name": "Computer_Process",
+            "type": 1,
+            "value": "",
+            "isHiddenWhenLocked": true,
+            "criteriaData": [
+              {
+                "condition": "else result = '{ServiceMapComputers}  let ipComputerMapping = computers | project Computer, Ipv4 = todynamic(tostring(Properties.Ipv4Addresses_s)) | mvexpand Ipv4 to typeof(string);  {MaliciousIpData}  let totalMaliciousConnectionsCount = maliciousIpData | summarize MaliciousIpInfo = count() | extend Type = 'Overall';  {ComputerData} {ProcessName}  let overalldata = VMConnection {vmSnippet} | where Direction == '{Direction}' | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) | extend Name = '🔵 Overall', Type = 'Overall', TypeKey = 0, Key = '--Overall--', ParentKey = '----' | join kind=leftouter totalMaliciousConnectionsCount on Type | extend MaliciousIpInfo = iff(MaliciousIpInfo == '0', '', tostring(MaliciousIpInfo)) | project-away Type1; {QueryPadDestinationPortTable} {QueryPadRemoteIpTable} computerData | union remoteIpPadding | union destinationPortPadding | union processData | union overalldata  {QueryProject}'",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "static",
+                  "resultVal": "{ServiceMapComputers}  let ipComputerMapping = computers | project Computer, Ipv4 = todynamic(tostring(Properties.Ipv4Addresses_s)) | mvexpand Ipv4 to typeof(string);  {MaliciousIpData}  let totalMaliciousConnectionsCount = maliciousIpData | summarize MaliciousIpInfo = count() | extend Type = 'Overall';  {ComputerData} {ProcessName}  let overalldata = VMConnection {vmSnippet} | where Direction == '{Direction}' | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) | extend Name = '🔵 Overall', Type = 'Overall', TypeKey = 0, Key = '--Overall--', ParentKey = '----' | join kind=leftouter totalMaliciousConnectionsCount on Type | extend MaliciousIpInfo = iff(MaliciousIpInfo == '0', '', tostring(MaliciousIpInfo)) | project-away Type1; {QueryPadDestinationPortTable} {QueryPadRemoteIpTable} computerData | union remoteIpPadding | union destinationPortPadding | union processData | union overalldata  {QueryProject}"
+                }
+              }
+            ]
+          },
+          {
+            "id": "084fb5fc-e8e4-42df-8a9f-ac1001950ba2",
+            "version": "KqlParameterItem/1.0",
+            "name": "QueryPadProcessNameTable",
+            "type": 1,
+            "isRequired": true,
+            "value": "let processNamePadding = datatable (ProcessName: string) [];",
+            "isHiddenWhenLocked": true,
+            "criteriaData": [
+              {
+                "condition": "else result = 'let processNamePadding = datatable (ProcessName: string) [];'",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "static",
+                  "resultVal": "let processNamePadding = datatable (ProcessName: string) [];"
+                }
+              }
+            ]
+          },
+          {
+            "id": "a4b0e146-7c89-40bb-ade2-ed2e392e9311",
+            "version": "KqlParameterItem/1.0",
+            "name": "Computer",
+            "type": 1,
+            "value": "",
+            "isHiddenWhenLocked": true,
+            "criteriaData": [
+              {
+                "condition": "else result = '{ServiceMapComputers}  let ipComputerMapping = computers | project Computer, Ipv4 = todynamic(tostring(Properties.Ipv4Addresses_s)) | mvexpand Ipv4 to typeof(string);  {MaliciousIpData}  let totalMaliciousConnectionsCount = maliciousIpData | summarize MaliciousIpInfo = count() | extend Type = 'Overall';  {ComputerData}  let overalldata = VMConnection {vmSnippet} | where Direction == '{Direction}' | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) | extend Name = '🔵 Overall', Type = 'Overall', TypeKey = 0, Key = '--Overall--', ParentKey = '----' | join kind=leftouter totalMaliciousConnectionsCount on Type | extend MaliciousIpInfo = iff(MaliciousIpInfo == '0', '', tostring(MaliciousIpInfo)) | project-away Type1; {QueryPadDestinationPortTable} {QueryPadRemoteIpTable} {QueryPadProcessNameTable} computerData | union remoteIpPadding | union processNamePadding | union destinationPortPadding | union overalldata  {QueryProject}'",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "static",
+                  "resultVal": "{ServiceMapComputers}  let ipComputerMapping = computers | project Computer, Ipv4 = todynamic(tostring(Properties.Ipv4Addresses_s)) | mvexpand Ipv4 to typeof(string);  {MaliciousIpData}  let totalMaliciousConnectionsCount = maliciousIpData | summarize MaliciousIpInfo = count() | extend Type = 'Overall';  {ComputerData}  let overalldata = VMConnection {vmSnippet} | where Direction == '{Direction}' | summarize Responses = sum(Responses), LinksFailed = sum(LinksFailed), MaxLinksLive = max(LinksLive), TotalBytesSent = sum(BytesSent), TotalBytesReceived = sum(BytesReceived), AverageResponseTime = 1.0 *  sum(ResponseTimeSum) / sum(Responses) | extend Name = '🔵 Overall', Type = 'Overall', TypeKey = 0, Key = '--Overall--', ParentKey = '----' | join kind=leftouter totalMaliciousConnectionsCount on Type | extend MaliciousIpInfo = iff(MaliciousIpInfo == '0', '', tostring(MaliciousIpInfo)) | project-away Type1; {QueryPadDestinationPortTable} {QueryPadRemoteIpTable} {QueryPadProcessNameTable} computerData | union remoteIpPadding | union processNamePadding | union destinationPortPadding | union overalldata  {QueryProject}"
+                }
+              }
+            ]
+          },
+          {
+            "id": "a08757da-e72b-474d-a1d2-65fb7020cc14",
+            "version": "KqlParameterItem/1.0",
+            "name": "FinalQuery",
+            "type": 1,
+            "value": "",
+            "isHiddenWhenLocked": true,
+            "criteriaData": [
+              {
+                "condition": "if (Hierarchy == '0'), result = '{Computer_Process_IP_Port} {TableFilter}'",
+                "criteriaContext": {
+                  "leftOperand": "Hierarchy",
+                  "operator": "==",
+                  "rightValType": "static",
+                  "rightVal": "0",
+                  "resultValType": "static",
+                  "resultVal": "{Computer_Process_IP_Port} {TableFilter}"
+                }
+              },
+              {
+                "condition": "if (Hierarchy == '1'), result = '{Computer_Process_IP} {TableFilter}'",
+                "criteriaContext": {
+                  "leftOperand": "Hierarchy",
+                  "operator": "==",
+                  "rightValType": "static",
+                  "rightVal": "1",
+                  "resultValType": "static",
+                  "resultVal": "{Computer_Process_IP} {TableFilter}"
+                }
+              },
+              {
+                "condition": "if (Hierarchy == '2'), result = '{Computer_Process} {TableFilter}'",
+                "criteriaContext": {
+                  "leftOperand": "Hierarchy",
+                  "operator": "==",
+                  "rightValType": "static",
+                  "rightVal": "2",
+                  "resultValType": "static",
+                  "resultVal": "{Computer_Process} {TableFilter}"
+                }
+              },
+              {
+                "condition": "if (Hierarchy == '3'), result = '{Computer} {TableFilter}'",
+                "criteriaContext": {
+                  "leftOperand": "Hierarchy",
+                  "operator": "==",
+                  "rightValType": "static",
+                  "rightVal": "3",
+                  "resultValType": "static",
+                  "resultVal": "{Computer} {TableFilter}"
+                }
+              },
+              {
+                "condition": "else result = '{Computer} {TableFilter}'",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "static",
+                  "resultVal": "{Computer} {TableFilter}"
+                }
+              }
+            ]
+          },
+          {
+            "id": "874eeebe-2ea2-4c04-a3b9-ab3b30e95573",
+            "version": "KqlParameterItem/1.0",
+            "name": "ConnectionGrid",
+            "type": 1,
+            "description": "Table placeholder",
+            "isHiddenWhenLocked": true
+          },
+          {
+            "id": "7d229be6-fe1e-4b68-9a88-e7a53e639198",
+            "version": "KqlParameterItem/1.0",
+            "name": "GridComputerName",
+            "type": 1,
+            "description": "Table placeholder",
+            "isHiddenWhenLocked": true,
+            "timeContext": {
+              "durationMs": 0
+            },
+            "timeContextFromParameter": "TimeRange"
+          },
+          {
+            "id": "e1562f78-bdb1-4bae-9cfd-5120e2061f5d",
+            "version": "KqlParameterItem/1.0",
+            "name": "GridProcessName",
+            "type": 1,
+            "description": "Table placeholder",
+            "isHiddenWhenLocked": true,
+            "timeContext": {
+              "durationMs": 0
+            },
+            "timeContextFromParameter": "TimeRange"
+          },
+          {
+            "id": "5423665b-218d-44fb-9cd5-0891168fd542",
+            "version": "KqlParameterItem/1.0",
+            "name": "GridRemoteIp",
+            "type": 1,
+            "description": "Table placeholder",
+            "isHiddenWhenLocked": true,
+            "timeContext": {
+              "durationMs": 0
+            },
+            "timeContextFromParameter": "TimeRange"
+          },
+          {
+            "id": "9a543572-e7dd-4332-8db3-7f039b06148a",
+            "version": "KqlParameterItem/1.0",
+            "name": "GridDestinationPort",
+            "type": 1,
+            "description": "Table placeholder",
+            "isHiddenWhenLocked": true,
+            "timeContext": {
+              "durationMs": 0
+            },
+            "timeContextFromParameter": "TimeRange"
+          }
+        ],
+        "style": "above",
+        "queryType": 0,
+        "resourceType": "microsoft.resources/subscriptions"
+      },
+      "name": "parameters - 3"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "💡 <em>Select a row from the table below to view connection details for that entry.</em>"
+      },
+      "name": "text - 4"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "{FinalQuery:value}",
+        "size": 0,
+        "noDataMessage": "No data to be shown for this particular scope combination, please adjust the time range, table filters, etc.",
+        "timeContext": {
+          "durationMs": 0
+        },
+        "timeContextFromParameter": "TimeRange",
+        "exportedParameters": [
+          {
+            "parameterName": "ConnectionGrid",
+            "parameterType": 1,
+            "defaultValue": "{}"
+          },
+          {
+            "fieldName": "ComputerName",
+            "parameterName": "GridComputerName",
+            "parameterType": 1
+          },
+          {
+            "fieldName": "ProcessName",
+            "parameterName": "GridProcessName",
+            "parameterType": 1
+          },
+          {
+            "fieldName": "RemoteIp",
+            "parameterName": "GridRemoteIp",
+            "parameterType": 1,
+            "defaultValue": ""
+          },
+          {
+            "fieldName": "DestinationPort",
+            "parameterName": "GridDestinationPort",
+            "parameterType": 1,
+            "defaultValue": ""
+          }
+        ],
+        "queryType": 0,
+        "resourceType": "microsoft.operationalinsights/workspaces",
+        "crossComponentResources": [
+          "{Workspaces}"
+        ],
+        "visualization": "table",
+        "gridSettings": {
+          "formatters": [
+            {
+              "columnMatch": "Computer",
+              "formatter": 5,
+              "formatOptions": {
+                "showIcon": true
+              }
+            },
+            {
+              "columnMatch": "ProcessName",
+              "formatter": 5,
+              "formatOptions": {
+                "showIcon": true
+              }
+            },
+            {
+              "columnMatch": "RemoteIp",
+              "formatter": 5,
+              "formatOptions": {
+                "showIcon": true
+              }
+            },
+            {
+              "columnMatch": "DestinationPort",
+              "formatter": 5,
+              "formatOptions": {
+                "showIcon": true
+              },
+              "numberFormat": {
+                "unit": 0,
+                "options": {
+                  "style": "decimal",
+                  "useGrouping": false
+                }
+              }
+            },
+            {
+              "columnMatch": "Name",
+              "formatter": 0,
+              "formatOptions": {
+                "showIcon": true
+              }
+            },
+            {
+              "columnMatch": "Type",
+              "formatter": 0,
+              "formatOptions": {
+                "showIcon": true
+              }
+            },
+            {
+              "columnMatch": "MaliciousConnections",
+              "formatter": 0,
+              "formatOptions": {
+                "showIcon": true
+              }
+            },
+            {
+              "columnMatch": "Responses",
+              "formatter": 4,
+              "formatOptions": {
+                "palette": "blueDark",
+                "showIcon": true
+              },
+              "numberFormat": {
+                "unit": 17,
+                "options": {
+                  "style": "decimal"
+                }
+              }
+            },
+            {
+              "columnMatch": "MaxLinksLive",
+              "formatter": 4,
+              "formatOptions": {
+                "palette": "lightBlue",
+                "showIcon": true
+              },
+              "numberFormat": {
+                "unit": 17,
+                "options": {
+                  "style": "decimal"
+                }
+              }
+            },
+            {
+              "columnMatch": "LinksFailed",
+              "formatter": 4,
+              "formatOptions": {
+                "palette": "red",
+                "showIcon": true
+              },
+              "numberFormat": {
+                "unit": 17,
+                "options": {
+                  "style": "decimal"
+                }
+              }
+            },
+            {
+              "columnMatch": "AverageResponseTime",
+              "formatter": 4,
+              "formatOptions": {
+                "palette": "purple",
+                "showIcon": true
+              },
+              "numberFormat": {
+                "unit": 23,
+                "options": {
+                  "style": "decimal"
+                }
+              }
+            },
+            {
+              "columnMatch": "TotalBytesSent",
+              "formatter": 4,
+              "formatOptions": {
+                "palette": "orange",
+                "showIcon": true
+              },
+              "numberFormat": {
+                "unit": 2,
+                "options": {
+                  "style": "decimal"
+                }
+              }
+            },
+            {
+              "columnMatch": "TotalBytesReceived",
+              "formatter": 4,
+              "formatOptions": {
+                "palette": "green",
+                "showIcon": true
+              },
+              "numberFormat": {
+                "unit": 2,
+                "options": {
+                  "style": "decimal"
+                }
+              }
+            },
+            {
+              "columnMatch": "Info",
+              "formatter": 5,
+              "formatOptions": {
+                "linkTarget": "CellDetails",
+                "linkLabel": "ℹ️ Info",
+                "showIcon": true
+              }
+            },
+            {
+              "columnMatch": "Key",
+              "formatter": 5,
+              "formatOptions": {
+                "showIcon": true
+              }
+            },
+            {
+              "columnMatch": "ParentKey",
+              "formatter": 5,
+              "formatOptions": {
+                "showIcon": true
+              }
+            },
+            {
+              "columnMatch": "MaliciousConnectionsCount",
+              "formatter": 5,
+              "formatOptions": {
+                "showIcon": true
+              }
+            }
+          ],
+          "rowLimit": 10000,
+          "filter": true,
+          "hierarchySettings": {
+            "idColumn": "Key",
+            "parentColumn": "ParentKey",
+            "treeType": 0,
+            "expanderColumn": "Name",
+            "expandTopLevel": false
+          }
+        },
+        "tileSettings": {
+          "showBorder": false,
+          "titleContent": {
+            "columnMatch": "Computer",
+            "formatter": 1
+          },
+          "leftContent": {
+            "columnMatch": "KPIValue",
+            "formatter": 12,
+            "formatOptions": {
+              "palette": "auto"
+            },
+            "numberFormat": {
+              "unit": 17,
+              "options": {
+                "maximumSignificantDigits": 3,
+                "maximumFractionDigits": 2
+              }
+            }
+          }
+        }
+      },
+      "showPin": true,
+      "name": "query - 5"
+    },
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "parameters": [
+          {
+            "id": "dcf5f274-fbbf-4fb8-8c35-6b528a08cac9",
+            "version": "KqlParameterItem/1.0",
+            "name": "ShowDetail",
+            "type": 1,
+            "isRequired": true,
+            "value": "False",
+            "isHiddenWhenLocked": true,
+            "criteriaData": [
+              {
+                "condition": "if (ConnectionGrid != '{}'), result = 'True'",
+                "criteriaContext": {
+                  "leftOperand": "ConnectionGrid",
+                  "operator": "!=",
+                  "rightValType": "static",
+                  "rightVal": "{}",
+                  "resultValType": "static",
+                  "resultVal": "True"
+                }
+              },
+              {
+                "condition": "else result = 'False'",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "static",
+                  "resultVal": "False"
+                }
+              }
+            ]
+          },
+          {
+            "id": "9a8b4514-a921-48d6-be63-f053286a2acb",
+            "version": "KqlParameterItem/1.0",
+            "name": "Blank",
+            "type": 1,
+            "isHiddenWhenLocked": true,
+            "timeContext": {
+              "durationMs": 0
+            },
+            "timeContextFromParameter": "TimeRange",
+            "value": ""
+          },
+          {
+            "id": "0e3e1001-dbf6-4ee8-8235-b8e19451a30d",
+            "version": "KqlParameterItem/1.0",
+            "name": "GridDestinationPort",
+            "type": 1,
+            "description": "Force blank if <unset>",
+            "value": "",
+            "isHiddenWhenLocked": true,
+            "criteriaData": [
+              {
+                "condition": "else result = '{GridDestinationPort}'",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "static",
+                  "resultVal": "{GridDestinationPort}"
+                }
+              }
+            ],
+            "timeContext": {
+              "durationMs": 0
+            },
+            "timeContextFromParameter": "TimeRange"
+          },
+          {
+            "id": "28944bf4-98f9-42ce-8f1f-b2a6e077347a",
+            "version": "KqlParameterItem/1.0",
+            "name": "HeadingDestinationPort",
+            "type": 1,
+            "isHiddenWhenLocked": true,
+            "criteriaData": [
+              {
+                "condition": "if (GridDestinationPort != Blank), result = ' > 🔸 {GridDestinationPort}'",
+                "criteriaContext": {
+                  "leftOperand": "GridDestinationPort",
+                  "operator": "!=",
+                  "rightValType": "param",
+                  "rightVal": "Blank",
+                  "resultValType": "static",
+                  "resultVal": " > 🔸 {GridDestinationPort}"
+                }
+              },
+              {
+                "condition": "else result = Blank",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "param",
+                  "resultVal": "Blank"
+                }
+              }
+            ],
+            "timeContext": {
+              "durationMs": 0
+            },
+            "timeContextFromParameter": "TimeRange",
+            "value": ""
+          },
+          {
+            "id": "02d4b80c-fc1f-4a4e-8fc7-c35ce670ace7",
+            "version": "KqlParameterItem/1.0",
+            "name": "HeadingRemoteIp",
+            "type": 1,
+            "isHiddenWhenLocked": true,
+            "criteriaData": [
+              {
+                "condition": "if (GridRemoteIp != Blank), result = ' > 🌐 {GridRemoteIp}'",
+                "criteriaContext": {
+                  "leftOperand": "GridRemoteIp",
+                  "operator": "!=",
+                  "rightValType": "param",
+                  "rightVal": "Blank",
+                  "resultValType": "static",
+                  "resultVal": " > 🌐 {GridRemoteIp}"
+                }
+              },
+              {
+                "condition": "else result = Blank",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "param",
+                  "resultVal": "Blank"
+                }
+              }
+            ],
+            "timeContext": {
+              "durationMs": 0
+            },
+            "timeContextFromParameter": "TimeRange",
+            "value": ""
+          },
+          {
+            "id": "7a5e3753-c1ae-4a94-b8f9-82c71ca46198",
+            "version": "KqlParameterItem/1.0",
+            "name": "HeadingDirection",
+            "type": 1,
+            "isHiddenWhenLocked": true,
+            "criteriaData": [
+              {
+                "condition": "if (Direction == 'outbound'), result = '{HeadingRemoteIp} {HeadingDestinationPort}'",
+                "criteriaContext": {
+                  "leftOperand": "Direction",
+                  "operator": "==",
+                  "rightValType": "static",
+                  "rightVal": "outbound",
+                  "resultValType": "static",
+                  "resultVal": "{HeadingRemoteIp} {HeadingDestinationPort}"
+                }
+              },
+              {
+                "condition": "else result = '{HeadingDestinationPort} {HeadingRemoteIp}'",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "static",
+                  "resultVal": "{HeadingDestinationPort} {HeadingRemoteIp}"
+                }
+              }
+            ],
+            "timeContext": {
+              "durationMs": 0
+            },
+            "timeContextFromParameter": "TimeRange",
+            "value": " "
+          },
+          {
+            "id": "e8d8beb6-0109-454f-a4e2-6c79addce3b0",
+            "version": "KqlParameterItem/1.0",
+            "name": "HeadingProcess",
+            "type": 1,
+            "isHiddenWhenLocked": true,
+            "criteriaData": [
+              {
+                "condition": "if (GridProcessName != Blank), result = ' > 🎫 {GridProcessName}'",
+                "criteriaContext": {
+                  "leftOperand": "GridProcessName",
+                  "operator": "!=",
+                  "rightValType": "param",
+                  "rightVal": "Blank",
+                  "resultValType": "static",
+                  "resultVal": " > 🎫 {GridProcessName}"
+                }
+              },
+              {
+                "condition": "else result = Blank",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "param",
+                  "resultVal": "Blank"
+                }
+              }
+            ],
+            "timeContext": {
+              "durationMs": 0
+            },
+            "timeContextFromParameter": "TimeRange",
+            "value": ""
+          },
+          {
+            "id": "1ce27926-6842-497b-ac53-70c006e11231",
+            "version": "KqlParameterItem/1.0",
+            "name": "Heading",
+            "type": 1,
+            "isHiddenWhenLocked": true,
+            "criteriaData": [
+              {
+                "condition": "else result = '💻 {GridComputerName} {HeadingProcess} {HeadingDirection}'",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "static",
+                  "resultVal": "💻 {GridComputerName} {HeadingProcess} {HeadingDirection}"
+                }
+              }
+            ],
+            "value": ""
+          },
+          {
+            "id": "4a155a6b-f28a-49c4-b3e3-a975316dcf20",
+            "version": "KqlParameterItem/1.0",
+            "name": "QueryProcessName",
+            "type": 1,
+            "value": "",
+            "isHiddenWhenLocked": true,
+            "criteriaData": [
+              {
+                "condition": "if (GridProcessName != Blank), result = ' | where ProcessName == \"{GridProcessName}\"'",
+                "criteriaContext": {
+                  "leftOperand": "GridProcessName",
+                  "operator": "!=",
+                  "rightValType": "param",
+                  "rightVal": "Blank",
+                  "resultValType": "static",
+                  "resultVal": " | where ProcessName == \"{GridProcessName}\""
+                }
+              },
+              {
+                "condition": "else result = Blank",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "param",
+                  "resultVal": "Blank"
+                }
+              }
+            ],
+            "timeContext": {
+              "durationMs": 0
+            },
+            "timeContextFromParameter": "TimeRange"
+          },
+          {
+            "id": "128e1c98-bae2-431c-99b7-ed214988e02b",
+            "version": "KqlParameterItem/1.0",
+            "name": "QueryRemoteIp",
+            "type": 1,
+            "value": "",
+            "isHiddenWhenLocked": true,
+            "criteriaData": [
+              {
+                "condition": "if (GridRemoteIp != Blank), result = ' | where RemoteIp == \"{GridRemoteIp}\"'",
+                "criteriaContext": {
+                  "leftOperand": "GridRemoteIp",
+                  "operator": "!=",
+                  "rightValType": "param",
+                  "rightVal": "Blank",
+                  "resultValType": "static",
+                  "resultVal": " | where RemoteIp == \"{GridRemoteIp}\""
+                }
+              },
+              {
+                "condition": "else result = Blank",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "param",
+                  "resultVal": "Blank"
+                }
+              }
+            ],
+            "timeContext": {
+              "durationMs": 0
+            },
+            "timeContextFromParameter": "TimeRange"
+          },
+          {
+            "id": "87897941-a28b-479d-a03b-921cdd1d36f5",
+            "version": "KqlParameterItem/1.0",
+            "name": "QueryDestinationPort",
+            "type": 1,
+            "value": "",
+            "isHiddenWhenLocked": true,
+            "criteriaData": [
+              {
+                "condition": "if (GridDestinationPort != Blank), result = ' | where DestinationPort == \"{GridDestinationPort}\"'",
+                "criteriaContext": {
+                  "leftOperand": "GridDestinationPort",
+                  "operator": "!=",
+                  "rightValType": "param",
+                  "rightVal": "Blank",
+                  "resultValType": "static",
+                  "resultVal": " | where DestinationPort == \"{GridDestinationPort}\""
+                }
+              },
+              {
+                "condition": "else result = Blank",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "param",
+                  "resultVal": "Blank"
+                }
+              }
+            ],
+            "timeContext": {
+              "durationMs": 0
+            },
+            "timeContextFromParameter": "TimeRange"
+          },
+          {
+            "id": "b44edb14-76ad-48b3-9921-b5dfb5a6db60",
+            "version": "KqlParameterItem/1.0",
+            "name": "QueryFilter",
+            "type": 1,
+            "value": "",
+            "isHiddenWhenLocked": true,
+            "criteriaData": [
+              {
+                "condition": "if (GridComputerName != Blank), result = '| where Computer == \"{GridComputerName}\" {QueryDestinationPort} {QueryRemoteIp} {QueryProcessName}'",
+                "criteriaContext": {
+                  "leftOperand": "GridComputerName",
+                  "operator": "!=",
+                  "rightValType": "param",
+                  "rightVal": "Blank",
+                  "resultValType": "static",
+                  "resultVal": "| where Computer == \"{GridComputerName}\" {QueryDestinationPort} {QueryRemoteIp} {QueryProcessName}"
+                }
+              },
+              {
+                "condition": "else result = Blank",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "param",
+                  "resultVal": "Blank"
+                }
+              }
+            ]
+          }
+        ],
+        "style": "above",
+        "queryType": 0,
+        "resourceType": "microsoft.operationalinsights/workspaces"
+      },
+      "name": "parameters - 6"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "<h2 style=\"font-weight:normal;\">{Heading}</h2>"
+      },
+      "conditionalVisibility": {
+        "parameterName": "ShowDetail",
+        "comparison": "isEqualTo",
+        "value": "True"
+      },
+      "name": "text - 7"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "### Responses"
+      },
+      "conditionalVisibility": {
+        "parameterName": "ShowDetail",
+        "comparison": "isEqualTo",
+        "value": "True"
+      },
+      "customWidth": "25",
+      "name": "text - 8"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "### Latency"
+      },
+      "conditionalVisibility": {
+        "parameterName": "ShowDetail",
+        "comparison": "isEqualTo",
+        "value": "True"
+      },
+      "customWidth": "25",
+      "name": "text - 9"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "### Network"
+      },
+      "conditionalVisibility": {
+        "parameterName": "ShowDetail",
+        "comparison": "isEqualTo",
+        "value": "True"
+      },
+      "customWidth": "25",
+      "name": "text - 10"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "### Links"
+      },
+      "conditionalVisibility": {
+        "parameterName": "ShowDetail",
+        "comparison": "isEqualTo",
+        "value": "True"
+      },
+      "customWidth": "25",
+      "name": "text - 11"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "let SourceMachineData = VMConnection  {vmSnippet}\r\n{QueryFilter}\r\n| where Direction == '{Direction}'\r\n| summarize Responses = sum(Responses) by bin(TimeGenerated, time('{TimeRange:grain}'));\r\nSourceMachineData",
+        "size": 1,
+        "timeContext": {
+          "durationMs": 0
+        },
+        "timeContextFromParameter": "TimeRange",
+        "queryType": 0,
+        "resourceType": "microsoft.operationalinsights/workspaces",
+        "crossComponentResources": [
+          "{Workspaces}"
+        ],
+        "visualization": "areachart"
+      },
+      "conditionalVisibility": {
+        "parameterName": "ShowDetail",
+        "comparison": "isEqualTo",
+        "value": "True"
+      },
+      "customWidth": "25",
+      "name": "query - 12"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "let SourceMachineData = VMConnection  {vmSnippet}\r\n{QueryFilter}\r\n| where Direction == '{Direction}'\r\n| summarize P50 = percentiles(ResponseTimeSum, 50), P90 = percentiles(ResponseTimeSum, 90), P95 = percentiles(ResponseTimeSum, 95) by bin(TimeGenerated, time('{TimeRange:grain}'));\r\nSourceMachineData",
+        "size": 1,
+        "aggregation": 3,
+        "timeContext": {
+          "durationMs": 0
+        },
+        "timeContextFromParameter": "TimeRange",
+        "queryType": 0,
+        "resourceType": "microsoft.operationalinsights/workspaces",
+        "crossComponentResources": [
+          "{Workspaces}"
+        ],
+        "visualization": "linechart"
+      },
+      "conditionalVisibility": {
+        "parameterName": "ShowDetail",
+        "comparison": "isEqualTo",
+        "value": "True"
+      },
+      "customWidth": "25",
+      "name": "query - 13"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "let SourceMachineData = VMConnection {vmSnippet}\r\n{QueryFilter}\r\n| where Direction == '{Direction}'\r\n| summarize Sent = sum(BytesSent), Received = sum(BytesReceived) by bin(TimeGenerated, time('{TimeRange:grain}'));\r\nSourceMachineData",
+        "size": 1,
+        "timeContext": {
+          "durationMs": 0
+        },
+        "timeContextFromParameter": "TimeRange",
+        "queryType": 0,
+        "resourceType": "microsoft.operationalinsights/workspaces",
+        "crossComponentResources": [
+          "{Workspaces}"
+        ],
+        "visualization": "areachart"
+      },
+      "conditionalVisibility": {
+        "parameterName": "ShowDetail",
+        "comparison": "isEqualTo",
+        "value": "True"
+      },
+      "customWidth": "25",
+      "name": "query - 14"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "let SourceMachineData = VMConnection {vmSnippet}\r\n{QueryFilter}\r\n| where Direction == '{Direction}'\r\n| summarize MaxOpenPorts = max(LinksLive), SumFailed = sum(LinksFailed) by bin(TimeGenerated, time('{TimeRange:grain}'));\r\nSourceMachineData",
+        "size": 1,
+        "aggregation": 3,
+        "timeContext": {
+          "durationMs": 0
+        },
+        "timeContextFromParameter": "TimeRange",
+        "queryType": 0,
+        "resourceType": "microsoft.operationalinsights/workspaces",
+        "crossComponentResources": [
+          "{Workspaces}"
+        ],
+        "visualization": "areachart"
+      },
+      "conditionalVisibility": {
+        "parameterName": "ShowDetail",
+        "comparison": "isEqualTo",
+        "value": "True"
+      },
+      "customWidth": "25",
+      "name": "query - 15"
+    }
+  ],
+  "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
+}

--- a/Workbooks/Virtual Machines - Network Dependencies/Connections Overview (Dev)/settings.json
+++ b/Workbooks/Virtual Machines - Network Dependencies/Connections Overview (Dev)/settings.json
@@ -4,6 +4,6 @@
     "author": "Microsoft",
     "isPreview": true,
     "galleries": [
-        { "type": "vm-insights", "resourceType": "Azure Monitor", "order": 100 },
+        { "type": "vm-insights", "resourceType": "Azure Monitor", "order": 100 }
     ]
 }

--- a/Workbooks/Virtual Machines - Network Dependencies/Connections Overview (Dev)/settings.json
+++ b/Workbooks/Virtual Machines - Network Dependencies/Connections Overview (Dev)/settings.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/settings.json",
+    "name":"Connections Overview (Dev)",
+    "author": "Microsoft",
+    "isPreview": true,
+    "galleries": [
+        { "type": "vm-insights", "resourceType": "Azure Monitor", "order": 100 },
+    ]
+}


### PR DESCRIPTION
Utilize the appropriate Azure-mode scope selections so that only
onboarded VMs and their respective reporting workspaces will be shown in
the workbook. Optimized the workbook by converting all query snippets to
use the Criteria parameter.

- Expand subscription context
- Import workspace region parameters
- Convert all query snippets to criterias
- Replace using vmSnippet
- Fix single selection Connections grid
- Update parameter names to avoid conflict
- Add table placeholders
- Fix empty GridDestinationPort table parameter

![image](https://user-images.githubusercontent.com/43890980/74501061-c169f480-4e9d-11ea-8ab5-66e3b87b4f98.png)
