### PR TITLE
VM Insights Performance Counters update with Perf and InsightsMetrics

### DIFF
--- a/Workbooks/Virtual Machines - Performance Analysis/Performance Counters (Perf)/Performance Counters (Perf).workbook
+++ b/Workbooks/Virtual Machines - Performance Analysis/Performance Counters (Perf)/Performance Counters (Perf).workbook
@@ -1,0 +1,1749 @@
+{
+  "version": "Notebook/1.0",
+  "items": [
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "crossComponentResources": [
+          "{Workspaces}"
+        ],
+        "parameters": [
+          {
+            "id": "80a15801-7442-49f3-a82f-6e55849ec7fb",
+            "version": "KqlParameterItem/1.0",
+            "name": "DefaultWorkspace",
+            "type": 5,
+            "isRequired": true,
+            "value": "value::1",
+            "isHiddenWhenLocked": true,
+            "typeSettings": {
+              "resourceTypeFilter": {
+                "microsoft.operationalinsights/workspaces": true
+              },
+              "additionalResourceOptions": [
+                "value::1"
+              ]
+            }
+          },
+          {
+            "id": "90119d28-e9c1-4c0d-8715-1f601d337f5c",
+            "version": "KqlParameterItem/1.0",
+            "name": "DefaultSubscription",
+            "type": 5,
+            "value": "value::1",
+            "isHiddenWhenLocked": true,
+            "typeSettings": {
+              "resourceTypeFilter": {
+                "microsoft.resources/subscriptions": true
+              },
+              "additionalResourceOptions": [
+                "value::1"
+              ]
+            }
+          },
+          {
+            "id": "7da21a07-10f4-4455-9105-c37132dcee0d",
+            "version": "KqlParameterItem/1.0",
+            "name": "ContextSelection",
+            "type": 1,
+            "query": "// {DefaultWorkspace}\r\nwhere strcat(\"'\", id, \"'\") =~ \"{DefaultWorkspace:value}\"\r\n| project value = tostring(pack('sub', subscriptionId, 'rg', resourceGroup, 'ws', id))",
+            "crossComponentResources": [
+              "value::all"
+            ],
+            "isHiddenWhenLocked": true,
+            "queryType": 1,
+            "resourceType": "microsoft.resourcegraph/resources"
+          },
+          {
+            "id": "7324c544-2fd2-4d61-b529-481a0f5fd286",
+            "version": "KqlParameterItem/1.0",
+            "name": "HybridMode",
+            "type": 1,
+            "value": "false",
+            "isHiddenWhenLocked": true,
+            "criteriaData": [
+              {
+                "condition": "if (ContextSelection is empty ), result = 'false'",
+                "criteriaContext": {
+                  "leftOperand": "ContextSelection",
+                  "operator": "is Empty",
+                  "rightValType": "param",
+                  "resultValType": "static",
+                  "resultVal": "false"
+                }
+              },
+              {
+                "condition": "else result = 'true'",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "static",
+                  "resultVal": "true"
+                }
+              }
+            ]
+          },
+          {
+            "id": "2942e38e-232e-4d89-9ada-12f9863b3c5b",
+            "version": "KqlParameterItem/1.0",
+            "name": "Subscriptions",
+            "type": 6,
+            "isRequired": true,
+            "multiSelect": true,
+            "quote": "'",
+            "delimiter": ",",
+            "query": "// {DefaultWorkspace} {ContextSelection} {DefaultSubscription}\r\nsummarize by subscriptionId\r\n| project strcat('/subscriptions/', subscriptionId), selected = iff({HybridMode} == true, iff(subscriptionId == todynamic('{ContextSelection}').sub, true, false), iff(strcat('/subscriptions/', subscriptionId) == '{DefaultSubscription}', true, false))",
+            "crossComponentResources": [
+              "value::all"
+            ],
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "queryType": 1,
+            "resourceType": "microsoft.resourcegraph/resources"
+          },
+          {
+            "id": "2bc1e5fc-cc2d-4eb5-bead-5f7d96664dec",
+            "version": "KqlParameterItem/1.0",
+            "name": "Workspaces",
+            "type": 5,
+            "isRequired": true,
+            "multiSelect": true,
+            "quote": "'",
+            "delimiter": ",",
+            "query": "// {DefaultWorkspace} {ContextSelection} {Subscriptions}\r\nwhere type =~ 'microsoft.operationalinsights/workspaces'\r\n| summarize by id, name\r\n| order by tolower(name) asc\r\n| extend Row = row_number()\r\n| project id, selected = iff({HybridMode} == 'true', iff(id == todynamic('{ContextSelection}').ws, true, false), Row == 1)",
+            "crossComponentResources": [
+              "{Subscriptions}"
+            ],
+            "typeSettings": {
+              "limitSelectTo": 5,
+              "additionalResourceOptions": [
+                "value::1"
+              ]
+            },
+            "queryType": 1,
+            "resourceType": "microsoft.resourcegraph/resources"
+          },
+          {
+            "id": "d0f502a4-2f0f-4d3d-af70-5198d41f3e0c",
+            "version": "KqlParameterItem/1.0",
+            "name": "TimeRange",
+            "type": 4,
+            "isRequired": true,
+            "value": {
+              "durationMs": 3600000
+            },
+            "typeSettings": {
+              "selectableValues": [
+                {
+                  "durationMs": 300000,
+                  "createdTime": "2019-02-20T19:49:16.686Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 900000,
+                  "createdTime": "2019-02-20T19:49:16.686Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 1800000,
+                  "createdTime": "2019-02-20T19:49:16.686Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 3600000,
+                  "createdTime": "2019-02-20T19:49:16.686Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 14400000,
+                  "createdTime": "2019-02-20T19:49:16.687Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 43200000,
+                  "createdTime": "2019-02-20T19:49:16.687Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 86400000,
+                  "createdTime": "2019-02-20T19:49:16.687Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 172800000,
+                  "createdTime": "2019-02-20T19:49:16.687Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 259200000,
+                  "createdTime": "2019-02-20T19:49:16.688Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 604800000,
+                  "createdTime": "2019-02-20T19:49:16.688Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 1209600000,
+                  "createdTime": "2019-02-20T19:49:16.688Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 2592000000,
+                  "createdTime": "2019-02-20T19:49:16.688Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 5184000000,
+                  "createdTime": "2019-02-20T19:49:16.688Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 7776000000,
+                  "createdTime": "2019-02-20T19:49:16.688Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                }
+              ],
+              "allowCustom": true
+            }
+          },
+          {
+            "id": "1a0a93cf-0406-40d1-80e1-572b1a8d640e",
+            "version": "KqlParameterItem/1.0",
+            "name": "TimeGrain",
+            "type": 2,
+            "isRequired": true,
+            "value": "15m",
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "jsonData": "[\r\n    {\r\n        \"label\": \"1 minute\",\r\n        \"value\": \"1m\"\r\n    },\r\n    {\r\n        \"label\": \"5 minutes\",\r\n        \"value\": \"5m\"\r\n    },\r\n    {\r\n        \"label\": \"15 minutes\",\r\n        \"value\": \"15m\"\r\n    },\r\n    {\r\n        \"label\": \"30 minutes\",\r\n        \"value\": \"30m\"\r\n    },\r\n    {\r\n        \"label\": \"1 hour\",\r\n        \"value\": \"1h\"\r\n    }\r\n]"
+          },
+          {
+            "id": "112823d7-bf58-4604-a299-78ccc5899516",
+            "version": "KqlParameterItem/1.0",
+            "name": "LineChartQuerySnippet",
+            "type": 1,
+            "query": "print(\"bin(TimeGenerated, {TimeGrain}), ResourceName | render linechart\")",
+            "crossComponentResources": [
+              "{Workspaces}"
+            ],
+            "isHiddenWhenLocked": true,
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          },
+          {
+            "id": "7055a395-0d53-4724-93ad-15e03d4e2ffa",
+            "version": "KqlParameterItem/1.0",
+            "name": "GridQuerySnippet",
+            "type": 1,
+            "value": "ResourceName",
+            "isHiddenWhenLocked": true
+          },
+          {
+            "id": "0b83d1f7-f49b-4dea-8727-ac6d03f51b2a",
+            "version": "KqlParameterItem/1.0",
+            "name": "ComputerNameContains",
+            "type": 1,
+            "value": ""
+          },
+          {
+            "id": "8e436ee8-ba56-4fe5-8a2b-46f77ad405ee",
+            "version": "KqlParameterItem/1.0",
+            "name": "CustomComputerQuery",
+            "type": 1,
+            "query": "let computerFilter = iff('{ComputerNameContains}' != '', \"| where Computer contains '{ComputerNameContains}'\", \"\");\r\nprint(computerFilter)",
+            "crossComponentResources": [
+              "{Workspaces}"
+            ],
+            "isHiddenWhenLocked": true,
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          },
+          {
+            "id": "3cd4c13e-bb7a-4b71-952e-ebf5779fba6a",
+            "version": "KqlParameterItem/1.0",
+            "name": "Computers",
+            "type": 2,
+            "isRequired": true,
+            "multiSelect": true,
+            "quote": "'",
+            "delimiter": ",",
+            "query": "Perf\r\n| where TimeGenerated {TimeRange}\r\n{CustomComputerQuery}\r\n| summarize by Computer\r\n| project Value = Computer, Display = Computer, isSelected = false\r\n| order by Display asc\r\n| union (datatable(Value:string, Display:string, isSelected:boolean)['*', 'All',true])",
+            "crossComponentResources": [
+              "{Workspaces}"
+            ],
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          },
+          {
+            "id": "28d4b81f-7dab-4e3b-abe4-a1f82e9d5561",
+            "version": "KqlParameterItem/1.0",
+            "name": "ComputerFilter",
+            "type": 1,
+            "query": "let computerFilter = iff('*' in ({Computers}), \"{CustomComputerQuery}\", \"| where Computer in ({Computers})\");\r\nprint(computerFilter)",
+            "crossComponentResources": [
+              "{Workspaces}"
+            ],
+            "isHiddenWhenLocked": true,
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          },
+          {
+            "id": "9c56155c-9a7e-41db-ac56-40cabb7d7ddf",
+            "version": "KqlParameterItem/1.0",
+            "name": "TopN",
+            "type": 1,
+            "isRequired": true,
+            "query": "print 5",
+            "crossComponentResources": [
+              "{Workspaces}"
+            ],
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          },
+          {
+            "id": "4261aa48-5274-47a9-8642-1618c8aa7a95",
+            "version": "KqlParameterItem/1.0",
+            "name": "Mode",
+            "type": 2,
+            "isRequired": true,
+            "value": "1",
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "jsonData": "[\r\n    {\r\n        \"label\": \"Locked\",\r\n        \"value\": \"1\"\r\n    },\r\n    {\r\n        \"label\": \"Unlocked\",\r\n        \"value\": \"0\"\r\n    }\r\n]"
+          },
+          {
+            "id": "48e2b8b9-e618-480c-80e6-5cf1cee85ee9",
+            "version": "KqlParameterItem/1.0",
+            "name": "Test",
+            "label": "Not Onboarded",
+            "type": 1,
+            "query": "VMConnection\r\n| take 1\r\n| summarize count()",
+            "crossComponentResources": [
+              "{Workspaces}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": "TimeRange",
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          }
+        ],
+        "style": "above",
+        "queryType": 0,
+        "resourceType": "microsoft.operationalinsights/workspaces"
+      },
+      "name": "parameters - 0"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "<hr style=\"height: 2px;\" />"
+      },
+      "name": "text - 1"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "⚠ No performance counters were detected in the selected workspace for the specified time period (`{TimeRange:label}`). Either try a broader time range, select a different workspace, or onboard virtual machines to the selected workspace `{Workspaces:label}`.\r\n\r\nIf you choose to onboard virtual machines to workspace `{Workspaces:label}`, follow the instruction in the following link: [Azure Monitor for VMs (preview)](https://docs.microsoft.com/en-us/azure/azure-monitor/insights/vminsights-overview)."
+      },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isNotEqualTo",
+        "value": "1"
+      },
+      "name": "text - 38"
+    },
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "crossComponentResources": [
+          "{Workspaces}"
+        ],
+        "parameters": [
+          {
+            "id": "aa2368fc-ad30-4608-b96a-72abf7b1e1af",
+            "version": "KqlParameterItem/1.0",
+            "name": "Counter",
+            "type": 2,
+            "isRequired": true,
+            "query": "// {Workspaces}\r\nPerf\r\n| where TimeGenerated {TimeRange}\r\n| summarize by CounterName, ObjectName, CounterText = CounterName\r\n| order by ObjectName asc, CounterText asc\r\n| project Counter = pack('counter', CounterName, 'object', ObjectName), CounterText, group = ObjectName",
+            "crossComponentResources": [
+              "{Workspaces}"
+            ],
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          },
+          {
+            "id": "6a7306ea-247f-46ca-abca-501911f9e9d3",
+            "version": "KqlParameterItem/1.0",
+            "name": "TrendAggregator",
+            "type": 2,
+            "isRequired": true,
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\", \"selected\":false},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\", \"selected\":false},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P80th = round(percentile(CounterValue, 80), 2)\", \"label\":\"P80th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\", \"selected\":true}    \r\n]"
+          },
+          {
+            "id": "0327f26e-cdde-4b48-b512-6c35f06ad1d0",
+            "version": "KqlParameterItem/1.0",
+            "name": "TrendAggregatorOrder1",
+            "type": 1,
+            "query": "print(iff('{TrendAggregator:label}' == 'P5th'  or '{TrendAggregator:label}' == 'P10th', 'asc', 'desc'))",
+            "crossComponentResources": [
+              "{Workspaces}"
+            ],
+            "isHiddenWhenLocked": true,
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          },
+          {
+            "id": "d026cf36-d22e-4f92-a577-94220726ba3f",
+            "version": "KqlParameterItem/1.0",
+            "name": "Visualization",
+            "type": 2,
+            "isRequired": true,
+            "query": "datatable (value:long, Display:string, isSelected:boolean)\r\n    [0, \"Line Chart\", true,\r\n     1, \"Grid\", false]",
+            "crossComponentResources": [
+              "{Workspaces}"
+            ],
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          },
+          {
+            "id": "a9ac011f-176f-4c31-b82e-139aba93a426",
+            "version": "KqlParameterItem/1.0",
+            "name": "Snippet1",
+            "type": 1,
+            "isRequired": true,
+            "query": "print(iff({Visualization} == 0, \"{LineChartQuerySnippet}\", \"{GridQuerySnippet}\") )",
+            "crossComponentResources": [
+              "{Workspaces}"
+            ],
+            "isHiddenWhenLocked": true,
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          },
+          {
+            "id": "2c9b88ba-fba2-41cf-b10d-8369f2b00377",
+            "version": "KqlParameterItem/1.0",
+            "name": "Counter1",
+            "type": 1,
+            "query": "print '{Counter}'",
+            "crossComponentResources": [
+              "{Workspaces}"
+            ],
+            "isHiddenWhenLocked": true,
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          },
+          {
+            "id": "028cfd79-33d7-4d82-be4d-348d17488ca1",
+            "version": "KqlParameterItem/1.0",
+            "name": "CounterLabel1",
+            "type": 1,
+            "query": "print '{Counter:label}'",
+            "crossComponentResources": [
+              "{Workspaces}"
+            ],
+            "isHiddenWhenLocked": true,
+            "resourceType": "microsoft.operationalinsights/workspaces",
+            "value": null
+          },
+          {
+            "id": "41eb7c98-b679-42b9-8454-432a4b8fff48",
+            "version": "KqlParameterItem/1.0",
+            "name": "TrendAggregatorValue1",
+            "type": 1,
+            "query": "print '{TrendAggregator}'",
+            "crossComponentResources": [
+              "{Workspaces}"
+            ],
+            "isHiddenWhenLocked": true,
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          },
+          {
+            "id": "5c8cbc8c-1776-42fd-9291-2fc4f0e0558b",
+            "version": "KqlParameterItem/1.0",
+            "name": "TrendAggregatorLabel1",
+            "type": 1,
+            "query": "print '{TrendAggregator:label}'",
+            "crossComponentResources": [
+              "{Workspaces}"
+            ],
+            "isHiddenWhenLocked": true,
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          },
+          {
+            "id": "26106dfe-4e33-4c7c-b4b6-2eff5cc76476",
+            "version": "KqlParameterItem/1.0",
+            "name": "Unit",
+            "type": 2,
+            "value": null,
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "jsonData": "[\r\n    {\r\n        \"label\": \"B -> MB\",\r\n        \"value\": \"/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"B -> GB\",\r\n        \"value\": \"/1024/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"MB -> GB\",\r\n        \"value\": \"/1024\"\r\n    },\r\n    {\r\n        \"label\": \"MB -> TB\",\r\n        \"value\": \"/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"b -> Mb\",\r\n        \"value\": \"/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"b -> Gb\",\r\n        \"value\": \"/1000/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"Mb -> Gb\",\r\n        \"value\": \"/1000\"\r\n    },\r\n    {\r\n        \"label\": \"Mb -> Tb\",\r\n        \"value\": \"/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"s -> ms\",\r\n        \"value\": \"*1000\"\r\n    },\r\n    {\r\n        \"label\": \"ms -> s\",\r\n        \"value\": \"/1000\"\r\n    }\r\n]"
+          }
+        ],
+        "style": "above",
+        "queryType": 0,
+        "resourceType": "microsoft.operationalinsights/workspaces"
+      },
+      "conditionalVisibilities": [
+        {
+          "parameterName": "Mode",
+          "comparison": "isEqualTo",
+          "value": "0"
+        },
+        {
+          "parameterName": "Test",
+          "comparison": "isEqualTo",
+          "value": "1"
+        }
+      ],
+      "conditionalVisibility": {
+        "parameterName": "Mode",
+        "comparison": "isEqualTo",
+        "value": "0"
+      },
+      "customWidth": "25",
+      "name": "parameters - 2"
+    },
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "parameters": [
+          {
+            "id": "aa2368fc-ad30-4608-b96a-72abf7b1e1af",
+            "version": "KqlParameterItem/1.0",
+            "name": "Counter2",
+            "type": 2,
+            "isRequired": true,
+            "query": "// {Workspaces}\r\nPerf\r\n| where TimeGenerated {TimeRange}\r\n| summarize by CounterName, ObjectName, CounterText = CounterName\r\n| order by ObjectName asc, CounterText asc\r\n| project Counter = pack('counter', CounterName, 'object', ObjectName), CounterText, group = ObjectName",
+            "crossComponentResources": [
+              "{Workspaces}"
+            ],
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          },
+          {
+            "id": "6a7306ea-247f-46ca-abca-501911f9e9d3",
+            "version": "KqlParameterItem/1.0",
+            "name": "TrendAggregator2",
+            "type": 2,
+            "isRequired": true,
+            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\", \"selected\":false},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\", \"selected\":false},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P80th = round(percentile(CounterValue, 80), 2)\", \"label\":\"P80th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\", \"selected\":true}    \r\n]"
+          },
+          {
+            "id": "0327f26e-cdde-4b48-b512-6c35f06ad1d0",
+            "version": "KqlParameterItem/1.0",
+            "name": "TrendAggregatorOrder2",
+            "type": 1,
+            "query": "print(iff('{TrendAggregator2:label}' == 'P5th'  or '{TrendAggregator2:label}' == 'P10th', 'asc', 'desc'))",
+            "crossComponentResources": [
+              "{Workspaces}"
+            ],
+            "isHiddenWhenLocked": true,
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          },
+          {
+            "id": "bf55b759-7b6a-4ea6-8040-e3e6cc2ffe25",
+            "version": "KqlParameterItem/1.0",
+            "name": "Visualization2",
+            "type": 2,
+            "isRequired": true,
+            "query": "datatable (value:long, Display:string, isSelected:boolean)\r\n    [0, \"Line Chart\", true,\r\n     1, \"Grid\", false]",
+            "crossComponentResources": [
+              "{Workspaces}"
+            ],
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          },
+          {
+            "id": "de7bf116-f413-457b-8c71-fb95cc6adc87",
+            "version": "KqlParameterItem/1.0",
+            "name": "Snippet2",
+            "type": 1,
+            "isRequired": true,
+            "query": "print(iff({Visualization2} == 0, \"{LineChartQuerySnippet}\", \"{GridQuerySnippet}\") )",
+            "crossComponentResources": [
+              "{Workspaces}"
+            ],
+            "isHiddenWhenLocked": true,
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          },
+          {
+            "id": "2ce20c70-a462-4c7d-b5af-7f3b4cc27511",
+            "version": "KqlParameterItem/1.0",
+            "name": "Unit2",
+            "type": 2,
+            "value": null,
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "jsonData": "[\r\n    {\r\n        \"label\": \"B -> MB\",\r\n        \"value\": \"/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"B -> GB\",\r\n        \"value\": \"/1024/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"MB -> GB\",\r\n        \"value\": \"/1024\"\r\n    },\r\n    {\r\n        \"label\": \"MB -> TB\",\r\n        \"value\": \"/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"b -> Mb\",\r\n        \"value\": \"/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"b -> Gb\",\r\n        \"value\": \"/1000/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"Mb -> Gb\",\r\n        \"value\": \"/1000\"\r\n    },\r\n    {\r\n        \"label\": \"Mb -> Tb\",\r\n        \"value\": \"/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"s -> ms\",\r\n        \"value\": \"*1000\"\r\n    },\r\n    {\r\n        \"label\": \"ms -> s\",\r\n        \"value\": \"/1000\"\r\n    }\r\n]"
+          }
+        ],
+        "style": "above",
+        "queryType": 0,
+        "resourceType": "microsoft.operationalinsights/workspaces"
+      },
+      "conditionalVisibilities": [
+        {
+          "parameterName": "Mode",
+          "comparison": "isEqualTo",
+          "value": "0"
+        },
+        {
+          "parameterName": "Test",
+          "comparison": "isEqualTo",
+          "value": "1"
+        }
+      ],
+      "conditionalVisibility": {
+        "parameterName": "Mode",
+        "comparison": "isEqualTo",
+        "value": "0"
+      },
+      "customWidth": "25",
+      "name": "parameters - 3"
+    },
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "parameters": [
+          {
+            "id": "aa2368fc-ad30-4608-b96a-72abf7b1e1af",
+            "version": "KqlParameterItem/1.0",
+            "name": "Counter3",
+            "type": 2,
+            "isRequired": true,
+            "query": "// {Workspaces}\r\nPerf\r\n| where TimeGenerated {TimeRange}\r\n| summarize by CounterName, ObjectName, CounterText = CounterName\r\n| order by ObjectName asc, CounterText asc\r\n| project Counter = pack('counter', CounterName, 'object', ObjectName), CounterText, group = ObjectName",
+            "crossComponentResources": [
+              "{Workspaces}"
+            ],
+            "typeSettings": {
+              "additionalResourceOptions": [
+                "value::1"
+              ]
+            },
+            "resourceType": "microsoft.operationalinsights/workspaces",
+            "value": "{\"counter\":\"Total Bytes Received\",\"object\":\"Network\"}"
+          },
+          {
+            "id": "6a7306ea-247f-46ca-abca-501911f9e9d3",
+            "version": "KqlParameterItem/1.0",
+            "name": "TrendAggregator3",
+            "type": 2,
+            "isRequired": true,
+            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\", \"selected\":false},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\", \"selected\":false},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P80th = round(percentile(CounterValue, 80), 2)\", \"label\":\"P80th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\", \"selected\":true}    \r\n]"
+          },
+          {
+            "id": "0327f26e-cdde-4b48-b512-6c35f06ad1d0",
+            "version": "KqlParameterItem/1.0",
+            "name": "TrendAggregatorOrder3",
+            "type": 1,
+            "query": "print(iff('{TrendAggregator3:label}' == 'P5th'  or '{TrendAggregator3:label}' == 'P10th', 'asc', 'desc'))",
+            "crossComponentResources": [
+              "{Workspaces}"
+            ],
+            "isHiddenWhenLocked": true,
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          },
+          {
+            "id": "db1c9737-0d87-41ad-8f3c-f22c853be400",
+            "version": "KqlParameterItem/1.0",
+            "name": "Visualization3",
+            "type": 2,
+            "isRequired": true,
+            "query": "datatable (value:long, Display:string, isSelected:boolean)\r\n    [0, \"Line Chart\", true,\r\n     1, \"Grid\", false]",
+            "crossComponentResources": [
+              "{Workspaces}"
+            ],
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          },
+          {
+            "id": "82cef2b6-4ce0-4a64-bd64-017810211147",
+            "version": "KqlParameterItem/1.0",
+            "name": "Snippet3",
+            "type": 1,
+            "isRequired": true,
+            "query": "print(iff({Visualization3} == 0, \"{LineChartQuerySnippet}\", \"{GridQuerySnippet}\") )",
+            "crossComponentResources": [
+              "{Workspaces}"
+            ],
+            "isHiddenWhenLocked": true,
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          },
+          {
+            "id": "def72a65-f496-4619-8fcb-85c338641907",
+            "version": "KqlParameterItem/1.0",
+            "name": "Unit3",
+            "type": 2,
+            "value": null,
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "jsonData": "[\r\n    {\r\n        \"label\": \"B -> MB\",\r\n        \"value\": \"/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"B -> GB\",\r\n        \"value\": \"/1024/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"MB -> GB\",\r\n        \"value\": \"/1024\"\r\n    },\r\n    {\r\n        \"label\": \"MB -> TB\",\r\n        \"value\": \"/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"b -> Mb\",\r\n        \"value\": \"/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"b -> Gb\",\r\n        \"value\": \"/1000/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"Mb -> Gb\",\r\n        \"value\": \"/1000\"\r\n    },\r\n    {\r\n        \"label\": \"Mb -> Tb\",\r\n        \"value\": \"/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"s -> ms\",\r\n        \"value\": \"*1000\"\r\n    },\r\n    {\r\n        \"label\": \"ms -> s\",\r\n        \"value\": \"/1000\"\r\n    }\r\n]"
+          }
+        ],
+        "style": "above",
+        "queryType": 0,
+        "resourceType": "microsoft.operationalinsights/workspaces"
+      },
+      "conditionalVisibilities": [
+        {
+          "parameterName": "Mode",
+          "comparison": "isEqualTo",
+          "value": "0"
+        },
+        {
+          "parameterName": "Test",
+          "comparison": "isEqualTo",
+          "value": "1"
+        }
+      ],
+      "conditionalVisibility": {
+        "parameterName": "Mode",
+        "comparison": "isEqualTo",
+        "value": "0"
+      },
+      "customWidth": "25",
+      "name": "parameters - 4"
+    },
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "parameters": [
+          {
+            "id": "aa2368fc-ad30-4608-b96a-72abf7b1e1af",
+            "version": "KqlParameterItem/1.0",
+            "name": "Counter4",
+            "type": 2,
+            "isRequired": true,
+            "query": "// {Workspaces}\r\nPerf\r\n| where TimeGenerated {TimeRange}\r\n| summarize by CounterName, ObjectName, CounterText = CounterName\r\n| order by ObjectName asc, CounterText asc\r\n| project Counter = pack('counter', CounterName, 'object', ObjectName), CounterText, group = ObjectName",
+            "crossComponentResources": [
+              "{Workspaces}"
+            ],
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "resourceType": "microsoft.operationalinsights/workspaces",
+            "value": "{\"counter\":\"Total Bytes Transmitted\",\"object\":\"Network\"}"
+          },
+          {
+            "id": "6a7306ea-247f-46ca-abca-501911f9e9d3",
+            "version": "KqlParameterItem/1.0",
+            "name": "TrendAggregator4",
+            "type": 2,
+            "isRequired": true,
+            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\", \"selected\":false},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\", \"selected\":false},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P80th = round(percentile(CounterValue, 80), 2)\", \"label\":\"P80th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\", \"selected\":true}    \r\n]"
+          },
+          {
+            "id": "0327f26e-cdde-4b48-b512-6c35f06ad1d0",
+            "version": "KqlParameterItem/1.0",
+            "name": "TrendAggregatorOrder4",
+            "type": 1,
+            "query": "print(iff('{TrendAggregator4:label}' == 'P5th'  or '{TrendAggregator4:label}' == 'P10th', 'asc', 'desc'))",
+            "crossComponentResources": [
+              "{Workspaces}"
+            ],
+            "isHiddenWhenLocked": true,
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          },
+          {
+            "id": "16d42161-ad5d-4bd8-9b2a-8e834e3b8fed",
+            "version": "KqlParameterItem/1.0",
+            "name": "Visualization4",
+            "type": 2,
+            "isRequired": true,
+            "query": "datatable (value:long, Display:string, isSelected:boolean)\r\n    [0, \"Line Chart\", true,\r\n     1, \"Grid\", false]",
+            "crossComponentResources": [
+              "{Workspaces}"
+            ],
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          },
+          {
+            "id": "d768c009-20aa-4476-83cd-afacf4694818",
+            "version": "KqlParameterItem/1.0",
+            "name": "Snippet4",
+            "type": 1,
+            "isRequired": true,
+            "query": "print(iff({Visualization4} == 0, \"{LineChartQuerySnippet}\", \"{GridQuerySnippet}\") )",
+            "crossComponentResources": [
+              "{Workspaces}"
+            ],
+            "isHiddenWhenLocked": true,
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          },
+          {
+            "id": "eb3e4d65-ee3c-481c-af2e-8b41e4049bf8",
+            "version": "KqlParameterItem/1.0",
+            "name": "Unit4",
+            "type": 2,
+            "value": null,
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "jsonData": "[\r\n    {\r\n        \"label\": \"B -> MB\",\r\n        \"value\": \"/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"B -> GB\",\r\n        \"value\": \"/1024/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"MB -> GB\",\r\n        \"value\": \"/1024\"\r\n    },\r\n    {\r\n        \"label\": \"MB -> TB\",\r\n        \"value\": \"/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"b -> Mb\",\r\n        \"value\": \"/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"b -> Gb\",\r\n        \"value\": \"/1000/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"Mb -> Gb\",\r\n        \"value\": \"/1000\"\r\n    },\r\n    {\r\n        \"label\": \"Mb -> Tb\",\r\n        \"value\": \"/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"s -> ms\",\r\n        \"value\": \"*1000\"\r\n    },\r\n    {\r\n        \"label\": \"ms -> s\",\r\n        \"value\": \"/1000\"\r\n    }\r\n]"
+          }
+        ],
+        "style": "above",
+        "queryType": 0,
+        "resourceType": "microsoft.operationalinsights/workspaces"
+      },
+      "conditionalVisibilities": [
+        {
+          "parameterName": "Mode",
+          "comparison": "isEqualTo",
+          "value": "0"
+        },
+        {
+          "parameterName": "Test",
+          "comparison": "isEqualTo",
+          "value": "1"
+        }
+      ],
+      "conditionalVisibility": {
+        "parameterName": "Mode",
+        "comparison": "isEqualTo",
+        "value": "0"
+      },
+      "customWidth": "25",
+      "name": "parameters - 5"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "<h3 style=\"margin-bottom:0;\">{CounterLabel1}</h3><h4 style=\"margin-top:0;font-weight:normal;color:#777;\">{TrendAggregatorLabel1} {TrendAggregatorOrder1} {Unit:label}</h4>"
+      },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isEqualTo",
+        "value": "1"
+      },
+      "customWidth": "25",
+      "name": "text - 6"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "<h3 style=\"margin-bottom:0;\">{Counter2:label}</h3><h4 style=\"margin-top:0;font-weight:normal;color:#777;\">{TrendAggregator2:label} {TrendAggregatorOrder2} {Unit2:label}</h4>"
+      },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isEqualTo",
+        "value": "1"
+      },
+      "customWidth": "25",
+      "name": "text - 7"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "<h3 style=\"margin-bottom:0;\">{Counter3:label}</h3><h4 style=\"margin-top:0;font-weight:normal;color:#777;\">{TrendAggregator3:label} {TrendAggregatorOrder3} {Unit3:label}</h4>"
+      },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isEqualTo",
+        "value": "1"
+      },
+      "customWidth": "25",
+      "name": "text - 8"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "<h3 style=\"margin-bottom:0;\">{Counter4:label}</h3><h4 style=\"margin-top:0;font-weight:normal;color:#777;\">{TrendAggregator4:label} {TrendAggregatorOrder4} {Unit4:label}</h4>"
+      },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isEqualTo",
+        "value": "1"
+      },
+      "customWidth": "25",
+      "name": "text - 9"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "let metric = dynamic({Counter1});\r\nlet cpuSummary=totable(Perf\r\n    {ComputerFilter}\r\n    | where TimeGenerated {TimeRange} \r\n    | where ObjectName == metric.object and CounterName == metric.counter\r\n    | summarize hint.shufflekey=Computer {TrendAggregatorValue1} by Computer, CounterName\r\n    | top {TopN} by {TrendAggregatorLabel1} {TrendAggregatorOrder1});\r\nlet computerList=(cpuSummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nPerf\r\n    | where TimeGenerated {TimeRange}\r\n    | where ObjectName == metric.object and CounterName == metric.counter\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {TrendAggregatorValue1}{Unit} by {Snippet1}\r\n\t\r\n",
+        "size": 0,
+        "aggregation": 3,
+        "showAnnotations": true,
+        "noDataMessage": "No computers are emitting data for this performance counter.",
+        "queryType": 0,
+        "resourceType": "microsoft.operationalinsights/workspaces",
+        "crossComponentResources": [
+          "{Workspaces}"
+        ],
+        "tileSettings": {
+          "showBorder": false,
+          "titleContent": {
+            "columnMatch": "Computer",
+            "formatter": 1
+          },
+          "leftContent": {
+            "columnMatch": "value",
+            "formatter": 12,
+            "formatOptions": {
+              "palette": "auto"
+            },
+            "numberFormat": {
+              "unit": 17,
+              "options": {
+                "maximumSignificantDigits": 3,
+                "maximumFractionDigits": 2
+              }
+            }
+          }
+        }
+      },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isEqualTo",
+        "value": "1"
+      },
+      "customWidth": "25",
+      "name": "query - 10"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "let metric = dynamic({Counter2});\r\nlet cpuSummary=totable(Perf\r\n    {ComputerFilter}\r\n    | where TimeGenerated {TimeRange} \r\n    | where ObjectName == metric.object and CounterName == metric.counter\r\n    | summarize hint.shufflekey=Computer {TrendAggregator2} by Computer, CounterName\r\n    | top {TopN} by {TrendAggregator2:label} {TrendAggregatorOrder2});\r\nlet computerList=(cpuSummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nPerf\r\n    | where TimeGenerated {TimeRange}\r\n    | where ObjectName == metric.object and CounterName == metric.counter\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {TrendAggregator2}{Unit2} by {Snippet2}",
+        "size": 0,
+        "aggregation": 3,
+        "showAnnotations": true,
+        "noDataMessage": "No computers are emitting data for this performance counter.",
+        "queryType": 0,
+        "resourceType": "microsoft.operationalinsights/workspaces",
+        "crossComponentResources": [
+          "{Workspaces}"
+        ],
+        "tileSettings": {
+          "showBorder": false,
+          "titleContent": {
+            "columnMatch": "Computer",
+            "formatter": 1
+          },
+          "leftContent": {
+            "columnMatch": "value",
+            "formatter": 12,
+            "formatOptions": {
+              "palette": "auto"
+            },
+            "numberFormat": {
+              "unit": 17,
+              "options": {
+                "maximumSignificantDigits": 3,
+                "maximumFractionDigits": 2
+              }
+            }
+          }
+        }
+      },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isEqualTo",
+        "value": "1"
+      },
+      "customWidth": "25",
+      "name": "query - 11"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "let metric = dynamic({Counter3});\r\nlet cpuSummary=totable(Perf\r\n    {ComputerFilter}\r\n    | where TimeGenerated {TimeRange} \r\n    | where ObjectName == metric.object and CounterName == metric.counter\r\n    | summarize hint.shufflekey=Computer {TrendAggregator3} by Computer, CounterName\r\n    | top {TopN} by {TrendAggregator3:label} {TrendAggregatorOrder3});\r\nlet computerList=(cpuSummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nPerf\r\n    | where TimeGenerated {TimeRange}\r\n    | where ObjectName == metric.object and CounterName == metric.counter\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {TrendAggregator3}{Unit3} by {Snippet3}",
+        "size": 0,
+        "aggregation": 3,
+        "showAnnotations": true,
+        "noDataMessage": "No computers are emitting data for this performance counter.",
+        "queryType": 0,
+        "resourceType": "microsoft.operationalinsights/workspaces",
+        "crossComponentResources": [
+          "{Workspaces}"
+        ],
+        "tileSettings": {
+          "showBorder": false,
+          "titleContent": {
+            "columnMatch": "Computer",
+            "formatter": 1
+          },
+          "leftContent": {
+            "columnMatch": "value",
+            "formatter": 12,
+            "formatOptions": {
+              "palette": "auto"
+            },
+            "numberFormat": {
+              "unit": 17,
+              "options": {
+                "maximumSignificantDigits": 3,
+                "maximumFractionDigits": 2
+              }
+            }
+          }
+        }
+      },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isEqualTo",
+        "value": "1"
+      },
+      "customWidth": "25",
+      "name": "query - 12"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "let metric = dynamic({Counter4});\r\nlet cpuSummary=totable(Perf\r\n    {ComputerFilter}\r\n    | where TimeGenerated {TimeRange} \r\n    | where ObjectName == metric.object and CounterName == metric.counter\r\n    | summarize hint.shufflekey=Computer {TrendAggregator4} by Computer, CounterName\r\n    | top {TopN} by {TrendAggregator4:label} {TrendAggregatorOrder4});\r\nlet computerList=(cpuSummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nPerf\r\n    | where TimeGenerated {TimeRange}\r\n    | where ObjectName == metric.object and CounterName == metric.counter\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {TrendAggregator4}{Unit4} by {Snippet4}",
+        "size": 0,
+        "aggregation": 3,
+        "showAnnotations": true,
+        "noDataMessage": "No computers are emitting data for this performance counter.",
+        "queryType": 0,
+        "resourceType": "microsoft.operationalinsights/workspaces",
+        "crossComponentResources": [
+          "{Workspaces}"
+        ],
+        "tileSettings": {
+          "showBorder": false,
+          "titleContent": {
+            "columnMatch": "Computer",
+            "formatter": 1
+          },
+          "leftContent": {
+            "columnMatch": "value",
+            "formatter": 12,
+            "formatOptions": {
+              "palette": "auto"
+            },
+            "numberFormat": {
+              "unit": 17,
+              "options": {
+                "maximumSignificantDigits": 3,
+                "maximumFractionDigits": 2
+              }
+            }
+          }
+        }
+      },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isEqualTo",
+        "value": "1"
+      },
+      "customWidth": "25",
+      "name": "query - 13"
+    },
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "parameters": [
+          {
+            "id": "aa2368fc-ad30-4608-b96a-72abf7b1e1af",
+            "version": "KqlParameterItem/1.0",
+            "name": "Counter5",
+            "type": 2,
+            "isRequired": true,
+            "query": "// {Workspaces}\r\nPerf\r\n| where TimeGenerated {TimeRange}\r\n| summarize by CounterName, ObjectName, CounterText = CounterName\r\n| order by ObjectName asc, CounterText asc\r\n| project Counter = pack('counter', CounterName, 'object', ObjectName), CounterText, group = ObjectName",
+            "crossComponentResources": [
+              "{Workspaces}"
+            ],
+            "typeSettings": {
+              "additionalResourceOptions": [
+                "value::1"
+              ]
+            },
+            "resourceType": "microsoft.operationalinsights/workspaces",
+            "value": "{\"counter\":\"Disk Reads/sec\",\"object\":\"Logical Disk\"}"
+          },
+          {
+            "id": "6a7306ea-247f-46ca-abca-501911f9e9d3",
+            "version": "KqlParameterItem/1.0",
+            "name": "TrendAggregator5",
+            "type": 2,
+            "isRequired": true,
+            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\", \"selected\":false},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\", \"selected\":false},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P80th = round(percentile(CounterValue, 80), 2)\", \"label\":\"P80th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\", \"selected\":true}    \r\n]"
+          },
+          {
+            "id": "0327f26e-cdde-4b48-b512-6c35f06ad1d0",
+            "version": "KqlParameterItem/1.0",
+            "name": "TrendAggregatorOrder5",
+            "type": 1,
+            "query": "print(iff('{TrendAggregator5:label}' == 'P5th'  or '{TrendAggregator5:label}' == 'P10th', 'asc', 'desc'))",
+            "crossComponentResources": [
+              "{Workspaces}"
+            ],
+            "isHiddenWhenLocked": true,
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          },
+          {
+            "id": "b75e4ca5-7d71-4d29-b69e-9104934905ba",
+            "version": "KqlParameterItem/1.0",
+            "name": "Visualization5",
+            "type": 2,
+            "isRequired": true,
+            "query": "datatable (value:long, Display:string, isSelected:boolean)\r\n    [0, \"Line Chart\", true,\r\n     1, \"Grid\", false]",
+            "crossComponentResources": [
+              "{Workspaces}"
+            ],
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          },
+          {
+            "id": "7df7ee71-c054-4a88-b8b1-33ba6dd9d70d",
+            "version": "KqlParameterItem/1.0",
+            "name": "Snippet5",
+            "type": 1,
+            "isRequired": true,
+            "query": "print(iff({Visualization5} == 0, \"{LineChartQuerySnippet}\", \"{GridQuerySnippet}\") )",
+            "crossComponentResources": [
+              "{Workspaces}"
+            ],
+            "isHiddenWhenLocked": true,
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          },
+          {
+            "id": "bb81032c-59e4-417f-a5e1-fc6552c3190f",
+            "version": "KqlParameterItem/1.0",
+            "name": "Unit5",
+            "type": 2,
+            "value": null,
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "jsonData": "[\r\n    {\r\n        \"label\": \"B -> MB\",\r\n        \"value\": \"/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"B -> GB\",\r\n        \"value\": \"/1024/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"MB -> GB\",\r\n        \"value\": \"/1024\"\r\n    },\r\n    {\r\n        \"label\": \"MB -> TB\",\r\n        \"value\": \"/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"b -> Mb\",\r\n        \"value\": \"/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"b -> Gb\",\r\n        \"value\": \"/1000/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"Mb -> Gb\",\r\n        \"value\": \"/1000\"\r\n    },\r\n    {\r\n        \"label\": \"Mb -> Tb\",\r\n        \"value\": \"/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"s -> ms\",\r\n        \"value\": \"*1000\"\r\n    },\r\n    {\r\n        \"label\": \"ms -> s\",\r\n        \"value\": \"/1000\"\r\n    }\r\n]"
+          }
+        ],
+        "style": "above",
+        "queryType": 0,
+        "resourceType": "microsoft.operationalinsights/workspaces"
+      },
+      "conditionalVisibilities": [
+        {
+          "parameterName": "Mode",
+          "comparison": "isEqualTo",
+          "value": "0"
+        },
+        {
+          "parameterName": "Test",
+          "comparison": "isEqualTo",
+          "value": "1"
+        }
+      ],
+      "conditionalVisibility": {
+        "parameterName": "Mode",
+        "comparison": "isEqualTo",
+        "value": "0"
+      },
+      "customWidth": "25",
+      "name": "parameters - 14"
+    },
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "parameters": [
+          {
+            "id": "aa2368fc-ad30-4608-b96a-72abf7b1e1af",
+            "version": "KqlParameterItem/1.0",
+            "name": "Counter6",
+            "type": 2,
+            "isRequired": true,
+            "query": "// {Workspaces}\r\nPerf\r\n| where TimeGenerated {TimeRange}\r\n| summarize by CounterName, ObjectName, CounterText = CounterName\r\n| order by ObjectName asc, CounterText asc\r\n| project Counter = pack('counter', CounterName, 'object', ObjectName), CounterText, group = ObjectName",
+            "crossComponentResources": [
+              "{Workspaces}"
+            ],
+            "typeSettings": {
+              "additionalResourceOptions": [
+                "value::1"
+              ]
+            },
+            "resourceType": "microsoft.operationalinsights/workspaces",
+            "value": "{\"counter\":\"Disk Read Bytes/sec\",\"object\":\"Logical Disk\"}"
+          },
+          {
+            "id": "6a7306ea-247f-46ca-abca-501911f9e9d3",
+            "version": "KqlParameterItem/1.0",
+            "name": "TrendAggregator6",
+            "type": 2,
+            "isRequired": true,
+            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\", \"selected\":false},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\", \"selected\":false},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P80th = round(percentile(CounterValue, 80), 2)\", \"label\":\"P80th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\", \"selected\":true}    \r\n]"
+          },
+          {
+            "id": "0327f26e-cdde-4b48-b512-6c35f06ad1d0",
+            "version": "KqlParameterItem/1.0",
+            "name": "TrendAggregatorOrder6",
+            "type": 1,
+            "query": "print(iff('{TrendAggregator6:label}' == 'P5th'  or '{TrendAggregator6:label}' == 'P10th', 'asc', 'desc'))",
+            "crossComponentResources": [
+              "{Workspaces}"
+            ],
+            "isHiddenWhenLocked": true,
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          },
+          {
+            "id": "5b1ee58a-5d4d-4be8-b38c-3a8eb37a2f3e",
+            "version": "KqlParameterItem/1.0",
+            "name": "Visualization6",
+            "type": 2,
+            "isRequired": true,
+            "query": "datatable (value:long, Display:string, isSelected:boolean)\r\n    [0, \"Line Chart\", true,\r\n     1, \"Grid\", false]",
+            "crossComponentResources": [
+              "{Workspaces}"
+            ],
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          },
+          {
+            "id": "d931d741-2f83-4ca0-bc2b-5c0c13fe8058",
+            "version": "KqlParameterItem/1.0",
+            "name": "Snippet6",
+            "type": 1,
+            "isRequired": true,
+            "query": "print(iff({Visualization6} == 0, \"{LineChartQuerySnippet}\", \"{GridQuerySnippet}\") )",
+            "crossComponentResources": [
+              "{Workspaces}"
+            ],
+            "isHiddenWhenLocked": true,
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          },
+          {
+            "id": "ab35d419-d8c1-45be-8885-e39a55c0648d",
+            "version": "KqlParameterItem/1.0",
+            "name": "Unit6",
+            "type": 2,
+            "value": null,
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "jsonData": "[\r\n    {\r\n        \"label\": \"B -> MB\",\r\n        \"value\": \"/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"B -> GB\",\r\n        \"value\": \"/1024/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"MB -> GB\",\r\n        \"value\": \"/1024\"\r\n    },\r\n    {\r\n        \"label\": \"MB -> TB\",\r\n        \"value\": \"/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"b -> Mb\",\r\n        \"value\": \"/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"b -> Gb\",\r\n        \"value\": \"/1000/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"Mb -> Gb\",\r\n        \"value\": \"/1000\"\r\n    },\r\n    {\r\n        \"label\": \"Mb -> Tb\",\r\n        \"value\": \"/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"s -> ms\",\r\n        \"value\": \"*1000\"\r\n    },\r\n    {\r\n        \"label\": \"ms -> s\",\r\n        \"value\": \"/1000\"\r\n    }\r\n]"
+          }
+        ],
+        "style": "above",
+        "queryType": 0,
+        "resourceType": "microsoft.operationalinsights/workspaces"
+      },
+      "conditionalVisibilities": [
+        {
+          "parameterName": "Mode",
+          "comparison": "isEqualTo",
+          "value": "0"
+        },
+        {
+          "parameterName": "Test",
+          "comparison": "isEqualTo",
+          "value": "1"
+        }
+      ],
+      "conditionalVisibility": {
+        "parameterName": "Mode",
+        "comparison": "isEqualTo",
+        "value": "0"
+      },
+      "customWidth": "25",
+      "name": "parameters - 15"
+    },
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "parameters": [
+          {
+            "id": "aa2368fc-ad30-4608-b96a-72abf7b1e1af",
+            "version": "KqlParameterItem/1.0",
+            "name": "Counter7",
+            "type": 2,
+            "isRequired": true,
+            "query": "// {Workspaces}\r\nPerf\r\n| where TimeGenerated {TimeRange}\r\n| summarize by CounterName, ObjectName, CounterText = CounterName\r\n| order by ObjectName asc, CounterText asc\r\n| project Counter = pack('counter', CounterName, 'object', ObjectName), CounterText, group = ObjectName",
+            "crossComponentResources": [
+              "{Workspaces}"
+            ],
+            "typeSettings": {
+              "additionalResourceOptions": [
+                "value::1"
+              ]
+            },
+            "resourceType": "microsoft.operationalinsights/workspaces",
+            "value": "{\"counter\":\"Disk Writes/sec\",\"object\":\"Logical Disk\"}"
+          },
+          {
+            "id": "6a7306ea-247f-46ca-abca-501911f9e9d3",
+            "version": "KqlParameterItem/1.0",
+            "name": "TrendAggregator7",
+            "type": 2,
+            "isRequired": true,
+            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\", \"selected\":false},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\", \"selected\":false},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P80th = round(percentile(CounterValue, 80), 2)\", \"label\":\"P80th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\", \"selected\":true}    \r\n]"
+          },
+          {
+            "id": "0327f26e-cdde-4b48-b512-6c35f06ad1d0",
+            "version": "KqlParameterItem/1.0",
+            "name": "TrendAggregatorOrder7",
+            "type": 1,
+            "query": "print(iff('{TrendAggregator7:label}' == 'P5th'  or '{TrendAggregator7:label}' == 'P10th', 'asc', 'desc'))",
+            "crossComponentResources": [
+              "{Workspaces}"
+            ],
+            "isHiddenWhenLocked": true,
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          },
+          {
+            "id": "bc1291ba-dd26-4224-9b25-3a1e7b3eb024",
+            "version": "KqlParameterItem/1.0",
+            "name": "Visualization7",
+            "type": 2,
+            "isRequired": true,
+            "query": "datatable (value:long, Display:string, isSelected:boolean)\r\n    [0, \"Line Chart\", true,\r\n     1, \"Grid\", false]",
+            "crossComponentResources": [
+              "{Workspaces}"
+            ],
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          },
+          {
+            "id": "6cc1a388-27c6-4cfe-a787-ff00cb8f4fae",
+            "version": "KqlParameterItem/1.0",
+            "name": "Snippet7",
+            "type": 1,
+            "isRequired": true,
+            "query": "print(iff({Visualization7} == 0, \"{LineChartQuerySnippet}\", \"{GridQuerySnippet}\") )",
+            "crossComponentResources": [
+              "{Workspaces}"
+            ],
+            "isHiddenWhenLocked": true,
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          },
+          {
+            "id": "dce874fa-b71d-4a09-bcee-bd1b3f672f7f",
+            "version": "KqlParameterItem/1.0",
+            "name": "Unit7",
+            "type": 2,
+            "value": null,
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "jsonData": "[\r\n    {\r\n        \"label\": \"B -> MB\",\r\n        \"value\": \"/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"B -> GB\",\r\n        \"value\": \"/1024/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"MB -> GB\",\r\n        \"value\": \"/1024\"\r\n    },\r\n    {\r\n        \"label\": \"MB -> TB\",\r\n        \"value\": \"/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"b -> Mb\",\r\n        \"value\": \"/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"b -> Gb\",\r\n        \"value\": \"/1000/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"Mb -> Gb\",\r\n        \"value\": \"/1000\"\r\n    },\r\n    {\r\n        \"label\": \"Mb -> Tb\",\r\n        \"value\": \"/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"s -> ms\",\r\n        \"value\": \"*1000\"\r\n    },\r\n    {\r\n        \"label\": \"ms -> s\",\r\n        \"value\": \"/1000\"\r\n    }\r\n]"
+          }
+        ],
+        "style": "above",
+        "queryType": 0,
+        "resourceType": "microsoft.operationalinsights/workspaces"
+      },
+      "conditionalVisibilities": [
+        {
+          "parameterName": "Mode",
+          "comparison": "isEqualTo",
+          "value": "0"
+        },
+        {
+          "parameterName": "Test",
+          "comparison": "isEqualTo",
+          "value": "1"
+        }
+      ],
+      "conditionalVisibility": {
+        "parameterName": "Mode",
+        "comparison": "isEqualTo",
+        "value": "0"
+      },
+      "customWidth": "25",
+      "name": "parameters - 16"
+    },
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "parameters": [
+          {
+            "id": "aa2368fc-ad30-4608-b96a-72abf7b1e1af",
+            "version": "KqlParameterItem/1.0",
+            "name": "Counter8",
+            "type": 2,
+            "isRequired": true,
+            "query": "// {Workspaces}\r\nPerf\r\n| where TimeGenerated {TimeRange}\r\n| summarize by CounterName, ObjectName, CounterText = CounterName\r\n| order by ObjectName asc, CounterText asc\r\n| project Counter = pack('counter', CounterName, 'object', ObjectName), CounterText, group = ObjectName",
+            "crossComponentResources": [
+              "{Workspaces}"
+            ],
+            "typeSettings": {
+              "additionalResourceOptions": [
+                "value::1"
+              ]
+            },
+            "resourceType": "microsoft.operationalinsights/workspaces",
+            "value": "{\"counter\":\"Disk Write Bytes/sec\",\"object\":\"Logical Disk\"}"
+          },
+          {
+            "id": "6a7306ea-247f-46ca-abca-501911f9e9d3",
+            "version": "KqlParameterItem/1.0",
+            "name": "TrendAggregator8",
+            "type": 2,
+            "isRequired": true,
+            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\", \"selected\":false},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\", \"selected\":false},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P80th = round(percentile(CounterValue, 80), 2)\", \"label\":\"P80th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\", \"selected\":true}    \r\n]"
+          },
+          {
+            "id": "0327f26e-cdde-4b48-b512-6c35f06ad1d0",
+            "version": "KqlParameterItem/1.0",
+            "name": "TrendAggregatorOrder8",
+            "type": 1,
+            "query": "print(iff('{TrendAggregator8:label}' == 'P5th'  or '{TrendAggregator8:label}' == 'P10th', 'asc', 'desc'))",
+            "crossComponentResources": [
+              "{Workspaces}"
+            ],
+            "isHiddenWhenLocked": true,
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          },
+          {
+            "id": "68468652-570f-4d77-af12-a59d463d5f02",
+            "version": "KqlParameterItem/1.0",
+            "name": "Visualization8",
+            "type": 2,
+            "isRequired": true,
+            "query": "datatable (value:long, Display:string, isSelected:boolean)\r\n    [0, \"Line Chart\", true,\r\n     1, \"Grid\", false]",
+            "crossComponentResources": [
+              "{Workspaces}"
+            ],
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          },
+          {
+            "id": "15738505-f7e6-446e-995d-280cf70dde93",
+            "version": "KqlParameterItem/1.0",
+            "name": "Snippet8",
+            "type": 1,
+            "isRequired": true,
+            "query": "print(iff({Visualization8} == 0, \"{LineChartQuerySnippet}\", \"{GridQuerySnippet}\") )",
+            "crossComponentResources": [
+              "{Workspaces}"
+            ],
+            "isHiddenWhenLocked": true,
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          },
+          {
+            "id": "c78d15dd-79cb-4cd2-8749-df9d97625b31",
+            "version": "KqlParameterItem/1.0",
+            "name": "Unit8",
+            "type": 2,
+            "value": null,
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "jsonData": "[\r\n    {\r\n        \"label\": \"B -> MB\",\r\n        \"value\": \"/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"B -> GB\",\r\n        \"value\": \"/1024/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"MB -> GB\",\r\n        \"value\": \"/1024\"\r\n    },\r\n    {\r\n        \"label\": \"MB -> TB\",\r\n        \"value\": \"/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"b -> Mb\",\r\n        \"value\": \"/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"b -> Gb\",\r\n        \"value\": \"/1000/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"Mb -> Gb\",\r\n        \"value\": \"/1000\"\r\n    },\r\n    {\r\n        \"label\": \"Mb -> Tb\",\r\n        \"value\": \"/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"s -> ms\",\r\n        \"value\": \"*1000\"\r\n    },\r\n    {\r\n        \"label\": \"ms -> s\",\r\n        \"value\": \"/1000\"\r\n    }\r\n]"
+          }
+        ],
+        "style": "above",
+        "queryType": 0,
+        "resourceType": "microsoft.operationalinsights/workspaces"
+      },
+      "conditionalVisibilities": [
+        {
+          "parameterName": "Mode",
+          "comparison": "isEqualTo",
+          "value": "0"
+        },
+        {
+          "parameterName": "Test",
+          "comparison": "isEqualTo",
+          "value": "1"
+        }
+      ],
+      "conditionalVisibility": {
+        "parameterName": "Mode",
+        "comparison": "isEqualTo",
+        "value": "0"
+      },
+      "customWidth": "25",
+      "name": "parameters - 17"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "<h3 style=\"margin-bottom:0;\">{Counter5:label}</h3><h4 style=\"margin-top:0;font-weight:normal;color:#777;\">{TrendAggregator5:label} {TrendAggregatorOrder5} {Unit5:label}</h4>"
+      },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isEqualTo",
+        "value": "1"
+      },
+      "customWidth": "25",
+      "name": "text - 18"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "<h3 style=\"margin-bottom:0;\">{Counter6:label}</h3><h4 style=\"margin-top:0;font-weight:normal;color:#777;\">{TrendAggregator6:label} {TrendAggregatorOrder6} {Unit6:label}</h4>"
+      },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isEqualTo",
+        "value": "1"
+      },
+      "customWidth": "25",
+      "name": "text - 19"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "<h3 style=\"margin-bottom:0;\">{Counter7:label}</h3><h4 style=\"margin-top:0;font-weight:normal;color:#777;\">{TrendAggregator7:label} {TrendAggregatorOrder7} {Unit7:label}</h4>"
+      },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isEqualTo",
+        "value": "1"
+      },
+      "customWidth": "25",
+      "name": "text - 20"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "<h3 style=\"margin-bottom:0;\">{Counter8:label}</h3><h4 style=\"margin-top:0;font-weight:normal;color:#777;\">{TrendAggregator8:label} {TrendAggregatorOrder8} {Unit8:label}</h4>"
+      },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isEqualTo",
+        "value": "1"
+      },
+      "customWidth": "25",
+      "name": "text - 21"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "let metric = dynamic({Counter5});\r\nlet cpuSummary=totable(Perf\r\n    {ComputerFilter}\r\n    | where TimeGenerated {TimeRange} \r\n    | where ObjectName == metric.object and CounterName == metric.counter\r\n    | summarize hint.shufflekey=Computer {TrendAggregator5} by Computer, CounterName\r\n    | top {TopN} by {TrendAggregator5:label} {TrendAggregatorOrder5});\r\nlet computerList=(cpuSummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nPerf\r\n    | where TimeGenerated {TimeRange}\r\n    | where ObjectName == metric.object and CounterName == metric.counter\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {TrendAggregator5}{Unit5} by {Snippet5}",
+        "size": 0,
+        "aggregation": 3,
+        "showAnnotations": true,
+        "noDataMessage": "No computers are emitting data for this performance counter.",
+        "queryType": 0,
+        "resourceType": "microsoft.operationalinsights/workspaces",
+        "crossComponentResources": [
+          "{Workspaces}"
+        ],
+        "tileSettings": {
+          "showBorder": false,
+          "titleContent": {
+            "columnMatch": "Computer",
+            "formatter": 1
+          },
+          "leftContent": {
+            "columnMatch": "value",
+            "formatter": 12,
+            "formatOptions": {
+              "palette": "auto"
+            },
+            "numberFormat": {
+              "unit": 17,
+              "options": {
+                "maximumSignificantDigits": 3,
+                "maximumFractionDigits": 2
+              }
+            }
+          }
+        }
+      },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isEqualTo",
+        "value": "1"
+      },
+      "customWidth": "25",
+      "name": "query - 22"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "let metric = dynamic({Counter6});\r\nlet cpuSummary=totable(Perf\r\n    {ComputerFilter}\r\n    | where TimeGenerated {TimeRange} \r\n    | where ObjectName == metric.object and CounterName == metric.counter\r\n    | summarize hint.shufflekey=Computer {TrendAggregator6} by Computer, CounterName\r\n    | top {TopN} by {TrendAggregator6:label} {TrendAggregatorOrder6});\r\nlet computerList=(cpuSummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nPerf\r\n    | where TimeGenerated {TimeRange}\r\n    | where ObjectName == metric.object and CounterName == metric.counter\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {TrendAggregator6}{Unit6} by {Snippet6}",
+        "size": 0,
+        "aggregation": 3,
+        "showAnnotations": true,
+        "noDataMessage": "No computers are emitting data for this performance counter.",
+        "queryType": 0,
+        "resourceType": "microsoft.operationalinsights/workspaces",
+        "crossComponentResources": [
+          "{Workspaces}"
+        ],
+        "tileSettings": {
+          "showBorder": false,
+          "titleContent": {
+            "columnMatch": "Computer",
+            "formatter": 1
+          },
+          "leftContent": {
+            "columnMatch": "value",
+            "formatter": 12,
+            "formatOptions": {
+              "palette": "auto"
+            },
+            "numberFormat": {
+              "unit": 17,
+              "options": {
+                "maximumSignificantDigits": 3,
+                "maximumFractionDigits": 2
+              }
+            }
+          }
+        }
+      },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isEqualTo",
+        "value": "1"
+      },
+      "customWidth": "25",
+      "name": "query - 23"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "let metric = dynamic({Counter7});\r\nlet cpuSummary=totable(Perf\r\n    {ComputerFilter}\r\n    | where TimeGenerated {TimeRange} \r\n    | where ObjectName == metric.object and CounterName == metric.counter\r\n    | summarize hint.shufflekey=Computer {TrendAggregator7} by Computer, CounterName\r\n    | top {TopN} by {TrendAggregator7:label} {TrendAggregatorOrder7});\r\nlet computerList=(cpuSummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nPerf\r\n    | where TimeGenerated {TimeRange}\r\n    | where ObjectName == metric.object and CounterName == metric.counter\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {TrendAggregator7}{Unit7} by {Snippet7}",
+        "size": 0,
+        "aggregation": 3,
+        "showAnnotations": true,
+        "noDataMessage": "No computers are emitting data for this performance counter.",
+        "queryType": 0,
+        "resourceType": "microsoft.operationalinsights/workspaces",
+        "crossComponentResources": [
+          "{Workspaces}"
+        ],
+        "tileSettings": {
+          "showBorder": false,
+          "titleContent": {
+            "columnMatch": "Computer",
+            "formatter": 1
+          },
+          "leftContent": {
+            "columnMatch": "value",
+            "formatter": 12,
+            "formatOptions": {
+              "palette": "auto"
+            },
+            "numberFormat": {
+              "unit": 17,
+              "options": {
+                "maximumSignificantDigits": 3,
+                "maximumFractionDigits": 2
+              }
+            }
+          }
+        }
+      },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isEqualTo",
+        "value": "1"
+      },
+      "customWidth": "25",
+      "name": "query - 24"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "let metric = dynamic({Counter8});\r\nlet cpuSummary=totable(Perf\r\n    {ComputerFilter}\r\n    | where TimeGenerated {TimeRange} \r\n    | where ObjectName == metric.object and CounterName == metric.counter\r\n    | summarize hint.shufflekey=Computer {TrendAggregator8} by Computer, CounterName\r\n    | top {TopN} by {TrendAggregator8:label} {TrendAggregatorOrder8});\r\nlet computerList=(cpuSummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nPerf\r\n    | where TimeGenerated {TimeRange}\r\n    | where ObjectName == metric.object and CounterName == metric.counter\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {TrendAggregator8}{Unit8} by {Snippet8}",
+        "size": 0,
+        "aggregation": 3,
+        "showAnnotations": true,
+        "noDataMessage": "No computers are emitting data for this performance counter.",
+        "queryType": 0,
+        "resourceType": "microsoft.operationalinsights/workspaces",
+        "crossComponentResources": [
+          "{Workspaces}"
+        ],
+        "tileSettings": {
+          "showBorder": false,
+          "titleContent": {
+            "columnMatch": "Computer",
+            "formatter": 1
+          },
+          "leftContent": {
+            "columnMatch": "value",
+            "formatter": 12,
+            "formatOptions": {
+              "palette": "auto"
+            },
+            "numberFormat": {
+              "unit": 17,
+              "options": {
+                "maximumSignificantDigits": 3,
+                "maximumFractionDigits": 2
+              }
+            }
+          }
+        }
+      },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isEqualTo",
+        "value": "1"
+      },
+      "customWidth": "25",
+      "name": "query - 25"
+    }
+  ],
+  "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
+}

