### PR TITLE
Add test parameters to VM Insights templates

### DIFF
--- a/Workbooks/Virtual Machines - Network Dependencies/Active Ports/Active Ports.workbook
+++ b/Workbooks/Virtual Machines - Network Dependencies/Active Ports/Active Ports.workbook
@@ -5,9 +5,8 @@
       "type": 9,
       "content": {
         "version": "KqlParameterItem/1.0",
-        "query": "",
         "crossComponentResources": [
-          "{Subscriptions}"
+          "{Workspaces}"
         ],
         "parameters": [
           {
@@ -238,30 +237,60 @@
               ],
               "allowCustom": true
             }
+          },
+          {
+            "id": "48e2b8b9-e618-480c-80e6-5cf1cee85ee9",
+            "version": "KqlParameterItem/1.0",
+            "name": "Test",
+            "label": "Not Onboarded",
+            "type": 1,
+            "query": "VMConnection\r\n| take 1\r\n| summarize count()",
+            "crossComponentResources": [
+              "{Workspaces}"
+            ],
+            "value": null,
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": "TimeRange",
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces"
           }
         ],
         "style": "pills",
-        "queryType": 1,
-        "resourceType": "microsoft.resourcegraph/resources"
+        "queryType": 0,
+        "resourceType": "microsoft.resources/subscriptions"
       },
-      "conditionalVisibility": null
+      "name": "parameters - 0"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "⚠ `VMConnection` table was either not detected or empty. Try the following:\r\n\r\n* Select a different time range\r\n* Try different scope selections\r\n* Onboard to Azure Monitor for VMs ([Azure Monitor for VMs GA FAQ](https://docs.microsoft.com/en-us/azure/azure-monitor/insights/vminsights-ga-release-faq))."
+      },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isNotEqualTo",
+        "value": "1"
+      },
+      "name": "text - 3"
     },
     {
       "type": 1,
       "content": {
         "json": "## Port activity by Computer, Process, IP and Port"
       },
-      "conditionalVisibility": null
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isEqualTo",
+        "value": "1"
+      },
+      "name": "text - 1"
     },
     {
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "// {DefaultWorkspace} {ContextSelection} {Subscriptions} {Workspaces} {TimeRange}\nVMBoundPort\n| where Ip != \"127.0.0.1\"\n| summarize BytesSent=sum(BytesSent), BytesReceived=sum(BytesReceived), LinksEstablished=sum(LinksEstablished), LinksTerminated=sum(LinksTerminated), arg_max(TimeGenerated, LinksLive) by Computer, ProcessName, Ip, Port, IsWildcardBind\n| project-away TimeGenerated\n| order by BytesSent desc",
-        "showQuery": false,
+        "query": "VMBoundPort\n| where Ip != \"127.0.0.1\"\n| summarize BytesSent=sum(BytesSent), BytesReceived=sum(BytesReceived), LinksEstablished=sum(LinksEstablished), LinksTerminated=sum(LinksTerminated), arg_max(TimeGenerated, LinksLive) by Computer, ProcessName, Ip, Port, IsWildcardBind\n| project-away TimeGenerated\n| order by BytesSent desc",
         "size": 2,
-        "aggregation": 0,
-        "showAnnotations": false,
         "showAnalytics": true,
         "timeContext": {
           "durationMs": 0
@@ -333,7 +362,12 @@
           "filter": true
         }
       },
-      "conditionalVisibility": null
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isEqualTo",
+        "value": "1"
+      },
+      "name": "query - 2"
     }
   ],
   "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"

--- a/Workbooks/Virtual Machines - Network Dependencies/Connections Overview/Connections Overview.workbook
+++ b/Workbooks/Virtual Machines - Network Dependencies/Connections Overview/Connections Overview.workbook
@@ -136,37 +136,26 @@
             ],
             "isHiddenWhenLocked": true,
             "queryType": 0,
-            "resourceType": "microsoft.operationalinsights/workspaces"
-          },
-          {
-            "id": "648ac90d-4be5-4c08-ac13-bcff7f8ddbf9",
-            "version": "KqlParameterItem/1.0",
-            "name": "DisclaimerText",
-            "type": 1,
-            "query": "print iff('{Test}' == '' , 'This workbook requires [Azure Monitor for VMs (preview)](https://docs.microsoft.com/en-us/azure/azure-monitor/insights/vminsights-overview) enabled', iff('{Test}' == '0', '⚠ There is currently no `VMConnection` data in this workspace', 'The following table presents the connection statistics for computers in your workspace (max `10,000` rows). Use the <em>Hierarchy</em> dropdown for more detailed information for each computer but fewer computers will be shown if the total number of rows rendered exceeds `10,000`.'))",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
-            "isHiddenWhenLocked": true,
-            "queryType": 0,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "resourceType": "microsoft.operationalinsights/workspaces",
+            "value": null,
+            "label": "Not Onboarded"
           }
         ],
         "style": "above",
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces"
       },
-      "conditionalVisibility": {
-        "parameterName": "_",
-        "comparison": "isNotEqualTo",
-        "value": null
-      },
       "name": "parameters - 0"
     },
     {
       "type": 1,
       "content": {
-        "json": "{DisclaimerText}\r\n\r\n---"
+        "json": "⚠ `VMConnection` table was either not detected or empty. Try the following:\r\n\r\n* Select a different time range\r\n* Try different scope selections\r\n* Onboard to Azure Monitor for VMs ([Azure Monitor for VMs GA FAQ](https://docs.microsoft.com/en-us/azure/azure-monitor/insights/vminsights-ga-release-faq))."
+      },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isNotEqualTo",
+        "value": "1"
       },
       "name": "text - 1"
     },
@@ -332,7 +321,8 @@
             },
             "timeContextFromParameter": "TimeRange",
             "queryType": 0,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "resourceType": "microsoft.operationalinsights/workspaces",
+            "value": null
           },
           {
             "id": "488d1f86-cabc-4fcc-8dc9-9a2e5803fb20",
@@ -346,7 +336,8 @@
             ],
             "isHiddenWhenLocked": true,
             "queryType": 0,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "resourceType": "microsoft.operationalinsights/workspaces",
+            "value": null
           },
           {
             "id": "56ab6626-c12d-4de1-8a3d-8a6099db3cd3",
@@ -386,6 +377,11 @@
         "style": "above",
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces"
+      },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isEqualTo",
+        "value": "1"
       },
       "name": "parameters - 2"
     },
@@ -636,12 +632,22 @@
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces"
       },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isEqualTo",
+        "value": "1"
+      },
       "name": "parameters - 3"
     },
     {
       "type": 1,
       "content": {
         "json": "💡 <em>Select a row from the table below to view connection details for that entry.</em>"
+      },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isEqualTo",
+        "value": "1"
       },
       "name": "text - 4"
     },
@@ -826,6 +832,11 @@
           }
         }
       },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isEqualTo",
+        "value": "1"
+      },
       "showPin": true,
       "name": "query - 5"
     },
@@ -934,6 +945,11 @@
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces"
       },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isEqualTo",
+        "value": "1"
+      },
       "name": "parameters - 6"
     },
     {
@@ -953,6 +969,18 @@
       "content": {
         "json": "### Responses"
       },
+      "conditionalVisibilities": [
+        {
+          "parameterName": "ShowDetail",
+          "comparison": "isEqualTo",
+          "value": "True"
+        },
+        {
+          "parameterName": "Test",
+          "comparison": "isEqualTo",
+          "value": "1"
+        }
+      ],
       "conditionalVisibility": {
         "parameterName": "ShowDetail",
         "comparison": "isEqualTo",
@@ -966,6 +994,18 @@
       "content": {
         "json": "### Latency"
       },
+      "conditionalVisibilities": [
+        {
+          "parameterName": "ShowDetail",
+          "comparison": "isEqualTo",
+          "value": "True"
+        },
+        {
+          "parameterName": "Test",
+          "comparison": "isEqualTo",
+          "value": "1"
+        }
+      ],
       "conditionalVisibility": {
         "parameterName": "ShowDetail",
         "comparison": "isEqualTo",
@@ -979,6 +1019,18 @@
       "content": {
         "json": "### Network"
       },
+      "conditionalVisibilities": [
+        {
+          "parameterName": "ShowDetail",
+          "comparison": "isEqualTo",
+          "value": "True"
+        },
+        {
+          "parameterName": "Test",
+          "comparison": "isEqualTo",
+          "value": "1"
+        }
+      ],
       "conditionalVisibility": {
         "parameterName": "ShowDetail",
         "comparison": "isEqualTo",
@@ -992,6 +1044,18 @@
       "content": {
         "json": "### Links"
       },
+      "conditionalVisibilities": [
+        {
+          "parameterName": "ShowDetail",
+          "comparison": "isEqualTo",
+          "value": "True"
+        },
+        {
+          "parameterName": "Test",
+          "comparison": "isEqualTo",
+          "value": "1"
+        }
+      ],
       "conditionalVisibility": {
         "parameterName": "ShowDetail",
         "comparison": "isEqualTo",
@@ -1013,6 +1077,18 @@
         ],
         "visualization": "areachart"
       },
+      "conditionalVisibilities": [
+        {
+          "parameterName": "ShowDetail",
+          "comparison": "isEqualTo",
+          "value": "True"
+        },
+        {
+          "parameterName": "Test",
+          "comparison": "isEqualTo",
+          "value": "1"
+        }
+      ],
       "conditionalVisibility": {
         "parameterName": "ShowDetail",
         "comparison": "isEqualTo",
@@ -1035,6 +1111,18 @@
         ],
         "visualization": "linechart"
       },
+      "conditionalVisibilities": [
+        {
+          "parameterName": "ShowDetail",
+          "comparison": "isEqualTo",
+          "value": "True"
+        },
+        {
+          "parameterName": "Test",
+          "comparison": "isEqualTo",
+          "value": "1"
+        }
+      ],
       "conditionalVisibility": {
         "parameterName": "ShowDetail",
         "comparison": "isEqualTo",
@@ -1056,6 +1144,18 @@
         ],
         "visualization": "areachart"
       },
+      "conditionalVisibilities": [
+        {
+          "parameterName": "ShowDetail",
+          "comparison": "isEqualTo",
+          "value": "True"
+        },
+        {
+          "parameterName": "Test",
+          "comparison": "isEqualTo",
+          "value": "1"
+        }
+      ],
       "conditionalVisibility": {
         "parameterName": "ShowDetail",
         "comparison": "isEqualTo",
@@ -1078,6 +1178,18 @@
         ],
         "visualization": "areachart"
       },
+      "conditionalVisibilities": [
+        {
+          "parameterName": "ShowDetail",
+          "comparison": "isEqualTo",
+          "value": "True"
+        },
+        {
+          "parameterName": "Test",
+          "comparison": "isEqualTo",
+          "value": "1"
+        }
+      ],
       "conditionalVisibility": {
         "parameterName": "ShowDetail",
         "comparison": "isEqualTo",

--- a/Workbooks/Virtual Machines - Network Dependencies/Failed Connections/Failed Connections.workbook
+++ b/Workbooks/Virtual Machines - Network Dependencies/Failed Connections/Failed Connections.workbook
@@ -5,6 +5,9 @@
       "type": 9,
       "content": {
         "version": "KqlParameterItem/1.0",
+        "crossComponentResources": [
+          "{Workspaces}"
+        ],
         "parameters": [
           {
             "id": "80a15801-7442-49f3-a82f-6e55849ec7fb",
@@ -234,6 +237,21 @@
               ],
               "allowCustom": true
             }
+          },
+          {
+            "id": "48e2b8b9-e618-480c-80e6-5cf1cee85ee9",
+            "version": "KqlParameterItem/1.0",
+            "name": "Test",
+            "label": "Not Onboarded",
+            "type": 1,
+            "query": "VMConnection\r\n| take 1\r\n| summarize count()",
+            "crossComponentResources": [
+              "{Workspaces}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": "TimeRange",
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces"
           }
         ],
         "style": "pills",
@@ -243,10 +261,22 @@
       "name": "parameters - 0"
     },
     {
+      "type": 1,
+      "content": {
+        "json": "⚠ `VMConnection` table was either not detected or empty. Try the following:\r\n\r\n* Select a different time range\r\n* Try different scope selections\r\n* Onboard to Azure Monitor for VMs ([Azure Monitor for VMs GA FAQ](https://docs.microsoft.com/en-us/azure/azure-monitor/insights/vminsights-ga-release-faq))."
+      },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isNotEqualTo",
+        "value": "1"
+      },
+      "name": "text - 3"
+    },
+    {
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let overallData = VMConnection\n| where TimeGenerated {TimeRange}\n| summarize Established = sum(LinksEstablished), Failed = sum(LinksFailed)\n| extend PercentFailed = (todouble(Failed)/todouble(Failed+Established))*100.0\n| extend Computer = '🔵 Overall', Type = '1';\nVMConnection\n| where TimeGenerated {TimeRange}\n| summarize Established = sum(LinksEstablished), Failed = sum(LinksFailed) by Computer\n| extend PercentFailed = (todouble(Failed)/todouble(Failed+Established))*100.0, Type = '2'\n| union overallData\n| order by Type asc, PercentFailed desc\n| project-away Type",
+        "query": "let overallData = VMConnection\n| summarize Established = sum(LinksEstablished), Failed = sum(LinksFailed)\n| extend PercentFailed = (todouble(Failed)/todouble(Failed+Established))*100.0\n| extend Computer = '🔵 Overall', Type = '1';\nVMConnection\n| summarize Established = sum(LinksEstablished), Failed = sum(LinksFailed) by Computer\n| extend PercentFailed = (todouble(Failed)/todouble(Failed+Established))*100.0, Type = '2'\n| union overallData\n| order by Type asc, PercentFailed desc\n| project-away Type",
         "size": 1,
         "timeContext": {
           "durationMs": 0
@@ -311,6 +341,11 @@
           ]
         }
       },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isEqualTo",
