### PR TITLE
Show onboarding prompt when missing VMConnection

### DIFF
--- a/Workbooks/Virtual Machines - Network Dependencies/Security and Audit/Security and Audit.workbook
+++ b/Workbooks/Virtual Machines - Network Dependencies/Security and Audit/Security and Audit.workbook
@@ -242,6 +242,43 @@
             }
           },
           {
+            "id": "42d77513-54a6-435f-bc00-c9fa399992ca",
+            "version": "KqlParameterItem/1.0",
+            "name": "Test",
+            "type": 1,
+            "query": "VMConnection\r\n| take 1\r\n| summarize count()",
+            "crossComponentResources": [
+              "{Workspaces}"
+            ],
+            "value": null,
+            "isHiddenWhenLocked": true,
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces",
+            "label": "Not Onboarded"
+          }
+        ],
+        "style": "above",
+        "queryType": 0,
+        "resourceType": "microsoft.operationalinsights/workspaces"
+      },
+      "name": "parameters - 0"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "⚠ `VMConnection` was not detected in this workspace. Please onboard to [Azure Monitor for VMs (preview)](https://docs.microsoft.com/en-us/azure/azure-monitor/insights/vminsights-overview) or wait until the data has been populated."
+      },
+      "name": "text - 17"
+    },
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "crossComponentResources": [
+          "{Workspaces}"
+        ],
+        "parameters": [
+          {
             "id": "e1e4b971-e05b-4657-bb86-177000f363fe",
             "version": "KqlParameterItem/1.0",
             "name": "UniqueDestinationsCount",
@@ -250,6 +287,7 @@
             "crossComponentResources": [
               "{Workspaces}"
             ],
+            "value": null,
             "isHiddenWhenLocked": true,
             "queryType": 0,
             "resourceType": "microsoft.operationalinsights/workspaces"
@@ -265,7 +303,8 @@
             ],
             "isHiddenWhenLocked": true,
             "queryType": 0,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "resourceType": "microsoft.operationalinsights/workspaces",
+            "value": null
           },
           {
             "id": "a4752c1b-f8cc-4b46-bb1e-2d98ceb0703f",
@@ -291,7 +330,8 @@
             ],
             "isHiddenWhenLocked": true,
             "queryType": 0,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "resourceType": "microsoft.operationalinsights/workspaces",
+            "value": null
           },
           {
             "id": "15e4ef79-1abe-49df-8c0a-d719e2635038",
@@ -304,7 +344,8 @@
             ],
             "isHiddenWhenLocked": true,
             "queryType": 0,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "resourceType": "microsoft.operationalinsights/workspaces",
+            "value": null
           },
           {
             "id": "0248fd53-f129-41b4-918f-b5dc6bfa4cb1",
@@ -317,7 +358,8 @@
             ],
             "isHiddenWhenLocked": true,
             "queryType": 0,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "resourceType": "microsoft.operationalinsights/workspaces",
+            "value": null
           },
           {
             "id": "92eb52e0-055c-4263-b0e1-98c37e16e499",
@@ -337,12 +379,20 @@
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces"
       },
-      "name": "parameters - 0"
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isNotEqualTo"
+      },
+      "name": "parameters - 16"
     },
     {
       "type": 1,
       "content": {
         "json": "## Malicious Traffic\r\n💡 *Select either `MaliciousIp` or `Country` (or both) to filter traffic data in the tables below. Select `Overall` in both tables to revert back to the overall traffic view.*"
+      },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isNotEqualTo"
       },
       "name": "text - 1"
     },
@@ -360,6 +410,10 @@
           "{Workspaces}"
         ],
         "visualization": "barchart"
+      },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isNotEqualTo"
       },
       "customWidth": "33",
       "name": "query - 2"
@@ -398,6 +452,10 @@
           "rowLimit": 10000,
           "filter": true
         }
+      },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isNotEqualTo"
       },
       "customWidth": "34",
       "name": "query - 3"
@@ -453,6 +511,10 @@
           "rowLimit": 10000,
           "filter": true
         }
+      },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isNotEqualTo"
       },
       "customWidth": "33",
       "name": "query - 4"
@@ -548,12 +610,20 @@
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces"
       },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isNotEqualTo"
+      },
       "name": "parameters - 5"
     },
     {
       "type": 1,
       "content": {
         "json": "## Overall Traffic{MaliciousIpText}{CountryName}"
+      },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isNotEqualTo"
       },
       "name": "text - 6"
     },
@@ -570,12 +640,20 @@
         ],
         "visualization": "barchart"
       },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isNotEqualTo"
+      },
       "name": "query - 7"
     },
     {
       "type": 1,
       "content": {
         "json": "## Top VMs (Network Traffic){MaliciousIpText}{CountryName}"
+      },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isNotEqualTo"
       },
       "name": "text - 8"
     },
@@ -640,12 +718,20 @@
           ]
         }
       },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isNotEqualTo"
+      },
       "name": "query - 9"
     },
     {
       "type": 1,
       "content": {
         "json": "## Top Destinations (Remote IPs){MaliciousIpText}{CountryName}"
+      },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isNotEqualTo"
       },
       "name": "text - 10"
     },
@@ -724,12 +810,20 @@
           "filter": true
         }
       },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isNotEqualTo"
+      },
       "name": "query - 11"
     },
     {
       "type": 1,
       "content": {
         "json": "## Security Detection"
+      },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isNotEqualTo"
       },
       "name": "text - 12"
     },


### PR DESCRIPTION
Add a `Test` parameter to check for data in `VMConnection` table and show onboarding prompt.

Not onboarded
![image](https://user-images.githubusercontent.com/43890980/75200634-0ce09600-571b-11ea-85c1-8e8d33e35388.png)

Onboarded
![image](https://user-images.githubusercontent.com/43890980/75200660-1b2eb200-571b-11ea-8f8d-57d843b546db.png)