--- a/Workbooks/Virtual Machines - Performance Analysis/Performance Counters (Perf)/Performance Counters (Perf).workbook
+++ b/Workbooks/Virtual Machines - Performance Analysis/Performance Counters (Perf)/Performance Counters (Perf).workbook
@@ -60,7 +60,7 @@
             "version": "KqlParameterItem/1.0",
             "name": "HybridMode",
             "type": 1,
-            "value": "false",
+            "value": null,
             "isHiddenWhenLocked": true,
             "criteriaData": [
               {
@@ -406,7 +406,8 @@
             "typeSettings": {
               "additionalResourceOptions": []
             },
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "resourceType": "microsoft.operationalinsights/workspaces",
+            "value": "{\"counter\":\"% Processor Time\",\"object\":\"Processor\"}"
           },
           {
             "id": "6a7306ea-247f-46ca-abca-501911f9e9d3",
@@ -481,8 +482,7 @@
               "{Workspaces}"
             ],
             "isHiddenWhenLocked": true,
-            "resourceType": "microsoft.operationalinsights/workspaces",
-            "value": null
+            "resourceType": "microsoft.operationalinsights/workspaces"
           },
           {
             "id": "41eb7c98-b679-42b9-8454-432a4b8fff48",
@@ -562,7 +562,8 @@
             "typeSettings": {
               "additionalResourceOptions": []
             },
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "resourceType": "microsoft.operationalinsights/workspaces",
+            "value": "{\"counter\":\"% Available Memory\",\"object\":\"Memory\"}"
           },
           {
             "id": "6a7306ea-247f-46ca-abca-501911f9e9d3",
@@ -669,7 +670,7 @@
               ]
             },
             "resourceType": "microsoft.operationalinsights/workspaces",