+        "value": "1"
+      },
       "name": "query - 1"
     },
     {
@@ -326,18 +361,41 @@
             "version": "KqlParameterItem/1.0",
             "name": "ComputerName",
             "type": 1,
-            "query": "print iff('{Computer}' == '🔵 Overall', '*', '{Computer}')",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
+            "value": "*",
             "isHiddenWhenLocked": true,
-            "queryType": 0,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "criteriaData": [
+              {
+                "condition": "if (Computer == '🔵 Overall'), result = '*'",
+                "criteriaContext": {
+                  "leftOperand": "Computer",
+                  "operator": "==",
+                  "rightValType": "static",
+                  "rightVal": "🔵 Overall",
+                  "resultValType": "static",
+                  "resultVal": "*"
+                }
+              },
+              {
+                "condition": "else result = Computer",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "param",
+                  "resultVal": "Computer"
+                }
+              }
+            ],
+            "timeContextFromParameter": "TimeRange"
           }
         ],
         "style": "pills",
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces"
+      },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isEqualTo",
+        "value": "1"
       },
       "name": "parameters - 2"
     },
@@ -345,7 +403,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "VMConnection\n| where TimeGenerated {TimeRange}\n| where Computer in (\"{ComputerName}\") or '*' in (\"{ComputerName}\") \n| summarize Established = sum(LinksEstablished), Failed = sum(LinksFailed) by bin(TimeGenerated, {TimeRange:grain})",
+        "query": "VMConnection\n| where Computer in (\"{ComputerName}\") or '*' in (\"{ComputerName}\") \n| summarize Established = sum(LinksEstablished), Failed = sum(LinksFailed) by bin(TimeGenerated, {TimeRange:grain})",
         "size": 0,
         "timeContext": {
           "durationMs": 0
@@ -358,6 +416,11 @@
         ],
         "visualization": "timechart"
       },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isEqualTo",
+        "value": "1"
+      },
       "customWidth": "50",
       "name": "query - 3"
     },
@@ -365,15 +428,21 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "VMConnection\r\n| where TimeGenerated {TimeRange}\r\n| where Computer in (\"{ComputerName}\") or '*' in (\"{ComputerName}\") \r\n| summarize Established = sum(LinksEstablished), Failed = sum(LinksFailed) by bin(TimeGenerated, {TimeRange:grain})\r\n| project TimeGenerated, PercentFailed = (todouble(Failed)/todouble(Failed+Established))*100",
+        "query": "VMConnection\r\n| where Computer in (\"{ComputerName}\") or '*' in (\"{ComputerName}\") \r\n| summarize Established = sum(LinksEstablished), Failed = sum(LinksFailed) by bin(TimeGenerated, {TimeRange:grain})\r\n| project TimeGenerated, PercentFailed = (todouble(Failed)/todouble(Failed+Established))*100",
         "size": 0,
         "aggregation": 3,
+        "timeContextFromParameter": "TimeRange",
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
         "crossComponentResources": [
           "{Workspaces}"
         ],
         "visualization": "timechart"
+      },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isEqualTo",
+        "value": "1"
       },
       "customWidth": "50",
       "name": "query - 4"

--- a/Workbooks/Virtual Machines - Network Dependencies/Open Ports/Open Ports.workbook
+++ b/Workbooks/Virtual Machines - Network Dependencies/Open Ports/Open Ports.workbook
@@ -6,7 +6,7 @@
       "content": {
         "version": "KqlParameterItem/1.0",
         "crossComponentResources": [
-          "value::all"
+          "{Workspaces}"
         ],
         "parameters": [
           {
@@ -237,18 +237,50 @@
               ],
               "allowCustom": true
             }
+          },
+          {
+            "id": "48e2b8b9-e618-480c-80e6-5cf1cee85ee9",
+            "version": "KqlParameterItem/1.0",
+            "name": "Test",
+            "label": "Not Onboarded",
+            "type": 1,
+            "query": "VMBoundPort\r\n| take 1\r\n| summarize count()",
+            "crossComponentResources": [
+              "{Workspaces}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": "TimeRange",
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces"
           }
         ],
         "style": "pills",
-        "queryType": 1,
-        "resourceType": "microsoft.resourcegraph/resources"
+        "queryType": 0,
+        "resourceType": "microsoft.operationalinsights/workspaces"
       },
       "name": "parameters - 0"
     },
     {
       "type": 1,
       "content": {
+        "json": "⚠ `VMBoundPort` table was either not detected or empty. Try the following:\r\n\r\n* Select a different time range\r\n* Try different scope selections\r\n* Onboard to Azure Monitor for VMs ([Azure Monitor for VMs GA FAQ](https://docs.microsoft.com/en-us/azure/azure-monitor/insights/vminsights-ga-release-faq))."
+      },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isNotEqualTo",
+        "value": "1"
+      },
+      "name": "text - 7"
+    },
+    {
+      "type": 1,
+      "content": {
         "json": "💡 <em>Select a row from the table below to view port details for that entry.</em>"
+      },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isEqualTo",
+        "value": "1"
       },
       "name": "text - 1"
     },
@@ -256,6 +288,11 @@
       "type": 1,
       "content": {
         "json": "<h2 style=\"font-weight:normal;\">List of Open Ports for all Computers in the Workspace</h2>"
+      },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isEqualTo",
+        "value": "1"
       },
       "customWidth": "50",
       "name": "text - 2"
@@ -265,6 +302,11 @@
       "content": {
         "json": "<h2 style=\"font-weight:normal;\">Ports in use by Processes on the Selected Computer</h2>"
       },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isEqualTo",
+        "value": "1"
+      },
       "customWidth": "50",
       "name": "text - 3"
     },
@@ -272,7 +314,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "// {DefaultWorkspace} {ContextSelection} {Subscriptions} {Workspaces} {TimeRange}\nVMBoundPort\n| where Ip != \"127.0.0.1\"\n| summarize by Computer, Port, Protocol\n| summarize OpenPorts=dcount(Port) by Computer\n| project Computer, [\"Number of Open Ports\"] = OpenPorts\n| order by [\"Number of Open Ports\"] desc",
+        "query": "VMBoundPort\n| where Ip != \"127.0.0.1\"\n| summarize by Computer, Port, Protocol\n| summarize OpenPorts=dcount(Port) by Computer\n| project Computer, [\"Number of Open Ports\"] = OpenPorts\n| order by [\"Number of Open Ports\"] desc",
         "size": 2,
         "timeContext": {
           "durationMs": 0
@@ -307,6 +349,11 @@
           "rowLimit": 10000,
           "filter": true
         }
+      },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isEqualTo",
+        "value": "1"
       },
       "customWidth": "50",
       "name": "query - 4"
@@ -349,7 +396,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "// {DefaultWorkspace} {ContextSelection} {Subscriptions} {Workspaces} {TimeRange}\nVMBoundPort\n| where Computer == '{ComputerName}'\n| summarize BytesSent=sum(BytesSent), BytesReceived=sum(BytesReceived), BytesTotal=sum(BytesSent + BytesReceived) by Port, ProcessName\n| project [\"Port Number\"] = Port, [\"Process Name\"] = ProcessName, [\"Bytes Sent\"] = BytesSent, [\"Bytes Received\"] = BytesReceived, [\"Bytes Total\"] = BytesTotal\n| order by [\"Bytes Total\"] desc",
+        "query": "VMBoundPort\n| where Computer == '{ComputerName}'\n| summarize BytesSent=sum(BytesSent), BytesReceived=sum(BytesReceived), BytesTotal=sum(BytesSent + BytesReceived) by Port, ProcessName\n| project [\"Port Number\"] = Port, [\"Process Name\"] = ProcessName, [\"Bytes Sent\"] = BytesSent, [\"Bytes Received\"] = BytesReceived, [\"Bytes Total\"] = BytesTotal\n| order by [\"Bytes Total\"] desc",
         "size": 2,
         "timeContext": {
           "durationMs": 0
@@ -419,6 +466,18 @@
           "filter": true
         }
       },
+      "conditionalVisibilities": [
+        {
+          "parameterName": "ShowDetail",
+          "comparison": "isEqualTo",
+          "value": "True"
+        },
+        {
+          "parameterName": "Test",
+          "comparison": "isEqualTo",
+          "value": "1"
+        }
+      ],
       "conditionalVisibility": {
         "parameterName": "ShowDetail",
         "comparison": "isEqualTo",
@@ -426,6 +485,19 @@
       },
       "customWidth": "50",
       "name": "query - 6"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "ℹ Select a computer from the table"
+      },
+      "conditionalVisibility": {
+        "parameterName": "ShowDetail",
+        "comparison": "isNotEqualTo",
+        "value": "True"
+      },
+      "customWidth": "50",
+      "name": "text - 8"
     }
   ],
   "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"

--- a/Workbooks/Virtual Machines - Network Dependencies/TCP Traffic/TCP Traffic.workbook
+++ b/Workbooks/Virtual Machines - Network Dependencies/TCP Traffic/TCP Traffic.workbook
@@ -5,6 +5,9 @@
       "type": 9,
       "content": {
         "version": "KqlParameterItem/1.0",
+        "crossComponentResources": [
+          "{Workspaces}"
+        ],
         "parameters": [
           {
             "id": "80a15801-7442-49f3-a82f-6e55849ec7fb",
@@ -234,6 +237,22 @@
               ],
               "allowCustom": true
             }
+          },
+          {
+            "id": "48e2b8b9-e618-480c-80e6-5cf1cee85ee9",
+            "version": "KqlParameterItem/1.0",
+            "name": "Test",
+            "label": "Not Onboarded",
+            "type": 1,
+            "query": "VMConnection\r\n| take 1\r\n| summarize count()",
+            "crossComponentResources": [
+              "{Workspaces}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": "TimeRange",
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces",
+            "value": null
           }
         ],
         "style": "pills",
@@ -243,11 +262,24 @@
       "name": "parameters - 0"
     },
     {
+      "type": 1,
+      "content": {
+        "json": "⚠ `VMConnection` table was either not detected or empty. Try the following:\r\n\r\n* Select a different time range\r\n* Try different scope selections\r\n* Onboard to Azure Monitor for VMs ([Azure Monitor for VMs GA FAQ](https://docs.microsoft.com/en-us/azure/azure-monitor/insights/vminsights-ga-release-faq))."
+      },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isNotEqualTo",
+        "value": "1"
+      },
+      "name": "text - 3"
+    },
+    {
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let overallData = VMConnection\n| where TimeGenerated {TimeRange}\n| summarize Sent = sum(BytesSent), Received = sum(BytesReceived)\n| extend Total = todouble(Sent)+todouble(Received)\n| extend Computer = '🔵 Overall', Type = '1';\nVMConnection\n| where TimeGenerated {TimeRange}\n| summarize Sent = sum(BytesSent), Received = sum(BytesReceived) by Computer\n| extend Total = todouble(Sent)+todouble(Received), Type = '2'\n| union overallData\n| order by Type asc, Total desc\n| project-away Type",
+        "query": "let overallData = VMConnection\n| summarize Sent = sum(BytesSent), Received = sum(BytesReceived)\n| extend Total = todouble(Sent)+todouble(Received)\n| extend Computer = '🔵 Overall', Type = '1';\nVMConnection\n| summarize Sent = sum(BytesSent), Received = sum(BytesReceived) by Computer\n| extend Total = todouble(Sent)+todouble(Received), Type = '2'\n| union overallData\n| order by Type asc, Total desc\n| project-away Type",
         "size": 1,
+        "timeContextFromParameter": "TimeRange",
         "exportFieldName": "Computer",
         "exportParameterName": "Computer",
         "exportDefaultValue": "🔵 Overall",
@@ -306,6 +338,11 @@
           ]
         }
       },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isEqualTo",
+        "value": "1"
+      },
       "name": "query - 1"
     },
     {
@@ -321,21 +358,43 @@
             "version": "KqlParameterItem/1.0",
             "name": "ComputerName",
             "type": 1,
-            "query": "print iff('{Computer}' == '🔵 Overall', '*', '{Computer}')",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
+            "value": null,
             "isHiddenWhenLocked": true,
+            "criteriaData": [
+              {
+                "condition": "if (Computer == '🔵 Overall'), result = '*'",
+                "criteriaContext": {
+                  "leftOperand": "Computer",
+                  "operator": "==",
+                  "rightValType": "static",
+                  "rightVal": "🔵 Overall",
+                  "resultValType": "static",
+                  "resultVal": "*"
+                }
+              },
+              {
+                "condition": "else result = Computer",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "param",
+                  "resultVal": "Computer"
+                }
+              }
+            ],
             "timeContext": {
               "durationMs": 86400000
-            },
-            "queryType": 0,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            }
           }
         ],
         "style": "pills",
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces"
+      },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isEqualTo",
+        "value": "1"
       },
       "name": "parameters - 2"
     },
@@ -343,14 +402,20 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "VMConnection\n| where TimeGenerated {TimeRange}\n| where Computer in (\"{ComputerName}\") or '*' in (\"{ComputerName}\") \n| summarize Sent = sum(BytesSent), Received = sum(BytesReceived) by bin(TimeGenerated, {TimeRange:grain})",
+        "query": "VMConnection\n| where Computer in (\"{ComputerName}\") or '*' in (\"{ComputerName}\") \n| summarize Sent = sum(BytesSent), Received = sum(BytesReceived) by bin(TimeGenerated, {TimeRange:grain})",
         "size": 0,
+        "timeContextFromParameter": "TimeRange",
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
         "crossComponentResources": [
           "{Workspaces}"
         ],
         "visualization": "linechart"
+      },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isEqualTo",
+        "value": "1"
       },
       "name": "query - 3"
     }

--- a/Workbooks/Virtual Machines - Network Dependencies/Traffic Comparison/Traffic Comparison.workbook
+++ b/Workbooks/Virtual Machines - Network Dependencies/Traffic Comparison/Traffic Comparison.workbook
@@ -234,18 +234,41 @@
               ],
               "allowCustom": true
             }
+          },
+          {
+            "id": "48e2b8b9-e618-480c-80e6-5cf1cee85ee9",
+            "version": "KqlParameterItem/1.0",
+            "name": "Test",
+            "label": "Not Onboarded",
+            "type": 1,
+            "query": "VMConnection\r\n| take 1\r\n| summarize count()",
+            "crossComponentResources": [
+              "{Workspaces}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": "TimeRange",
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces",
+            "value": null
           }
         ],
