### PR TITLE
Optimize top-level scope selectors for VM Group Performance

### DIFF
--- a/Workbooks/Virtual Machines - Performance Analysis/Performance Analysis for a Group of VMs (Dev)/Performance Analysis for a Group of VMs (Dev).workbook
+++ b/Workbooks/Virtual Machines - Performance Analysis/Performance Analysis for a Group of VMs (Dev)/Performance Analysis for a Group of VMs (Dev).workbook
@@ -12,273 +12,194 @@
       "type": 9,
       "content": {
         "version": "KqlParameterItem/1.0",
-        "crossComponentResources": [
-          "{Subscription}"
-        ],
         "parameters": [
           {
-            "id": "3f34a4f7-9a42-46ed-ac12-7369edbd80a8",
+            "id": "10607c01-15dc-4df0-a70f-8d1823c41ac0",
             "version": "KqlParameterItem/1.0",
-            "name": "blank",
-            "type": 1,
-            "isHiddenWhenLocked": true
-          },
-          {
-            "id": "7d3239b1-19a0-44fd-a771-df82340e0d88",
-            "version": "KqlParameterItem/1.0",
-            "name": "DefaultResource",
+            "name": "DefaultSubscription",
             "type": 5,
+            "isRequired": true,
             "value": "value::1",
             "isHiddenWhenLocked": true,
             "typeSettings": {
               "resourceTypeFilter": {
-                "microsoft.resources/subscriptions": true,
+                "microsoft.resources/subscriptions": true
+              },
+              "additionalResourceOptions": [
+                "value::1"
+              ]
+            },
+            "timeContextFromParameter": "TimeRange"
+          },
+          {
+            "id": "f95de9f8-8ce2-45d7-9515-c1396cb125eb",
+            "version": "KqlParameterItem/1.0",
+            "name": "DefaultResourceGroup",
+            "type": 5,
+            "isRequired": true,
+            "value": "value::1",
+            "isHiddenWhenLocked": true,
+            "typeSettings": {
+              "resourceTypeFilter": {
                 "microsoft.resources/resourcegroups": true
               },
               "additionalResourceOptions": [
                 "value::1"
               ]
-            }
+            },
+            "timeContextFromParameter": "TimeRange"
           },
           {
-            "id": "0caf61ec-d776-4642-8553-5293060a62c7",
+            "id": "54f9b46f-0363-425f-9411-d79d847caa21",
             "version": "KqlParameterItem/1.0",
-            "name": "ContextFree",
+            "name": "SelectedResourceGroup",
             "type": 1,
-            "query": "{\"version\":\"1.0.0\",\"content\":\"\\\"{DefaultResource}\\\"\"}",
+            "value": "true",
             "isHiddenWhenLocked": true,
-            "queryType": 8,
-            "resourceType": "microsoft.operationalinsights/workspaces"
-          },
-          {
-            "id": "6e82c4c1-769e-4549-bd80-b356ef999efa",
-            "version": "KqlParameterItem/1.0",
-            "name": "Selection",
-            "type": 1,
-            "query": "take 1\r\n| extend x = split ({DefaultResource:value}, '/')\r\n| project value = tostring(pack('sub', x[2], 'rg', case(x[4] != 'null', x[4], ''), 'vm', case(x[8] != 'null', x[8], '')))",
-            "crossComponentResources": [
-              "value::all"
+            "criteriaData": [
+              {
+                "condition": "if (DefaultResourceGroup != 'value::1'), result = 'false'",
+                "criteriaContext": {
+                  "leftOperand": "DefaultResourceGroup",
+                  "operator": "!=",
+                  "rightValType": "static",
+                  "rightVal": "value::1",
+                  "resultValType": "static",
+                  "resultVal": "false"
+                }
+              },
+              {
+                "condition": "else result = 'true'",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "static",
+                  "resultVal": "true"
+                }
+              }
             ],
-            "isHiddenWhenLocked": true,
-            "timeContextFromParameter": "TimeRange",
-            "queryType": 1,
-            "resourceType": "microsoft.resourcegraph/resources"
+            "timeContextFromParameter": "TimeRange"
           },
           {
-            "id": "604f6d89-c6f9-4bdb-b4ca-483f56a8946c",
+            "id": "6388d6d7-d4ca-4f3d-b581-42aeaa41e63f",
+            "version": "KqlParameterItem/1.0",
+            "name": "DefaultWorkspace",
+            "type": 5,
+            "isRequired": true,
+            "value": "value::1",
+            "isHiddenWhenLocked": true,
+            "typeSettings": {
+              "resourceTypeFilter": {
+                "microsoft.operationalinsights/workspaces": true
+              },
+              "additionalResourceOptions": [
+                "value::1"
+              ]
+            },
+            "timeContextFromParameter": "TimeRange"
+          },
+          {
+            "id": "1f191d03-002b-4b04-a4ee-c5bedb8e6527",
             "version": "KqlParameterItem/1.0",
             "name": "Subscription",
             "type": 6,
             "isRequired": true,
-            "query": "where type in~('microsoft.compute/virtualmachines', 'microsoft.compute/virtualmachinescalesets')\r\n| summarize Count = count() by subscriptionId\r\n| order by Count desc\r\n| extend Rank = row_number()\r\n| project value = subscriptionId, label = subscriptionId, selected = iff(subscriptionId =~ todynamic('{Selection}').sub, true, false)",
+            "query": "where type in~('microsoft.compute/virtualmachines', 'microsoft.compute/virtualmachinescalesets')\r\n| summarize Count = count() by subscriptionId\r\n| order by Count desc\r\n| project value = subscriptionId, label = subscriptionId, selected = iff(strcat('/subscriptions/', subscriptionId) =~ '{DefaultSubscription}', true, false)",
             "crossComponentResources": [
               "value::all"
             ],
             "typeSettings": {
-              "additionalResourceOptions": []
+              "additionalResourceOptions": [],
+              "showDefault": false
             },
             "timeContextFromParameter": "TimeRange",
             "queryType": 1,
             "resourceType": "microsoft.resourcegraph/resources"
           },
           {
-            "id": "efc388e8-ac7b-4e72-8573-e97cfe370f16",
+            "id": "ebdc8ba1-90cc-4029-8df5-bf9deb31df0a",
             "version": "KqlParameterItem/1.0",
-            "name": "ResourceGroup",
-            "label": "Resource group",
+            "name": "ResourceGroups",
+            "label": "Resource groups",
             "type": 2,
             "isRequired": true,
-            "multiSelect": true,
-            "quote": "'",
-            "delimiter": ",",
-            "query": "where type in~('microsoft.compute/virtualmachines', 'microsoft.compute/virtualmachinescalesets')\r\n| summarize Count = count() by resourceGroup\r\n| order by Count desc\r\n| extend Rank = row_number()\r\n| project value = resourceGroup, label = resourceGroup, selected = iff(resourceGroup =~ todynamic('{Selection}').rg, true, false)\r\n| order by value asc",
+            "query": "Resources\r\n| where type in~('microsoft.compute/virtualmachines', 'microsoft.compute/virtualmachinescalesets')\r\n| summarize Count = count() by ResourceGroup = strcat('/subscriptions/', subscriptionId, '/resourceGroups/', resourceGroup), ResourceGroupName = resourceGroup\r\n| order by Count desc\r\n| project value = ResourceGroup, label = ResourceGroupName, selected = iff(ResourceGroup =~ '{DefaultResourceGroup}', true, false)\r\n| union (datatable(value:string, label:string, selected:boolean)[\r\n'*', 'All resource groups', {SelectedResourceGroup}\r\n])",
             "crossComponentResources": [
               "{Subscription}"
             ],
             "typeSettings": {
-              "limitSelectTo": 1,
-              "additionalResourceOptions": [
-                "value::1",
-                "value::all"
-              ],
-              "selectAllValue": "all"
+              "additionalResourceOptions": [],
+              "showDefault": false
             },
             "timeContextFromParameter": "TimeRange",
             "queryType": 1,
-            "resourceType": "microsoft.resourcegraph/resources",
-            "value": [
-              "value::all"
-            ]
+            "resourceType": "microsoft.resourcegraph/resources"
           },
           {
-            "id": "ab4d0200-d7f0-4705-a006-c9f63e4e161e",
+            "id": "236186d0-04f4-4752-826b-239202ec9b44",
             "version": "KqlParameterItem/1.0",
-            "name": "validResourceGroup",
+            "name": "ArmPrefix",
             "type": 1,
+            "isRequired": true,
             "isHiddenWhenLocked": true,
             "criteriaData": [
               {
-                "condition": "if (ResourceGroup == 'all'), result = blank",
+                "condition": "if (ResourceGroups != '*'), result = '{ResourceGroups:unformatted}'",
                 "criteriaContext": {
-                  "leftOperand": "ResourceGroup",
-                  "operator": "==",
+                  "leftOperand": "ResourceGroups",
+                  "operator": "!=",
                   "rightValType": "static",
-                  "rightVal": "all",
-                  "resultValType": "param",
-                  "resultVal": "blank"
+                  "rightVal": "*",
+                  "resultValType": "static",
+                  "resultVal": "{ResourceGroups:unformatted}"
                 }
               },
               {
-                "condition": "if (ResourceGroup == blank), result = blank",
-                "criteriaContext": {
-                  "leftOperand": "ResourceGroup",
-                  "operator": "==",
-                  "rightValType": "param",
-                  "rightVal": "blank",
-                  "resultValType": "param",
-                  "resultVal": "blank"
-                }
-              },
-              {
-                "condition": "else result = '{ResourceGroup:unformatted}'",
+                "condition": "else result = '{Subscription}'",
                 "criteriaContext": {
                   "operator": "Default",
                   "rightValType": "param",
-                  "resultValType": "static",
-                  "resultVal": "{ResourceGroup:unformatted}"
-                }
-              }
-            ],
-            "timeContextFromParameter": "TimeRange"
-          },
-          {
-            "id": "f1d9afb3-4e74-4ef7-8e21-e2d0f84534ea",
-            "version": "KqlParameterItem/1.0",
-            "name": "armPrefix",
-            "type": 1,
-            "value": "",
-            "isHiddenWhenLocked": true,
-            "criteriaData": [
-              {
-                "condition": "if (validResourceGroup != blank), result = '{Subscription}/resourcegroups/{validResourceGroup}'",
-                "criteriaContext": {
-                  "leftOperand": "validResourceGroup",
-                  "operator": "!=",
-                  "rightValType": "param",
-                  "rightVal": "blank",
-                  "resultValType": "static",
-                  "resultVal": "{Subscription}/resourcegroups/{validResourceGroup}"
-                }
-              },
-              {
-                "condition": "if (Subscription != blank), result = '{Subscription}'",
-                "criteriaContext": {
-                  "leftOperand": "Subscription",
-                  "operator": "!=",
-                  "rightValType": "param",
-                  "rightVal": "blank",
                   "resultValType": "static",
                   "resultVal": "{Subscription}"
                 }
-              },
-              {
-                "condition": "else result = blank",
-                "criteriaContext": {
-                  "operator": "Default",
-                  "rightValType": "param",
-                  "resultValType": "param",
-                  "resultVal": "blank"
-                }
               }
-            ]
-          },
-          {
-            "id": "7e3ee42f-fa46-47fe-ae7e-1fecdecc094a",
-            "version": "KqlParameterItem/1.0",
-            "name": "armUrl",
-            "type": 1,
-            "value": "",
-            "isHiddenWhenLocked": true,
-            "criteriaData": [
-              {
-                "condition": "if (armPrefix != blank), result = '{armPrefix}/providers/Microsoft.Insights/vmInsightsOnboardingStatuses?api-version=2018-11-27-preview'",
-                "criteriaContext": {
-                  "leftOperand": "armPrefix",
-                  "operator": "!=",
-                  "rightValType": "param",
-                  "rightVal": "blank",
-                  "resultValType": "static",
-                  "resultVal": "{armPrefix}/providers/Microsoft.Insights/vmInsightsOnboardingStatuses?api-version=2018-11-27-preview"
-                }
-              },
-              {
-                "condition": "else result = blank",
-                "criteriaContext": {
-                  "operator": "Default",
-                  "rightValType": "param",
-                  "resultValType": "param",
-                  "resultVal": "blank"
-                }
-              }
-            ]
-          },
-          {
-            "id": "8cfecad8-d483-42de-abb3-9cb558a00acd",
-            "version": "KqlParameterItem/1.0",
-            "name": "Resources",
-            "label": "Virtual Machines",
-            "type": 5,
-            "description": "Onboarded Virtual Machines",
-            "isRequired": true,
-            "multiSelect": true,
-            "quote": "'",
-            "delimiter": ",",
-            "query": "{\"version\":\"ARMEndpoint/1.0\",\"data\":null,\"headers\":[],\"method\":\"GET\",\"path\":\"{armUrl}\",\"urlParams\":[],\"batchDisabled\":false,\"transformers\":[{\"type\":\"jsonpath\",\"settings\":{\"tablePath\":\"$.value\",\"columns\":[{\"path\":\"$.properties.resourceId\",\"columnid\":\"resourceId\"}]}}]}",
-            "value": [
-              "value::all"
             ],
-            "typeSettings": {
-              "additionalResourceOptions": [
-                "value::all"
-              ],
-              "selectAllValue": "all"
-            },
+            "timeContextFromParameter": "TimeRange",
+            "value": ""
+          },
+          {
+            "id": "19132bc7-1624-4205-98d7-abc779dc1824",
+            "version": "KqlParameterItem/1.0",
+            "name": "ArmUrl",
+            "type": 1,
+            "query": "{\"version\":\"1.0.0\",\"content\":\"\\\"{ArmPrefix}/providers/Microsoft.Insights/vmInsightsOnboardingStatuses?api-version=2018-11-27-preview\\\"\",\"transformers\":null}",
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": "TimeRange",
+            "queryType": 8,
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          },
+          {
+            "id": "de30cdfe-fcab-4c1a-8e84-cf12e08fb804",
+            "version": "KqlParameterItem/1.0",
+            "name": "OnboardQueryResult",
+            "type": 1,
+            "isRequired": true,
+            "query": "{\"version\":\"ARMEndpoint/1.0\",\"data\":null,\"headers\":[],\"method\":\"GET\",\"path\":\"{ArmUrl}\",\"urlParams\":[],\"batchDisabled\":false,\"transformers\":null}",
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": "TimeRange",
             "queryType": 12,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
           {
-            "id": "b829835f-1161-457d-96c5-72fc444db73a",
+            "id": "d0dc9f80-0be7-48cb-a4b3-fdb9f64932a1",
             "version": "KqlParameterItem/1.0",
-            "name": "Location",
-            "label": "Workspace Regions",
-            "type": 8,
-            "description": "Queries with workspaces in 5 or more regions may take excessive time to complete",
-            "isRequired": true,
-            "multiSelect": true,
-            "quote": "'",
-            "delimiter": ",",
-            "value": [
-              "value::3"
-            ],
-            "typeSettings": {
-              "limitSelectTo": 20,
-              "additionalResourceOptions": [
-                "value::3"
-              ],
-              "includeAll": true
-            },
-            "timeContextFromParameter": "TimeRange"
-          },
-          {
-            "id": "0b488656-655a-4716-9438-bb3137c98055",
-            "version": "KqlParameterItem/1.0",
-            "name": "allWorkspaces",
+            "name": "OnboardedVms",
             "type": 5,
             "isRequired": true,
             "multiSelect": true,
             "quote": "'",
             "delimiter": ",",
-            "query": "{\"version\":\"ARMEndpoint/1.0\",\"data\":null,\"headers\":[],\"method\":\"GET\",\"path\":\"{armUrl}\",\"urlParams\":[],\"batchDisabled\":false,\"transformers\":[{\"type\":\"jsonpath\",\"settings\":{\"tablePath\":\"$..workspace\",\"columns\":[{\"path\":\"$.id\",\"columnid\":\"workspaceId\"}]}}]}",
+            "query": "{\"version\":\"1.0.0\",\"content\":\"{OnboardQueryResult}\",\"transformers\":[{\"type\":\"jsonpath\",\"settings\":{\"tablePath\":\"$.value.*\",\"columns\":[{\"path\":\"$.properties.resourceId\",\"columnid\":\"Workspaces\"}]}}]}",
             "value": [
               "value::all"
             ],
@@ -289,22 +210,97 @@
               ]
             },
             "timeContextFromParameter": "TimeRange",
-            "queryType": 12,
+            "queryType": 8,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
           {
-            "id": "598a32fb-b4b3-4f0e-adcf-4357a9cd53c3",
+            "id": "f3884e38-09d5-40cb-baa7-f5906e23d307",
             "version": "KqlParameterItem/1.0",
-            "name": "Workspaces",
+            "name": "VirtualMachines",
+            "label": "Virtual machines",
             "type": 5,
+            "isRequired": true,
             "multiSelect": true,
             "quote": "'",
             "delimiter": ",",
-            "query": "where type =~ \"microsoft.operationalinsights/workspaces\"\r\n| where id in~ ({allWorkspaces})\r\n| where location in~ ({Location})",
+            "query": "Resources\n| take 1\n| project ids = dynamic([{OnboardedVms}])\n| mvexpand ids limit 400\n| extend id = tolower(tostring(ids))\n| extend vmss = extract(@'(/subscriptions/.+/resourcegroups/.+/providers/microsoft.compute/virtualmachinescalesets/.+)/virtualmachines/.+', 1, id)\n| project id = iff(vmss == '', id, vmss), group = iff(vmss == '', 'Virtual machines', 'Virtual machine scale sets')\n| summarize by id, group\n| project value = id, label = id, selected = false, group",
             "crossComponentResources": [
-              "value::all"
+              "{Subscription}"
             ],
             "value": [
+              "value::all"
+            ],
+            "typeSettings": {
+              "additionalResourceOptions": [
+                "value::all"
+              ]
+            },
+            "timeContextFromParameter": "TimeRange",
+            "queryType": 1,
+            "resourceType": "microsoft.resourcegraph/resources"
+          },
+          {
+            "id": "c50c67ca-3dba-4a7f-ad19-2d5d28185e12",
+            "version": "KqlParameterItem/1.0",
+            "name": "TargetWorkspaces",
+            "type": 5,
+            "isRequired": true,
+            "multiSelect": true,
+            "quote": "\"",
+            "delimiter": ",",
+            "query": "{\"version\":\"1.0.0\",\"content\":\"{OnboardQueryResult}\",\"transformers\":[{\"type\":\"jsonpath\",\"settings\":{\"tablePath\":\"$.value.*\",\"columns\":[{\"path\":\"$.properties.data.*.workspace.id\",\"columnid\":\"Workspaces\"}]}}]}",
+            "value": [
+              "value::all"
+            ],
+            "isHiddenWhenLocked": true,
+            "typeSettings": {
+              "additionalResourceOptions": [
+                "value::all"
+              ]
+            },
+            "timeContextFromParameter": "TimeRange",
+            "queryType": 8,
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          },
+          {
+            "id": "97011276-637b-46e6-9e9f-056c30389501",
+            "version": "KqlParameterItem/1.0",
+            "name": "DistinctTargetWorkspaces",
+            "type": 5,
+            "isRequired": true,
+            "multiSelect": true,
+            "quote": "'",
+            "delimiter": ",",
+            "query": "Resources\n| take 1\n| project ws = '{TargetWorkspaces}'\n| extend ws = replace(@'\"\\[', '', ws)\n| extend ws = replace(@'\\]\"', '', ws)\n| extend ws = todynamic(strcat('[', ws, ']'))\n| mvexpand ws limit 400\n| summarize by tolower(tostring(ws))",
+            "crossComponentResources": [
+              "{Subscription}"
+            ],
+            "value": [
+              "value::all"
+            ],
+            "isHiddenWhenLocked": true,
+            "typeSettings": {
+              "additionalResourceOptions": [
+                "value::all"
+              ],
+              "showDefault": false
+            },
+            "timeContextFromParameter": "TimeRange",
+            "queryType": 1,
+            "resourceType": "microsoft.resourcegraph/resources"
+          },
+          {
+            "id": "a40d5985-4da2-4c55-b73e-4cca93c8b560",
+            "version": "KqlParameterItem/1.0",
+            "name": "WorkspaceLocations",
+            "label": "Workspace locations",
+            "type": 8,
+            "isRequired": true,
+            "multiSelect": true,
+            "quote": "'",
+            "delimiter": ",",
+            "query": "Resources\n| where id in~ ({DistinctTargetWorkspaces})\n| summarize Count = count() by location\n| order by Count desc\n| extend Row = row_number()\n| project value = location, label = location, selected = Row == 1",
+            "crossComponentResources": [
               "value::all"
             ],
             "typeSettings": {
@@ -318,16 +314,43 @@
             "resourceType": "microsoft.resourcegraph/resources"
           },
           {
-            "id": "feb5ccab-6fe6-4c5f-9161-ca0e412bd637",
+            "id": "2454837b-8bc8-4707-8245-0560c029b0ac",
+            "version": "KqlParameterItem/1.0",
+            "name": "Workspaces",
+            "type": 5,
+            "multiSelect": true,
+            "quote": "'",
+            "delimiter": ",",
+            "query": "Resources\n| where id in~ ({DistinctTargetWorkspaces}) and location in ({WorkspaceLocations})\n| project value = id, label = id, selected = true",
+            "crossComponentResources": [
+              "value::all"
+            ],
+            "typeSettings": {
+              "additionalResourceOptions": [],
+              "showDefault": false
+            },
+            "timeContextFromParameter": "TimeRange",
+            "queryType": 1,
+            "resourceType": "microsoft.resourcegraph/resources"
+          },
+          {
+            "id": "7b41836d-1da2-4f43-91fe-4edc728e87fa",
             "version": "KqlParameterItem/1.0",
             "name": "TimeRange",
-            "label": "Time range",
+            "label": "Time Range",
             "type": 4,
+            "isRequired": true,
             "value": {
               "durationMs": 86400000
             },
             "typeSettings": {
               "selectableValues": [
+                {
+                  "durationMs": 300000
+                },
+                {
+                  "durationMs": 900000
+                },
                 {
                   "durationMs": 1800000
                 },
@@ -357,36 +380,27 @@
                 },
                 {
                   "durationMs": 2592000000
+                },
+                {
+                  "durationMs": 5184000000
+                },
+                {
+                  "durationMs": 7776000000
                 }
               ],
               "allowCustom": true
             }
           },
           {
-            "id": "e36a2c69-a3c1-4b0c-b758-b37bc16b4669",
+            "id": "905e418c-ddf2-4d5f-9821-66e15381ceed",
             "version": "KqlParameterItem/1.0",
             "name": "Test",
+            "label": "Not Onboarded",
             "type": 1,
-            "query": "let perf = InsightsMetrics\r\n| where TimeGenerated {TimeRange}\r\n| take 1;\r\nlet servicemap = ServiceMapComputer_CL\r\n| where TimeGenerated {TimeRange}\r\n| take 1;\r\nperf\r\n| union servicemap",
+            "query": "{\"version\":\"1.0.0\",\"content\":\"\\\"{OnboardedVms}\\\"\",\"transformers\":null}",
             "crossComponentResources": [
               "{Workspaces}"
             ],
-            "isHiddenWhenLocked": true,
-            "timeContext": {
-              "durationMs": 0
-            },
-            "timeContextFromParameter": "TimeRange",
-            "queryType": 0,
-            "resourceType": "microsoft.operationalinsights/workspaces",
-            "label": "Not Onboarded"
-          },
-          {
-            "id": "ea980bb9-09d6-4966-bdd3-dc54b2246226",
-            "version": "KqlParameterItem/1.0",
-            "name": "resourcesValueSnippet",
-            "type": 1,
-            "description": "query snippet when user selects from Resources dropdown",
-            "query": "{\"version\":\"1.0.0\",\"content\":\"\\\"| where _ResourceId in ({Resources})\\\"\",\"transformers\":null}",
             "isHiddenWhenLocked": true,
             "timeContext": {
               "durationMs": 0
@@ -396,11 +410,11 @@
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
           {
-            "id": "ce1f0e30-7383-4dc2-826f-b9ea83e11851",
+            "id": "9711af09-11eb-4b4d-8de0-ea21677fae4d",
             "version": "KqlParameterItem/1.0",
-            "name": "resourcesValue",
+            "name": "virtualMachinesSnippet",
             "type": 1,
-            "query": "{\"version\":\"1.0.0\",\"content\":\"\\\"{Resources}\\\"\",\"transformers\":null}",
+            "query": "{\"version\":\"1.0.0\",\"content\":\"\\\"| where _ResourceId in ({VirtualMachines})\\\"\",\"transformers\":null}",
             "isHiddenWhenLocked": true,
             "timeContext": {
               "durationMs": 0
@@ -409,7 +423,20 @@
             "queryType": 8
           },
           {
-            "id": "6f523dd4-292d-468c-b058-a76f628347d6",
+            "id": "c94a9f39-9d0c-406e-92e2-2dc0a3c2ac9b",
+            "version": "KqlParameterItem/1.0",
+            "name": "virtualMachinesValue",
+            "type": 1,
+            "query": "{\"version\":\"1.0.0\",\"content\":\"\\\"{VirtualMachines}\\\"\",\"transformers\":null}",
+            "isHiddenWhenLocked": true,
+            "timeContext": {
+              "durationMs": 0
+            },
+            "timeContextFromParameter": "TimeRange",
+            "queryType": 8
+          },
+          {
+            "id": "80df5c1e-5eaf-4f4a-bf40-8c81aaebcc19",
             "version": "KqlParameterItem/1.0",
             "name": "vmSnippet",
             "type": 1,
@@ -417,23 +444,23 @@
             "isHiddenWhenLocked": true,
             "criteriaData": [
               {
-                "condition": "if (resourcesValue != ''all''), result = resourcesValueSnippet",
+                "condition": "if (virtualMachinesValue == '*'), result = virtualMachinesSnippet",
                 "criteriaContext": {
-                  "leftOperand": "resourcesValue",
-                  "operator": "!=",
+                  "leftOperand": "virtualMachinesValue",
+                  "operator": "==",
                   "rightValType": "static",
-                  "rightVal": "'all'",
+                  "rightVal": "*",
                   "resultValType": "param",
-                  "resultVal": "resourcesValueSnippet"
+                  "resultVal": "virtualMachinesSnippet"
                 }
               },
               {
-                "condition": "else result = '| where _ResourceId startswith \"{armPrefix}\"'",
+                "condition": "else result = '| where _ResourceId startswith \"{ArmPrefix}\"'",
                 "criteriaContext": {
                   "operator": "Default",
                   "rightValType": "param",
                   "resultValType": "static",
-                  "resultVal": "| where _ResourceId startswith \"{armPrefix}\""
+                  "resultVal": "| where _ResourceId startswith \"{ArmPrefix}\""
                 }
               }
             ],
@@ -444,8 +471,8 @@
           }
         ],
         "style": "above",
-        "queryType": 1,
-        "resourceType": "microsoft.resourcegraph/resources"
+        "queryType": 0,
+        "resourceType": "microsoft.operationalinsights/workspaces"
       },
       "name": "top-level parameters"
     },


### PR DESCRIPTION
Provide better user experience with top-level scope selectors by
auto-filtering subscriptions with VMs all the way to filtering relevant
locations and resource groups.

- Fix selecting default resource group
- Fix selecting resource group if passed in
- Update Test parameter
- Prevent malformed ARM URL

![image](https://user-images.githubusercontent.com/43890980/74990991-9f222a80-53f9-11ea-8131-5c4b8e0c117f.png)

![image](https://user-images.githubusercontent.com/43890980/74991021-b6611800-53f9-11ea-804b-fd3c74fbea4e.png)