-            "value": "{\"counter\":\"Total Bytes Received\",\"object\":\"Network\"}"
+            "value": "{\"counter\":\"Bytes Sent/sec\",\"object\":\"Network Adapter\"}"
           },
           {
             "id": "6a7306ea-247f-46ca-abca-501911f9e9d3",
@@ -774,7 +775,7 @@
               "additionalResourceOptions": []
             },
             "resourceType": "microsoft.operationalinsights/workspaces",
-            "value": "{\"counter\":\"Total Bytes Transmitted\",\"object\":\"Network\"}"
+            "value": "{\"counter\":\"Bytes Received/sec\",\"object\":\"Network Adapter\"}"
           },
           {
             "id": "6a7306ea-247f-46ca-abca-501911f9e9d3",
@@ -1109,7 +1110,7 @@
               ]
             },
             "resourceType": "microsoft.operationalinsights/workspaces",
-            "value": "{\"counter\":\"Disk Reads/sec\",\"object\":\"Logical Disk\"}"
+            "value": "{\"counter\":\"% Used Space\",\"object\":\"Logical Disk\"}"
           },
           {
             "id": "6a7306ea-247f-46ca-abca-501911f9e9d3",
@@ -1216,7 +1217,7 @@
               ]
             },
             "resourceType": "microsoft.operationalinsights/workspaces",