-        "style": "above",
+        "style": "pills",
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces"
       },
-      "conditionalVisibility": {
-        "parameterName": "_",
-        "comparison": "isNotEqualTo",
-        "value": null
-      },
       "name": "parameters - 0"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "⚠ `VMConnection` table was either not detected or empty. Try the following:\r\n\r\n* Select a different time range\r\n* Try different scope selections\r\n* Onboard to Azure Monitor for VMs ([Azure Monitor for VMs GA FAQ](https://docs.microsoft.com/en-us/azure/azure-monitor/insights/vminsights-ga-release-faq))."
+      },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isNotEqualTo",
+        "value": "1"
+      },
+      "name": "text - 3"
     },
     {
       "type": 9,
@@ -261,7 +284,7 @@
             "name": "Computer",
             "type": 2,
             "isRequired": true,
-            "query": "// {Workspaces}\r\nVMConnection\r\n| distinct Computer",
+            "query": "VMConnection\r\n| distinct Computer",
             "crossComponentResources": [
               "{Workspaces}"
             ],
@@ -283,12 +306,22 @@
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces"
       },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isEqualTo",
+        "value": "1"
+      },
       "name": "parameters - 1"
     },
     {
       "type": 1,
       "content": {
         "json": "Compare traffic between two times periods for machine <span title=\"{Computer:value}\">`{Computer}`</span> in workspace <span title=\"{Workspace:value}\">`{Workspace:label}`</span>\r\n\r\n---"
+      },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isEqualTo",
+        "value": "1"
       },
       "name": "text - 2"
     },
@@ -375,6 +408,11 @@
         "style": "above",
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces"
+      },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isEqualTo",
+        "value": "1"
       },
       "customWidth": "50",
       "name": "parameters - 3"
@@ -463,6 +501,11 @@
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces"
       },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isEqualTo",
+        "value": "1"
+      },
       "customWidth": "50",
       "name": "parameters - 4"
     },
@@ -470,7 +513,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "//{Computer} {StartDateA}\r\nlet Computer = \"{Computer}\";\r\nlet TimeRange = time(\"{TimeRangeA}\");\r\nlet BinSize = time(\"{TimeGrainA}\");\r\nlet StartTime = datetime(\"{StartDateA}\");\r\nlet EndTime = StartTime + TimeRange;\r\nVMConnection​\r\n| where Computer == Computer\r\n| where TimeGenerated between( StartTime .. EndTime )\r\n| summarize BytesSent = sum(BytesSent), ByteReceived = sum(BytesReceived) by bin(TimeGenerated, BinSize)​\r\n| render timechart",
+        "query": "let Computer = \"{Computer}\";\r\nlet TimeRange = time(\"{TimeRangeA}\");\r\nlet BinSize = time(\"{TimeGrainA}\");\r\nlet StartTime = datetime(\"{StartDateA}\");\r\nlet EndTime = StartTime + TimeRange;\r\nVMConnection​\r\n| where Computer == Computer\r\n| where TimeGenerated between( StartTime .. EndTime )\r\n| summarize BytesSent = sum(BytesSent), ByteReceived = sum(BytesReceived) by bin(TimeGenerated, BinSize)​\r\n| render timechart",
         "size": 0,
         "showAnalytics": true,
         "queryType": 0,
@@ -478,6 +521,11 @@
         "crossComponentResources": [
           "{Workspaces}"
         ]
+      },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isEqualTo",
+        "value": "1"
       },
       "customWidth": "50",
       "name": "query - 5"
@@ -486,7 +534,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "// {Computer} {StartDateB}\r\nlet Computer = \"{Computer}\";\r\nlet TimeRange = time(\"{TimeRangeB}\");\r\nlet BinSize = time(\"{TimeGrainB}\");\r\nlet StartTime = datetime(\"{StartDateB}\");\r\nlet EndTime = StartTime + TimeRange;\r\nVMConnection​\r\n| where Computer == Computer\r\n| where TimeGenerated between( StartTime .. EndTime )\r\n| summarize BytesSent = sum(BytesSent), ByteReceived = sum(BytesReceived) by bin(TimeGenerated, BinSize)​\r\n| render timechart",
+        "query": "let Computer = \"{Computer}\";\r\nlet TimeRange = time(\"{TimeRangeB}\");\r\nlet BinSize = time(\"{TimeGrainB}\");\r\nlet StartTime = datetime(\"{StartDateB}\");\r\nlet EndTime = StartTime + TimeRange;\r\nVMConnection​\r\n| where Computer == Computer\r\n| where TimeGenerated between( StartTime .. EndTime )\r\n| summarize BytesSent = sum(BytesSent), ByteReceived = sum(BytesReceived) by bin(TimeGenerated, BinSize)​\r\n| render timechart",
         "size": 0,
         "showAnalytics": true,
         "queryType": 0,
@@ -495,6 +543,11 @@
           "{Workspaces}"
         ]
       },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isEqualTo",
+        "value": "1"
+      },
       "customWidth": "50",
       "name": "query - 6"
     },
@@ -502,7 +555,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "// {Computer} {StartDateA}\r\nlet Computer = \"{Computer}\";\r\nlet TimeRange = time(\"{TimeRangeA}\");\r\nlet BinSize = time(\"{TimeGrainA}\");\r\nlet StartTime = datetime(\"{StartDateA}\");\r\nlet EndTime = StartTime + TimeRange;\r\nVMConnection​\r\n| where Computer == Computer\r\n| where TimeGenerated between( StartTime .. EndTime )\r\n| summarize BytesSent = sum(BytesSent), BytesReceived = sum(BytesReceived) by ProcessName\r\n| order by BytesSent desc",
+        "query": "let Computer = \"{Computer}\";\r\nlet TimeRange = time(\"{TimeRangeA}\");\r\nlet BinSize = time(\"{TimeGrainA}\");\r\nlet StartTime = datetime(\"{StartDateA}\");\r\nlet EndTime = StartTime + TimeRange;\r\nVMConnection​\r\n| where Computer == Computer\r\n| where TimeGenerated between( StartTime .. EndTime )\r\n| summarize BytesSent = sum(BytesSent), BytesReceived = sum(BytesReceived) by ProcessName\r\n| order by BytesSent desc",
         "size": 0,
         "showAnalytics": true,
         "exportParameterName": "ProcessA",
@@ -542,8 +595,14 @@
                 }
               }
             }
-          ]
+          ],
+          "rowLimit": 10000
         }
+      },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isEqualTo",
+        "value": "1"
       },
       "customWidth": "50",
       "name": "query - 7"
@@ -552,7 +611,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "// {Computer} {StartDateB}\r\nlet Computer = \"{Computer}\";\r\nlet TimeRange = time(\"{TimeRangeB}\");\r\nlet BinSize = time(\"{TimeGrainB}\");\r\nlet StartTime = datetime(\"{StartDateB}\");\r\nlet EndTime = StartTime + TimeRange;\r\nVMConnection​\r\n| where Computer == Computer\r\n| where TimeGenerated between( StartTime .. EndTime )\r\n| summarize BytesSent = sum(BytesSent), BytesReceived = sum(BytesReceived) by ProcessName\r\n| order by BytesSent desc",
+        "query": "let Computer = \"{Computer}\";\r\nlet TimeRange = time(\"{TimeRangeB}\");\r\nlet BinSize = time(\"{TimeGrainB}\");\r\nlet StartTime = datetime(\"{StartDateB}\");\r\nlet EndTime = StartTime + TimeRange;\r\nVMConnection​\r\n| where Computer == Computer\r\n| where TimeGenerated between( StartTime .. EndTime )\r\n| summarize BytesSent = sum(BytesSent), BytesReceived = sum(BytesReceived) by ProcessName\r\n| order by BytesSent desc",
         "size": 0,
         "showAnalytics": true,
         "exportParameterName": "ProcessB",
@@ -591,8 +650,14 @@
                 }
               }
             }
-          ]
+          ],
+          "rowLimit": 10000
         }
+      },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isEqualTo",
+        "value": "1"
       },
       "customWidth": "50",
       "name": "query - 8"

--- a/Workbooks/Virtual Machines - Performance Analysis/Performance Counters/Performance Counters.workbook
+++ b/Workbooks/Virtual Machines - Performance Analysis/Performance Counters/Performance Counters.workbook
@@ -60,7 +60,6 @@
             "version": "KqlParameterItem/1.0",
             "name": "HybridMode",
             "type": 1,
-            "value": "false",
             "isHiddenWhenLocked": true,
             "criteriaData": [
               {
@@ -309,8 +308,7 @@
               "additionalResourceOptions": []
             },
             "queryType": 0,
-            "resourceType": "microsoft.operationalinsights/workspaces",
-            "value": null
+            "resourceType": "microsoft.operationalinsights/workspaces"
           },
           {
             "id": "28d4b81f-7dab-4e3b-abe4-a1f82e9d5561",
@@ -339,7 +337,7 @@
             "name": "Mode",
             "type": 2,
             "isRequired": true,
-            "value": "0",
+            "value": "1",
             "typeSettings": {
               "additionalResourceOptions": []
             },
@@ -358,8 +356,7 @@
             "isHiddenWhenLocked": true,
             "timeContextFromParameter": "TimeRange",
             "queryType": 0,
-            "resourceType": "microsoft.operationalinsights/workspaces",
-            "value": null
+            "resourceType": "microsoft.operationalinsights/workspaces"
           }
         ],
         "style": "above",
@@ -405,7 +402,7 @@
             "crossComponentResources": [
               "{Workspaces}"
             ],
-            "value": null,
+            "value": "{\"counter\":\"UtilizationPercentage\",\"object\":\"Processor\"}",
             "typeSettings": {
               "additionalResourceOptions": []
             },
@@ -517,7 +514,7 @@
             "crossComponentResources": [
               "{Workspaces}"
             ],
-            "value": null,
+            "value": "{\"counter\":\"AvailableMB\",\"object\":\"Memory\"}",
             "typeSettings": {
               "additionalResourceOptions": []
             },
@@ -630,7 +627,7 @@
             "crossComponentResources": [
               "{Workspaces}"
             ],
