### PR TITLE
Fix dropdown grouping

### DIFF
--- a/Workbooks/Virtual Machines - Performance Analysis/Performance Analysis for a Single VM (Preview)/Performance Analysis for a Single VM.workbook
+++ b/Workbooks/Virtual Machines - Performance Analysis/Performance Analysis for a Single VM (Preview)/Performance Analysis for a Single VM.workbook
@@ -12,7 +12,6 @@
       "type": 9,
       "content": {
         "version": "KqlParameterItem/1.0",
-        "query": "",
         "crossComponentResources": [
           "{Computer}"
         ],
@@ -165,7 +164,6 @@
       "type": 9,
       "content": {
         "version": "KqlParameterItem/1.0",
-        "query": "",
         "crossComponentResources": [
           "{Computer}"
         ],
@@ -177,7 +175,7 @@
             "type": 2,
             "description": "Select a virtual machine performance counter to display in the chart below",
             "isRequired": true,
-            "query": "InsightsMetrics\r\n| where TimeGenerated {TimeRange}\r\n| summarize by Namespace, Name\r\n| order by Namespace asc, Name asc\r\n| project Counter = pack('counter', Name, 'object', Namespace), Name, group = Name",
+            "query": "InsightsMetrics\r\n| where TimeGenerated {TimeRange}\r\n| summarize by Namespace, Name\r\n| order by Namespace asc, Name asc\r\n| project Counter = pack('counter', Name, 'object', Namespace), Name, group = Namespace",
             "crossComponentResources": [
               "{Computer}"
             ],
@@ -239,7 +237,6 @@
         "query": "let metric = dynamic({Counter});\r\nInsightsMetrics\r\n| where TimeGenerated {TimeRange}\r\n| where Namespace == metric.object and Name == metric.counter\r\n| summarize {Aggregates} by bin(TimeGenerated, totimespan('{grain}'))",
         "size": 0,
         "aggregation": 3,
-        "exportToExcelOptions": "visible",
         "noDataMessage": "Current machine is not emitting data for this performance counter.",
         "queryType": 0,
         "resourceType": "microsoft.compute/virtualmachines",
@@ -277,7 +274,6 @@
       "type": 9,
       "content": {
         "version": "KqlParameterItem/1.0",
-        "query": "",
         "crossComponentResources": [
           "{Computer}"
         ],
@@ -316,7 +312,6 @@
       "type": 9,
       "content": {
         "version": "KqlParameterItem/1.0",
-        "query": "",
         "crossComponentResources": [
           "{Computer}"
         ],
@@ -359,7 +354,6 @@
         "size": 0,
         "aggregation": 3,
         "showAnnotations": true,
-        "exportToExcelOptions": "visible",
         "noDataMessage": "Current machine is not emitting data for this performance counter.",
         "queryType": 0,
         "resourceType": "microsoft.compute/virtualmachines",
@@ -379,7 +373,6 @@
         "size": 0,
         "aggregation": 3,
         "showAnnotations": true,
-        "exportToExcelOptions": "visible",
         "noDataMessage": "Current machine is not emitting data for this performance counter.",
         "queryType": 0,
         "resourceType": "microsoft.compute/virtualmachines",
@@ -411,7 +404,6 @@
       "type": 9,
       "content": {
         "version": "KqlParameterItem/1.0",
-        "query": "",
         "crossComponentResources": [
           "{Computer}"
         ],
@@ -450,7 +442,6 @@
       "type": 9,
       "content": {
         "version": "KqlParameterItem/1.0",
-        "query": "",
         "crossComponentResources": [
           "{Computer}"
         ],
@@ -493,7 +484,6 @@
         "size": 0,
         "aggregation": 3,
         "showAnnotations": true,
-        "exportToExcelOptions": "visible",
         "noDataMessage": "Current machine is not emitting data for this performance counter.",
         "queryType": 0,
         "resourceType": "microsoft.compute/virtualmachines",
@@ -513,7 +503,6 @@
         "size": 0,
         "aggregation": 3,
         "showAnnotations": true,
-        "exportToExcelOptions": "visible",
         "noDataMessage": "Current machine is not emitting data for this performance counter.",
         "queryType": 0,
         "resourceType": "microsoft.compute/virtualmachines",
@@ -545,7 +534,6 @@
       "type": 9,
       "content": {
         "version": "KqlParameterItem/1.0",
-        "query": "",
         "crossComponentResources": [
           "{Computer}"
         ],
@@ -561,7 +549,6 @@
       "type": 9,
       "content": {
         "version": "KqlParameterItem/1.0",
-        "query": "",
         "crossComponentResources": [
           "{Computer}"
         ],
@@ -604,7 +591,6 @@
         "size": 0,
         "aggregation": 2,
         "showAnnotations": true,
-        "exportToExcelOptions": "visible",
         "noDataMessage": "Current machine is not emitting data for this performance counter.",
         "queryType": 0,
         "resourceType": "microsoft.compute/virtualmachines",
@@ -624,7 +610,6 @@
         "size": 0,
         "aggregation": 3,
         "showAnnotations": true,
-        "exportToExcelOptions": "visible",
         "noDataMessage": "Current machine is not emitting data for this performance counter.",
         "queryType": 0,
         "resourceType": "microsoft.compute/virtualmachines",
@@ -656,7 +641,6 @@
       "type": 9,
       "content": {
         "version": "KqlParameterItem/1.0",
-        "query": "",
         "crossComponentResources": [
           "{Computer}"
         ],
@@ -695,7 +679,6 @@
       "type": 9,
       "content": {
         "version": "KqlParameterItem/1.0",
-        "query": "",
         "crossComponentResources": [
           "{Computer}"
         ],
@@ -715,7 +698,6 @@
         "size": 0,
         "aggregation": 3,
         "showAnnotations": true,
-        "exportToExcelOptions": "visible",
         "noDataMessage": "Current machine is not emitting data for this performance counter.",
         "queryType": 0,
         "resourceType": "microsoft.compute/virtualmachines",
@@ -728,7 +710,5 @@
       "name": "query - 28"
     }
   ],
-  "fallbackResourceIds": [],
-  "styleSettings": {},
   "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
 }


### PR DESCRIPTION
Minor fix to the Single VM Performance workbook template with grouping of the counter dropdowns.

![image](https://user-images.githubusercontent.com/43890980/75910028-02508b80-5e02-11ea-9757-699112fae10c.png)