-            "value": "{\"counter\":\"Disk Read Bytes/sec\",\"object\":\"Logical Disk\"}"
+            "value": "{\"counter\":\"% Free Space\",\"object\":\"LogicalDisk\"}"
           },
           {
             "id": "6a7306ea-247f-46ca-abca-501911f9e9d3",
@@ -1323,7 +1324,7 @@
               ]
             },
             "resourceType": "microsoft.operationalinsights/workspaces",
-            "value": "{\"counter\":\"Disk Writes/sec\",\"object\":\"Logical Disk\"}"
+            "value": "{\"counter\":\"Disk Write Bytes/sec\",\"object\":\"LogicalDisk\"}"
           },
           {
             "id": "6a7306ea-247f-46ca-abca-501911f9e9d3",
@@ -1430,7 +1431,7 @@
               ]
             },
             "resourceType": "microsoft.operationalinsights/workspaces",
-            "value": "{\"counter\":\"Disk Write Bytes/sec\",\"object\":\"Logical Disk\"}"
+            "value": "{\"counter\":\"Disk Read Bytes/sec\",\"object\":\"Logical Disk\"}"
           },
           {
             "id": "6a7306ea-247f-46ca-abca-501911f9e9d3",

--- a/Workbooks/Virtual Machines - Performance Analysis/Performance Counters (Perf)/settings.json
+++ b/Workbooks/Virtual Machines - Performance Analysis/Performance Counters (Perf)/settings.json
@@ -3,6 +3,6 @@
     "name":"Performance Counters",
     "author": "Microsoft",
     "galleries": [
-        { "type": "vm-insights", "resourceType": "Azure Monitor", "categoryKey": "vmInsightsVirtualMachinesInsightsMetrics", "order": 200 }
+        { "type": "vm-insights", "resourceType": "Azure Monitor", "categoryKey": "vmInsightsVirtualMachinesPerf", "order": 200 }
     ]
 }