-            "value": null,
+            "value": "{\"counter\":\"WriteBytesPerSecond\",\"object\":\"Network\"}",
             "typeSettings": {
               "additionalResourceOptions": [
                 "value::1"
@@ -741,7 +738,7 @@
             "crossComponentResources": [
               "{Workspaces}"
             ],
-            "value": null,
+            "value": "{\"counter\":\"ReadBytesPerSecond\",\"object\":\"Network\"}",
             "typeSettings": {
               "additionalResourceOptions": []
             },
@@ -1078,7 +1075,7 @@
             "crossComponentResources": [
               "{Workspaces}"
             ],
-            "value": null,
+            "value": "{\"counter\":\"FreeSpacePercentage\",\"object\":\"LogicalDisk\"}",
             "typeSettings": {
               "additionalResourceOptions": [
                 "value::1"
@@ -1189,7 +1186,7 @@
             "crossComponentResources": [
               "{Workspaces}"
             ],
-            "value": null,
+            "value": "{\"counter\":\"ReadsPerSecond\",\"object\":\"LogicalDisk\"}",
             "typeSettings": {
               "additionalResourceOptions": [
                 "value::1"
@@ -1300,7 +1297,7 @@
             "crossComponentResources": [
               "{Workspaces}"
             ],
-            "value": null,
+            "value": "{\"counter\":\"WritesPerSecond\",\"object\":\"LogicalDisk\"}",
             "typeSettings": {
               "additionalResourceOptions": [
                 "value::1"
@@ -1411,7 +1408,7 @@
             "crossComponentResources": [
               "{Workspaces}"
             ],
-            "value": null,
+            "value": "{\"counter\":\"TransfersPerSecond\",\"object\":\"LogicalDisk\"}",
             "typeSettings": {
               "additionalResourceOptions": [
                 "value::1"

--- a/Workbooks/Virtual Machines - Performance Analysis/Performance Counters/Performance Counters.workbook
+++ b/Workbooks/Virtual Machines - Performance Analysis/Performance Counters/Performance Counters.workbook
@@ -248,7 +248,8 @@
             "typeSettings": {
               "additionalResourceOptions": []
             },
-            "jsonData": "[\r\n    {\r\n        \"label\": \"1 minute\",\r\n        \"value\": \"1m\"\r\n    },\r\n    {\r\n        \"label\": \"5 minutes\",\r\n        \"value\": \"5m\"\r\n    },\r\n    {\r\n        \"label\": \"15 minutes\",\r\n        \"value\": \"15m\"\r\n    },\r\n    {\r\n        \"label\": \"30 minutes\",\r\n        \"value\": \"30m\"\r\n    },\r\n    {\r\n        \"label\": \"1 hour\",\r\n        \"value\": \"1h\"\r\n    }\r\n]"
+            "jsonData": "[\r\n    {\r\n        \"label\": \"1 minute\",\r\n        \"value\": \"1m\"\r\n    },\r\n    {\r\n        \"label\": \"5 minutes\",\r\n        \"value\": \"5m\"\r\n    },\r\n    {\r\n        \"label\": \"15 minutes\",\r\n        \"value\": \"15m\"\r\n    },\r\n    {\r\n        \"label\": \"30 minutes\",\r\n        \"value\": \"30m\"\r\n    },\r\n    {\r\n        \"label\": \"1 hour\",\r\n        \"value\": \"1h\"\r\n    }\r\n]",
+            "label": "Time Grain"
           },
           {
             "id": "112823d7-bf58-4604-a299-78ccc5899516",
@@ -275,7 +276,8 @@
             "version": "KqlParameterItem/1.0",
             "name": "ComputerNameContains",
             "type": 1,
-            "value": ""
+            "value": "",
+            "label": "Computer Name Contains"
           },
           {
             "id": "8e436ee8-ba56-4fe5-8a2b-46f77ad405ee",
@@ -299,14 +301,16 @@
             "multiSelect": true,
             "quote": "'",
             "delimiter": ",",
-            "query": "Perf\r\n| where TimeGenerated {TimeRange}\r\n{CustomComputerQuery}\r\n| summarize by Computer\r\n| project Value = Computer, Display = Computer, isSelected = false\r\n| order by Display asc\r\n| union (datatable(Value:string, Display:string, isSelected:boolean)['*', 'All',true])",
+            "query": "InsightsMetrics\r\n| where TimeGenerated {TimeRange}\r\n{CustomComputerQuery}\r\n| summarize by Computer\r\n| project Value = Computer, Display = Computer, isSelected = false\r\n| order by Display asc\r\n| union (datatable(Value:string, Display:string, isSelected:boolean)['*', 'All',true])",
             "crossComponentResources": [
               "{Workspaces}"
             ],
             "typeSettings": {
               "additionalResourceOptions": []
             },
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces",
+            "value": null
           },
           {
             "id": "28d4b81f-7dab-4e3b-abe4-a1f82e9d5561",
@@ -324,13 +328,10 @@
             "id": "9c56155c-9a7e-41db-ac56-40cabb7d7ddf",
             "version": "KqlParameterItem/1.0",
             "name": "TopN",
+            "label": "Top N",
             "type": 1,
             "isRequired": true,
-            "query": "print 5",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "value": "5"
           },
           {
             "id": "4261aa48-5274-47a9-8642-1618c8aa7a95",
@@ -338,11 +339,27 @@
             "name": "Mode",
             "type": 2,
             "isRequired": true,
-            "value": "1",
+            "value": "0",
             "typeSettings": {
               "additionalResourceOptions": []
             },
             "jsonData": "[\r\n    {\r\n        \"label\": \"Locked\",\r\n        \"value\": \"1\"\r\n    },\r\n    {\r\n        \"label\": \"Unlocked\",\r\n        \"value\": \"0\"\r\n    }\r\n]"
+          },
+          {
+            "id": "48e2b8b9-e618-480c-80e6-5cf1cee85ee9",
+            "version": "KqlParameterItem/1.0",
+            "name": "Test",
+            "label": "Not Onboarded",
+            "type": 1,
+            "query": "VMConnection\r\n| take 1\r\n| summarize count()",
+            "crossComponentResources": [
+              "{Workspaces}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": "TimeRange",
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces",
+            "value": null
           }
         ],
         "style": "above",
@@ -359,6 +376,18 @@
       "name": "text - 1"
     },
     {
+      "type": 1,
+      "content": {
+        "json": "⚠ No performance counters were detected in the selected workspace for the specified time period (`{TimeRange:label}`). Either try a broader time range, select a different workspace, or onboard virtual machines to the selected workspace `{Workspaces:label}`.\r\n\r\nIf you choose to onboard virtual machines to workspace `{Workspaces:label}`, follow the instruction in the following link: [Azure Monitor for VMs (preview)](https://docs.microsoft.com/en-us/azure/azure-monitor/insights/vminsights-overview)."
+      },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isNotEqualTo",
+        "value": "1"
+      },
+      "name": "text - 38"
+    },
+    {
       "type": 9,
       "content": {
         "version": "KqlParameterItem/1.0",
@@ -369,39 +398,44 @@
           {
             "id": "aa2368fc-ad30-4608-b96a-72abf7b1e1af",
             "version": "KqlParameterItem/1.0",
-            "name": "Counter",
+            "name": "Counter1",
             "type": 2,
             "isRequired": true,
-            "query": "// {Workspaces}\r\nPerf\r\n| where TimeGenerated {TimeRange}\r\n| summarize by CounterName, ObjectName, CounterText = CounterName\r\n| order by ObjectName asc, CounterText asc\r\n| project Counter = pack('counter', CounterName, 'object', ObjectName), CounterText, group = ObjectName",
+            "query": "InsightsMetrics\r\n| where TimeGenerated {TimeRange}\r\n| summarize by Name, Namespace, CounterText = Name\r\n| order by Namespace asc, CounterText asc\r\n| project Counter = pack('counter', Name, 'object', Namespace), CounterText, group = Namespace",
             "crossComponentResources": [
               "{Workspaces}"
             ],
+            "value": null,
             "typeSettings": {
               "additionalResourceOptions": []
             },
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces",
+            "label": "Counter"
           },
           {
             "id": "6a7306ea-247f-46ca-abca-501911f9e9d3",
             "version": "KqlParameterItem/1.0",
-            "name": "TrendAggregator",
+            "name": "TrendAggregator1",
+            "label": "Trend Aggregator",
             "type": 2,
             "isRequired": true,
             "typeSettings": {
               "additionalResourceOptions": []
             },
-            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\", \"selected\":false},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\", \"selected\":false},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P80th = round(percentile(CounterValue, 80), 2)\", \"label\":\"P80th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\", \"selected\":true}    \r\n]"
+            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(Val), 2)\", \"label\":\"Average\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(Val, 5), 2)\", \"label\":\"P5th\", \"selected\":false},\r\n    { \"value\":\"P10th = round(percentile(Val, 10), 2)\", \"label\":\"P10th\", \"selected\":false},\r\n    { \"value\":\"P50th = round(percentile(Val, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P80th = round(percentile(Val, 80), 2)\", \"label\":\"P80th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(Val, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(Val, 95), 2)\", \"label\":\"P95th\", \"selected\":true}    \r\n]"
           },
           {
             "id": "0327f26e-cdde-4b48-b512-6c35f06ad1d0",
             "version": "KqlParameterItem/1.0",
             "name": "TrendAggregatorOrder1",
             "type": 1,
-            "query": "print(iff('{TrendAggregator:label}' == 'P5th'  or '{TrendAggregator:label}' == 'P10th', 'asc', 'desc'))",
+            "query": "print(iff('{TrendAggregator1:label}' == 'P5th'  or '{TrendAggregator1:label}' == 'P10th', 'asc', 'desc'))",
             "crossComponentResources": [
               "{Workspaces}"
             ],
             "isHiddenWhenLocked": true,
+            "queryType": 0,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
           {
@@ -433,55 +467,6 @@
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
           {
-            "id": "2c9b88ba-fba2-41cf-b10d-8369f2b00377",
-            "version": "KqlParameterItem/1.0",
-            "name": "Counter1",
-            "type": 1,
-            "query": "print '{Counter}'",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
-            "isHiddenWhenLocked": true,
-            "resourceType": "microsoft.operationalinsights/workspaces"
-          },
-          {
-            "id": "028cfd79-33d7-4d82-be4d-348d17488ca1",
-            "version": "KqlParameterItem/1.0",
-            "name": "CounterLabel1",
-            "type": 1,
-            "query": "print '{Counter:label}'",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
-            "isHiddenWhenLocked": true,
-            "resourceType": "microsoft.operationalinsights/workspaces",
-            "value": null
-          },
-          {
-            "id": "41eb7c98-b679-42b9-8454-432a4b8fff48",
-            "version": "KqlParameterItem/1.0",
-            "name": "TrendAggregatorValue1",
-            "type": 1,
-            "query": "print '{TrendAggregator}'",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
-            "isHiddenWhenLocked": true,
-            "resourceType": "microsoft.operationalinsights/workspaces"
-          },
-          {
-            "id": "5c8cbc8c-1776-42fd-9291-2fc4f0e0558b",
-            "version": "KqlParameterItem/1.0",
-            "name": "TrendAggregatorLabel1",
-            "type": 1,
-            "query": "print '{TrendAggregator:label}'",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
-            "isHiddenWhenLocked": true,
-            "resourceType": "microsoft.operationalinsights/workspaces"
-          },
-          {
             "id": "26106dfe-4e33-4c7c-b4b6-2eff5cc76476",
             "version": "KqlParameterItem/1.0",
             "name": "Unit",
@@ -497,6 +482,18 @@
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces"
       },
+      "conditionalVisibilities": [
+        {
+          "parameterName": "Mode",
+          "comparison": "isEqualTo",
+          "value": "0"
+        },
+        {
+          "parameterName": "Test",
+          "comparison": "isEqualTo",
+          "value": "1"
+        }
+      ],
       "conditionalVisibility": {
         "parameterName": "Mode",
         "comparison": "isEqualTo",
@@ -516,13 +513,15 @@
             "name": "Counter2",
             "type": 2,
             "isRequired": true,
-            "query": "// {Workspaces}\r\nPerf\r\n| where TimeGenerated {TimeRange}\r\n| summarize by CounterName, ObjectName, CounterText = CounterName\r\n| order by ObjectName asc, CounterText asc\r\n| project Counter = pack('counter', CounterName, 'object', ObjectName), CounterText, group = ObjectName",
+            "query": "InsightsMetrics\r\n| where TimeGenerated {TimeRange}\r\n| summarize by Name, Namespace, CounterText = Name\r\n| order by Namespace asc, CounterText asc\r\n| project Counter = pack('counter', Name, 'object', Namespace), CounterText, group = Namespace",
             "crossComponentResources": [
               "{Workspaces}"
             ],
+            "value": null,
             "typeSettings": {
               "additionalResourceOptions": []
             },
+            "queryType": 0,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
           {
@@ -531,7 +530,11 @@
             "name": "TrendAggregator2",
             "type": 2,
             "isRequired": true,
-            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\", \"selected\":false},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\", \"selected\":false},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P80th = round(percentile(CounterValue, 80), 2)\", \"label\":\"P80th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\", \"selected\":true}    \r\n]"
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(Val), 2)\", \"label\":\"Average\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(Val, 5), 2)\", \"label\":\"P5th\", \"selected\":false},\r\n    { \"value\":\"P10th = round(percentile(Val, 10), 2)\", \"label\":\"P10th\", \"selected\":false},\r\n    { \"value\":\"P50th = round(percentile(Val, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P80th = round(percentile(Val, 80), 2)\", \"label\":\"P80th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(Val, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(Val, 95), 2)\", \"label\":\"P95th\", \"selected\":true}    \r\n]",
+            "value": "P5th = round(percentile(Val, 5), 2)"
           },
           {
             "id": "0327f26e-cdde-4b48-b512-6c35f06ad1d0",
@@ -589,6 +592,18 @@
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces"
       },
+      "conditionalVisibilities": [
+        {
+          "parameterName": "Mode",
+          "comparison": "isEqualTo",
+          "value": "0"
+        },
+        {
+          "parameterName": "Test",
+          "comparison": "isEqualTo",
+          "value": "1"
+        }
+      ],
       "conditionalVisibility": {
         "parameterName": "Mode",
         "comparison": "isEqualTo",
@@ -601,6 +616,9 @@
       "type": 9,
       "content": {
         "version": "KqlParameterItem/1.0",
+        "crossComponentResources": [
+          "{Workspaces}"
+        ],
         "parameters": [
           {
             "id": "aa2368fc-ad30-4608-b96a-72abf7b1e1af",
@@ -608,17 +626,18 @@
             "name": "Counter3",
             "type": 2,
             "isRequired": true,
-            "query": "// {Workspaces}\r\nPerf\r\n| where TimeGenerated {TimeRange}\r\n| summarize by CounterName, ObjectName, CounterText = CounterName\r\n| order by ObjectName asc, CounterText asc\r\n| project Counter = pack('counter', CounterName, 'object', ObjectName), CounterText, group = ObjectName",
+            "query": "InsightsMetrics\r\n| where TimeGenerated {TimeRange}\r\n| summarize by Name, Namespace, CounterText = Name\r\n| order by Namespace asc, CounterText asc\r\n| project Counter = pack('counter', Name, 'object', Namespace), CounterText, group = Namespace",
             "crossComponentResources": [
               "{Workspaces}"
             ],
+            "value": null,
             "typeSettings": {
               "additionalResourceOptions": [
                 "value::1"
               ]
             },
-            "resourceType": "microsoft.operationalinsights/workspaces",
-            "value": "{\"counter\":\"Total Bytes Received\",\"object\":\"Network\"}"
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces"
           },
           {
             "id": "6a7306ea-247f-46ca-abca-501911f9e9d3",
@@ -626,7 +645,10 @@
             "name": "TrendAggregator3",
             "type": 2,
             "isRequired": true,
-            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\", \"selected\":false},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\", \"selected\":false},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P80th = round(percentile(CounterValue, 80), 2)\", \"label\":\"P80th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\", \"selected\":true}    \r\n]"
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(Val), 2)\", \"label\":\"Average\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(Val, 5), 2)\", \"label\":\"P5th\", \"selected\":false},\r\n    { \"value\":\"P10th = round(percentile(Val, 10), 2)\", \"label\":\"P10th\", \"selected\":false},\r\n    { \"value\":\"P50th = round(percentile(Val, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P80th = round(percentile(Val, 80), 2)\", \"label\":\"P80th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(Val, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(Val, 95), 2)\", \"label\":\"P95th\", \"selected\":true}    \r\n]"
           },
           {
             "id": "0327f26e-cdde-4b48-b512-6c35f06ad1d0",
@@ -684,6 +706,18 @@
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces"
       },
+      "conditionalVisibilities": [
+        {
+          "parameterName": "Mode",
+          "comparison": "isEqualTo",
+          "value": "0"
+        },
+        {
+          "parameterName": "Test",
+          "comparison": "isEqualTo",
+          "value": "1"
+        }
+      ],
       "conditionalVisibility": {
         "parameterName": "Mode",
         "comparison": "isEqualTo",
@@ -703,15 +737,16 @@
             "name": "Counter4",
             "type": 2,
             "isRequired": true,
-            "query": "// {Workspaces}\r\nPerf\r\n| where TimeGenerated {TimeRange}\r\n| summarize by CounterName, ObjectName, CounterText = CounterName\r\n| order by ObjectName asc, CounterText asc\r\n| project Counter = pack('counter', CounterName, 'object', ObjectName), CounterText, group = ObjectName",
+            "query": "InsightsMetrics\r\n| where TimeGenerated {TimeRange}\r\n| summarize by Name, Namespace, CounterText = Name\r\n| order by Namespace asc, CounterText asc\r\n| project Counter = pack('counter', Name, 'object', Namespace), CounterText, group = Namespace",
             "crossComponentResources": [
               "{Workspaces}"
             ],
+            "value": null,
             "typeSettings": {
               "additionalResourceOptions": []
             },
-            "resourceType": "microsoft.operationalinsights/workspaces",
-            "value": "{\"counter\":\"Total Bytes Transmitted\",\"object\":\"Network\"}"
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces"
           },
           {
             "id": "6a7306ea-247f-46ca-abca-501911f9e9d3",
@@ -719,7 +754,10 @@
             "name": "TrendAggregator4",
             "type": 2,
             "isRequired": true,
-            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\", \"selected\":false},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\", \"selected\":false},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P80th = round(percentile(CounterValue, 80), 2)\", \"label\":\"P80th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\", \"selected\":true}    \r\n]"
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(Val), 2)\", \"label\":\"Average\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(Val, 5), 2)\", \"label\":\"P5th\", \"selected\":false},\r\n    { \"value\":\"P10th = round(percentile(Val, 10), 2)\", \"label\":\"P10th\", \"selected\":false},\r\n    { \"value\":\"P50th = round(percentile(Val, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P80th = round(percentile(Val, 80), 2)\", \"label\":\"P80th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(Val, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(Val, 95), 2)\", \"label\":\"P95th\", \"selected\":true}    \r\n]"
           },
           {
             "id": "0327f26e-cdde-4b48-b512-6c35f06ad1d0",
@@ -777,6 +815,18 @@
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces"
       },
+      "conditionalVisibilities": [
+        {
+          "parameterName": "Mode",
+          "comparison": "isEqualTo",
+          "value": "0"
+        },
+        {
+          "parameterName": "Test",
+          "comparison": "isEqualTo",
+          "value": "1"
+        }
+      ],
       "conditionalVisibility": {
         "parameterName": "Mode",
         "comparison": "isEqualTo",
@@ -788,7 +838,12 @@
     {
       "type": 1,
       "content": {
-        "json": "<h3 style=\"margin-bottom:0;\">{CounterLabel1}</h3><h4 style=\"margin-top:0;font-weight:normal;color:#777;\">{TrendAggregatorLabel1} {TrendAggregatorOrder1} {Unit:label}</h4>"
+        "json": "<h3 style=\"margin-bottom:0;\">{Counter1:label}</h3><h4 style=\"margin-top:0;font-weight:normal;color:#777;\">{TrendAggregator1:label} {TrendAggregatorOrder1} {Unit:label}</h4>"
+      },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isEqualTo",
+        "value": "1"
       },
       "customWidth": "25",
       "name": "text - 6"
@@ -798,6 +853,11 @@
       "content": {
         "json": "<h3 style=\"margin-bottom:0;\">{Counter2:label}</h3><h4 style=\"margin-top:0;font-weight:normal;color:#777;\">{TrendAggregator2:label} {TrendAggregatorOrder2} {Unit2:label}</h4>"
       },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isEqualTo",
+        "value": "1"
+      },
       "customWidth": "25",
       "name": "text - 7"
     },
@@ -805,6 +865,11 @@
       "type": 1,
       "content": {
         "json": "<h3 style=\"margin-bottom:0;\">{Counter3:label}</h3><h4 style=\"margin-top:0;font-weight:normal;color:#777;\">{TrendAggregator3:label} {TrendAggregatorOrder3} {Unit3:label}</h4>"
+      },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isEqualTo",
+        "value": "1"
       },
       "customWidth": "25",
       "name": "text - 8"
@@ -814,6 +879,11 @@
       "content": {
         "json": "<h3 style=\"margin-bottom:0;\">{Counter4:label}</h3><h4 style=\"margin-top:0;font-weight:normal;color:#777;\">{TrendAggregator4:label} {TrendAggregatorOrder4} {Unit4:label}</h4>"
       },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isEqualTo",
+        "value": "1"
+      },
       "customWidth": "25",
       "name": "text - 9"
     },
@@ -821,7 +891,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let metric = dynamic({Counter1});\r\nlet cpuSummary=totable(Perf\r\n    {ComputerFilter}\r\n    | where TimeGenerated {TimeRange} \r\n    | where ObjectName == metric.object and CounterName == metric.counter\r\n    | summarize hint.shufflekey=Computer {TrendAggregatorValue1} by Computer, CounterName\r\n    | top {TopN} by {TrendAggregatorLabel1} {TrendAggregatorOrder1});\r\nlet computerList=(cpuSummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nPerf\r\n    | where TimeGenerated {TimeRange}\r\n    | where ObjectName == metric.object and CounterName == metric.counter\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {TrendAggregatorValue1}{Unit} by {Snippet1}\r\n\t\r\n",
+        "query": "let metric = dynamic({Counter1});\r\nlet cpuSummary=totable(InsightsMetrics\r\n    {ComputerFilter}\r\n    | where TimeGenerated {TimeRange} \r\n    | where Namespace == metric.object and Name == metric.counter\r\n    | summarize hint.shufflekey=Computer {TrendAggregator1:value} by Computer, Name\r\n    | top {TopN} by {TrendAggregator1:label} {TrendAggregatorOrder1});\r\nlet computerList=(cpuSummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nInsightsMetrics\r\n    | where TimeGenerated {TimeRange}\r\n    | where Namespace == metric.object and Name == metric.counter\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {TrendAggregator1:value}{Unit} by {Snippet1}\r\n\t\r\n",
         "size": 0,
         "aggregation": 3,
         "showAnnotations": true,
@@ -852,6 +922,11 @@
             }
           }
         }
+      },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isEqualTo",
+        "value": "1"
       },
       "customWidth": "25",
       "name": "query - 10"
@@ -860,7 +935,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let metric = dynamic({Counter2});\r\nlet cpuSummary=totable(Perf\r\n    {ComputerFilter}\r\n    | where TimeGenerated {TimeRange} \r\n    | where ObjectName == metric.object and CounterName == metric.counter\r\n    | summarize hint.shufflekey=Computer {TrendAggregator2} by Computer, CounterName\r\n    | top {TopN} by {TrendAggregator2:label} {TrendAggregatorOrder2});\r\nlet computerList=(cpuSummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nPerf\r\n    | where TimeGenerated {TimeRange}\r\n    | where ObjectName == metric.object and CounterName == metric.counter\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {TrendAggregator2}{Unit2} by {Snippet2}",
+        "query": "let metric = dynamic({Counter2});\r\nlet cpuSummary=totable(InsightsMetrics\r\n    {ComputerFilter}\r\n    | where TimeGenerated {TimeRange} \r\n    | where Namespace == metric.object and Name == metric.counter\r\n    | summarize hint.shufflekey=Computer {TrendAggregator2} by Computer, Name\r\n    | top {TopN} by {TrendAggregator2:label} {TrendAggregatorOrder2});\r\nlet computerList=(cpuSummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nInsightsMetrics\r\n    | where TimeGenerated {TimeRange}\r\n    | where Namespace == metric.object and Name == metric.counter\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {TrendAggregator2}{Unit2} by {Snippet2}",
         "size": 0,
         "aggregation": 3,
         "showAnnotations": true,
@@ -891,6 +966,11 @@
             }
           }
         }
+      },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isEqualTo",
+        "value": "1"
       },
       "customWidth": "25",
       "name": "query - 11"
