### PR TITLE
Remove preview flag from Azure AD entitlement management access package activity workbook

### DIFF
--- a/Workbooks/Azure Active Directory/EntitlementManagementAccessPackageActivity/EntitlementManagementAccessPackageActivity.workbook
+++ b/Workbooks/Azure Active Directory/EntitlementManagementAccessPackageActivity/EntitlementManagementAccessPackageActivity.workbook
@@ -4,7 +4,7 @@
     {
       "type": 1,
       "content": {
-        "json": "## Entitlement management access package activity"
+        "json": "## Entitlement Management Access Package Activity"
       },
       "name": "text - 2"
     },

--- a/Workbooks/Azure Active Directory/EntitlementManagementAccessPackageActivity/settings.json
+++ b/Workbooks/Azure Active Directory/EntitlementManagementAccessPackageActivity/settings.json
@@ -1,7 +1,6 @@
 {
     "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/settings.json",
-    "name":"Entitlement management access package activity",
+    "name":"Access Package Activity",
     "author": "Microsoft",
-    "isPreview": true,
     "galleries": [{ "type": "workbook", "resourceType": "microsoft.aadiam/tenant", "order": 300 }]
 }


### PR DESCRIPTION
Remove the preview flag from this workbook, and shorten workbook title so that it fits into the gallery tile in English.  Update the capitalization in the workbook top heading to match that of other Azure AD workbooks.