--- a/Workbooks/Virtual Machines - Performance Analysis/Performance Counters (Preview)/Performance Counters (Preview).workbook
+++ b/Workbooks/Virtual Machines - Performance Analysis/Performance Counters (Preview)/Performance Counters (Preview).workbook
@@ -10,17 +10,12 @@
         ],
         "parameters": [
           {
-            "id": "e41c2177-932a-4c58-ba24-03ef070eb197",
+            "id": "80a15801-7442-49f3-a82f-6e55849ec7fb",
             "version": "KqlParameterItem/1.0",
-            "name": "Workspaces",
+            "name": "DefaultWorkspace",
             "type": 5,
             "isRequired": true,
-            "multiSelect": true,
-            "quote": "'",
-            "delimiter": ",",
-            "value": [
-              "value::1"
-            ],
+            "value": "value::1",
             "isHiddenWhenLocked": true,
             "typeSettings": {
               "resourceTypeFilter": {
@@ -32,117 +27,215 @@
             }
           },
           {
-            "id": "5f8cce4b-9c4c-47da-8683-7e5ccc9faed3",
+            "id": "90119d28-e9c1-4c0d-8715-1f601d337f5c",
+            "version": "KqlParameterItem/1.0",
+            "name": "DefaultSubscription",
+            "type": 5,
+            "value": "value::1",
+            "isHiddenWhenLocked": true,
+            "typeSettings": {
+              "resourceTypeFilter": {
+                "microsoft.resources/subscriptions": true
+              },
+              "additionalResourceOptions": [
+                "value::1"
+              ]
+            }
+          },
+          {
+            "id": "7da21a07-10f4-4455-9105-c37132dcee0d",
+            "version": "KqlParameterItem/1.0",
+            "name": "ContextSelection",
+            "type": 1,
+            "query": "// {DefaultWorkspace}\r\nwhere strcat(\"'\", id, \"'\") =~ \"{DefaultWorkspace:value}\"\r\n| project value = tostring(pack('sub', subscriptionId, 'rg', resourceGroup, 'ws', id))",
+            "crossComponentResources": [
+              "value::all"
+            ],
+            "isHiddenWhenLocked": true,
+            "queryType": 1,
+            "resourceType": "microsoft.resourcegraph/resources"
+          },
+          {
+            "id": "7324c544-2fd2-4d61-b529-481a0f5fd286",
+            "version": "KqlParameterItem/1.0",
+            "name": "HybridMode",
+            "type": 1,
+            "isHiddenWhenLocked": true,
+            "criteriaData": [
+              {
+                "condition": "if (ContextSelection is empty ), result = 'false'",
+                "criteriaContext": {
+                  "leftOperand": "ContextSelection",
+                  "operator": "is Empty",
+                  "rightValType": "param",
+                  "resultValType": "static",
+                  "resultVal": "false"
+                }
+              },
+              {
+                "condition": "else result = 'true'",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "static",
+                  "resultVal": "true"
+                }
+              }
+            ]
+          },
+          {
+            "id": "2942e38e-232e-4d89-9ada-12f9863b3c5b",
+            "version": "KqlParameterItem/1.0",
+            "name": "Subscriptions",
+            "type": 6,
+            "isRequired": true,
+            "multiSelect": true,
+            "quote": "'",
+            "delimiter": ",",
+            "query": "// {DefaultWorkspace} {ContextSelection} {DefaultSubscription}\r\nsummarize by subscriptionId\r\n| project strcat('/subscriptions/', subscriptionId), selected = iff({HybridMode} == true, iff(subscriptionId == todynamic('{ContextSelection}').sub, true, false), iff(strcat('/subscriptions/', subscriptionId) == '{DefaultSubscription}', true, false))",
+            "crossComponentResources": [
+              "value::all"
+            ],
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "queryType": 1,
+            "resourceType": "microsoft.resourcegraph/resources"
+          },
+          {
+            "id": "2bc1e5fc-cc2d-4eb5-bead-5f7d96664dec",
+            "version": "KqlParameterItem/1.0",
+            "name": "Workspaces",
+            "type": 5,
+            "isRequired": true,
+            "multiSelect": true,
+            "quote": "'",
+            "delimiter": ",",
+            "query": "// {DefaultWorkspace} {ContextSelection} {Subscriptions}\r\nwhere type =~ 'microsoft.operationalinsights/workspaces'\r\n| summarize by id, name\r\n| order by tolower(name) asc\r\n| extend Row = row_number()\r\n| project id, selected = iff({HybridMode} == 'true', iff(id == todynamic('{ContextSelection}').ws, true, false), Row == 1)",
+            "crossComponentResources": [
+              "{Subscriptions}"
+            ],
+            "typeSettings": {
+              "limitSelectTo": 5,
+              "additionalResourceOptions": [
+                "value::1"
+              ]
+            },
+            "queryType": 1,
+            "resourceType": "microsoft.resourcegraph/resources"
+          },
+          {
+            "id": "d0f502a4-2f0f-4d3d-af70-5198d41f3e0c",
             "version": "KqlParameterItem/1.0",
             "name": "TimeRange",
             "type": 4,
+            "isRequired": true,
             "value": {
-              "durationMs": 172800000
+              "durationMs": 3600000
             },
             "typeSettings": {
               "selectableValues": [
                 {
                   "durationMs": 300000,
-                  "createdTime": "2018-10-04T22:01:18.372Z",
+                  "createdTime": "2019-02-20T19:49:16.686Z",
                   "isInitialTime": false,
                   "grain": 1,
                   "useDashboardTimeRange": false
                 },
                 {
                   "durationMs": 900000,
-                  "createdTime": "2018-10-04T22:01:18.372Z",
+                  "createdTime": "2019-02-20T19:49:16.686Z",
                   "isInitialTime": false,
                   "grain": 1,
                   "useDashboardTimeRange": false
                 },
                 {
                   "durationMs": 1800000,
-                  "createdTime": "2018-10-04T22:01:18.372Z",
+                  "createdTime": "2019-02-20T19:49:16.686Z",
                   "isInitialTime": false,
                   "grain": 1,
                   "useDashboardTimeRange": false
                 },
                 {
                   "durationMs": 3600000,
-                  "createdTime": "2018-10-04T22:01:18.372Z",
+                  "createdTime": "2019-02-20T19:49:16.686Z",
                   "isInitialTime": false,
                   "grain": 1,
                   "useDashboardTimeRange": false
                 },
                 {
                   "durationMs": 14400000,
-                  "createdTime": "2018-10-04T22:01:18.374Z",
+                  "createdTime": "2019-02-20T19:49:16.687Z",
                   "isInitialTime": false,
                   "grain": 1,
                   "useDashboardTimeRange": false
                 },
                 {
                   "durationMs": 43200000,
-                  "createdTime": "2018-10-04T22:01:18.374Z",
+                  "createdTime": "2019-02-20T19:49:16.687Z",
                   "isInitialTime": false,
                   "grain": 1,
                   "useDashboardTimeRange": false
                 },
                 {
                   "durationMs": 86400000,
-                  "createdTime": "2018-10-04T22:01:18.374Z",
+                  "createdTime": "2019-02-20T19:49:16.687Z",
                   "isInitialTime": false,
                   "grain": 1,
                   "useDashboardTimeRange": false
                 },
                 {
                   "durationMs": 172800000,
-                  "createdTime": "2018-10-04T22:01:18.374Z",
+                  "createdTime": "2019-02-20T19:49:16.687Z",
                   "isInitialTime": false,
                   "grain": 1,
                   "useDashboardTimeRange": false
                 },
                 {
                   "durationMs": 259200000,
-                  "createdTime": "2018-10-04T22:01:18.375Z",
+                  "createdTime": "2019-02-20T19:49:16.688Z",
                   "isInitialTime": false,
                   "grain": 1,
                   "useDashboardTimeRange": false
                 },
                 {
                   "durationMs": 604800000,
-                  "createdTime": "2018-10-04T22:01:18.375Z",
+                  "createdTime": "2019-02-20T19:49:16.688Z",
                   "isInitialTime": false,
                   "grain": 1,
                   "useDashboardTimeRange": false
                 },
                 {
                   "durationMs": 1209600000,
-                  "createdTime": "2018-10-04T22:01:18.375Z",
+                  "createdTime": "2019-02-20T19:49:16.688Z",
                   "isInitialTime": false,
                   "grain": 1,
                   "useDashboardTimeRange": false
                 },
                 {
                   "durationMs": 2592000000,
-                  "createdTime": "2018-10-04T22:01:18.375Z",
+                  "createdTime": "2019-02-20T19:49:16.688Z",
                   "isInitialTime": false,
                   "grain": 1,
                   "useDashboardTimeRange": false
                 },
                 {
                   "durationMs": 5184000000,
-                  "createdTime": "2018-10-04T22:01:18.375Z",
+                  "createdTime": "2019-02-20T19:49:16.688Z",
                   "isInitialTime": false,
                   "grain": 1,
                   "useDashboardTimeRange": false
                 },
                 {
                   "durationMs": 7776000000,
-                  "createdTime": "2018-10-04T22:01:18.375Z",
+                  "createdTime": "2019-02-20T19:49:16.688Z",
                   "isInitialTime": false,
                   "grain": 1,
                   "useDashboardTimeRange": false
                 }
               ],
               "allowCustom": true
-            },
-            "label": "Time Range"
+            }
           },
           {
             "id": "1a0a93cf-0406-40d1-80e1-572b1a8d640e",
@@ -244,11 +337,26 @@
             "name": "Mode",
             "type": 2,
             "isRequired": true,
-            "value": "0",
+            "value": "1",
             "typeSettings": {
               "additionalResourceOptions": []
             },
             "jsonData": "[\r\n    {\r\n        \"label\": \"Locked\",\r\n        \"value\": \"1\"\r\n    },\r\n    {\r\n        \"label\": \"Unlocked\",\r\n        \"value\": \"0\"\r\n    }\r\n]"
+          },
+          {
+            "id": "48e2b8b9-e618-480c-80e6-5cf1cee85ee9",
+            "version": "KqlParameterItem/1.0",
+            "name": "Test",
+            "label": "Not Onboarded",
+            "type": 1,
+            "query": "VMConnection\r\n| take 1\r\n| summarize count()",
+            "crossComponentResources": [
+              "{Workspaces}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": "TimeRange",
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces"
           }
         ],
         "style": "above",