@@ -899,7 +979,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let metric = dynamic({Counter3});\r\nlet cpuSummary=totable(Perf\r\n    {ComputerFilter}\r\n    | where TimeGenerated {TimeRange} \r\n    | where ObjectName == metric.object and CounterName == metric.counter\r\n    | summarize hint.shufflekey=Computer {TrendAggregator3} by Computer, CounterName\r\n    | top {TopN} by {TrendAggregator3:label} {TrendAggregatorOrder3});\r\nlet computerList=(cpuSummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nPerf\r\n    | where TimeGenerated {TimeRange}\r\n    | where ObjectName == metric.object and CounterName == metric.counter\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {TrendAggregator3}{Unit3} by {Snippet3}",
+        "query": "let metric = dynamic({Counter3});\r\nlet cpuSummary=totable(InsightsMetrics\r\n    {ComputerFilter}\r\n    | where TimeGenerated {TimeRange} \r\n    | where Namespace == metric.object and Name == metric.counter\r\n    | summarize hint.shufflekey=Computer {TrendAggregator3} by Computer, Name\r\n    | top {TopN} by {TrendAggregator3:label} {TrendAggregatorOrder3});\r\nlet computerList=(cpuSummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nInsightsMetrics\r\n    | where TimeGenerated {TimeRange}\r\n    | where Namespace == metric.object and Name == metric.counter\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {TrendAggregator3}{Unit3} by {Snippet3}",
         "size": 0,
         "aggregation": 3,
         "showAnnotations": true,
@@ -931,6 +1011,11 @@
           }
         }
       },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isEqualTo",
+        "value": "1"
+      },
       "customWidth": "25",
       "name": "query - 12"
     },
@@ -938,7 +1023,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let metric = dynamic({Counter4});\r\nlet cpuSummary=totable(Perf\r\n    {ComputerFilter}\r\n    | where TimeGenerated {TimeRange} \r\n    | where ObjectName == metric.object and CounterName == metric.counter\r\n    | summarize hint.shufflekey=Computer {TrendAggregator4} by Computer, CounterName\r\n    | top {TopN} by {TrendAggregator4:label} {TrendAggregatorOrder4});\r\nlet computerList=(cpuSummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nPerf\r\n    | where TimeGenerated {TimeRange}\r\n    | where ObjectName == metric.object and CounterName == metric.counter\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {TrendAggregator4}{Unit4} by {Snippet4}",
+        "query": "let metric = dynamic({Counter4});\r\nlet cpuSummary=totable(InsightsMetrics\r\n    {ComputerFilter}\r\n    | where TimeGenerated {TimeRange} \r\n    | where Namespace == metric.object and Name == metric.counter\r\n    | summarize hint.shufflekey=Computer {TrendAggregator4} by Computer, Name\r\n    | top {TopN} by {TrendAggregator4:label} {TrendAggregatorOrder4});\r\nlet computerList=(cpuSummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nInsightsMetrics\r\n    | where TimeGenerated {TimeRange}\r\n    | where Namespace == metric.object and Name == metric.counter\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {TrendAggregator4}{Unit4} by {Snippet4}",
         "size": 0,
         "aggregation": 3,
         "showAnnotations": true,
@@ -969,6 +1054,11 @@
             }
           }
         }
+      },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isEqualTo",
+        "value": "1"
       },
       "customWidth": "25",
       "name": "query - 13"
@@ -984,17 +1074,18 @@
             "name": "Counter5",
             "type": 2,
             "isRequired": true,
-            "query": "// {Workspaces}\r\nPerf\r\n| where TimeGenerated {TimeRange}\r\n| summarize by CounterName, ObjectName, CounterText = CounterName\r\n| order by ObjectName asc, CounterText asc\r\n| project Counter = pack('counter', CounterName, 'object', ObjectName), CounterText, group = ObjectName",
+            "query": "InsightsMetrics\r\n| where TimeGenerated {TimeRange}\r\n| summarize by Name, Namespace, CounterText = Name\r\n| order by Namespace asc, CounterText asc\r\n| project Counter = pack('counter', Name, 'object', Namespace), CounterText, group = Namespace",
             "crossComponentResources": [
               "{Workspaces}"
             ],
+            "value": null,
             "typeSettings": {
               "additionalResourceOptions": [
                 "value::1"
               ]
             },
-            "resourceType": "microsoft.operationalinsights/workspaces",
-            "value": "{\"counter\":\"Disk Reads/sec\",\"object\":\"Logical Disk\"}"
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces"
           },
           {
             "id": "6a7306ea-247f-46ca-abca-501911f9e9d3",
@@ -1002,7 +1093,10 @@
             "name": "TrendAggregator5",
             "type": 2,
             "isRequired": true,
-            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\", \"selected\":false},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\", \"selected\":false},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P80th = round(percentile(CounterValue, 80), 2)\", \"label\":\"P80th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\", \"selected\":true}    \r\n]"
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(Val), 2)\", \"label\":\"Average\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(Val, 5), 2)\", \"label\":\"P5th\", \"selected\":false},\r\n    { \"value\":\"P10th = round(percentile(Val, 10), 2)\", \"label\":\"P10th\", \"selected\":false},\r\n    { \"value\":\"P50th = round(percentile(Val, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P80th = round(percentile(Val, 80), 2)\", \"label\":\"P80th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(Val, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(Val, 95), 2)\", \"label\":\"P95th\", \"selected\":true}    \r\n]"
           },
           {
             "id": "0327f26e-cdde-4b48-b512-6c35f06ad1d0",
@@ -1060,6 +1154,18 @@
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces"
       },
+      "conditionalVisibilities": [
+        {
+          "parameterName": "Mode",
+          "comparison": "isEqualTo",
+          "value": "0"
+        },
+        {
+          "parameterName": "Test",
+          "comparison": "isEqualTo",
+          "value": "1"
+        }
+      ],
       "conditionalVisibility": {
         "parameterName": "Mode",
         "comparison": "isEqualTo",
@@ -1079,17 +1185,18 @@
             "name": "Counter6",
             "type": 2,
             "isRequired": true,
-            "query": "// {Workspaces}\r\nPerf\r\n| where TimeGenerated {TimeRange}\r\n| summarize by CounterName, ObjectName, CounterText = CounterName\r\n| order by ObjectName asc, CounterText asc\r\n| project Counter = pack('counter', CounterName, 'object', ObjectName), CounterText, group = ObjectName",
+            "query": "InsightsMetrics\r\n| where TimeGenerated {TimeRange}\r\n| summarize by Name, Namespace, CounterText = Name\r\n| order by Namespace asc, CounterText asc\r\n| project Counter = pack('counter', Name, 'object', Namespace), CounterText, group = Namespace",
             "crossComponentResources": [
               "{Workspaces}"
             ],
+            "value": null,
             "typeSettings": {
               "additionalResourceOptions": [
                 "value::1"
               ]
             },
-            "resourceType": "microsoft.operationalinsights/workspaces",
-            "value": "{\"counter\":\"Disk Read Bytes/sec\",\"object\":\"Logical Disk\"}"
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces"
           },
           {
             "id": "6a7306ea-247f-46ca-abca-501911f9e9d3",
@@ -1097,7 +1204,10 @@
             "name": "TrendAggregator6",
             "type": 2,
             "isRequired": true,
-            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\", \"selected\":false},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\", \"selected\":false},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P80th = round(percentile(CounterValue, 80), 2)\", \"label\":\"P80th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\", \"selected\":true}    \r\n]"
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(Val), 2)\", \"label\":\"Average\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(Val, 5), 2)\", \"label\":\"P5th\", \"selected\":false},\r\n    { \"value\":\"P10th = round(percentile(Val, 10), 2)\", \"label\":\"P10th\", \"selected\":false},\r\n    { \"value\":\"P50th = round(percentile(Val, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P80th = round(percentile(Val, 80), 2)\", \"label\":\"P80th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(Val, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(Val, 95), 2)\", \"label\":\"P95th\", \"selected\":true}    \r\n]"
           },
           {
             "id": "0327f26e-cdde-4b48-b512-6c35f06ad1d0",
@@ -1155,6 +1265,18 @@
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces"
       },
+      "conditionalVisibilities": [
+        {
+          "parameterName": "Mode",
+          "comparison": "isEqualTo",
+          "value": "0"
+        },
+        {
+          "parameterName": "Test",
+          "comparison": "isEqualTo",
+          "value": "1"
+        }
+      ],
       "conditionalVisibility": {
         "parameterName": "Mode",
         "comparison": "isEqualTo",
@@ -1174,17 +1296,18 @@
             "name": "Counter7",
             "type": 2,
             "isRequired": true,
-            "query": "// {Workspaces}\r\nPerf\r\n| where TimeGenerated {TimeRange}\r\n| summarize by CounterName, ObjectName, CounterText = CounterName\r\n| order by ObjectName asc, CounterText asc\r\n| project Counter = pack('counter', CounterName, 'object', ObjectName), CounterText, group = ObjectName",
+            "query": "InsightsMetrics\r\n| where TimeGenerated {TimeRange}\r\n| summarize by Name, Namespace, CounterText = Name\r\n| order by Namespace asc, CounterText asc\r\n| project Counter = pack('counter', Name, 'object', Namespace), CounterText, group = Namespace",
             "crossComponentResources": [
               "{Workspaces}"
             ],
+            "value": null,
             "typeSettings": {
               "additionalResourceOptions": [
                 "value::1"
               ]
             },
-            "resourceType": "microsoft.operationalinsights/workspaces",
-            "value": "{\"counter\":\"Disk Writes/sec\",\"object\":\"Logical Disk\"}"
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces"
           },
           {
             "id": "6a7306ea-247f-46ca-abca-501911f9e9d3",
@@ -1192,7 +1315,10 @@
             "name": "TrendAggregator7",
             "type": 2,
             "isRequired": true,
-            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\", \"selected\":false},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\", \"selected\":false},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P80th = round(percentile(CounterValue, 80), 2)\", \"label\":\"P80th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\", \"selected\":true}    \r\n]"
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(Val), 2)\", \"label\":\"Average\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(Val, 5), 2)\", \"label\":\"P5th\", \"selected\":false},\r\n    { \"value\":\"P10th = round(percentile(Val, 10), 2)\", \"label\":\"P10th\", \"selected\":false},\r\n    { \"value\":\"P50th = round(percentile(Val, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P80th = round(percentile(Val, 80), 2)\", \"label\":\"P80th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(Val, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(Val, 95), 2)\", \"label\":\"P95th\", \"selected\":true}    \r\n]"
           },
           {
             "id": "0327f26e-cdde-4b48-b512-6c35f06ad1d0",
@@ -1250,6 +1376,18 @@
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces"
       },
+      "conditionalVisibilities": [
+        {
+          "parameterName": "Mode",
+          "comparison": "isEqualTo",
+          "value": "0"
+        },
+        {
+          "parameterName": "Test",
+          "comparison": "isEqualTo",
+          "value": "1"
+        }
+      ],
       "conditionalVisibility": {
         "parameterName": "Mode",
         "comparison": "isEqualTo",
@@ -1269,17 +1407,18 @@
             "name": "Counter8",
             "type": 2,
             "isRequired": true,
-            "query": "// {Workspaces}\r\nPerf\r\n| where TimeGenerated {TimeRange}\r\n| summarize by CounterName, ObjectName, CounterText = CounterName\r\n| order by ObjectName asc, CounterText asc\r\n| project Counter = pack('counter', CounterName, 'object', ObjectName), CounterText, group = ObjectName",
+            "query": "InsightsMetrics\r\n| where TimeGenerated {TimeRange}\r\n| summarize by Name, Namespace, CounterText = Name\r\n| order by Namespace asc, CounterText asc\r\n| project Counter = pack('counter', Name, 'object', Namespace), CounterText, group = Namespace",
             "crossComponentResources": [
               "{Workspaces}"
             ],
+            "value": null,
             "typeSettings": {
               "additionalResourceOptions": [
                 "value::1"
               ]
             },
-            "resourceType": "microsoft.operationalinsights/workspaces",
-            "value": "{\"counter\":\"Disk Write Bytes/sec\",\"object\":\"Logical Disk\"}"
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces"
           },
           {
             "id": "6a7306ea-247f-46ca-abca-501911f9e9d3",
@@ -1287,7 +1426,10 @@
             "name": "TrendAggregator8",
             "type": 2,
             "isRequired": true,
-            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\", \"selected\":false},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\", \"selected\":false},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P80th = round(percentile(CounterValue, 80), 2)\", \"label\":\"P80th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\", \"selected\":true}    \r\n]"
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(Val), 2)\", \"label\":\"Average\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(Val, 5), 2)\", \"label\":\"P5th\", \"selected\":false},\r\n    { \"value\":\"P10th = round(percentile(Val, 10), 2)\", \"label\":\"P10th\", \"selected\":false},\r\n    { \"value\":\"P50th = round(percentile(Val, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P80th = round(percentile(Val, 80), 2)\", \"label\":\"P80th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(Val, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(Val, 95), 2)\", \"label\":\"P95th\", \"selected\":true}    \r\n]"
           },
           {
             "id": "0327f26e-cdde-4b48-b512-6c35f06ad1d0",
@@ -1345,6 +1487,18 @@
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces"
       },
+      "conditionalVisibilities": [
+        {
+          "parameterName": "Mode",
+          "comparison": "isEqualTo",
+          "value": "0"
+        },
+        {
+          "parameterName": "Test",
+          "comparison": "isEqualTo",
+          "value": "1"
+        }
+      ],
       "conditionalVisibility": {
         "parameterName": "Mode",
         "comparison": "isEqualTo",
@@ -1358,6 +1512,11 @@
       "content": {
         "json": "<h3 style=\"margin-bottom:0;\">{Counter5:label}</h3><h4 style=\"margin-top:0;font-weight:normal;color:#777;\">{TrendAggregator5:label} {TrendAggregatorOrder5} {Unit5:label}</h4>"
       },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isEqualTo",
+        "value": "1"
+      },
       "customWidth": "25",
       "name": "text - 18"
     },
@@ -1365,6 +1524,11 @@
       "type": 1,
       "content": {
         "json": "<h3 style=\"margin-bottom:0;\">{Counter6:label}</h3><h4 style=\"margin-top:0;font-weight:normal;color:#777;\">{TrendAggregator6:label} {TrendAggregatorOrder6} {Unit6:label}</h4>"
+      },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isEqualTo",
+        "value": "1"
       },
       "customWidth": "25",
       "name": "text - 19"
@@ -1374,6 +1538,11 @@
       "content": {
         "json": "<h3 style=\"margin-bottom:0;\">{Counter7:label}</h3><h4 style=\"margin-top:0;font-weight:normal;color:#777;\">{TrendAggregator7:label} {TrendAggregatorOrder7} {Unit7:label}</h4>"
       },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isEqualTo",
+        "value": "1"
+      },
       "customWidth": "25",
       "name": "text - 20"
     },
@@ -1382,6 +1551,11 @@
       "content": {
         "json": "<h3 style=\"margin-bottom:0;\">{Counter8:label}</h3><h4 style=\"margin-top:0;font-weight:normal;color:#777;\">{TrendAggregator8:label} {TrendAggregatorOrder8} {Unit8:label}</h4>"
       },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isEqualTo",
+        "value": "1"
+      },
       "customWidth": "25",
       "name": "text - 21"
     },
@@ -1389,7 +1563,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let metric = dynamic({Counter5});\r\nlet cpuSummary=totable(Perf\r\n    {ComputerFilter}\r\n    | where TimeGenerated {TimeRange} \r\n    | where ObjectName == metric.object and CounterName == metric.counter\r\n    | summarize hint.shufflekey=Computer {TrendAggregator5} by Computer, CounterName\r\n    | top {TopN} by {TrendAggregator5:label} {TrendAggregatorOrder5});\r\nlet computerList=(cpuSummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nPerf\r\n    | where TimeGenerated {TimeRange}\r\n    | where ObjectName == metric.object and CounterName == metric.counter\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {TrendAggregator5}{Unit5} by {Snippet5}",
+        "query": "let metric = dynamic({Counter5});\r\nlet cpuSummary=totable(InsightsMetrics\r\n    {ComputerFilter}\r\n    | where TimeGenerated {TimeRange} \r\n    | where Namespace == metric.object and Name == metric.counter\r\n    | summarize hint.shufflekey=Computer {TrendAggregator5} by Computer, Name\r\n    | top {TopN} by {TrendAggregator5:label} {TrendAggregatorOrder5});\r\nlet computerList=(cpuSummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nInsightsMetrics\r\n    | where TimeGenerated {TimeRange}\r\n    | where Namespace == metric.object and Name == metric.counter\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {TrendAggregator5}{Unit5} by {Snippet5}",
         "size": 0,
         "aggregation": 3,
         "showAnnotations": true,
@@ -1420,6 +1594,11 @@
             }
           }
         }
+      },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isEqualTo",
+        "value": "1"
       },
       "customWidth": "25",
       "name": "query - 22"
@@ -1428,7 +1607,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let metric = dynamic({Counter6});\r\nlet cpuSummary=totable(Perf\r\n    {ComputerFilter}\r\n    | where TimeGenerated {TimeRange} \r\n    | where ObjectName == metric.object and CounterName == metric.counter\r\n    | summarize hint.shufflekey=Computer {TrendAggregator6} by Computer, CounterName\r\n    | top {TopN} by {TrendAggregator6:label} {TrendAggregatorOrder6});\r\nlet computerList=(cpuSummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nPerf\r\n    | where TimeGenerated {TimeRange}\r\n    | where ObjectName == metric.object and CounterName == metric.counter\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {TrendAggregator6}{Unit6} by {Snippet6}",
+        "query": "let metric = dynamic({Counter6});\r\nlet cpuSummary=totable(InsightsMetrics\r\n    {ComputerFilter}\r\n    | where TimeGenerated {TimeRange} \r\n    | where Namespace == metric.object and Name == metric.counter\r\n    | summarize hint.shufflekey=Computer {TrendAggregator6} by Computer, Name\r\n    | top {TopN} by {TrendAggregator6:label} {TrendAggregatorOrder6});\r\nlet computerList=(cpuSummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nInsightsMetrics\r\n    | where TimeGenerated {TimeRange}\r\n    | where Namespace == metric.object and Name == metric.counter\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {TrendAggregator6}{Unit6} by {Snippet6}",
         "size": 0,
         "aggregation": 3,
         "showAnnotations": true,
@@ -1459,6 +1638,11 @@
             }
           }
         }
+      },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isEqualTo",
+        "value": "1"
       },
       "customWidth": "25",
       "name": "query - 23"
@@ -1467,7 +1651,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let metric = dynamic({Counter7});\r\nlet cpuSummary=totable(Perf\r\n    {ComputerFilter}\r\n    | where TimeGenerated {TimeRange} \r\n    | where ObjectName == metric.object and CounterName == metric.counter\r\n    | summarize hint.shufflekey=Computer {TrendAggregator7} by Computer, CounterName\r\n    | top {TopN} by {TrendAggregator7:label} {TrendAggregatorOrder7});\r\nlet computerList=(cpuSummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nPerf\r\n    | where TimeGenerated {TimeRange}\r\n    | where ObjectName == metric.object and CounterName == metric.counter\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {TrendAggregator7}{Unit7} by {Snippet7}",
+        "query": "let metric = dynamic({Counter7});\r\nlet cpuSummary=totable(InsightsMetrics\r\n    {ComputerFilter}\r\n    | where TimeGenerated {TimeRange} \r\n    | where Namespace == metric.object and Name == metric.counter\r\n    | summarize hint.shufflekey=Computer {TrendAggregator7} by Computer, Name\r\n    | top {TopN} by {TrendAggregator7:label} {TrendAggregatorOrder7});\r\nlet computerList=(cpuSummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nInsightsMetrics\r\n    | where TimeGenerated {TimeRange}\r\n    | where Namespace == metric.object and Name == metric.counter\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {TrendAggregator7}{Unit7} by {Snippet7}",
         "size": 0,
         "aggregation": 3,
         "showAnnotations": true,
@@ -1498,6 +1682,11 @@
             }
           }
         }
+      },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isEqualTo",
+        "value": "1"
       },
       "customWidth": "25",
       "name": "query - 24"
@@ -1506,7 +1695,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let metric = dynamic({Counter8});\r\nlet cpuSummary=totable(Perf\r\n    {ComputerFilter}\r\n    | where TimeGenerated {TimeRange} \r\n    | where ObjectName == metric.object and CounterName == metric.counter\r\n    | summarize hint.shufflekey=Computer {TrendAggregator8} by Computer, CounterName\r\n    | top {TopN} by {TrendAggregator8:label} {TrendAggregatorOrder8});\r\nlet computerList=(cpuSummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nPerf\r\n    | where TimeGenerated {TimeRange}\r\n    | where ObjectName == metric.object and CounterName == metric.counter\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {TrendAggregator8}{Unit8} by {Snippet8}",
+        "query": "let metric = dynamic({Counter8});\r\nlet cpuSummary=totable(InsightsMetrics\r\n    {ComputerFilter}\r\n    | where TimeGenerated {TimeRange} \r\n    | where Namespace == metric.object and Name == metric.counter\r\n    | summarize hint.shufflekey=Computer {TrendAggregator8} by Computer, Name\r\n    | top {TopN} by {TrendAggregator8:label} {TrendAggregatorOrder8});\r\nlet computerList=(cpuSummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nInsightsMetrics\r\n    | where TimeGenerated {TimeRange}\r\n    | where Namespace == metric.object and Name == metric.counter\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {TrendAggregator8}{Unit8} by {Snippet8}",
         "size": 0,
         "aggregation": 3,
         "showAnnotations": true,
@@ -1537,573 +1726,14 @@
             }
           }
         }