@@ -263,6 +371,18 @@
         "json": "<hr style=\"height: 2px;\" />"
       },
       "name": "text - 1"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "⚠ No performance counters were detected in the selected workspace for the specified time period (`{TimeRange:label}`). Either try a broader time range, select a different workspace, or onboard virtual machines to the selected workspace `{Workspaces:label}`.\r\n\r\nIf you choose to onboard virtual machines to workspace `{Workspaces:label}`, follow the instruction in the following link: [Azure Monitor for VMs (preview)](https://docs.microsoft.com/en-us/azure/azure-monitor/insights/vminsights-overview)."
+      },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isNotEqualTo",
+        "value": "1"
+      },
+      "name": "text - 38"
     },
     {
       "type": 9,
@@ -359,6 +479,18 @@
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces"
       },
+      "conditionalVisibilities": [
+        {
+          "parameterName": "Mode",
+          "comparison": "isEqualTo",
+          "value": "0"
+        },
+        {
+          "parameterName": "Test",
+          "comparison": "isEqualTo",
+          "value": "1"
+        }
+      ],
       "conditionalVisibility": {
         "parameterName": "Mode",
         "comparison": "isEqualTo",
@@ -457,6 +589,18 @@
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces"
       },
+      "conditionalVisibilities": [
+        {
+          "parameterName": "Mode",
+          "comparison": "isEqualTo",
+          "value": "0"
+        },
+        {
+          "parameterName": "Test",
+          "comparison": "isEqualTo",
+          "value": "1"
+        }
+      ],
       "conditionalVisibility": {
         "parameterName": "Mode",
         "comparison": "isEqualTo",
@@ -483,7 +627,7 @@
             "crossComponentResources": [
               "{Workspaces}"
             ],
-            "value": "{\"counter\":\"ReadBytesPerSecond\",\"object\":\"Network\"}",
+            "value": "{\"counter\":\"WriteBytesPerSecond\",\"object\":\"Network\"}",
             "typeSettings": {
               "additionalResourceOptions": [
                 "value::1"
@@ -559,6 +703,18 @@
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces"
       },
+      "conditionalVisibilities": [
+        {
+          "parameterName": "Mode",
+          "comparison": "isEqualTo",
+          "value": "0"
+        },
+        {
+          "parameterName": "Test",
+          "comparison": "isEqualTo",
+          "value": "1"
+        }
+      ],
       "conditionalVisibility": {
         "parameterName": "Mode",
         "comparison": "isEqualTo",
@@ -582,7 +738,7 @@
             "crossComponentResources": [
               "{Workspaces}"
             ],
-            "value": "{\"counter\":\"WriteBytesPerSecond\",\"object\":\"LogicalDisk\"}",
+            "value": "{\"counter\":\"ReadBytesPerSecond\",\"object\":\"Network\"}",
             "typeSettings": {
               "additionalResourceOptions": []
             },
@@ -656,6 +812,18 @@
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces"
       },
+      "conditionalVisibilities": [
+        {
+          "parameterName": "Mode",
+          "comparison": "isEqualTo",
+          "value": "0"
+        },
+        {
+          "parameterName": "Test",
+          "comparison": "isEqualTo",
+          "value": "1"
+        }
+      ],
       "conditionalVisibility": {
         "parameterName": "Mode",
         "comparison": "isEqualTo",
@@ -669,6 +837,11 @@
       "content": {
         "json": "<h3 style=\"margin-bottom:0;\">{Counter1:label}</h3><h4 style=\"margin-top:0;font-weight:normal;color:#777;\">{TrendAggregator1:label} {TrendAggregatorOrder1} {Unit:label}</h4>"
       },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isEqualTo",
+        "value": "1"
+      },
       "customWidth": "25",
       "name": "text - 6"
     },
@@ -676,6 +849,11 @@
       "type": 1,
       "content": {
         "json": "<h3 style=\"margin-bottom:0;\">{Counter2:label}</h3><h4 style=\"margin-top:0;font-weight:normal;color:#777;\">{TrendAggregator2:label} {TrendAggregatorOrder2} {Unit2:label}</h4>"
+      },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isEqualTo",
+        "value": "1"
       },
       "customWidth": "25",
       "name": "text - 7"
@@ -685,6 +863,11 @@
       "content": {
         "json": "<h3 style=\"margin-bottom:0;\">{Counter3:label}</h3><h4 style=\"margin-top:0;font-weight:normal;color:#777;\">{TrendAggregator3:label} {TrendAggregatorOrder3} {Unit3:label}</h4>"
       },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isEqualTo",
+        "value": "1"
+      },
       "customWidth": "25",
       "name": "text - 8"
     },
@@ -692,6 +875,11 @@
       "type": 1,
       "content": {
         "json": "<h3 style=\"margin-bottom:0;\">{Counter4:label}</h3><h4 style=\"margin-top:0;font-weight:normal;color:#777;\">{TrendAggregator4:label} {TrendAggregatorOrder4} {Unit4:label}</h4>"
+      },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isEqualTo",
+        "value": "1"
       },
       "customWidth": "25",
       "name": "text - 9"
@@ -705,7 +893,6 @@
         "aggregation": 3,
         "showAnnotations": true,
         "noDataMessage": "No computers are emitting data for this performance counter.",
-        "exportToExcelOptions": "visible",
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
         "crossComponentResources": [
@@ -732,6 +919,11 @@
             }
           }
         }
+      },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isEqualTo",
+        "value": "1"
       },
       "customWidth": "25",
       "name": "query - 10"
@@ -745,7 +937,6 @@
         "aggregation": 3,
         "showAnnotations": true,
         "noDataMessage": "No computers are emitting data for this performance counter.",
-        "exportToExcelOptions": "visible",
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
         "crossComponentResources": [
@@ -772,6 +963,11 @@
             }
           }
         }
+      },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isEqualTo",
+        "value": "1"
       },
       "customWidth": "25",
       "name": "query - 11"
@@ -785,7 +981,6 @@
         "aggregation": 3,
         "showAnnotations": true,
         "noDataMessage": "No computers are emitting data for this performance counter.",
-        "exportToExcelOptions": "visible",
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
         "crossComponentResources": [
@@ -813,6 +1008,11 @@
           }
         }
       },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isEqualTo",
+        "value": "1"
+      },
       "customWidth": "25",
       "name": "query - 12"
     },
@@ -825,7 +1025,6 @@
         "aggregation": 3,
         "showAnnotations": true,
         "noDataMessage": "No computers are emitting data for this performance counter.",
-        "exportToExcelOptions": "visible",
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
         "crossComponentResources": [
@@ -852,6 +1051,11 @@
             }
           }
         }
+      },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isEqualTo",
+        "value": "1"
       },
       "customWidth": "25",
       "name": "query - 13"
@@ -871,7 +1075,7 @@
             "crossComponentResources": [
               "{Workspaces}"
             ],
-            "value": "{\"counter\":\"ReadsPerSecond\",\"object\":\"LogicalDisk\"}",
+            "value": "{\"counter\":\"FreeSpacePercentage\",\"object\":\"LogicalDisk\"}",
             "typeSettings": {
               "additionalResourceOptions": [
                 "value::1"
@@ -947,6 +1151,18 @@
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces"
       },
+      "conditionalVisibilities": [
+        {
+          "parameterName": "Mode",
+          "comparison": "isEqualTo",
+          "value": "0"
+        },
+        {
+          "parameterName": "Test",
+          "comparison": "isEqualTo",
+          "value": "1"
+        }
+      ],
       "conditionalVisibility": {
         "parameterName": "Mode",
         "comparison": "isEqualTo",
@@ -970,7 +1186,7 @@
             "crossComponentResources": [
               "{Workspaces}"
             ],
-            "value": "{\"counter\":\"ReadBytesPerSecond\",\"object\":\"LogicalDisk\"}",
+            "value": "{\"counter\":\"ReadsPerSecond\",\"object\":\"LogicalDisk\"}",
             "typeSettings": {
               "additionalResourceOptions": [
                 "value::1"
@@ -1046,6 +1262,18 @@
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces"
       },
+      "conditionalVisibilities": [
+        {
+          "parameterName": "Mode",
+          "comparison": "isEqualTo",
+          "value": "0"
+        },
+        {
+          "parameterName": "Test",
+          "comparison": "isEqualTo",
+          "value": "1"
+        }
+      ],
       "conditionalVisibility": {
         "parameterName": "Mode",
         "comparison": "isEqualTo",
@@ -1145,6 +1373,18 @@
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces"
       },
+      "conditionalVisibilities": [
+        {
+          "parameterName": "Mode",
+          "comparison": "isEqualTo",
+          "value": "0"
+        },
+        {
+          "parameterName": "Test",
+          "comparison": "isEqualTo",
+          "value": "1"
+        }
+      ],
       "conditionalVisibility": {
         "parameterName": "Mode",
         "comparison": "isEqualTo",
@@ -1168,7 +1408,7 @@
             "crossComponentResources": [
               "{Workspaces}"
             ],
-            "value": "{\"counter\":\"WriteBytesPerSecond\",\"object\":\"LogicalDisk\"}",
+            "value": "{\"counter\":\"TransfersPerSecond\",\"object\":\"LogicalDisk\"}",
             "typeSettings": {
               "additionalResourceOptions": [
                 "value::1"
@@ -1244,6 +1484,18 @@
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces"
       },
+      "conditionalVisibilities": [
+        {
+          "parameterName": "Mode",
+          "comparison": "isEqualTo",
+          "value": "0"
+        },
+        {
+          "parameterName": "Test",
+          "comparison": "isEqualTo",
+          "value": "1"
+        }
+      ],
       "conditionalVisibility": {
         "parameterName": "Mode",
         "comparison": "isEqualTo",
@@ -1257,6 +1509,11 @@
       "content": {
         "json": "<h3 style=\"margin-bottom:0;\">{Counter5:label}</h3><h4 style=\"margin-top:0;font-weight:normal;color:#777;\">{TrendAggregator5:label} {TrendAggregatorOrder5} {Unit5:label}</h4>"
       },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isEqualTo",
+        "value": "1"
+      },
       "customWidth": "25",
       "name": "text - 18"
     },
@@ -1264,6 +1521,11 @@
       "type": 1,
       "content": {
         "json": "<h3 style=\"margin-bottom:0;\">{Counter6:label}</h3><h4 style=\"margin-top:0;font-weight:normal;color:#777;\">{TrendAggregator6:label} {TrendAggregatorOrder6} {Unit6:label}</h4>"
+      },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isEqualTo",
+        "value": "1"
       },
       "customWidth": "25",
       "name": "text - 19"
@@ -1273,6 +1535,11 @@
       "content": {
         "json": "<h3 style=\"margin-bottom:0;\">{Counter7:label}</h3><h4 style=\"margin-top:0;font-weight:normal;color:#777;\">{TrendAggregator7:label} {TrendAggregatorOrder7} {Unit7:label}</h4>"
       },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isEqualTo",
+        "value": "1"
+      },
       "customWidth": "25",
       "name": "text - 20"
     },
@@ -1280,6 +1547,11 @@
       "type": 1,
       "content": {
         "json": "<h3 style=\"margin-bottom:0;\">{Counter8:label}</h3><h4 style=\"margin-top:0;font-weight:normal;color:#777;\">{TrendAggregator8:label} {TrendAggregatorOrder8} {Unit8:label}</h4>"
+      },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isEqualTo",
+        "value": "1"
       },
       "customWidth": "25",
       "name": "text - 21"
@@ -1293,7 +1565,6 @@
         "aggregation": 3,
         "showAnnotations": true,
         "noDataMessage": "No computers are emitting data for this performance counter.",
-        "exportToExcelOptions": "visible",
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
         "crossComponentResources": [
@@ -1320,6 +1591,11 @@
             }
           }
         }
+      },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isEqualTo",
+        "value": "1"
       },
       "customWidth": "25",
       "name": "query - 22"
@@ -1333,7 +1609,6 @@
         "aggregation": 3,
         "showAnnotations": true,
         "noDataMessage": "No computers are emitting data for this performance counter.",
-        "exportToExcelOptions": "visible",
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
         "crossComponentResources": [
@@ -1360,6 +1635,11 @@
             }
           }
         }
+      },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isEqualTo",
+        "value": "1"
       },
       "customWidth": "25",
       "name": "query - 23"
@@ -1373,7 +1653,6 @@
         "aggregation": 3,
         "showAnnotations": true,
         "noDataMessage": "No computers are emitting data for this performance counter.",
-        "exportToExcelOptions": "visible",
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
         "crossComponentResources": [
@@ -1400,6 +1679,11 @@
             }
           }
         }
+      },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isEqualTo",
+        "value": "1"
       },
       "customWidth": "25",
       "name": "query - 24"
@@ -1413,7 +1697,6 @@
         "aggregation": 3,
         "showAnnotations": true,
         "noDataMessage": "No computers are emitting data for this performance counter.",
-        "exportToExcelOptions": "visible",
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
         "crossComponentResources": [
@@ -1440,599 +1723,15 @@
             }
           }
         }
+      },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isEqualTo",
+        "value": "1"
       },
       "customWidth": "25",
       "name": "query - 25"
-    },
-    {
-      "type": 9,
-      "content": {
-        "version": "KqlParameterItem/1.0",
-        "parameters": [
-          {
-            "id": "eba3fa3a-2f37-4dfb-80be-c19b680f31b0",
-            "version": "KqlParameterItem/1.0",
-            "name": "Counter9",
-            "type": 2,
-            "isRequired": true,
-            "query": "InsightsMetrics\r\n| where TimeGenerated {TimeRange}\r\n| summarize by Name, Namespace, CounterText = Name\r\n| order by Namespace asc, CounterText asc\r\n| project Counter = pack('counter', Name, 'object', Namespace), CounterText, group = Namespace",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
-            "value": "{\"counter\":\"TransfersPerSecond\",\"object\":\"LogicalDisk\"}",
-            "typeSettings": {
-              "additionalResourceOptions": [
-                "value::1"
-              ]
-            },
-            "queryType": 0,
-            "resourceType": "microsoft.operationalinsights/workspaces"
-          },
-          {
-            "id": "f3137f3e-9ff1-4a7f-b503-5b2b87431713",
-            "version": "KqlParameterItem/1.0",
-            "name": "TrendAggregator9",
-            "type": 2,
-            "isRequired": true,
-            "typeSettings": {
-              "additionalResourceOptions": []
-            },
-            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(Val), 2)\", \"label\":\"Average\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(Val, 5), 2)\", \"label\":\"P5th\", \"selected\":false},\r\n    { \"value\":\"P10th = round(percentile(Val, 10), 2)\", \"label\":\"P10th\", \"selected\":false},\r\n    { \"value\":\"P50th = round(percentile(Val, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P80th = round(percentile(Val, 80), 2)\", \"label\":\"P80th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(Val, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(Val, 95), 2)\", \"label\":\"P95th\", \"selected\":true}    \r\n]"
-          },
-          {
-            "id": "01a4cf96-e12f-4d2a-9cf3-25da44a6ebe4",
-            "version": "KqlParameterItem/1.0",
-            "name": "TrendAggregatorOrder9",
-            "type": 1,
-            "query": "print(iff('{TrendAggregator9:label}' == 'P5th'  or '{TrendAggregator9:label}' == 'P10th', 'asc', 'desc'))",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
-            "isHiddenWhenLocked": true,
-            "resourceType": "microsoft.operationalinsights/workspaces"
-          },
-          {
-            "id": "2ad65081-725a-4bc6-9198-9ab653dbb1aa",
-            "version": "KqlParameterItem/1.0",
-            "name": "Visualization9",
-            "type": 2,
-            "isRequired": true,
-            "query": "datatable (value:long, Display:string, isSelected:boolean)\r\n    [0, \"Line Chart\", true,\r\n     1, \"Grid\", false]",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
-            "typeSettings": {
-              "additionalResourceOptions": []
-            },
-            "resourceType": "microsoft.operationalinsights/workspaces"
-          },
-          {
-            "id": "d08e406f-4725-45f5-a5ec-1aa0b6ae4afd",
-            "version": "KqlParameterItem/1.0",
-            "name": "Snippet9",
-            "type": 1,
-            "isRequired": true,
-            "query": "print(iff({Visualization5} == 0, \"{LineChartQuerySnippet}\", \"{GridQuerySnippet}\") )",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
-            "isHiddenWhenLocked": true,
-            "resourceType": "microsoft.operationalinsights/workspaces"
-          },
-          {
-            "id": "31e0e738-54eb-4fab-92b7-ae000819fc7d",
-            "version": "KqlParameterItem/1.0",
-            "name": "Unit9",
-            "type": 2,
-            "value": null,
-            "typeSettings": {
-              "additionalResourceOptions": []
-            },
-            "jsonData": "[\r\n    {\r\n        \"label\": \"B -> MB\",\r\n        \"value\": \"/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"B -> GB\",\r\n        \"value\": \"/1024/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"MB -> GB\",\r\n        \"value\": \"/1024\"\r\n    },\r\n    {\r\n        \"label\": \"MB -> TB\",\r\n        \"value\": \"/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"b -> Mb\",\r\n        \"value\": \"/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"b -> Gb\",\r\n        \"value\": \"/1000/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"Mb -> Gb\",\r\n        \"value\": \"/1000\"\r\n    },\r\n    {\r\n        \"label\": \"Mb -> Tb\",\r\n        \"value\": \"/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"s -> ms\",\r\n        \"value\": \"*1000\"\r\n    },\r\n    {\r\n        \"label\": \"ms -> s\",\r\n        \"value\": \"/1000\"\r\n    }\r\n]"
-          }
-        ],
-        "style": "above",
-        "queryType": 0,
-        "resourceType": "microsoft.operationalinsights/workspaces"
-      },
-      "conditionalVisibility": {
-        "parameterName": "Mode",
-        "comparison": "isEqualTo",
-        "value": "0"
-      },
-      "customWidth": "25",
-      "name": "parameters - 26"
-    },
-    {
-      "type": 9,
-      "content": {
-        "version": "KqlParameterItem/1.0",
-        "parameters": [
-          {
-            "id": "aa2368fc-ad30-4608-b96a-72abf7b1e1ad",
-            "version": "KqlParameterItem/1.0",
-            "name": "Counter10",
-            "type": 2,
-            "isRequired": true,
-            "query": "InsightsMetrics\r\n| where TimeGenerated {TimeRange}\r\n| summarize by Name, Namespace, CounterText = Name\r\n| order by Namespace asc, CounterText asc\r\n| project Counter = pack('counter', Name, 'object', Namespace), CounterText, group = Namespace",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
-            "value": "{\"counter\":\"TransferLatencyMs\",\"object\":\"LogicalDisk\"}",
-            "typeSettings": {
-              "additionalResourceOptions": [
-                "value::1"
-              ]
-            },
-            "queryType": 0,
-            "resourceType": "microsoft.operationalinsights/workspaces"
-          },
-          {
-            "id": "6a7306ea-247f-46ca-abca-501911f9e9dd",
-            "version": "KqlParameterItem/1.0",
-            "name": "TrendAggregator10",
-            "type": 2,
-            "isRequired": true,
-            "typeSettings": {
-              "additionalResourceOptions": []
-            },
-            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(Val), 2)\", \"label\":\"Average\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(Val, 5), 2)\", \"label\":\"P5th\", \"selected\":false},\r\n    { \"value\":\"P10th = round(percentile(Val, 10), 2)\", \"label\":\"P10th\", \"selected\":false},\r\n    { \"value\":\"P50th = round(percentile(Val, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P80th = round(percentile(Val, 80), 2)\", \"label\":\"P80th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(Val, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(Val, 95), 2)\", \"label\":\"P95th\", \"selected\":true}    \r\n]"
-          },
-          {
-            "id": "0327f26e-cdde-4b48-b512-6c35f06ad1dd",
-            "version": "KqlParameterItem/1.0",
-            "name": "TrendAggregatorOrder10",
-            "type": 1,
-            "query": "print(iff('{TrendAggregator10:label}' == 'P5th'  or '{TrendAggregator10:label}' == 'P10th', 'asc', 'desc'))",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
-            "isHiddenWhenLocked": true,
-            "resourceType": "microsoft.operationalinsights/workspaces"
-          },
-          {
-            "id": "5b1ee58a-5d4d-4be8-b38c-3a8eb37a2f3d",
-            "version": "KqlParameterItem/1.0",
-            "name": "Visualization10",
-            "type": 2,
-            "isRequired": true,
-            "query": "datatable (value:long, Display:string, isSelected:boolean)\r\n    [0, \"Line Chart\", true,\r\n     1, \"Grid\", false]",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
-            "typeSettings": {
-              "additionalResourceOptions": []
-            },
-            "resourceType": "microsoft.operationalinsights/workspaces"
-          },
-          {
-            "id": "d931d741-2f83-4ca0-bc2b-5c0c13fe805d",
-            "version": "KqlParameterItem/1.0",
-            "name": "Snippet10",
-            "type": 1,
-            "isRequired": true,
-            "query": "print(iff({Visualization6} == 0, \"{LineChartQuerySnippet}\", \"{GridQuerySnippet}\") )",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
-            "isHiddenWhenLocked": true,
-            "resourceType": "microsoft.operationalinsights/workspaces"
-          },
-          {
-            "id": "089bb686-434d-43ea-a958-c344763cef7f",
-            "version": "KqlParameterItem/1.0",
-            "name": "Unit10",
-            "type": 2,
-            "value": null,
-            "typeSettings": {
-              "additionalResourceOptions": []
-            },
-            "jsonData": "[\r\n    {\r\n        \"label\": \"B -> MB\",\r\n        \"value\": \"/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"B -> GB\",\r\n        \"value\": \"/1024/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"MB -> GB\",\r\n        \"value\": \"/1024\"\r\n    },\r\n    {\r\n        \"label\": \"MB -> TB\",\r\n        \"value\": \"/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"b -> Mb\",\r\n        \"value\": \"/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"b -> Gb\",\r\n        \"value\": \"/1000/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"Mb -> Gb\",\r\n        \"value\": \"/1000\"\r\n    },\r\n    {\r\n        \"label\": \"Mb -> Tb\",\r\n        \"value\": \"/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"s -> ms\",\r\n        \"value\": \"*1000\"\r\n    },\r\n    {\r\n        \"label\": \"ms -> s\",\r\n        \"value\": \"/1000\"\r\n    }\r\n]"
-          }
-        ],
-        "style": "above",
-        "queryType": 0,
-        "resourceType": "microsoft.operationalinsights/workspaces"
-      },
-      "conditionalVisibility": {
-        "parameterName": "Mode",
-        "comparison": "isEqualTo",
-        "value": "0"
-      },
-      "customWidth": "25",
-      "name": "parameters - 27"
-    },
-    {
-      "type": 9,
-      "content": {
-        "version": "KqlParameterItem/1.0",
-        "parameters": [
-          {
-            "id": "aa2368fc-ad30-4608-b96a-72abf7b1e1ad",
-            "version": "KqlParameterItem/1.0",
-            "name": "Counter11",
-            "type": 2,
-            "isRequired": true,
-            "query": "InsightsMetrics\r\n| where TimeGenerated {TimeRange}\r\n| summarize by Name, Namespace, CounterText = Name\r\n| order by Namespace asc, CounterText asc\r\n| project Counter = pack('counter', Name, 'object', Namespace), CounterText, group = Namespace",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
-            "value": "{\"counter\":\"FreeSpaceMB\",\"object\":\"LogicalDisk\"}",
-            "typeSettings": {
-              "additionalResourceOptions": [
-                "value::1"
-              ]
-            },
-            "queryType": 0,
-            "resourceType": "microsoft.operationalinsights/workspaces"
-          },
-          {
-            "id": "6a7306ea-247f-46ca-abca-501911f9e9dd",
-            "version": "KqlParameterItem/1.0",
-            "name": "TrendAggregator11",
-            "type": 2,
-            "isRequired": true,
-            "typeSettings": {
-              "additionalResourceOptions": []
-            },
-            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(Val), 2)\", \"label\":\"Average\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(Val, 5), 2)\", \"label\":\"P5th\", \"selected\":false},\r\n    { \"value\":\"P10th = round(percentile(Val, 10), 2)\", \"label\":\"P10th\", \"selected\":false},\r\n    { \"value\":\"P50th = round(percentile(Val, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P80th = round(percentile(Val, 80), 2)\", \"label\":\"P80th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(Val, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(Val, 95), 2)\", \"label\":\"P95th\", \"selected\":true}    \r\n]"
-          },
-          {
-            "id": "0327f26e-cdde-4b48-b512-6c35f06ad1dd",
-            "version": "KqlParameterItem/1.0",
-            "name": "TrendAggregatorOrder11",
-            "type": 1,
-            "query": "print(iff('{TrendAggregator11:label}' == 'P5th'  or '{TrendAggregator11:label}' == 'P10th', 'asc', 'desc'))",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
-            "isHiddenWhenLocked": true,
-            "resourceType": "microsoft.operationalinsights/workspaces"
-          },
-          {
-            "id": "bc1291ba-dd26-4224-9b25-3a1e7b3eb02d",
-            "version": "KqlParameterItem/1.0",
-            "name": "Visualization11",
-            "type": 2,
-            "isRequired": true,
-            "query": "datatable (value:long, Display:string, isSelected:boolean)\r\n    [0, \"Line Chart\", true,\r\n     1, \"Grid\", false]",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
-            "typeSettings": {
-              "additionalResourceOptions": []
-            },
-            "resourceType": "microsoft.operationalinsights/workspaces"
-          },
-          {
-            "id": "6cc1a388-27c6-4cfe-a787-ff00cb8f4fad",
-            "version": "KqlParameterItem/1.0",
-            "name": "Snippet11",
-            "type": 1,
-            "isRequired": true,
-            "query": "print(iff({Visualization7} == 0, \"{LineChartQuerySnippet}\", \"{GridQuerySnippet}\") )",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
-            "isHiddenWhenLocked": true,
-            "resourceType": "microsoft.operationalinsights/workspaces"
-          },
-          {
-            "id": "77870d8a-bf65-4405-a722-fdf0826106ac",
-            "version": "KqlParameterItem/1.0",
-            "name": "Unit11",
-            "type": 2,
-            "value": null,
-            "typeSettings": {
-              "additionalResourceOptions": []
-            },
-            "jsonData": "[\r\n    {\r\n        \"label\": \"B -> MB\",\r\n        \"value\": \"/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"B -> GB\",\r\n        \"value\": \"/1024/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"MB -> GB\",\r\n        \"value\": \"/1024\"\r\n    },\r\n    {\r\n        \"label\": \"MB -> TB\",\r\n        \"value\": \"/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"b -> Mb\",\r\n        \"value\": \"/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"b -> Gb\",\r\n        \"value\": \"/1000/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"Mb -> Gb\",\r\n        \"value\": \"/1000\"\r\n    },\r\n    {\r\n        \"label\": \"Mb -> Tb\",\r\n        \"value\": \"/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"s -> ms\",\r\n        \"value\": \"*1000\"\r\n    },\r\n    {\r\n        \"label\": \"ms -> s\",\r\n        \"value\": \"/1000\"\r\n    }\r\n]"
-          }
-        ],
-        "style": "above",
-        "queryType": 0,
-        "resourceType": "microsoft.operationalinsights/workspaces"
-      },
-      "conditionalVisibility": {
-        "parameterName": "Mode",
-        "comparison": "isEqualTo",
-        "value": "0"
-      },
-      "customWidth": "25",
-      "name": "parameters - 28"
-    },
-    {
-      "type": 9,
-      "content": {
-        "version": "KqlParameterItem/1.0",
-        "parameters": [
-          {
-            "id": "aa2368fc-ad30-4608-b96a-72abf7b1e1ad",
-            "version": "KqlParameterItem/1.0",
-            "name": "Counter12",
-            "type": 2,
-            "isRequired": true,
-            "query": "InsightsMetrics\r\n| where TimeGenerated {TimeRange}\r\n| summarize by Name, Namespace, CounterText = Name\r\n| order by Namespace asc, CounterText asc\r\n| project Counter = pack('counter', Name, 'object', Namespace), CounterText, group = Namespace",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
-            "value": "{\"counter\":\"FreeSpacePercentage\",\"object\":\"LogicalDisk\"}",
-            "typeSettings": {
-              "additionalResourceOptions": [
-                "value::1"
-              ]
-            },
-            "queryType": 0,
-            "resourceType": "microsoft.operationalinsights/workspaces"
-          },
-          {
-            "id": "6a7306ea-247f-46ca-abca-501911f9e9dd",
-            "version": "KqlParameterItem/1.0",
-            "name": "TrendAggregator12",
-            "type": 2,
-            "isRequired": true,
-            "typeSettings": {
-              "additionalResourceOptions": []
-            },
-            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(Val), 2)\", \"label\":\"Average\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(Val, 5), 2)\", \"label\":\"P5th\", \"selected\":false},\r\n    { \"value\":\"P10th = round(percentile(Val, 10), 2)\", \"label\":\"P10th\", \"selected\":false},\r\n    { \"value\":\"P50th = round(percentile(Val, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P80th = round(percentile(Val, 80), 2)\", \"label\":\"P80th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(Val, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(Val, 95), 2)\", \"label\":\"P95th\", \"selected\":true}    \r\n]"
-          },
-          {
-            "id": "0327f26e-cdde-4b48-b512-6c35f06ad1dd",
-            "version": "KqlParameterItem/1.0",
-            "name": "TrendAggregatorOrder12",
-            "type": 1,
-            "query": "print(iff('{TrendAggregator12:label}' == 'P5th'  or '{TrendAggregator12:label}' == 'P10th', 'asc', 'desc'))",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
-            "isHiddenWhenLocked": true,
-            "resourceType": "microsoft.operationalinsights/workspaces"
-          },
-          {
-            "id": "68468652-570f-4d77-af12-a59d463d5f0d",
-            "version": "KqlParameterItem/1.0",
-            "name": "Visualization12",
-            "type": 2,
-            "isRequired": true,
-            "query": "datatable (value:long, Display:string, isSelected:boolean)\r\n    [0, \"Line Chart\", true,\r\n     1, \"Grid\", false]",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
-            "typeSettings": {
-              "additionalResourceOptions": []
-            },
-            "resourceType": "microsoft.operationalinsights/workspaces"
-          },
-          {
-            "id": "15738505-f7e6-446e-995d-280cf70dde9d",
-            "version": "KqlParameterItem/1.0",
-            "name": "Snippet12",
-            "type": 1,
-            "isRequired": true,
-            "query": "print(iff({Visualization8} == 0, \"{LineChartQuerySnippet}\", \"{GridQuerySnippet}\") )",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
-            "isHiddenWhenLocked": true,
-            "resourceType": "microsoft.operationalinsights/workspaces"
-          },
-          {
-            "id": "beb8493f-b5db-4bb5-865b-c8a4fed0ca0c",
-            "version": "KqlParameterItem/1.0",
-            "name": "Unit12",
-            "type": 2,
-            "value": null,
-            "typeSettings": {
-              "additionalResourceOptions": []
-            },
-            "jsonData": "[\r\n    {\r\n        \"label\": \"B -> MB\",\r\n        \"value\": \"/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"B -> GB\",\r\n        \"value\": \"/1024/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"MB -> GB\",\r\n        \"value\": \"/1024\"\r\n    },\r\n    {\r\n        \"label\": \"MB -> TB\",\r\n        \"value\": \"/1024/1024\"\r\n    },\r\n    {\r\n        \"label\": \"b -> Mb\",\r\n        \"value\": \"/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"b -> Gb\",\r\n        \"value\": \"/1000/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"Mb -> Gb\",\r\n        \"value\": \"/1000\"\r\n    },\r\n    {\r\n        \"label\": \"Mb -> Tb\",\r\n        \"value\": \"/1000/1000\"\r\n    },\r\n    {\r\n        \"label\": \"s -> ms\",\r\n        \"value\": \"*1000\"\r\n    },\r\n    {\r\n        \"label\": \"ms -> s\",\r\n        \"value\": \"/1000\"\r\n    }\r\n]"
-          }
-        ],
-        "style": "above",
-        "queryType": 0,
-        "resourceType": "microsoft.operationalinsights/workspaces"
-      },
-      "conditionalVisibility": {
-        "parameterName": "Mode",
-        "comparison": "isEqualTo",
-        "value": "0"
-      },
-      "customWidth": "25",
-      "name": "parameters - 29"
-    },
-    {
-      "type": 1,
-      "content": {
-        "json": "<h3 style=\"margin-bottom:0;\">{Counter9:label}</h3><h4 style=\"margin-top:0;font-weight:normal;color:#777;\">{TrendAggregator9:label} {TrendAggregatorOrder9} {Unit9:label}</h4>"
-      },
-      "customWidth": "25",
-      "name": "text - 30"
-    },
-    {
-      "type": 1,
-      "content": {
-        "json": "<h3 style=\"margin-bottom:0;\">{Counter10:label}</h3><h4 style=\"margin-top:0;font-weight:normal;color:#777;\">{TrendAggregator10:label} {TrendAggregatorOrder10} {Unit10:label}</h4>"
-      },
-      "customWidth": "25",
-      "name": "text - 31"
-    },
-    {
-      "type": 1,
-      "content": {
-        "json": "<h3 style=\"margin-bottom:0;\">{Counter11:label}</h3><h4 style=\"margin-top:0;font-weight:normal;color:#777;\">{TrendAggregator11:label} {TrendAggregatorOrder11} {Unit11:label}</h4>"
-      },
-      "customWidth": "25",
-      "name": "text - 32"
-    },
-    {
-      "type": 1,
-      "content": {
-        "json": "<h3 style=\"margin-bottom:0;\">{Counter12:label}</h3><h4 style=\"margin-top:0;font-weight:normal;color:#777;\">{TrendAggregator12:label} {TrendAggregatorOrder12} {Unit12:label}</h4>"
-      },
-      "customWidth": "25",
-      "name": "text - 33"
-    },
-    {
-      "type": 3,
-      "content": {
-        "version": "KqlItem/1.0",
-        "query": "let metric = dynamic({Counter9});\r\nlet cpuSummary=totable(InsightsMetrics\r\n    {ComputerFilter}\r\n    | where TimeGenerated {TimeRange} \r\n    | where Namespace == metric.object and Name == metric.counter\r\n    | summarize hint.shufflekey=Computer {TrendAggregator9} by Computer, Name\r\n    | top {TopN} by {TrendAggregator9:label} {TrendAggregatorOrder9});\r\nlet computerList=(cpuSummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nInsightsMetrics\r\n    | where TimeGenerated {TimeRange}\r\n    | where Namespace == metric.object and Name == metric.counter\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {TrendAggregator9}{Unit9} by {Snippet9}",
-        "size": 0,
-        "aggregation": 3,
-        "showAnnotations": true,
-        "noDataMessage": "No computers are emitting data for this performance counter.",
-        "exportToExcelOptions": "visible",
-        "queryType": 0,
-        "resourceType": "microsoft.operationalinsights/workspaces",
-        "crossComponentResources": [
-          "{Workspaces}"
-        ],
-        "tileSettings": {
-          "showBorder": false,
-          "titleContent": {
-            "columnMatch": "Computer",
-            "formatter": 1
-          },
-          "leftContent": {
-            "columnMatch": "value",
-            "formatter": 12,
-            "formatOptions": {
-              "palette": "auto"
-            },
-            "numberFormat": {
-              "unit": 17,
-              "options": {
-                "maximumSignificantDigits": 3,
-                "maximumFractionDigits": 2
-              }
-            }
-          }
-        }
-      },
-      "customWidth": "25",
-      "name": "query - 34"
-    },
-    {
-      "type": 3,
-      "content": {
-        "version": "KqlItem/1.0",
-        "query": "let metric = dynamic({Counter10});\r\nlet cpuSummary=totable(InsightsMetrics\r\n    {ComputerFilter}\r\n    | where TimeGenerated {TimeRange} \r\n    | where Namespace == metric.object and Name == metric.counter\r\n    | summarize hint.shufflekey=Computer {TrendAggregator10} by Computer, Name\r\n    | top {TopN} by {TrendAggregator10:label} {TrendAggregatorOrder10});\r\nlet computerList=(cpuSummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nInsightsMetrics\r\n    | where TimeGenerated {TimeRange}\r\n    | where Namespace == metric.object and Name == metric.counter\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {TrendAggregator10}{Unit10} by {Snippet10}",
-        "size": 0,
-        "aggregation": 3,
-        "showAnnotations": true,
-        "noDataMessage": "No computers are emitting data for this performance counter.",
-        "exportToExcelOptions": "visible",
-        "queryType": 0,
-        "resourceType": "microsoft.operationalinsights/workspaces",
-        "crossComponentResources": [
-          "{Workspaces}"
-        ],
-        "tileSettings": {
-          "showBorder": false,
-          "titleContent": {
-            "columnMatch": "Computer",
-            "formatter": 1
-          },
-          "leftContent": {
-            "columnMatch": "value",
-            "formatter": 12,
-            "formatOptions": {
-              "palette": "auto"
-            },
-            "numberFormat": {
-              "unit": 17,
-              "options": {
-                "maximumSignificantDigits": 3,
-                "maximumFractionDigits": 2
-              }
-            }
-          }
-        }
-      },
-      "customWidth": "25",
-      "name": "query - 35"
-    },
-    {
-      "type": 3,
-      "content": {
-        "version": "KqlItem/1.0",
-        "query": "let metric = dynamic({Counter11});\r\nlet cpuSummary=totable(InsightsMetrics\r\n    {ComputerFilter}\r\n    | where TimeGenerated {TimeRange} \r\n    | where Namespace == metric.object and Name == metric.counter\r\n    | summarize hint.shufflekey=Computer {TrendAggregator11} by Computer, Name\r\n    | top {TopN} by {TrendAggregator11:label} {TrendAggregatorOrder11});\r\nlet computerList=(cpuSummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nInsightsMetrics\r\n    | where TimeGenerated {TimeRange}\r\n    | where Namespace == metric.object and Name == metric.counter\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {TrendAggregator11}{Unit11} by {Snippet11}",
-        "size": 0,
-        "aggregation": 3,
-        "showAnnotations": true,
-        "noDataMessage": "No computers are emitting data for this performance counter.",
-        "exportToExcelOptions": "visible",
-        "queryType": 0,
-        "resourceType": "microsoft.operationalinsights/workspaces",
-        "crossComponentResources": [
-          "{Workspaces}"
-        ],
-        "tileSettings": {
-          "showBorder": false,
-          "titleContent": {
-            "columnMatch": "Computer",
-            "formatter": 1
-          },
-          "leftContent": {
-            "columnMatch": "value",
-            "formatter": 12,
-            "formatOptions": {
-              "palette": "auto"
-            },
-            "numberFormat": {
-              "unit": 17,
-              "options": {
-                "maximumSignificantDigits": 3,
-                "maximumFractionDigits": 2
-              }
-            }
-          }
-        }
-      },
-      "customWidth": "25",
-      "name": "query - 36"
-    },
-    {
-      "type": 3,
-      "content": {
-        "version": "KqlItem/1.0",
-        "query": "let metric = dynamic({Counter12});\r\nlet cpuSummary=totable(InsightsMetrics\r\n    {ComputerFilter}\r\n    | where TimeGenerated {TimeRange} \r\n    | where Namespace == metric.object and Name == metric.counter\r\n    | summarize hint.shufflekey=Computer {TrendAggregator12} by Computer, Name\r\n    | top {TopN} by {TrendAggregator12:label} {TrendAggregatorOrder12});\r\nlet computerList=(cpuSummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nInsightsMetrics\r\n    | where TimeGenerated {TimeRange}\r\n    | where Namespace == metric.object and Name == metric.counter\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {TrendAggregator12}{Unit12} by {Snippet12}",
-        "size": 0,
-        "aggregation": 3,
-        "showAnnotations": true,
-        "noDataMessage": "No computers are emitting data for this performance counter.",
-        "exportToExcelOptions": "visible",
-        "queryType": 0,
-        "resourceType": "microsoft.operationalinsights/workspaces",
-        "crossComponentResources": [
-          "{Workspaces}"
-        ],
-        "tileSettings": {
-          "showBorder": false,
-          "titleContent": {
-            "columnMatch": "Computer",
-            "formatter": 1
-          },
-          "leftContent": {
-            "columnMatch": "value",
-            "formatter": 12,
-            "formatOptions": {
-              "palette": "auto"
-            },
-            "numberFormat": {
-              "unit": 17,
-              "options": {
-                "maximumSignificantDigits": 3,
-                "maximumFractionDigits": 2
-              }
-            }
-          }
-        }
-      },
-      "customWidth": "25",
-      "name": "query - 37"
     }
   ],