+      },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isEqualTo",
+        "value": "1"
       },
       "customWidth": "25",
       "name": "query - 25"
-    },
-    {
-      "type": 9,
-      "content": {
-        "version": "KqlParameterItem/1.0",
-        "parameters": [
-          {
-            "id": "eba3fa3a-2f37-4dfb-80be-c19b680f31b0",
-            "version": "KqlParameterItem/1.0",
-            "name": "Counter9",
-            "type": 2,
-            "isRequired": true,
-            "query": "// {Workspaces}\r\nPerf\r\n| where TimeGenerated {TimeRange}\r\n| summarize by CounterName, ObjectName, CounterText = CounterName\r\n| order by ObjectName asc, CounterText asc\r\n| project Counter = pack('counter', CounterName, 'object', ObjectName), CounterText, group = ObjectName",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
-            "typeSettings": {
-              "additionalResourceOptions": [
-                "value::1"
-              ]
-            },
-            "resourceType": "microsoft.operationalinsights/workspaces"
-          },
-          {
-            "id": "f3137f3e-9ff1-4a7f-b503-5b2b87431713",
-            "version": "KqlParameterItem/1.0",
-            "name": "TrendAggregator9",
-            "type": 2,
-            "isRequired": true,
-            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\", \"selected\":false},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\", \"selected\":false},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P80th = round(percentile(CounterValue, 80), 2)\", \"label\":\"P80th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\", \"selected\":true}    \r\n]"
-          },
-          {
-            "id": "01a4cf96-e12f-4d2a-9cf3-25da44a6ebe4",
-            "version": "KqlParameterItem/1.0",
-            "name": "TrendAggregatorOrder9",
-            "type": 1,
-            "query": "print(iff('{TrendAggregator9:label}' == 'P5th'  or '{TrendAggregator9:label}' == 'P10th', 'asc', 'desc'))",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
-            "isHiddenWhenLocked": true,
-            "resourceType": "microsoft.operationalinsights/workspaces"
-          },
-          {
-            "id": "2ad65081-725a-4bc6-9198-9ab653dbb1aa",
-            "version": "KqlParameterItem/1.0",
-            "name": "Visualization9",
-            "type": 2,
-            "isRequired": true,
-            "query": "datatable (value:long, Display:string, isSelected:boolean)\r\n    [0, \"Line Chart\", true,\r\n     1, \"Grid\", false]",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
-            "typeSettings": {
-              "additionalResourceOptions": []
-            },
-            "resourceType": "microsoft.operationalinsights/workspaces"
-          },
-          {
-            "id": "d08e406f-4725-45f5-a5ec-1aa0b6ae4afd",
-            "version": "KqlParameterItem/1.0",
-            "name": "Snippet9",
-            "type": 1,
-            "isRequired": true,
-            "query": "print(iff({Visualization5} == 0, \"{LineChartQuerySnippet}\", \"{GridQuerySnippet}\") )",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
-            "isHiddenWhenLocked": true,
-            "resourceType": "microsoft.operationalinsights/workspaces"
-          },
-          {
-            "id": "31e0e738-54eb-4fab-92b7-ae000819fc7d",
-            "version": "KqlParameterItem/1.0",
-            "name": "Unit9",
-            "type": 2,
-            "value": null,
-            "typeSettings": {
-              "additionalResourceOptions": []
-            },
-            "jsonData": "[\r\n    {\r\n        \"label\": \"B -> MB\",\r\n        \"value\": \"/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"B -> GB\",\r\n        \"value\": \"/1024/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"MB -> GB\",\r\n        \"value\": \"/1024\"\r\n    },\r\n    {\r\n        \"label\": \"MB -> TB\",\r\n        \"value\": \"/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"b -> Mb\",\r\n        \"value\": \"/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"b -> Gb\",\r\n        \"value\": \"/1000/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"Mb -> Gb\",\r\n        \"value\": \"/1000\"\r\n    },\r\n    {\r\n        \"label\": \"Mb -> Tb\",\r\n        \"value\": \"/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"s -> ms\",\r\n        \"value\": \"*1000\"\r\n    },\r\n    {\r\n        \"label\": \"ms -> s\",\r\n        \"value\": \"/1000\"\r\n    }\r\n]"
-          }
-        ],
-        "style": "above",
-        "queryType": 0,
-        "resourceType": "microsoft.operationalinsights/workspaces"
-      },
-      "conditionalVisibility": {
-        "parameterName": "Mode",
-        "comparison": "isEqualTo",
-        "value": "0"
-      },
-      "customWidth": "25",
-      "name": "parameters - 26"
-    },
-    {
-      "type": 9,
-      "content": {
-        "version": "KqlParameterItem/1.0",
-        "parameters": [
-          {
-            "id": "aa2368fc-ad30-4608-b96a-72abf7b1e1ad",
-            "version": "KqlParameterItem/1.0",
-            "name": "Counter10",
-            "type": 2,
-            "isRequired": true,
-            "query": "// {Workspaces}\r\nPerf\r\n| where TimeGenerated {TimeRange}\r\n| summarize by CounterName, ObjectName, CounterText = CounterName\r\n| order by ObjectName asc, CounterText asc\r\n| project Counter = pack('counter', CounterName, 'object', ObjectName), CounterText, group = ObjectName",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
-            "typeSettings": {
-              "additionalResourceOptions": [
-                "value::1"
-              ]
-            },
-            "resourceType": "microsoft.operationalinsights/workspaces"
-          },
-          {
-            "id": "6a7306ea-247f-46ca-abca-501911f9e9dd",
-            "version": "KqlParameterItem/1.0",
-            "name": "TrendAggregator10",
-            "type": 2,
-            "isRequired": true,
-            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\", \"selected\":false},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\", \"selected\":false},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P80th = round(percentile(CounterValue, 80), 2)\", \"label\":\"P80th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\", \"selected\":true}    \r\n]"
-          },
-          {
-            "id": "0327f26e-cdde-4b48-b512-6c35f06ad1dd",
-            "version": "KqlParameterItem/1.0",
-            "name": "TrendAggregatorOrder10",
-            "type": 1,
-            "query": "print(iff('{TrendAggregator10:label}' == 'P5th'  or '{TrendAggregator10:label}' == 'P10th', 'asc', 'desc'))",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
-            "isHiddenWhenLocked": true,
-            "resourceType": "microsoft.operationalinsights/workspaces"
-          },
-          {
-            "id": "5b1ee58a-5d4d-4be8-b38c-3a8eb37a2f3d",
-            "version": "KqlParameterItem/1.0",
-            "name": "Visualization10",
-            "type": 2,
-            "isRequired": true,
-            "query": "datatable (value:long, Display:string, isSelected:boolean)\r\n    [0, \"Line Chart\", true,\r\n     1, \"Grid\", false]",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
-            "typeSettings": {
-              "additionalResourceOptions": []
-            },
-            "resourceType": "microsoft.operationalinsights/workspaces"
-          },
-          {
-            "id": "d931d741-2f83-4ca0-bc2b-5c0c13fe805d",
-            "version": "KqlParameterItem/1.0",
-            "name": "Snippet10",
-            "type": 1,
-            "isRequired": true,
-            "query": "print(iff({Visualization6} == 0, \"{LineChartQuerySnippet}\", \"{GridQuerySnippet}\") )",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
-            "isHiddenWhenLocked": true,
-            "resourceType": "microsoft.operationalinsights/workspaces"
-          },
-          {
-            "id": "089bb686-434d-43ea-a958-c344763cef7f",
-            "version": "KqlParameterItem/1.0",
-            "name": "Unit10",
-            "type": 2,
-            "value": null,
-            "typeSettings": {
-              "additionalResourceOptions": []
-            },
-            "jsonData": "[\r\n    {\r\n        \"label\": \"B -> MB\",\r\n        \"value\": \"/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"B -> GB\",\r\n        \"value\": \"/1024/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"MB -> GB\",\r\n        \"value\": \"/1024\"\r\n    },\r\n    {\r\n        \"label\": \"MB -> TB\",\r\n        \"value\": \"/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"b -> Mb\",\r\n        \"value\": \"/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"b -> Gb\",\r\n        \"value\": \"/1000/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"Mb -> Gb\",\r\n        \"value\": \"/1000\"\r\n    },\r\n    {\r\n        \"label\": \"Mb -> Tb\",\r\n        \"value\": \"/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"s -> ms\",\r\n        \"value\": \"*1000\"\r\n    },\r\n    {\r\n        \"label\": \"ms -> s\",\r\n        \"value\": \"/1000\"\r\n    }\r\n]"
-          }
-        ],
-        "style": "above",
-        "queryType": 0,
-        "resourceType": "microsoft.operationalinsights/workspaces"
-      },
-      "conditionalVisibility": {
-        "parameterName": "Mode",
-        "comparison": "isEqualTo",
-        "value": "0"
-      },
-      "customWidth": "25",
-      "name": "parameters - 27"
-    },
-    {
-      "type": 9,
-      "content": {
-        "version": "KqlParameterItem/1.0",
-        "parameters": [
-          {
-            "id": "aa2368fc-ad30-4608-b96a-72abf7b1e1ad",
-            "version": "KqlParameterItem/1.0",
-            "name": "Counter11",
-            "type": 2,
-            "isRequired": true,
-            "query": "// {Workspaces}\r\nPerf\r\n| where TimeGenerated {TimeRange}\r\n| summarize by CounterName, ObjectName, CounterText = CounterName\r\n| order by ObjectName asc, CounterText asc\r\n| project Counter = pack('counter', CounterName, 'object', ObjectName), CounterText, group = ObjectName",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
-            "typeSettings": {
-              "additionalResourceOptions": [
-                "value::1"
-              ]
-            },
-            "resourceType": "microsoft.operationalinsights/workspaces"
-          },
-          {
-            "id": "6a7306ea-247f-46ca-abca-501911f9e9dd",
-            "version": "KqlParameterItem/1.0",
-            "name": "TrendAggregator11",
-            "type": 2,
-            "isRequired": true,
-            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\", \"selected\":false},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\", \"selected\":false},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P80th = round(percentile(CounterValue, 80), 2)\", \"label\":\"P80th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\", \"selected\":true}    \r\n]"
-          },
-          {
-            "id": "0327f26e-cdde-4b48-b512-6c35f06ad1dd",
-            "version": "KqlParameterItem/1.0",
-            "name": "TrendAggregatorOrder11",
-            "type": 1,
-            "query": "print(iff('{TrendAggregator11:label}' == 'P5th'  or '{TrendAggregator11:label}' == 'P10th', 'asc', 'desc'))",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
-            "isHiddenWhenLocked": true,
-            "resourceType": "microsoft.operationalinsights/workspaces"
-          },
-          {
-            "id": "bc1291ba-dd26-4224-9b25-3a1e7b3eb02d",
-            "version": "KqlParameterItem/1.0",
-            "name": "Visualization11",
-            "type": 2,
-            "isRequired": true,
-            "query": "datatable (value:long, Display:string, isSelected:boolean)\r\n    [0, \"Line Chart\", true,\r\n     1, \"Grid\", false]",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
-            "typeSettings": {
-              "additionalResourceOptions": []
-            },
-            "resourceType": "microsoft.operationalinsights/workspaces"
-          },
-          {
-            "id": "6cc1a388-27c6-4cfe-a787-ff00cb8f4fad",
-            "version": "KqlParameterItem/1.0",
-            "name": "Snippet11",
-            "type": 1,
-            "isRequired": true,
-            "query": "print(iff({Visualization7} == 0, \"{LineChartQuerySnippet}\", \"{GridQuerySnippet}\") )",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
-            "isHiddenWhenLocked": true,
-            "resourceType": "microsoft.operationalinsights/workspaces"
-          },
-          {
-            "id": "77870d8a-bf65-4405-a722-fdf0826106ac",
-            "version": "KqlParameterItem/1.0",
-            "name": "Unit11",
-            "type": 2,
-            "value": null,
-            "typeSettings": {
-              "additionalResourceOptions": []
-            },
-            "jsonData": "[\r\n    {\r\n        \"label\": \"B -> MB\",\r\n        \"value\": \"/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"B -> GB\",\r\n        \"value\": \"/1024/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"MB -> GB\",\r\n        \"value\": \"/1024\"\r\n    },\r\n    {\r\n        \"label\": \"MB -> TB\",\r\n        \"value\": \"/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"b -> Mb\",\r\n        \"value\": \"/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"b -> Gb\",\r\n        \"value\": \"/1000/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"Mb -> Gb\",\r\n        \"value\": \"/1000\"\r\n    },\r\n    {\r\n        \"label\": \"Mb -> Tb\",\r\n        \"value\": \"/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"s -> ms\",\r\n        \"value\": \"*1000\"\r\n    },\r\n    {\r\n        \"label\": \"ms -> s\",\r\n        \"value\": \"/1000\"\r\n    }\r\n]"
-          }
-        ],
-        "style": "above",
-        "queryType": 0,
-        "resourceType": "microsoft.operationalinsights/workspaces"
-      },
-      "conditionalVisibility": {
-        "parameterName": "Mode",
-        "comparison": "isEqualTo",
-        "value": "0"
-      },
-      "customWidth": "25",
-      "name": "parameters - 28"
-    },
-    {
-      "type": 9,
-      "content": {
-        "version": "KqlParameterItem/1.0",
-        "parameters": [
-          {
-            "id": "aa2368fc-ad30-4608-b96a-72abf7b1e1ad",
-            "version": "KqlParameterItem/1.0",
-            "name": "Counter12",
-            "type": 2,
-            "isRequired": true,
-            "query": "// {Workspaces}\r\nPerf\r\n| where TimeGenerated {TimeRange}\r\n| summarize by CounterName, ObjectName, CounterText = CounterName\r\n| order by ObjectName asc, CounterText asc\r\n| project Counter = pack('counter', CounterName, 'object', ObjectName), CounterText, group = ObjectName",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
-            "typeSettings": {
-              "additionalResourceOptions": [
-                "value::1"
-              ]
-            },
-            "resourceType": "microsoft.operationalinsights/workspaces"
-          },
-          {
-            "id": "6a7306ea-247f-46ca-abca-501911f9e9dd",
-            "version": "KqlParameterItem/1.0",
-            "name": "TrendAggregator12",
-            "type": 2,
-            "isRequired": true,
-            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\", \"selected\":false},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\", \"selected\":false},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P80th = round(percentile(CounterValue, 80), 2)\", \"label\":\"P80th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\", \"selected\":true}    \r\n]"
-          },
-          {
-            "id": "0327f26e-cdde-4b48-b512-6c35f06ad1dd",
-            "version": "KqlParameterItem/1.0",
-            "name": "TrendAggregatorOrder12",
-            "type": 1,
-            "query": "print(iff('{TrendAggregator12:label}' == 'P5th'  or '{TrendAggregator12:label}' == 'P10th', 'asc', 'desc'))",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
-            "isHiddenWhenLocked": true,
-            "resourceType": "microsoft.operationalinsights/workspaces"
-          },
-          {
-            "id": "68468652-570f-4d77-af12-a59d463d5f0d",
-            "version": "KqlParameterItem/1.0",
-            "name": "Visualization12",
-            "type": 2,
-            "isRequired": true,
-            "query": "datatable (value:long, Display:string, isSelected:boolean)\r\n    [0, \"Line Chart\", true,\r\n     1, \"Grid\", false]",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
-            "typeSettings": {
-              "additionalResourceOptions": []
-            },
-            "resourceType": "microsoft.operationalinsights/workspaces"
-          },
-          {
-            "id": "15738505-f7e6-446e-995d-280cf70dde9d",
-            "version": "KqlParameterItem/1.0",
-            "name": "Snippet12",
-            "type": 1,
-            "isRequired": true,
-            "query": "print(iff({Visualization8} == 0, \"{LineChartQuerySnippet}\", \"{GridQuerySnippet}\") )",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
-            "isHiddenWhenLocked": true,
-            "resourceType": "microsoft.operationalinsights/workspaces"
-          },
-          {
-            "id": "beb8493f-b5db-4bb5-865b-c8a4fed0ca0c",
-            "version": "KqlParameterItem/1.0",
-            "name": "Unit12",
-            "type": 2,
-            "value": null,
-            "typeSettings": {
-              "additionalResourceOptions": []
-            },
-            "jsonData": "[\r\n    {\r\n        \"label\": \"B -> MB\",\r\n        \"value\": \"/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"B -> GB\",\r\n        \"value\": \"/1024/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"MB -> GB\",\r\n        \"value\": \"/1024\"\r\n    },\r\n    {\r\n        \"label\": \"MB -> TB\",\r\n        \"value\": \"/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"b -> Mb\",\r\n        \"value\": \"/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"b -> Gb\",\r\n        \"value\": \"/1000/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"Mb -> Gb\",\r\n        \"value\": \"/1000\"\r\n    },\r\n    {\r\n        \"label\": \"Mb -> Tb\",\r\n        \"value\": \"/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"s -> ms\",\r\n        \"value\": \"*1000\"\r\n    },\r\n    {\r\n        \"label\": \"ms -> s\",\r\n        \"value\": \"/1000\"\r\n    }\r\n]"
-          }
-        ],
-        "style": "above",
-        "queryType": 0,
-        "resourceType": "microsoft.operationalinsights/workspaces"
-      },
-      "conditionalVisibility": {
-        "parameterName": "Mode",
-        "comparison": "isEqualTo",
-        "value": "0"
-      },
-      "customWidth": "25",
-      "name": "parameters - 29"
-    },
-    {
-      "type": 1,
-      "content": {
-        "json": "<h3 style=\"margin-bottom:0;\">{Counter9:label}</h3><h4 style=\"margin-top:0;font-weight:normal;color:#777;\">{TrendAggregator9:label} {TrendAggregatorOrder9} {Unit9:label}</h4>"
-      },
-      "customWidth": "25",
-      "name": "text - 30"
-    },
-    {
-      "type": 1,
-      "content": {
-        "json": "<h3 style=\"margin-bottom:0;\">{Counter10:label}</h3><h4 style=\"margin-top:0;font-weight:normal;color:#777;\">{TrendAggregator10:label} {TrendAggregatorOrder10} {Unit10:label}</h4>"
-      },
-      "customWidth": "25",
-      "name": "text - 31"
-    },
-    {
-      "type": 1,
-      "content": {
-        "json": "<h3 style=\"margin-bottom:0;\">{Counter11:label}</h3><h4 style=\"margin-top:0;font-weight:normal;color:#777;\">{TrendAggregator11:label} {TrendAggregatorOrder11} {Unit11:label}</h4>"
-      },
-      "customWidth": "25",
-      "name": "text - 32"
-    },
-    {
-      "type": 1,
-      "content": {
-        "json": "<h3 style=\"margin-bottom:0;\">{Counter12:label}</h3><h4 style=\"margin-top:0;font-weight:normal;color:#777;\">{TrendAggregator12:label} {TrendAggregatorOrder12} {Unit12:label}</h4>"
-      },
-      "customWidth": "25",
-      "name": "text - 33"
-    },
-    {
-      "type": 3,
-      "content": {
-        "version": "KqlItem/1.0",
-        "query": "let metric = dynamic({Counter9});\r\nlet cpuSummary=totable(Perf\r\n    {ComputerFilter}\r\n    | where TimeGenerated {TimeRange} \r\n    | where ObjectName == metric.object and CounterName == metric.counter\r\n    | summarize hint.shufflekey=Computer {TrendAggregator9} by Computer, CounterName\r\n    | top {TopN} by {TrendAggregator9:label} {TrendAggregatorOrder9});\r\nlet computerList=(cpuSummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nPerf\r\n    | where TimeGenerated {TimeRange}\r\n    | where ObjectName == metric.object and CounterName == metric.counter\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {TrendAggregator9}{Unit9} by {Snippet9}",
-        "size": 0,
-        "aggregation": 3,
-        "showAnnotations": true,
-        "noDataMessage": "No computers are emitting data for this performance counter.",
-        "queryType": 0,
-        "resourceType": "microsoft.operationalinsights/workspaces",
-        "crossComponentResources": [
-          "{Workspaces}"
-        ],
-        "tileSettings": {
-          "showBorder": false,
-          "titleContent": {
-            "columnMatch": "Computer",
-            "formatter": 1
-          },
-          "leftContent": {
-            "columnMatch": "value",
-            "formatter": 12,
-            "formatOptions": {
-              "palette": "auto"
-            },
-            "numberFormat": {
-              "unit": 17,
-              "options": {
-                "maximumSignificantDigits": 3,
-                "maximumFractionDigits": 2
-              }
-            }
-          }
-        }
-      },
-      "customWidth": "25",
-      "name": "query - 34"
-    },
-    {
-      "type": 3,
-      "content": {
-        "version": "KqlItem/1.0",
-        "query": "let metric = dynamic({Counter10});\r\nlet cpuSummary=totable(Perf\r\n    {ComputerFilter}\r\n    | where TimeGenerated {TimeRange} \r\n    | where ObjectName == metric.object and CounterName == metric.counter\r\n    | summarize hint.shufflekey=Computer {TrendAggregator10} by Computer, CounterName\r\n    | top {TopN} by {TrendAggregator10:label} {TrendAggregatorOrder10});\r\nlet computerList=(cpuSummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nPerf\r\n    | where TimeGenerated {TimeRange}\r\n    | where ObjectName == metric.object and CounterName == metric.counter\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {TrendAggregator10}{Unit10} by {Snippet10}",
-        "size": 0,
-        "aggregation": 3,
-        "showAnnotations": true,
-        "noDataMessage": "No computers are emitting data for this performance counter.",
-        "queryType": 0,
-        "resourceType": "microsoft.operationalinsights/workspaces",
-        "crossComponentResources": [
-          "{Workspaces}"
-        ],
-        "tileSettings": {
-          "showBorder": false,
-          "titleContent": {
-            "columnMatch": "Computer",
-            "formatter": 1
-          },
-          "leftContent": {
-            "columnMatch": "value",
-            "formatter": 12,
-            "formatOptions": {
-              "palette": "auto"
-            },
-            "numberFormat": {
-              "unit": 17,
-              "options": {
-                "maximumSignificantDigits": 3,
-                "maximumFractionDigits": 2
-              }
-            }
-          }
-        }
-      },
-      "customWidth": "25",
-      "name": "query - 35"
-    },
-    {
-      "type": 3,
-      "content": {
-        "version": "KqlItem/1.0",
-        "query": "let metric = dynamic({Counter11});\r\nlet cpuSummary=totable(Perf\r\n    {ComputerFilter}\r\n    | where TimeGenerated {TimeRange} \r\n    | where ObjectName == metric.object and CounterName == metric.counter\r\n    | summarize hint.shufflekey=Computer {TrendAggregator11} by Computer, CounterName\r\n    | top {TopN} by {TrendAggregator11:label} {TrendAggregatorOrder11});\r\nlet computerList=(cpuSummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nPerf\r\n    | where TimeGenerated {TimeRange}\r\n    | where ObjectName == metric.object and CounterName == metric.counter\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {TrendAggregator11}{Unit11} by {Snippet11}",
-        "size": 0,
-        "aggregation": 3,
-        "showAnnotations": true,
-        "noDataMessage": "No computers are emitting data for this performance counter.",
-        "queryType": 0,
-        "resourceType": "microsoft.operationalinsights/workspaces",
-        "crossComponentResources": [
-          "{Workspaces}"
-        ],
-        "tileSettings": {
-          "showBorder": false,
-          "titleContent": {
-            "columnMatch": "Computer",
-            "formatter": 1
-          },
-          "leftContent": {
-            "columnMatch": "value",
-            "formatter": 12,
-            "formatOptions": {
-              "palette": "auto"
-            },
-            "numberFormat": {
-              "unit": 17,
-              "options": {
-                "maximumSignificantDigits": 3,
-                "maximumFractionDigits": 2
-              }
-            }
-          }
-        }
-      },
-      "customWidth": "25",
-      "name": "query - 36"
-    },
-    {
-      "type": 3,
-      "content": {
-        "version": "KqlItem/1.0",
-        "query": "let metric = dynamic({Counter12});\r\nlet cpuSummary=totable(Perf\r\n    {ComputerFilter}\r\n    | where TimeGenerated {TimeRange} \r\n    | where ObjectName == metric.object and CounterName == metric.counter\r\n    | summarize hint.shufflekey=Computer {TrendAggregator12} by Computer, CounterName\r\n    | top {TopN} by {TrendAggregator12:label} {TrendAggregatorOrder12});\r\nlet computerList=(cpuSummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nPerf\r\n    | where TimeGenerated {TimeRange}\r\n    | where ObjectName == metric.object and CounterName == metric.counter\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {TrendAggregator12}{Unit12} by {Snippet12}",
-        "size": 0,
-        "aggregation": 3,
-        "showAnnotations": true,
-        "noDataMessage": "No computers are emitting data for this performance counter.",
-        "queryType": 0,
-        "resourceType": "microsoft.operationalinsights/workspaces",
-        "crossComponentResources": [
-          "{Workspaces}"
-        ],
-        "tileSettings": {
-          "showBorder": false,
-          "titleContent": {
-            "columnMatch": "Computer",
-            "formatter": 1
-          },
-          "leftContent": {
-            "columnMatch": "value",
-            "formatter": 12,
-            "formatOptions": {
-              "palette": "auto"
-            },
-            "numberFormat": {
-              "unit": 17,
-              "options": {
-                "maximumSignificantDigits": 3,
-                "maximumFractionDigits": 2
-              }
-            }
-          }
-        }
-      },
-      "customWidth": "25",
-      "name": "query - 37"
     }
   ],
   "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"


### PR DESCRIPTION
Support non-onboarding scenarios across all the hybrid workbooks since
they can be accessed via Azure mode from VM Insights. In addition, clean
up some of the queries and minor optimizations using the Criteria
parameter. The Performance Counter workbook was updated to use
InsightsMetrics and revamped with fewer charts for better performance.

- Add test parameter to Active Ports template
- Add test parameter to Open Ports template
- Fix test parameters and update Failed Connections template
- Clean-up queries in Failed Connections template
- Add onboarding support to TCP Traffic template
- Update Traffic Comparison template
- Update hybrid Connections Overview workbook with onboarding prompt
- Revamp Performance Counters workbook
- Add prompt to Open Ports template

Connections Overview
![image](https://user-images.githubusercontent.com/43890980/76158415-72913280-60ca-11ea-98c1-ab9bbc54a333.png)

Active Ports
![image](https://user-images.githubusercontent.com/43890980/76158434-8fc60100-60ca-11ea-8056-92fc1770c0e0.png)

Open Ports
![image](https://user-images.githubusercontent.com/43890980/76158444-a8361b80-60ca-11ea-850f-c9fa1f3aed16.png)

Failed Connections
![image](https://user-images.githubusercontent.com/43890980/76158459-c9970780-60ca-11ea-95b5-38f098484af1.png)

TCP Traffic
![image](https://user-images.githubusercontent.com/43890980/76158470-edf2e400-60ca-11ea-87bf-a8b61c29f4a1.png)

Traffic Comparison
![image](https://user-images.githubusercontent.com/43890980/76158518-5fcb2d80-60cb-11ea-876c-4c7488890b9c.png)

Performance Counters
![image](https://user-images.githubusercontent.com/43890980/76358239-65489380-62d6-11ea-8942-6e010094a7ef.png)

Signed-off-by: andrewki-msft <43890980+andrewki-msft@users.noreply.github.com>