-  "styleSettings": {},
   "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
 }

--- a/Workbooks/Virtual Machines - Performance Analysis/categoryResources.json
+++ b/Workbooks/Virtual Machines - Performance Analysis/categoryResources.json
@@ -1,25 +1,3 @@
 {
-    "en-us": {"name":"Performance Analysis", "description": "Look for common issues with your VM via metrics", "order": 200},
-    "categories": [
-        {
-            "key": "vmInsightsVirtualMachinesInsightsMetrics",
-            "settings": {
-                "en-us": {
-                    "name": "Performance Analysis (Insights Metrics)",
-                    "description": "Look for common issues with your VM via metrics",
-                    "order": 205
-                }
-            }
-        },
-        {
-            "key": "vmInsightsVirtualMachinesPerf",
-            "settings": {
-                "en-us": {
-                    "name": "Performance Analysis (Perf)",
-                    "description": "Look for common issues with your VM via metrics",
-                    "order": 205
-                }
-            }
-        }
-    ]
+    "en-us": {"name":"Performance Analysis", "description": "Look for common issues with your VM via metrics", "order": 200}
 }

--- a/Workbooks/Virtual Machines - Performance Analysis/categoryResources.json
+++ b/Workbooks/Virtual Machines - Performance Analysis/categoryResources.json
@@ -1,3 +1,25 @@
 {
-    "en-us": {"name":"Performance Analysis", "description": "Look for common issues with your VM via metrics", "order": 200}
+    "en-us": {"name":"Performance Analysis", "description": "Look for common issues with your VM via metrics", "order": 200},
+    "categories": [
+        {
+            "key": "vmInsightsVirtualMachinesInsightsMetrics",
+            "settings": {
+                "en-us": {
+                    "name": "Performance Analysis (Insights Metrics)",
+                    "description": "Look for common issues with your VM via metrics",
+                    "order": 205
+                }
+            }
+        },
+        {
+            "key": "vmInsightsVirtualMachinesPerf",
+            "settings": {
+                "en-us": {
+                    "name": "Performance Analysis (Perf)",
+                    "description": "Look for common issues with your VM via metrics",
+                    "order": 205
+                }
+            }
+        }
+    ]
 }

--- a/Workbooks/categoryResources.json
+++ b/Workbooks/categoryResources.json
@@ -14,7 +14,7 @@
 			"key": "azureMonitorVirtualMachines",
 			"settings": {
 				"en-us": {
-					"name": "Virtual Machines",
+					"name": "Virtual Machines (Insights Metrics)",
 					"description": "Analyze monitoring data from your VMs",
 					"order": 100
 				}
@@ -41,24 +41,24 @@
 			}
 		},
 		{
-            "key": "vmInsightsVirtualMachinesInsightsMetrics",
-            "settings": {
-                "en-us": {
-                    "name": "Performance Analysis",
-                    "description": "Look for common issues with your VM via metrics",
-                    "order": 205
-                }
-            }
-        },
-        {
-            "key": "vmInsightsVirtualMachinesPerf",
-            "settings": {
-                "en-us": {
-                    "name": "Performance Analysis (Perf)",
-                    "description": "Look for common issues with your VM via metrics",
-                    "order": 205
-                }
-            }
-        }
+			"key": "vmInsightsVirtualMachinesInsightsMetrics",
+			"settings": {
+				"en-us": {
+					"name": "Performance Analysis",
+					"description": "Look for common issues with your VM via metrics",
+					"order": 205
+				}
+			}
+		},
+		{
+			"key": "vmInsightsVirtualMachinesPerf",
+			"settings": {
+				"en-us": {
+					"name": "Performance Analysis (Perf)",
+					"description": "Look for common issues with your VM via metrics",
+					"order": 205
+				}
+			}
+		}
 	]
 }

--- a/Workbooks/categoryResources.json
+++ b/Workbooks/categoryResources.json
@@ -44,7 +44,7 @@
 			"key": "vmInsightsVirtualMachinesInsightsMetrics",
 			"settings": {
 				"en-us": {
-					"name": "Performance Analysis",
+					"name": "Performance Analysis (Insights Metrics)",
 					"description": "Look for common issues with your VM via metrics",
 					"order": 205
 				}

--- a/Workbooks/categoryResources.json
+++ b/Workbooks/categoryResources.json
@@ -14,7 +14,7 @@
 			"key": "azureMonitorVirtualMachines",
 			"settings": {
 				"en-us": {
-					"name": "Virtual Machines (Insights Metrics)",
+					"name": "Virtual Machines",
 					"description": "Analyze monitoring data from your VMs",
 					"order": 100
 				}


### PR DESCRIPTION
Introduce Perf version of the Performance Counters VM Insights template
to support existing customers. Also minor whitespace fix.

- Fix onboarding case in Perf Counters template
- Also fix formatting error in `categoryResources.json`

Signed-off-by: andrewki-msft <43890980+andrewki-msft@users.noreply.github.com>

Test
--

Performance Counters (Perf)
![image](https://user-images.githubusercontent.com/43890980/76578063-9797f380-6484-11ea-8a58-c37f3d7815f0.png)

Performance Counters (Insights Metrics)
![image](https://user-images.githubusercontent.com/43890980/76578554-3709b600-6486-11ea-8dcd-514410d41456.png)
