### PR TITLE
Update VMSS Perf workbook

### DIFF
--- a/Workbooks/Virtual Machine Scale Sets - Performance Analysis/Performance Analysis (Perf)/Performance Analysis (Perf).workbook
+++ b/Workbooks/Virtual Machine Scale Sets - Performance Analysis/Performance Analysis (Perf)/Performance Analysis (Perf).workbook
@@ -1,0 +1,1509 @@
+{
+  "version": "Notebook/1.0",
+  "items": [
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "query": "",
+        "crossComponentResources": [
+          "value::selected"
+        ],
+        "parameters": [
+          {
+            "id": "688dc7cb-bea3-41ae-ae94-32d22e09568c",
+            "version": "KqlParameterItem/1.0",
+            "name": "Resource",
+            "type": 5,
+            "isRequired": true,
+            "value": "value::1",
+            "isHiddenWhenLocked": true,
+            "typeSettings": {
+              "resourceTypeFilter": {
+                "microsoft.compute/virtualmachinescalesets": true
+              },
+              "additionalResourceOptions": [
+                "value::1"
+              ]
+            },
+            "timeContextFromParameter": null
+          }
+        ],
+        "style": "above",
+        "queryType": 1,
+        "resourceType": "microsoft.resourcegraph/resources"
+      },
+      "conditionalVisibility": {
+        "parameterName": "_",
+        "comparison": "isEqualTo",
+        "value": "_"
+      },
+      "name": "parameters - 0"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "# Performance Analysis"
+      },
+      "conditionalVisibility": {
+        "parameterName": "ContextFree",
+        "comparison": "isEqualTo",
+        "value": "value::1"
+      },
+      "name": "text - 1"
+    },
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "query": "",
+        "crossComponentResources": [
+          "{Resource}"
+        ],
+        "parameters": [
+          {
+            "id": "5f8cce4b-9c4c-47da-8683-7e5ccc9faed3",
+            "version": "KqlParameterItem/1.0",
+            "name": "TimeRange",
+            "type": 4,
+            "isRequired": false,
+            "value": {
+              "durationMs": 1800000
+            },
+            "isHiddenWhenLocked": false,
+            "typeSettings": {
+              "selectableValues": [
+                {
+                  "durationMs": 300000,
+                  "createdTime": "2018-10-04T22:01:18.372Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 900000,
+                  "createdTime": "2018-10-04T22:01:18.372Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 1800000,
+                  "createdTime": "2018-10-04T22:01:18.372Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 3600000,
+                  "createdTime": "2018-10-04T22:01:18.372Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 14400000,
+                  "createdTime": "2018-10-04T22:01:18.374Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 43200000,
+                  "createdTime": "2018-10-04T22:01:18.374Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 86400000,
+                  "createdTime": "2018-10-04T22:01:18.374Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 172800000,
+                  "createdTime": "2018-10-04T22:01:18.374Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 259200000,
+                  "createdTime": "2018-10-04T22:01:18.375Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 604800000,
+                  "createdTime": "2018-10-04T22:01:18.375Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 1209600000,
+                  "createdTime": "2018-10-04T22:01:18.375Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 2592000000,
+                  "createdTime": "2018-10-04T22:01:18.375Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 5184000000,
+                  "createdTime": "2018-10-04T22:01:18.375Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                },
+                {
+                  "durationMs": 7776000000,
+                  "createdTime": "2018-10-04T22:01:18.375Z",
+                  "isInitialTime": false,
+                  "grain": 1,
+                  "useDashboardTimeRange": false
+                }
+              ],
+              "allowCustom": true
+            }
+          },
+          {
+            "id": "d6de19ff-cde4-41c2-9fba-b441312ea5c9",
+            "version": "KqlParameterItem/1.0",
+            "name": "Test",
+            "type": 1,
+            "isRequired": false,
+            "query": "Perf\r\n| take 1\r\n| summarize count()",
+            "crossComponentResources": [
+              "{Resource}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "queryType": 0,
+            "resourceType": "microsoft.compute/virtualmachinescalesets"
+          }
+        ],
+        "style": "above",
+        "queryType": 0,
+        "resourceType": "microsoft.compute/virtualmachinescalesets"
+      },
+      "conditionalVisibility": null,
+      "name": "parameters - 2"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "⚠ This workbook requires [Azure Monitor for VMs (preview)](https://docs.microsoft.com/en-us/azure/azure-monitor/insights/vminsights-overview) enabled in order to show accurate and complete information for your VMs. Follow the link to onboard machines or select a different workspace."
+      },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isEqualTo",
+        "value": null
+      },
+      "name": "text - 3"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "---"
+      },
+      "conditionalVisibility": null,
+      "name": "text - 4"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "<h2 style=\"margin-bottom:0;padding-bottom:0;\">Top 100 Machines</h2>"
+      },
+      "conditionalVisibility": null,
+      "name": "text - 5"
+    },
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "query": "",
+        "crossComponentResources": [
+          "{Resource}"
+        ],
+        "parameters": [
+          {
+            "id": "aa2368fc-ad30-4608-b96a-72abf7b1e1af",
+            "version": "KqlParameterItem/1.0",
+            "name": "Counter",
+            "type": 2,
+            "description": "Select a VM performance counter for the table below",
+            "isRequired": false,
+            "query": "// {Resource} {Test}\r\nPerf\r\n| where TimeGenerated {TimeRange}\r\n| where ObjectName != 'Network' and ObjectName != 'Network Interface'\r\n| summarize by CounterName, ObjectName, CounterText = CounterName\r\n| order by ObjectName asc, CounterText asc\r\n| project Counter = pack('counter', CounterName, 'object', ObjectName), CounterText, group = ObjectName",
+            "crossComponentResources": [
+              "{Resource}"
+            ],
+            "isHiddenWhenLocked": false,
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "timeContextFromParameter": null,
+            "queryType": 0,
+            "resourceType": "microsoft.compute/virtualmachinescalesets"
+          },
+          {
+            "id": "974d5ac2-4fc5-48e7-a8f7-16fc9dddc4ac",
+            "version": "KqlParameterItem/1.0",
+            "name": "CounterText",
+            "type": 1,
+            "isRequired": false,
+            "query": "let metric = dynamic({Counter});\r\nrange Steps from 1 to 1 step 1\r\n| project strcat(metric.object, \" > \", metric.counter)",
+            "crossComponentResources": [
+              "{Resource}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "queryType": 0,
+            "resourceType": "microsoft.compute/virtualmachinescalesets"
+          },
+          {
+            "id": "ce228deb-88eb-4438-9dce-6c6d1972ff09",
+            "version": "KqlParameterItem/1.0",
+            "name": "IsNetworkCounter",
+            "type": 1,
+            "isRequired": false,
+            "query": "let counter = dynamic({Counter});\r\nprint tostring(counter.object == 'Network Adapter')",
+            "crossComponentResources": [
+              "{Resource}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "queryType": 0,
+            "resourceType": "microsoft.compute/virtualmachinescalesets"
+          },
+          {
+            "id": "3b23aa7a-2afd-40ba-a710-0e2cc73c764b",
+            "version": "KqlParameterItem/1.0",
+            "name": "NetworkDirection",
+            "type": 1,
+            "isRequired": false,
+            "query": "let metric = dynamic({Counter});\r\nprint(iff(metric.counter == 'Bytes Received/sec', 'Received', 'Sent'))",
+            "crossComponentResources": [
+              "{Resource}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "queryType": 0,
+            "resourceType": "microsoft.compute/virtualmachinescalesets"
+          },
+          {
+            "id": "9ad8858d-8ef3-4144-94b1-66a8bf9fa9c9",
+            "version": "KqlParameterItem/1.0",
+            "name": "Aggregators",
+            "type": 2,
+            "description": "Select one or more different aggregates to display in the table below",
+            "isRequired": true,
+            "multiSelect": true,
+            "quote": "",
+            "delimiter": ",",
+            "isHiddenWhenLocked": false,
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "jsonData": "[\r\n    { \"value\":\"Average\", \"label\":\"Average\", \"selected\": true },\r\n    { \"value\":\"P5th\", \"label\":\"P5th\", \"selected\": false },\r\n    { \"value\":\"P10th\", \"label\":\"P10th\", \"selected\": false },\r\n    { \"value\":\"P50th\", \"label\":\"P50th\", \"selected\": false },\r\n    { \"value\":\"P80th\", \"label\":\"P80th\", \"selected\": false },\r\n    { \"value\":\"P90th\", \"label\":\"P90th\", \"selected\": false },\r\n    { \"value\":\"P95th\", \"label\":\"P95th\", \"selected\": true },\r\n    { \"value\":\"Min\", \"label\":\"Min\", \"selected\": false },\r\n    { \"value\":\"Max\", \"label\":\"Max\", \"selected\": true }\r\n]",
+            "timeContextFromParameter": null
+          },
+          {
+            "id": "6a7306ea-247f-46ca-abca-501911f9e9d3",
+            "version": "KqlParameterItem/1.0",
+            "name": "TableTrend",
+            "type": 2,
+            "description": "Select a percentile to display in the Trend column in the table below",
+            "isRequired": true,
+            "isHiddenWhenLocked": false,
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\", \"selected\": true },\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\", \"selected\": false },\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\", \"selected\": false },\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\", \"selected\": false },\r\n    { \"value\":\"P80th = round(percentile(CounterValue, 80), 2)\", \"label\":\"P80th\", \"selected\": false },\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\", \"selected\": false },\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\", \"selected\": false }\r\n]",
+            "timeContextFromParameter": null
+          },
+          {
+            "id": "0327f26e-cdde-4b48-b512-6c35f06ad1d0",
+            "version": "KqlParameterItem/1.0",
+            "name": "tableTrendOrder",
+            "type": 1,
+            "isRequired": false,
+            "query": "range Steps from 1 to 1 step 1\r\n| project value = iff('{TableTrend}' contains 'P5th'  or '{TableTrend}' contains 'P10th', 'asc', 'desc')",
+            "crossComponentResources": [
+              "{Resource}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "queryType": 0,
+            "resourceType": "microsoft.compute/virtualmachinescalesets"
+          },
+          {
+            "id": "c2f05b6d-970d-4fde-88b0-868387c02250",
+            "version": "KqlParameterItem/1.0",
+            "name": "mergedAggregators",
+            "type": 1,
+            "isRequired": false,
+            "query": "let aggregators = iff('{Aggregators}' contains '{TableTrend:label}', '{Aggregators}', '{Aggregators},{TableTrend:label}');\r\nrange Steps from 1 to 1 step 1\r\n| project aggregators",
+            "crossComponentResources": [
+              "{Resource}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "queryType": 0,
+            "resourceType": "microsoft.compute/virtualmachinescalesets"
+          },
+          {
+            "id": "27faa340-a75f-4ae1-a43a-1aa6ece37cff",
+            "version": "KqlParameterItem/1.0",
+            "name": "StandardQuery",
+            "type": 1,
+            "isRequired": false,
+            "query": "// {Resource} {Test}\r\nlet metric = dynamic({Counter}); \r\nlet timeRangeStart = {TimeRange:start};\r\nlet timeRangeEnd = {TimeRange:end};\r\nlet timeRangeGrain = {TimeRange:grain};\r\nprint(iff({IsNetworkCounter} == 'False', strcat(\"let maxResultCount = 100; let metric = dynamic(\", metric, \"); let summaryPerComputer = totable(Perf      | where TimeGenerated {TimeRange}       | where ObjectName == metric.object and CounterName == metric.counter     | summarize hint.shufflekey = Computer Average = avg(CounterValue), Max = max(CounterValue), Min = min(CounterValue), percentiles(CounterValue, 5, 10, 50, 80, 90, 95) by Computer      | project Computer, Average, Max, Min, P5th = percentile_CounterValue_5, P10th = percentile_CounterValue_10, P50th = percentile_CounterValue_50, P80th = percentile_CounterValue_80, P90th = percentile_CounterValue_90, P95th = percentile_CounterValue_95      | order by {TableTrend:label} {tableTrendOrder}, Computer      | limit maxResultCount);  let computerList = summaryPerComputer      | project Computer;  let MachineSummary = ServiceMapComputer_CL     | where TimeGenerated {TimeRange}     | where Computer in (computerList)     | summarize arg_max(TimeGenerated, *) by Computer     | project Computer, MachineSummary = pack('Fully Qualified Domain Name', Computer, 'OS Type', OperatingSystemFamily_s, 'Operating System', OperatingSystemFullName_s, 'Ipv4 Addresses', Ipv4Addresses_s,         'Ipv6 Addresses', Ipv6Addresses_s, 'Mac Addresses', MacAddresses_s, 'DNS Names', DnsNames_s, 'CPUs', strcat(Cpus_d, ' @ ', CpuSpeed_d, ' MHz'), 'Bitness', Bitness_s,         'Physcial Memory', strcat(PhysicalMemory_d, ' MB'), 'Virtualization State', VirtualizationState_s, 'VM Type', VirtualMachineType_s, 'OMS Agent', split(ResourceName_s, 'm-')[1]); let EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) []; let OmsNodeIdentityAndProps = computerList     | extend NodeId = Computer     | extend Priority = 1     | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer); let ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL     | where TimeGenerated {TimeRange}     | where Computer in (computerList)     | summarize arg_max(TimeGenerated, *) by Computer     | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2; let NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                                 | summarize arg_max(Priority, *) by Computer;  let NodeIdentityAndPropsMin = NodeIdentityAndProps     | extend Type = iff(NodeProps.type == 'StandAloneNode', iff(NodeProps.azureResourceId == '', 'Non-Azure Virtual Machine', 'Azure Virtual Machine'), NodeProps.type),      ResourceId = iff(NodeProps.type == 'AzureScaleSetNode', NodeProps.vmScaleSetResourceId,          iff(NodeProps.type == 'AzureCloudServiceNode', NodeProps.cloudServiceDeploymentId, Computer)),     ResourceName = iff(NodeProps.type == 'AzureScaleSetNode', strcat(NodeProps.vmScaleSetName, ' | ', NodeProps.scaleSetInstanceId),          iff(NodeProps.type == 'AzureCloudServiceNode', strcat(NodeProps.cloudServiceRoleName, ' | ', NodeProps.cloudServiceInstanceId), Computer))     | project Computer, Type, ResourceId, ResourceName; let trend = Perf          | where TimeGenerated {TimeRange}         | where Computer in (computerList)          | where ObjectName == metric.object and CounterName == metric.counter        | make-series {TableTrend} default = 0 on TimeGenerated in range(datetime('\", timeRangeStart,\"'), datetime('\", timeRangeEnd ,\"'), totimespan('\", timeRangeGrain, \"')) by Computer     | project Computer, ['Trend ({TableTrend:label})'] = {TableTrend:label}; summaryPerComputer     | join kind=leftouter (trend) on Computer     | join kind=leftouter (NodeIdentityAndProps) on Computer     | join kind=leftouter (NodeIdentityAndPropsMin) on Computer     | join kind=leftouter (MachineSummary) on Computer     | project ResourceName, Type, {mergedAggregators}, ['Trend ({TableTrend:label})'], Properties = MachineSummary     | sort by {TableTrend:label} {tableTrendOrder}\"), ''));",
+            "crossComponentResources": [
+              "{Resource}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "queryType": 0,
+            "resourceType": "microsoft.compute/virtualmachinescalesets"
+          },
+          {
+            "id": "6e392933-2f72-45a6-889b-90351f9130db",
+            "version": "KqlParameterItem/1.0",
+            "name": "NetworkQuery",
+            "type": 1,
+            "isRequired": false,
+            "query": "let metric = dynamic({Counter});\r\nlet timeRangeStart = {TimeRange:start};\r\nlet timeRangeEnd = {TimeRange:end};\r\nlet timeRangeGrain = {TimeRange:grain};\r\nprint(iff({IsNetworkCounter} == 'True', strcat(\"let metric = dynamic(\", metric, \"); let linux = iff(metric.counter == 'Bytes Received/sec', dynamic({'object': 'Network', 'counter': 'Total Bytes Received'}), dynamic({'object': 'Network', 'counter': 'Total Bytes Transmitted'})); let maxResultCount = 100; let windowsNetworkRaw = Perf | where TimeGenerated {TimeRange} | where ObjectName == metric.object and CounterName == metric.couter; let windowsNetworkSum = windowsNetworkRaw | summarize hint.shufflekey=Computer CounterValue=sum(CounterValue) by Computer, TimeGenerated; let windowsNetworkPctl = windowsNetworkRaw | summarize hint.shufflekey=Computer Average = avg(CounterValue), Max = max(CounterValue), Min = min(CounterValue), percentiles(CounterValue, 5, 10, 50, 80, 90, 95) by Computer, TimeGenerated | project TimeGenerated, Computer, Average, Max, Min, P5th = percentile_CounterValue_5, P10th = percentile_CounterValue_10, P50th = percentile_CounterValue_50, P80th = percentile_CounterValue_80, P90th = percentile_CounterValue_90, P95th = percentile_CounterValue_95; let linuxNetworkRaw = Perf | where TimeGenerated {TimeRange} | where ObjectName == linux.object and CounterName == linux.counter | order by InstanceName, TimeGenerated asc | extend prev_Value = prev(CounterValue), prev_t = prev(TimeGenerated), prev_instance = prev(InstanceName) | project TimeGenerated, Computer, CounterValue = iff(prev_instance == InstanceName and CounterValue >= prev_Value and TimeGenerated > prev_t, (CounterValue - prev_Value) / ((TimeGenerated - prev_t) / 1s), real(0)); let linuxNetworkSum = linuxNetworkRaw | summarize hint.shufflekey=Computer CounterValue=sum(CounterValue) by Computer, TimeGenerated; let linuxNetworkPctl = linuxNetworkRaw | summarize hint.shufflekey=Computer Average = avg(CounterValue), Max = max(CounterValue), Min = min(CounterValue), percentiles(CounterValue, 5, 10, 50, 80, 90, 95) by Computer, TimeGenerated | project TimeGenerated, Computer, Average, Max, Min, P5th = percentile_CounterValue_5, P10th = percentile_CounterValue_10, P50th = percentile_CounterValue_50, P80th = percentile_CounterValue_80, P90th = percentile_CounterValue_90, P95th = percentile_CounterValue_95; let networkDataSum = union windowsNetworkSum, linuxNetworkSum; let networkDataPctl = union windowsNetworkPctl, linuxNetworkPctl; let computerList = Perf  | project Computer; let EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) []; let OmsNodeIdentityAndProps = computerList | extend NodeId = Computer | extend Priority = 1 | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer); let ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL | where TimeGenerated {TimeRange} | where Computer in (computerList) | summarize hint.shufflekey=Computer arg_max(TimeGenerated, *) by Computer | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|', columnifexists('AzureCloudServiceDeployment_g', '')), ''), AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')), strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|', columnifexists('AzureVmScaleSetDeployment_g', '')), ''), ComputerProps = pack('type', 'StandAloneNode', 'name', ComputerName_s, 'mappingResourceId', ResourceId, 'subscriptionId', AzureSubscriptionId_g, 'resourceGroup', AzureResourceGroup_s, 'azureResourceId', columnifexists('AzureResourceId_s', '')), AzureCloudServiceNodeProps = pack('type', 'AzureCloudServiceNode', 'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''), 'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''), 'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''), 'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''), 'mappingResourceId', ResourceId), AzureScaleSetNodeProps = pack('type', 'AzureScaleSetNode', 'scaleSetInstanceId', columnifexists('AzureName_s', ''), 'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''), 'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''), 'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''), 'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''), 'resourceGroupName', columnifexists('AzureResourceGroup_s', ''), 'subscriptionId', columnifexists('AzureSubscriptionId_g', ''), 'mappingResourceId', ResourceId)| project   Computer, NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity, isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer), NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps, isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps), Priority = 2; let NodeIdentityAndProps = union kind=inner isfuzzy = true EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps | summarize hint.shufflekey=Computer arg_max(Priority, *) by Computer; let NodeIdentityAndPropsMin = NodeIdentityAndProps | extend Type = iff(NodeProps.type == 'StandAloneNode', iff(NodeProps.azureResourceId == '', 'Non-Azure Virtual Machine', 'Azure Virtual Machine'), NodeProps.type), ResourceId = iff(NodeProps.type == 'AzureScaleSetNode', NodeProps.vmScaleSetResourceId, iff(NodeProps.type == 'AzureCloudServiceNode', NodeProps.cloudServiceDeploymentId, Computer)), ResourceName = iff(NodeProps.type == 'AzureScaleSetNode', strcat(NodeProps.vmScaleSetName, ' | ', NodeProps.scaleSetInstanceId), iff(NodeProps.type == 'AzureCloudServiceNode', strcat(NodeProps.cloudServiceRoleName, ' | ', NodeProps.cloudServiceInstanceId), Computer)) | project Computer, Type, ResourceId, ResourceName; let MachineSummary = ServiceMapComputer_CL | where TimeGenerated {TimeRange} | where Computer in (computerList) | summarize hint.shufflekey=Computer arg_max(TimeGenerated, *) by Computer | project Computer, MachineSummary = pack('Fully Qualified Domain Name', Computer, 'OS Type', OperatingSystemFamily_s, 'Operating System', OperatingSystemFullName_s, 'Ipv4 Addresses', Ipv4Addresses_s, 'Ipv6 Addresses', Ipv6Addresses_s, 'Mac Addresses', MacAddresses_s, 'DNS Names', DnsNames_s, 'CPUs', strcat(Cpus_d, ' @ ', CpuSpeed_d, ' MHz'), 'Bitness', Bitness_s, 'Physcial Memory', strcat(PhysicalMemory_d, ' MB'), 'Virtualization State', VirtualizationState_s, 'VM Type', VirtualMachineType_s, 'OMS Agent', split(ResourceName_s, 'm-')[1]); let trend = networkDataSum | make-series {TableTrend} default=0 on TimeGenerated in range(datetime('\", timeRangeStart,\"'), datetime('\", timeRangeEnd ,\"'), totimespan('\", timeRangeGrain, \"')) by Computer | project Computer, ['Trend ({TableTrend:label})'] = {TableTrend:label}; networkDataPctl | join kind=leftouter hint.shufflekey=Computer (trend) on Computer | join kind=leftouter hint.shufflekey=Computer (NodeIdentityAndPropsMin) on Computer | join kind=leftouter hint.shufflekey=Computer (MachineSummary) on Computer | project ResourceName, Type, {mergedAggregators}, ['Trend ({TableTrend:label})'], Properties = MachineSummary | sort by {TableTrend:label} {tableTrendOrder} | limit maxResultCount\"), ''));",
+            "crossComponentResources": [
+              "{Resource}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "queryType": 0,
+            "resourceType": "microsoft.compute/virtualmachinescalesets"
+          },
+          {
+            "id": "69c79551-68b9-4c84-bf57-202540482a02",
+            "version": "KqlParameterItem/1.0",
+            "name": "ShowTable",
+            "type": 1,
+            "isRequired": false,
+            "query": "print iff(\"{Test:value}\" == \"\", \"False\", iff(\"{IsNetworkCounter:value}\" == \"False\", \"True\", \"False\"))",
+            "crossComponentResources": [
+              "{Resource}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "queryType": 0,
+            "resourceType": "microsoft.compute/virtualmachinescalesets"
+          },
+          {
+            "id": "6b664a24-d9a3-47b0-9d94-9cada9ddb8ce",
+            "version": "KqlParameterItem/1.0",
+            "name": "ShowNetworkTable",
+            "type": 1,
+            "isRequired": false,
+            "query": "print iff(\"{Test:value}\" == \"\", \"False\", \"{IsNetworkCounter:value}\")",
+            "crossComponentResources": [
+              "{Resource}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "queryType": 0,
+            "resourceType": "microsoft.compute/virtualmachinescalesets"
+          },
+          {
+            "id": "343c4eae-e482-4678-a936-c4ad43b2ec19",
+            "version": "KqlParameterItem/1.0",
+            "name": "CounterTest",
+            "type": 1,
+            "isRequired": false,
+            "query": "Perf\r\n| take 1",
+            "crossComponentResources": [
+              "{Resource}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "queryType": 0,
+            "resourceType": "microsoft.compute/virtualmachinescalesets"
+          }
+        ],
+        "style": "above",
+        "queryType": 0,
+        "resourceType": "microsoft.compute/virtualmachinescalesets"
+      },
+      "conditionalVisibility": {
+        "parameterName": "Test",
+        "comparison": "isNotEqualTo",
+        "value": null
+      },
+      "name": "parameters - 6"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "There are no performance counters, either onboard machines to this workspace or enable performance counters."
+      },
+      "conditionalVisibility": {
+        "parameterName": "CounterTest",
+        "comparison": "isEqualTo",
+        "value": ""
+      },
+      "name": "text - 7"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "// {Resource} {Test}\r\n{StandardQuery}",
+        "size": 0,
+        "noDataMessage": "There is no data for this counter, either enable the counter or onboard machines to this workspace",
+        "queryType": 0,
+        "resourceType": "microsoft.compute/virtualmachinescalesets",
+        "crossComponentResources": [
+          "{Resource}"
+        ],
+        "visualization": "table",
+        "gridSettings": {
+          "formatters": [
+            {
+              "columnMatch": "Type",
+              "formatter": 1,
+              "formatOptions": {}
+            },
+            {
+              "columnMatch": "Average",
+              "formatter": 8,
+              "formatOptions": {
+                "palette": "blue"
+              },
+              "numberFormat": {
+                "unit": 0,
+                "options": {
+                  "style": "decimal"
+                }
+              }
+            },
+            {
+              "columnMatch": "P50th",
+              "formatter": 8,
+              "formatOptions": {
+                "palette": "blue"
+              },
+              "numberFormat": {
+                "unit": 0,
+                "options": {
+                  "style": "decimal"
+                }
+              }
+            },
+            {
+              "columnMatch": "Trend (Average)",
+              "formatter": 10,
+              "formatOptions": {
+                "palette": "blue"
+              }
+            },
+            {
+              "columnMatch": "Properties",
+              "formatter": 7,
+              "formatOptions": {
+                "linkTarget": "CellDetails",
+                "linkLabel": "ℹ️ Info"
+              }
+            },
+            {
+              "columnMatch": "P95th",
+              "formatter": 8,
+              "formatOptions": {
+                "palette": "blue"
+              },
+              "numberFormat": {
+                "unit": 0,
+                "options": {
+                  "style": "decimal"
+                }
+              }
+            },
+            {
+              "columnMatch": "P5th",
+              "formatter": 8,
+              "formatOptions": {
+                "palette": "blue"
+              },
+              "numberFormat": {
+                "unit": 0,
+                "options": {
+                  "style": "decimal"
+                }
+              }
+            },
+            {
+              "columnMatch": "P10th",
+              "formatter": 8,
+              "formatOptions": {
+                "palette": "blue"
+              },
+              "numberFormat": {
+                "unit": 0,
+                "options": {
+                  "style": "decimal"
+                }
+              }
+            },
+            {
+              "columnMatch": "P80th",
+              "formatter": 8,
+              "formatOptions": {
+                "palette": "blue"
+              },
+              "numberFormat": {
+                "unit": 0,
+                "options": {
+                  "style": "decimal"
+                }
+              }
+            },
+            {
+              "columnMatch": "P90th",
+              "formatter": 8,
+              "formatOptions": {
+                "palette": "blue"
+              },
+              "numberFormat": {
+                "unit": 0,
+                "options": {
+                  "style": "decimal"
+                }
+              }
+            },
+            {
+              "columnMatch": "Min",
+              "formatter": 8,
+              "formatOptions": {
+                "palette": "blue"
+              },
+              "numberFormat": {
+                "unit": 0,
+                "options": {
+                  "style": "decimal"
+                }
+              }
+            },
+            {
+              "columnMatch": "Max",
+              "formatter": 8,
+              "formatOptions": {
+                "palette": "blue"
+              },
+              "numberFormat": {
+                "unit": 0,
+                "options": {
+                  "style": "decimal"
+                }
+              }
+            },
+            {
+              "columnMatch": "Trend (P95th)",
+              "formatter": 10,
+              "formatOptions": {
+                "palette": "blue"
+              }
+            },
+            {
+              "columnMatch": "Trend (P5th)",
+              "formatter": 10,
+              "formatOptions": {
+                "palette": "blue"
+              }
+            },
+            {
+              "columnMatch": "Trend (P90th)",
+              "formatter": 10,
+              "formatOptions": {
+                "palette": "blue"
+              }
+            },
+            {
+              "columnMatch": "Trend (P80th)",
+              "formatter": 10,
+              "formatOptions": {
+                "palette": "blue"
+              }
+            },
+            {
+              "columnMatch": "Trend (P50th)",
+              "formatter": 10,
+              "formatOptions": {
+                "palette": "blue"
+              }
+            },
+            {
+              "columnMatch": "Trend (P10th)",
+              "formatter": 10,
+              "formatOptions": {
+                "palette": "blue"
+              }
+            }
+          ]
+        }
+      },
+      "conditionalVisibility": {
+        "parameterName": "ShowTable",
+        "comparison": "isEqualTo",
+        "value": "True"
+      },
+      "name": "query - 8"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "#### ℹ `Total Bytes {NetworkDirection}` counters are also being utilized to display the network table. The delta of `Total Bytes {NetworkDirection}` over a time period is being calculated to match up with the `Bytes {NetworkDirection}/sec` counter to display an accurate representation of network activity over all machines"
+      },
+      "conditionalVisibility": {
+        "parameterName": "ShowNetworkTable",
+        "comparison": "isEqualTo",
+        "value": "True"
+      },
+      "name": "text - 9"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "// {Resource} {Test}\r\n{NetworkQuery}",
+        "size": 0,
+        "noDataMessage": "There is no data for this counter, either enable the counter or onboard machines to this workspace",
+        "queryType": 0,
+        "resourceType": "microsoft.compute/virtualmachinescalesets",
+        "crossComponentResources": [
+          "{Resource}"
+        ],
+        "visualization": "table",
+        "gridSettings": {
+          "formatters": [
+            {
+              "columnMatch": "Type",
+              "formatter": 1,
+              "formatOptions": {}
+            },
+            {
+              "columnMatch": "P95th",
+              "formatter": 8,
+              "formatOptions": {
+                "palette": "blue"
+              },
+              "numberFormat": {
+                "unit": 2,
+                "options": {
+                  "style": "decimal"
+                }
+              }
+            },
+            {
+              "columnMatch": "Average",
+              "formatter": 1,
+              "formatOptions": {
+                "palette": "greenRed"
+              },
+              "numberFormat": {
+                "unit": 2,
+                "options": {
+                  "style": "decimal"
+                }
+              }
+            },
+            {
+              "columnMatch": "P10th",
+              "formatter": 1,
+              "formatOptions": {},
+              "numberFormat": {
+                "unit": 2,
+                "options": {
+                  "style": "decimal"
+                }
+              }
+            },
+            {
+              "columnMatch": "P50th",
+              "formatter": 1,
+              "formatOptions": {
+                "palette": "greenRed"
+              },
+              "numberFormat": {
+                "unit": 2,
+                "options": {
+                  "style": "decimal"
+                }
+              }
+            },
+            {
+              "columnMatch": "Trend (P95th)",
+              "formatter": 10,
+              "formatOptions": {
+                "palette": "blue"
+              }
+            },
+            {
+              "columnMatch": "Properties",
+              "formatter": 7,
+              "formatOptions": {
+                "linkTarget": "CellDetails",
+                "linkLabel": "️️️ℹ Info"
+              }
+            },
+            {
+              "columnMatch": "P5th",
+              "formatter": 8,
+              "formatOptions": {
+                "palette": "blue"
+              },
+              "numberFormat": {
+                "unit": 2,
+                "options": {
+                  "style": "decimal"
+                }
+              }
+            },
+            {
+              "columnMatch": "P80th",
+              "formatter": 1,
+              "formatOptions": {
+                "palette": "greenRed"
+              },
+              "numberFormat": {
+                "unit": 2,
+                "options": {
+                  "style": "decimal"
+                }
+              }
+            },
+            {
+              "columnMatch": "P90th",
+              "formatter": 1,
+              "formatOptions": {
+                "palette": "greenRed"
+              },
+              "numberFormat": {
+                "unit": 2,
+                "options": {
+                  "style": "decimal"
+                }
+              }
+            },
+            {
+              "columnMatch": "Min",
+              "formatter": 1,
+              "formatOptions": {},
+              "numberFormat": {
+                "unit": 2,
+                "options": {
+                  "style": "decimal"
+                }
+              }
+            },
+            {
+              "columnMatch": "Max",
+              "formatter": 1,
+              "formatOptions": {
+                "palette": "greenRed"
+              },
+              "numberFormat": {
+                "unit": 2,
+                "options": {
+                  "style": "decimal"
+                }
+              }
+            },
+            {
+              "columnMatch": "Trend (P5th)",
+              "formatter": 10,
+              "formatOptions": {
+                "palette": "blue"
+              }
+            },
+            {
+              "columnMatch": "Trend (P90th)",
+              "formatter": 10,
+              "formatOptions": {
+                "palette": "blue"
+              }
+            },
+            {
+              "columnMatch": "Trend (P80th)",
+              "formatter": 10,
+              "formatOptions": {
+                "palette": "blue"
+              }
+            },
+            {
+              "columnMatch": "Trend (P50th)",
+              "formatter": 10,
+              "formatOptions": {
+                "palette": "blue"
+              }
+            },
+            {
+              "columnMatch": "Trend (P10th)",
+              "formatter": 10,
+              "formatOptions": {
+                "palette": "blue"
+              }
+            },
+            {
+              "columnMatch": "Trend (Average)",
+              "formatter": 10,
+              "formatOptions": {
+                "palette": "blue"
+              }
+            }
+          ]
+        }
+      },
+      "conditionalVisibility": {
+        "parameterName": "ShowNetworkTable",
+        "comparison": "isEqualTo",
+        "value": "True"
+      },
+      "name": "query - 10"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "---\r\n## Top 10 Machines"
+      },
+      "conditionalVisibility": null,
+      "name": "text - 11"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "### CPU Utilization %"
+      },
+      "conditionalVisibility": null,
+      "customWidth": "50",
+      "name": "text - 12"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "### Available Memory"
+      },
+      "conditionalVisibility": null,
+      "customWidth": "50",
+      "name": "text - 13"
+    },
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "query": "",
+        "crossComponentResources": [
+          "{Resource}"
+        ],
+        "parameters": [
+          {
+            "id": "92358ae0-d5e1-494b-b65b-6d904f1325c5",
+            "version": "KqlParameterItem/1.0",
+            "name": "Aggregate",
+            "type": 2,
+            "isRequired": true,
+            "value": "P95th = round(percentile(CounterValue, 95), 2)",
+            "isHiddenWhenLocked": false,
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\"},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\"},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\"},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\"},\r\n    { \"value\":\"P80th = round(percentile(CounterValue, 80), 2)\", \"label\":\"P80th\"},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\"},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\"}\r\n]",
+            "timeContextFromParameter": null
+          },
+          {
+            "id": "27345375-4376-4e2f-8ac4-59d4eab9d235",
+            "version": "KqlParameterItem/1.0",
+            "name": "aggregateOrderLeft",
+            "type": 1,
+            "isRequired": false,
+            "query": "range Steps from 1 to 1 step 1\r\n| project value = iff('{Aggregate}' contains 'P5th'  or '{Aggregate}' contains 'P10th', 'asc', 'desc')",
+            "crossComponentResources": [
+              "{Resource}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "queryType": 0,
+            "resourceType": "microsoft.compute/virtualmachinescalesets"
+          },
+          {
+            "id": "4d9ba0ec-9d22-4fec-9f85-4be334f42d91",
+            "version": "KqlParameterItem/1.0",
+            "name": "aggregateLeftValue",
+            "type": 1,
+            "isRequired": true,
+            "query": "print \"{Aggregate:value}\"",
+            "crossComponentResources": [
+              "{Resource}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "queryType": 0,
+            "resourceType": "microsoft.compute/virtualmachinescalesets"
+          },
+          {
+            "id": "50242f48-6c7d-449b-ad93-838c94e615a0",
+            "version": "KqlParameterItem/1.0",
+            "name": "aggregateLeftLabel",
+            "type": 1,
+            "isRequired": true,
+            "query": "print \"{Aggregate:label}\"",
+            "crossComponentResources": [
+              "{Resource}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "queryType": 0,
+            "resourceType": "microsoft.compute/virtualmachinescalesets"
+          }
+        ],
+        "style": "above",
+        "queryType": 0,
+        "resourceType": "microsoft.compute/virtualmachinescalesets"
+      },
+      "conditionalVisibility": null,
+      "customWidth": "50",
+      "name": "parameters - 14"
+    },
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "query": "",
+        "crossComponentResources": [
+          "{Resource}"
+        ],
+        "parameters": [
+          {
+            "id": "333837c2-d5a4-4173-9aad-3db1dca17e2a",
+            "version": "KqlParameterItem/1.0",
+            "name": "Aggregate",
+            "type": 2,
+            "isRequired": true,
+            "value": "P95th = round(percentile(CounterValue, 95), 2)",
+            "isHiddenWhenLocked": false,
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\"},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\"},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\"},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\"},\r\n    { \"value\":\"P80th = round(percentile(CounterValue, 80), 2)\", \"label\":\"P80th\"},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\"},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\"}\r\n]",
+            "timeContextFromParameter": null
+          },
+          {
+            "id": "a23b29a5-5e4a-4d8e-ba73-bfdf27b2980e",
+            "version": "KqlParameterItem/1.0",
+            "name": "aggregateOrderRight",
+            "type": 1,
+            "isRequired": false,
+            "query": "range Steps from 1 to 1 step 1\r\n| project value = iff('{Aggregate}' contains 'P5th'  or '{Aggregate}' contains 'P10th', 'asc', 'desc')",
+            "crossComponentResources": [
+              "{Resource}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "queryType": 0,
+            "resourceType": "microsoft.compute/virtualmachinescalesets"
+          },
+          {
+            "id": "cc8dfabc-9eb9-4227-97bb-f5e9319030ec",
+            "version": "KqlParameterItem/1.0",
+            "name": "aggregateRightValue",
+            "type": 1,
+            "isRequired": true,
+            "query": "print \"{Aggregate:value}\"",
+            "crossComponentResources": [
+              "{Resource}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "queryType": 0,
+            "resourceType": "microsoft.compute/virtualmachinescalesets"
+          },
+          {
+            "id": "ff7a79ff-742a-4c6e-8628-c52f45b3bf71",
+            "version": "KqlParameterItem/1.0",
+            "name": "aggregateRightLabel",
+            "type": 1,
+            "isRequired": true,
+            "query": "print \"{Aggregate:label}\"",
+            "crossComponentResources": [
+              "{Resource}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "queryType": 0,
+            "resourceType": "microsoft.compute/virtualmachinescalesets"
+          }
+        ],
+        "style": "above",
+        "queryType": 0,
+        "resourceType": "microsoft.compute/virtualmachinescalesets"
+      },
+      "conditionalVisibility": null,
+      "customWidth": "50",
+      "name": "parameters - 15"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "let cpuSummary=totable(Perf\r\n    | where TimeGenerated {TimeRange} \r\n    | where (ObjectName == 'Processor' and InstanceName == '_Total' and CounterName == '% Processor Time')\r\n    | summarize hint.shufflekey=Computer {aggregateLeftValue} by Computer, CounterName\r\n    | top 10 by {aggregateLeftLabel} {aggregateOrderLeft});\r\nlet computerList=(cpuSummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nPerf\r\n    | where TimeGenerated {TimeRange}\r\n    | where (ObjectName == 'Processor' and InstanceName == '_Total' and CounterName == '% Processor Time')\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {aggregateLeftValue} by bin(TimeGenerated, ({TimeRange:end} - {TimeRange:start})/100), ResourceName",
+        "size": 0,
+        "aggregation": 3,
+        "showAnnotations": true,
+        "noDataMessage": "There is no data for this counter, either enable the counter or onboard machines to this workspace",
+        "queryType": 0,
+        "resourceType": "microsoft.compute/virtualmachinescalesets",
+        "crossComponentResources": [
+          "{Resource}"
+        ],
+        "visualization": "linechart",
+        "tileSettings": {
+          "showBorder": false,
+          "titleContent": {
+            "columnMatch": "Computer",
+            "formatter": 1
+          },
+          "leftContent": {
+            "columnMatch": "value",
+            "formatter": 12,
+            "formatOptions": {
+              "palette": "auto"
+            },
+            "numberFormat": {
+              "unit": 17,
+              "options": {
+                "maximumSignificantDigits": 3,
+                "maximumFractionDigits": 2
+              }
+            }
+          }
+        }
+      },
+      "conditionalVisibility": null,
+      "customWidth": "50",
+      "name": "query - 16"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "let memorySummary=totable(Perf\r\n    | where TimeGenerated {TimeRange} \r\n    | where ObjectName == 'Memory' and CounterName in ('Available MBytes', 'Available MBytes Memory')\r\n    | summarize hint.shufflekey=Computer {aggregateRightValue} by Computer, CounterName\r\n    | top 10 by {aggregateRightLabel} {aggregateOrderRight});\r\nlet computerList=(memorySummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nPerf\r\n    | where TimeGenerated {TimeRange}\r\n    | where ObjectName == 'Memory' and CounterName in ('Available MBytes', 'Available MBytes Memory')\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {aggregateRightValue} by bin(TimeGenerated, ({TimeRange:end} - {TimeRange:start})/100), ResourceName",
+        "size": 0,
+        "aggregation": 3,
+        "showAnnotations": true,
+        "noDataMessage": "There is no data for this counter, either enable the counter or onboard machines to this workspace",
+        "queryType": 0,
+        "resourceType": "microsoft.compute/virtualmachinescalesets",
+        "crossComponentResources": [
+          "{Resource}"
+        ],
+        "visualization": "linechart",
+        "tileSettings": {
+          "showBorder": false,
+          "titleContent": {
+            "columnMatch": "Computer",
+            "formatter": 1
+          },
+          "leftContent": {
+            "columnMatch": "value",
+            "formatter": 12,
+            "formatOptions": {
+              "palette": "auto"
+            },
+            "numberFormat": {
+              "unit": 17,
+              "options": {
+                "maximumSignificantDigits": 3,
+                "maximumFractionDigits": 2
+              }
+            }
+          }
+        }
+      },
+      "conditionalVisibility": null,
+      "customWidth": "50",
+      "name": "query - 17"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "### Bytes Sent Rate"
+      },
+      "conditionalVisibility": null,
+      "customWidth": "50",
+      "name": "text - 18"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "### Bytes Received Rate"
+      },
+      "conditionalVisibility": null,
+      "customWidth": "50",
+      "name": "text - 19"
+    },
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "query": "",
+        "crossComponentResources": [
+          "{Resource}"
+        ],
+        "parameters": [
+          {
+            "id": "360da4c1-97fa-4b15-a008-33a6110d0acd",
+            "version": "KqlParameterItem/1.0",
+            "name": "Aggregate",
+            "type": 2,
+            "isRequired": true,
+            "value": "P95th = round(percentile(CounterValue, 95), 2)",
+            "isHiddenWhenLocked": false,
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\"},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\"},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\"},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\"},\r\n    { \"value\":\"P80th = round(percentile(CounterValue, 80), 2)\", \"label\":\"P80th\"},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\"},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\"}\r\n]",
+            "timeContextFromParameter": null
+          },
+          {
+            "id": "31ccd4a1-d626-44bb-a5de-1780a33b37a5",
+            "version": "KqlParameterItem/1.0",
+            "name": "aggregateOrderLeft",
+            "type": 1,
+            "isRequired": false,
+            "query": "range Steps from 1 to 1 step 1\r\n| project value = iff('{Aggregate}' contains 'P5th'  or '{Aggregate}' contains 'P10th', 'asc', 'desc')",
+            "crossComponentResources": [
+              "{Resource}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "queryType": 0,
+            "resourceType": "microsoft.compute/virtualmachinescalesets"
+          },
+          {
+            "id": "4765abab-a682-49f6-bb41-d64852aba192",
+            "version": "KqlParameterItem/1.0",
+            "name": "aggregateLeftValue",
+            "type": 1,
+            "isRequired": true,
+            "query": "print \"{Aggregate:value}\"",
+            "crossComponentResources": [
+              "{Resource}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "queryType": 0,
+            "resourceType": "microsoft.compute/virtualmachinescalesets"
+          },
+          {
+            "id": "1d9b0ea9-09d4-4c73-8e59-fa7ab760b880",
+            "version": "KqlParameterItem/1.0",
+            "name": "aggregateLeftLabel",
+            "type": 1,
+            "isRequired": true,
+            "query": "print \"{Aggregate:label}\"",
+            "crossComponentResources": [
+              "{Resource}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "queryType": 0,
+            "resourceType": "microsoft.compute/virtualmachinescalesets"
+          }
+        ],
+        "style": "above",
+        "queryType": 0,
+        "resourceType": "microsoft.compute/virtualmachinescalesets"
+      },
+      "conditionalVisibility": null,
+      "customWidth": "50",
+      "name": "parameters - 20"
+    },
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "query": "",
+        "crossComponentResources": [
+          "{Resource}"
+        ],
+        "parameters": [
+          {
+            "id": "6772b281-d17d-4293-a227-1b2ed67f399e",
+            "version": "KqlParameterItem/1.0",
+            "name": "Aggregate",
+            "type": 2,
+            "isRequired": true,
+            "value": "P95th = round(percentile(CounterValue, 95), 2)",
+            "isHiddenWhenLocked": false,
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\"},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\"},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\"},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\"},\r\n    { \"value\":\"P80th = round(percentile(CounterValue, 80), 2)\", \"label\":\"P80th\"},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\"},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\"}\r\n]",
+            "timeContextFromParameter": null
+          },
+          {
+            "id": "5e2eef28-0528-406f-86b5-ceae535455f9",
+            "version": "KqlParameterItem/1.0",
+            "name": "aggregateOrderRight",
+            "type": 1,
+            "isRequired": false,
+            "query": "range Steps from 1 to 1 step 1\r\n| project value = iff('{Aggregate}' contains 'P5th'  or '{Aggregate}' contains 'P10th', 'asc', 'desc')",
+            "crossComponentResources": [
+              "{Resource}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "queryType": 0,
+            "resourceType": "microsoft.compute/virtualmachinescalesets"
+          },
+          {
+            "id": "586fa51c-1a45-4602-adcb-62eb0f619b7f",
+            "version": "KqlParameterItem/1.0",
+            "name": "aggregateRightValue",
+            "type": 1,
+            "isRequired": true,
+            "query": "print \"{Aggregate:value}\"",
+            "crossComponentResources": [
+              "{Resource}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "queryType": 0,
+            "resourceType": "microsoft.compute/virtualmachinescalesets"
+          },
+          {
+            "id": "912085b6-f920-4a37-9ce3-f1ef86bd5df8",
+            "version": "KqlParameterItem/1.0",
+            "name": "aggregateRightLabel",
+            "type": 1,
+            "isRequired": true,
+            "query": "print \"{Aggregate:label}\"",
+            "crossComponentResources": [
+              "{Resource}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "queryType": 0,
+            "resourceType": "microsoft.compute/virtualmachinescalesets"
+          }
+        ],
+        "style": "above",
+        "queryType": 0,
+        "resourceType": "microsoft.compute/virtualmachinescalesets"
+      },
+      "conditionalVisibility": null,
+      "customWidth": "50",
+      "name": "parameters - 21"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "let linuxNetworkSend=Perf \r\n    | where TimeGenerated {TimeRange} \r\n    | where ObjectName == 'Network' and CounterName == 'Total Bytes Transmitted'\r\n    | order by CounterName asc, InstanceName, Computer asc, TimeGenerated asc\r\n    | extend prev_Computer=prev(Computer), prev_Value=prev(CounterValue), prev_t=prev(TimeGenerated), prev_counter=prev(CounterName), prev_instance=prev(InstanceName)\r\n    | project   TimeGenerated,            Computer,            CounterValue = iff(prev_Computer == Computer and prev_instance == InstanceName and prev_counter == CounterName and CounterValue >= prev_Value and TimeGenerated > prev_t, (CounterValue-prev_Value)/((TimeGenerated-prev_t)/1s), real(0))\r\n    | summarize hint.shufflekey=Computer CounterValue = sum(CounterValue) by Computer, bin(TimeGenerated, 2s);\r\nlet windowsNetworkSend = Perf \r\n    | where TimeGenerated {TimeRange} \r\n    | where ObjectName == 'Network Adapter' and CounterName == 'Bytes Sent/sec'\r\n    | summarize hint.shufflekey=Computer CounterValue = sum(CounterValue) by Computer, bin(TimeGenerated, 2s);\r\nlet networkDataSend = union linuxNetworkSend, windowsNetworkSend;\r\nlet networkSendSummary = totable(networkDataSend\r\n    | where TimeGenerated {TimeRange}\r\n    | summarize hint.shufflekey=Computer {aggregateLeftValue} by Computer\r\n    | top 10 by {aggregateLeftLabel} {aggregateOrderLeft});\r\nlet computerList=(networkSendSummary | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nnetworkDataSend\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {aggregateLeftValue} by bin(TimeGenerated, ({TimeRange:end} - {TimeRange:start})/100), ResourceName",
+        "size": 0,
+        "showAnnotations": true,
+        "noDataMessage": "There is no data for this counter, either enable the counter or onboard machines to this workspace",
+        "queryType": 0,
+        "resourceType": "microsoft.compute/virtualmachinescalesets",
+        "crossComponentResources": [
+          "{Resource}"
+        ],
+        "visualization": "linechart",
+        "tileSettings": {
+          "showBorder": false,
+          "titleContent": {
+            "columnMatch": "Computer",
+            "formatter": 1
+          },
+          "leftContent": {
+            "columnMatch": "value",
+            "formatter": 12,
+            "formatOptions": {
+              "palette": "auto"
+            },
+            "numberFormat": {
+              "unit": 17,
+              "options": {
+                "maximumSignificantDigits": 3,
+                "maximumFractionDigits": 2
+              }
+            }
+          }
+        }
+      },
+      "conditionalVisibility": null,
+      "customWidth": "50",
+      "name": "query - 22"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "let linuxNetworkReceive=Perf \r\n    | where TimeGenerated {TimeRange} \r\n    | where ObjectName == 'Network' and CounterName == 'Total Bytes Received'\r\n    | order by CounterName asc, InstanceName, Computer asc, TimeGenerated asc\r\n    | extend prev_Computer=prev(Computer), prev_Value=prev(CounterValue), prev_t=prev(TimeGenerated), prev_counter=prev(CounterName), prev_instance=prev(InstanceName)\r\n    | project   TimeGenerated,            Computer,            CounterValue = iff(prev_Computer == Computer and prev_instance == InstanceName and prev_counter == CounterName and CounterValue >= prev_Value and TimeGenerated > prev_t, (CounterValue-prev_Value)/((TimeGenerated-prev_t)/1s), real(0))\r\n    | summarize hint.shufflekey=Computer CounterValue = sum(CounterValue) by Computer, bin(TimeGenerated, 2s);\r\nlet windowsNetworkReceive = Perf \r\n    | where TimeGenerated {TimeRange} \r\n    | where ObjectName == 'Network Adapter' and CounterName == 'Bytes Received/sec'\r\n    | summarize hint.shufflekey=Computer CounterValue = sum(CounterValue) by Computer, bin(TimeGenerated, 2s);\r\nlet networkDataReceive = union linuxNetworkReceive, windowsNetworkReceive;\r\nlet networkReceiveSummary = totable(networkDataReceive\r\n    | where TimeGenerated {TimeRange}\r\n    | summarize hint.shufflekey=Computer {aggregateRightValue} by Computer\r\n    | top 10 by {aggregateRightLabel} {aggregateOrderRight});\r\nlet computerList=(networkReceiveSummary | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nnetworkDataReceive\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {aggregateRightValue} by bin(TimeGenerated, ({TimeRange:end} - {TimeRange:start})/100), ResourceName",
+        "size": 0,
+        "showAnnotations": true,
+        "noDataMessage": "There is no data for this counter, either enable the counter or onboard machines to this workspace",
+        "queryType": 0,
+        "resourceType": "microsoft.compute/virtualmachinescalesets",
+        "crossComponentResources": [
+          "{Resource}"
+        ],
+        "visualization": "linechart",
+        "tileSettings": {
+          "showBorder": false,
+          "titleContent": {
+            "columnMatch": "Computer",
+            "formatter": 1
+          },
+          "leftContent": {
+            "columnMatch": "value",
+            "formatter": 12,
+            "formatOptions": {
+              "palette": "auto"
+            },
+            "numberFormat": {
+              "unit": 17,
+              "options": {
+                "maximumSignificantDigits": 3,
+                "maximumFractionDigits": 2
+              }
+            }
+          }
+        }
+      },
+      "conditionalVisibility": null,
+      "customWidth": "50",
+      "name": "query - 23"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "### Logical Disk Space Used %"
+      },
+      "conditionalVisibility": null,
+      "customWidth": "50",
+      "name": "text - 24"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": ""
+      },
+      "conditionalVisibility": null,
+      "customWidth": "50",
+      "name": "text - 25"
+    },
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "query": "",
+        "crossComponentResources": [
+          "{Resource}"
+        ],
+        "parameters": [
+          {
+            "id": "5d6afbec-79f6-4cd1-b3a1-361503478304",
+            "version": "KqlParameterItem/1.0",
+            "name": "Aggregate",
+            "type": 2,
+            "isRequired": true,
+            "value": "P95th = round(percentile(CounterValue, 95), 2)",
+            "isHiddenWhenLocked": false,
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\"},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\"},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\"},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\"},\r\n    { \"value\":\"P80th = round(percentile(CounterValue, 80), 2)\", \"label\":\"P80th\"},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\"},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\"}\r\n]",
+            "timeContextFromParameter": null
+          },
+          {
+            "id": "1d5a805c-acce-4afe-a38b-c2740fb3ff26",
+            "version": "KqlParameterItem/1.0",
+            "name": "aggregateOrder",
+            "type": 1,
+            "isRequired": false,
+            "query": "range Steps from 1 to 1 step 1\r\n| project value = iff('{Aggregate}' contains 'P5th'  or '{Aggregate}' contains 'P10th', 'asc', 'desc')",
+            "crossComponentResources": [
+              "{Resource}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContextFromParameter": null,
+            "queryType": 0,
+            "resourceType": "microsoft.compute/virtualmachinescalesets"
+          }
+        ],
+        "style": "above",
+        "queryType": 0,
+        "resourceType": "microsoft.compute/virtualmachinescalesets"
+      },
+      "conditionalVisibility": null,
+      "customWidth": "50",
+      "name": "parameters - 26"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": ""
+      },
+      "conditionalVisibility": null,
+      "customWidth": "50",
+      "name": "text - 27"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "let diskSummary=totable(Perf\r\n    | where TimeGenerated {TimeRange} \r\n    | where (ObjectName == 'LogicalDisk' and InstanceName != '_Total' and CounterName in ('% Free Space')) or        (ObjectName == 'Logical Disk' and InstanceName != '_Total' and CounterName in ('% Used Space'))\r\n    | project TimeGenerated, Computer,    CounterName = '% Used Space',    CounterValue = case(ObjectName == 'LogicalDisk' and CounterName == '% Free Space', 100 - CounterValue,                CounterValue < 0, real(0),                CounterValue)\r\n    | summarize hint.shufflekey=Computer {Aggregate} by Computer, CounterName\r\n    | top 10 by {Aggregate:label} {aggregateOrder});\r\nlet computerList=(diskSummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nPerf\r\n    | where TimeGenerated {TimeRange}\r\n    | where (ObjectName == 'LogicalDisk' and InstanceName != '_Total' and CounterName in ('% Free Space')) or        (ObjectName == 'Logical Disk' and InstanceName != '_Total' and CounterName in ('% Used Space'))\r\n    | where Computer in (computerList)\r\n    | project TimeGenerated, Computer,    CounterName = '% Used Space',    CounterValue = case(ObjectName == 'LogicalDisk' and CounterName == '% Free Space', 100 - CounterValue,                CounterValue < 0, real(0),                CounterValue)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {Aggregate} by bin(TimeGenerated, ({TimeRange:end} - {TimeRange:start})/100), ResourceName",
+        "size": 0,
+        "aggregation": 3,
+        "showAnnotations": true,
+        "noDataMessage": "There is no data for this counter, either enable the counter or onboard machines to this workspace",
+        "queryType": 0,
+        "resourceType": "microsoft.compute/virtualmachinescalesets",
+        "crossComponentResources": [
+          "{Resource}"
+        ],
+        "visualization": "linechart",
+        "tileSettings": {
+          "showBorder": false,
+          "titleContent": {
+            "columnMatch": "Computer",
+            "formatter": 1
+          },
+          "leftContent": {
+            "columnMatch": "value",
+            "formatter": 12,
+            "formatOptions": {
+              "palette": "auto"
+            },
+            "numberFormat": {
+              "unit": 17,
+              "options": {
+                "maximumSignificantDigits": 3,
+                "maximumFractionDigits": 2
+              }
+            }
+          }
+        }
+      },
+      "conditionalVisibility": null,
+      "customWidth": "50",
+      "name": "query - 28"
+    }
+  ],
+  "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
+}

--- a/Workbooks/Virtual Machine Scale Sets - Performance Analysis/Performance Analysis (Perf)/settings.json
+++ b/Workbooks/Virtual Machine Scale Sets - Performance Analysis/Performance Analysis (Perf)/settings.json
@@ -2,8 +2,7 @@
     "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/settings.json",
     "name":"Performance",
     "author": "Microsoft",
-    "isPreview": true,
     "galleries": [
-        { "type": "insights", "resourceType": "microsoft.compute/virtualmachinescalesets", "categoryKey": "vmInsightsVirtualMachinesInsightsMetrics", "order": 200 }
+        { "type": "insights", "resourceType": "microsoft.compute/virtualmachinescalesets", "categoryKey": "vmInsightsVirtualMachinesPerf", "order": 200 }
     ]
 }

--- a/Workbooks/Virtual Machine Scale Sets - Performance Analysis/Performance Analysis (Preview)/Performance Analysis (Preview).workbook
+++ b/Workbooks/Virtual Machine Scale Sets - Performance Analysis/Performance Analysis (Preview)/Performance Analysis (Preview).workbook
@@ -6,13 +6,13 @@
       "content": {
         "version": "KqlParameterItem/1.0",
         "crossComponentResources": [
-          "value::selected"
+          "value::all"
         ],
         "parameters": [
           {
             "id": "688dc7cb-bea3-41ae-ae94-32d22e09568c",
             "version": "KqlParameterItem/1.0",
-            "name": "Resource",
+            "name": "DefaultResource",
             "type": 5,
             "isRequired": true,
             "value": "value::1",
@@ -25,6 +25,19 @@
                 "value::1"
               ]
             }
+          },
+          {
+            "id": "bbbc300a-6f91-4b2b-b4b5-842b4bf8577a",
+            "version": "KqlParameterItem/1.0",
+            "name": "Selection",
+            "type": 1,
+            "query": "where type =~ 'microsoft.compute/virtualmachinescalesets'\r\n| extend match = id =~ \"{DefaultResource}\"\r\n| order by match desc, name asc\r\n| take 1\r\n| project value = tostring(pack('sub', subscriptionId, 'rg', resourceGroup, 'ws', id))",
+            "crossComponentResources": [
+              "value::all"
+            ],
+            "isHiddenWhenLocked": true,
+            "queryType": 1,
+            "resourceType": "microsoft.resourcegraph/resources"
           }
         ],
         "style": "above",
@@ -59,12 +72,51 @@
         ],
         "parameters": [
           {
+            "id": "1db5ee15-fe52-458b-91d1-7ee39d8c2cd3",
+            "version": "KqlParameterItem/1.0",
+            "name": "Subscriptions",
+            "type": 6,
+            "isRequired": true,
+            "multiSelect": true,
+            "quote": "'",
+            "delimiter": ",",
+            "query": "summarize by subscriptionId\r\n| project value = strcat('/subscriptions/', subscriptionId), label = subscriptionId, selected = iff(subscriptionId =~ todynamic('{Selection}').sub, true, false)",
+            "crossComponentResources": [
+              "value::all"
+            ],
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "queryType": 1,
+            "resourceType": "microsoft.resourcegraph/resources"
+          },
+          {
+            "id": "9732eff8-fb57-4cbd-8ade-5ae746f33760",
+            "version": "KqlParameterItem/1.0",
+            "name": "Resource",
+            "label": "Virtual Machine Scale Set",
+            "type": 5,
+            "isRequired": true,
+            "multiSelect": true,
+            "quote": "'",
+            "delimiter": ",",
+            "query": "where type =~ 'microsoft.compute/virtualmachinescalesets'\r\n| summarize by id, name\r\n| project id, selected = iff(id =~ todynamic('{Selection}').ws, true, false)",
+            "crossComponentResources": [
+              "{Subscriptions}"
+            ],
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "queryType": 1,
+            "resourceType": "microsoft.resourcegraph/resources"
+          },
+          {
             "id": "5f8cce4b-9c4c-47da-8683-7e5ccc9faed3",
             "version": "KqlParameterItem/1.0",
             "name": "TimeRange",
             "type": 4,
             "value": {
-              "durationMs": 172800000
+              "durationMs": 14400000
             },
             "typeSettings": {
               "selectableValues": [
@@ -168,14 +220,15 @@
                 }
               ],
               "allowCustom": true
-            }
+            },
+            "label": "Time Range"
           },
           {
             "id": "d6de19ff-cde4-41c2-9fba-b441312ea5c9",
             "version": "KqlParameterItem/1.0",
             "name": "Test",
             "type": 1,
-            "query": "// {Resource}\r\nPerf\r\n| take 1",
+            "query": "InsightsMetrics\r\n| where TimeGenerated {TimeRange}\r\n| take 1",
             "crossComponentResources": [
               "{Resource}"
             ],
@@ -193,7 +246,19 @@
     {
       "type": 1,
       "content": {
-        "json": "⚠ This workbook requires [Azure Monitor for VMs (preview)](https://docs.microsoft.com/en-us/azure/azure-monitor/insights/vminsights-overview) enabled in order to show accurate and complete information for your VMs. Follow the link to onboard machines or select a different workspace."
+        "json": "⚠ A subscription has not yet been selected. Select a subscription under the `Subscriptions` dropdown or refresh the workbook."
+      },
+      "conditionalVisibility": {
+        "parameterName": "Subscriptions",
+        "comparison": "isEqualTo",
+        "value": null
+      },
+      "name": "text - 29"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "⚠ No performance counters were detected in the selected workspace for the specified time period (`{TimeRange:label}`). Either try a broader time range, select a different workspace, or onboard virtual machines to the selected workspace `{Workspaces:label}`.\r\n\r\nIf you choose to onboard virtual machines to workspace `{Workspaces:label}`, follow the instruction in the following link: [Azure Monitor for VMs (preview)](https://docs.microsoft.com/en-us/azure/azure-monitor/insights/vminsights-overview)."
       },
       "conditionalVisibility": {
         "parameterName": "Test",
@@ -212,20 +277,19 @@
             "cellValue": "tab",
             "linkTarget": "parameter",
             "linkLabel": "Top 100 Machines",
-            "subTarget": "100",
-            "preText": "Top 100 Machines",
+            "subTarget": "top100",
             "style": "link"
           },
           {
             "cellValue": "tab",
             "linkTarget": "parameter",
             "linkLabel": "Top 10 Machines",
-            "subTarget": "10",
+            "subTarget": "top10",
             "style": "link"
           }
         ]
       },
-      "name": "links - 29"
+      "name": "links - 28"
     },
     {
       "type": 9,
@@ -236,12 +300,33 @@
         ],
         "parameters": [
           {
+            "id": "41bb3710-5e9e-4b66-91fd-e11435899880",
+            "version": "KqlParameterItem/1.0",
+            "name": "ComputerNameContains",
+            "label": "Computer Name Contains",
+            "type": 1,
+            "description": "This will filter the computers whose name contains the keyword. This will query all the machines in the workspace.",
+            "value": ""
+          },
+          {
+            "id": "b533865a-3539-42b1-8dcd-33ca0d481c2a",
+            "version": "KqlParameterItem/1.0",
+            "name": "ComputerFilter",
+            "type": 1,
+            "query": "{\"version\":\"1.0.0\",\"content\":\"{\\\"snippet\\\": \\\"| where Computer contains '{ComputerNameContains}'\\\"}\"}",
+            "crossComponentResources": [
+              "{Resource}"
+            ],
+            "isHiddenWhenLocked": true,
+            "queryType": 8
+          },
+          {
             "id": "aa2368fc-ad30-4608-b96a-72abf7b1e1af",
             "version": "KqlParameterItem/1.0",
             "name": "Counter",
             "type": 2,
             "description": "Select a VM performance counter for the table below",
-            "query": "// {Resource} {Test}\r\nPerf\r\n| where TimeGenerated {TimeRange}\r\n| where ObjectName != 'Network' and ObjectName != 'Network Interface'\r\n| summarize by CounterName, ObjectName, CounterText = CounterName\r\n| order by ObjectName asc, CounterText asc\r\n| project Counter = pack('counter', CounterName, 'object', ObjectName), CounterText, group = ObjectName",
+            "query": "InsightsMetrics\r\n| where TimeGenerated {TimeRange}\r\n| summarize by Namespace, Name, CounterText = Name\r\n| order by Name asc, Namespace asc\r\n| project Counter = pack('counter', Name, 'object', Namespace), CounterText, group = Namespace",
             "crossComponentResources": [
               "{Resource}"
             ],
@@ -257,32 +342,6 @@
             "name": "CounterText",
             "type": 1,
             "query": "let metric = dynamic({Counter});\r\nrange Steps from 1 to 1 step 1\r\n| project strcat(metric.object, \" > \", metric.counter)",
-            "crossComponentResources": [
-              "{Resource}"
-            ],
-            "isHiddenWhenLocked": true,
-            "queryType": 0,
-            "resourceType": "microsoft.compute/virtualmachinescalesets"
-          },
-          {
-            "id": "ce228deb-88eb-4438-9dce-6c6d1972ff09",
-            "version": "KqlParameterItem/1.0",
-            "name": "IsNetworkCounter",
-            "type": 1,
-            "query": "let counter = dynamic({Counter});\r\nprint tostring(counter.object == 'Network Adapter')",
-            "crossComponentResources": [
-              "{Resource}"
-            ],
-            "isHiddenWhenLocked": true,
-            "queryType": 0,
-            "resourceType": "microsoft.compute/virtualmachinescalesets"
-          },
-          {
-            "id": "3b23aa7a-2afd-40ba-a710-0e2cc73c764b",
-            "version": "KqlParameterItem/1.0",
-            "name": "NetworkDirection",
-            "type": 1,
-            "query": "let metric = dynamic({Counter});\r\nprint(iff(metric.counter == 'Bytes Received/sec', 'Received', 'Sent'))",
             "crossComponentResources": [
               "{Resource}"
             ],
@@ -315,19 +374,57 @@
             "typeSettings": {
               "additionalResourceOptions": []
             },
-            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\", \"selected\": true },\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\", \"selected\": false },\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\", \"selected\": false },\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\", \"selected\": false },\r\n    { \"value\":\"P80th = round(percentile(CounterValue, 80), 2)\", \"label\":\"P80th\", \"selected\": false },\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\", \"selected\": false },\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\", \"selected\": false }\r\n]"
+            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(Val), 2)\", \"label\":\"Average\", \"selected\": true },\r\n    { \"value\":\"P5th = round(percentile(Val, 5), 2)\", \"label\":\"P5th\", \"selected\": false },\r\n    { \"value\":\"P10th = round(percentile(Val, 10), 2)\", \"label\":\"P10th\", \"selected\": false },\r\n    { \"value\":\"P50th = round(percentile(Val, 50), 2)\", \"label\":\"P50th\", \"selected\": false },\r\n    { \"value\":\"P80th = round(percentile(Val, 80), 2)\", \"label\":\"P80th\", \"selected\": false },\r\n    { \"value\":\"P90th = round(percentile(Val, 90), 2)\", \"label\":\"P90th\", \"selected\": false },\r\n    { \"value\":\"P95th = round(percentile(Val, 95), 2)\", \"label\":\"P95th\", \"selected\": false }\r\n]"
           },
           {
             "id": "0327f26e-cdde-4b48-b512-6c35f06ad1d0",
             "version": "KqlParameterItem/1.0",
             "name": "tableTrendOrder",
             "type": 1,
-            "query": "range Steps from 1 to 1 step 1\r\n| project value = iff('{TableTrend}' contains 'P5th'  or '{TableTrend}' contains 'P10th', 'asc', 'desc')",
-            "crossComponentResources": [
-              "{Resource}"
-            ],
+            "value": "desc",
             "isHiddenWhenLocked": true,
-            "queryType": 0,
+            "criteriaData": [
+              {
+                "condition": "if (TableTrend contains 'P5th'), result = 'asc'",
+                "criteriaContext": {
+                  "leftOperand": "TableTrend",
+                  "operator": "contains",
+                  "rightValType": "static",
+                  "rightVal": "P5th",
+                  "resultValType": "static",
+                  "resultVal": "asc"
+                }
+              },
+              {
+                "condition": "if (TableTrend contains 'P10th'), result = 'asc'",
+                "criteriaContext": {
+                  "leftOperand": "TableTrend",
+                  "operator": "contains",
+                  "rightValType": "static",
+                  "rightVal": "P10th",
+                  "resultValType": "static",
+                  "resultVal": "asc"
+                }
+              },
+              {
+                "condition": "else result = 'desc'",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "static",
+                  "resultVal": "desc"
+                }
+              }
+            ]
+          },
+          {
+            "id": "6868a13a-498e-4c1b-80c2-8c44b3427126",
+            "version": "KqlParameterItem/1.0",
+            "name": "tableTrendLabel",
+            "type": 1,
+            "query": "{\"version\":\"1.0.0\",\"content\":\"\\\"{TableTrend:label}\\\"\",\"transformers\":null}",
+            "isHiddenWhenLocked": true,
+            "queryType": 8,
             "resourceType": "microsoft.compute/virtualmachinescalesets"
           },
           {
@@ -335,33 +432,37 @@
             "version": "KqlParameterItem/1.0",
             "name": "mergedAggregators",
             "type": 1,
-            "query": "let aggregators = iff('{Aggregators}' contains '{TableTrend:label}', '{Aggregators}', '{Aggregators},{TableTrend:label}');\r\nrange Steps from 1 to 1 step 1\r\n| project aggregators",
-            "crossComponentResources": [
-              "{Resource}"
-            ],
+            "value": "Average",
             "isHiddenWhenLocked": true,
-            "queryType": 0,
-            "resourceType": "microsoft.compute/virtualmachinescalesets"
+            "criteriaData": [
+              {
+                "condition": "if (Aggregators contains tableTrendLabel), result = Aggregators",
+                "criteriaContext": {
+                  "leftOperand": "Aggregators",
+                  "operator": "contains",
+                  "rightValType": "param",
+                  "rightVal": "tableTrendLabel",
+                  "resultValType": "param",
+                  "resultVal": "Aggregators"
+                }
+              },
+              {
+                "condition": "else result = '{Aggregators},{tableTrendLabel}'",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "static",
+                  "resultVal": "{Aggregators},{tableTrendLabel}"
+                }
+              }
+            ]
           },
           {
             "id": "27faa340-a75f-4ae1-a43a-1aa6ece37cff",
             "version": "KqlParameterItem/1.0",
             "name": "StandardQuery",
             "type": 1,
-            "query": "// {Resource} {Test}\r\nlet metric = dynamic({Counter}); \r\nlet timeRangeStart = {TimeRange:start};\r\nlet timeRangeEnd = {TimeRange:end};\r\nlet timeRangeGrain = {TimeRange:grain};\r\nprint(iff({IsNetworkCounter} == 'False', strcat(\"let maxResultCount = 100; let metric = dynamic(\", metric, \"); let summaryPerComputer = totable(Perf      | where TimeGenerated {TimeRange}       | where ObjectName == metric.object and CounterName == metric.counter     | summarize hint.shufflekey = Computer Average = avg(CounterValue), Max = max(CounterValue), Min = min(CounterValue), percentiles(CounterValue, 5, 10, 50, 80, 90, 95) by Computer      | project Computer, Average, Max, Min, P5th = percentile_CounterValue_5, P10th = percentile_CounterValue_10, P50th = percentile_CounterValue_50, P80th = percentile_CounterValue_80, P90th = percentile_CounterValue_90, P95th = percentile_CounterValue_95      | order by {TableTrend:label} {tableTrendOrder}, Computer      | limit maxResultCount);  let computerList = summaryPerComputer      | project Computer;  let MachineSummary = ServiceMapComputer_CL     | where TimeGenerated {TimeRange}     | where Computer in (computerList)     | summarize arg_max(TimeGenerated, *) by Computer     | project Computer, MachineSummary = pack('Fully Qualified Domain Name', Computer, 'OS Type', OperatingSystemFamily_s, 'Operating System', OperatingSystemFullName_s, 'Ipv4 Addresses', Ipv4Addresses_s,         'Ipv6 Addresses', Ipv6Addresses_s, 'Mac Addresses', MacAddresses_s, 'DNS Names', DnsNames_s, 'CPUs', strcat(Cpus_d, ' @ ', CpuSpeed_d, ' MHz'), 'Bitness', Bitness_s,         'Physcial Memory', strcat(PhysicalMemory_d, ' MB'), 'Virtualization State', VirtualizationState_s, 'VM Type', VirtualMachineType_s, 'OMS Agent', split(ResourceName_s, 'm-')[1]); let EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) []; let OmsNodeIdentityAndProps = computerList     | extend NodeId = Computer     | extend Priority = 1     | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer); let ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL     | where TimeGenerated {TimeRange}     | where Computer in (computerList)     | summarize arg_max(TimeGenerated, *) by Computer     | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2; let NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                                 | summarize arg_max(Priority, *) by Computer;  let NodeIdentityAndPropsMin = NodeIdentityAndProps     | extend Type = iff(NodeProps.type == 'StandAloneNode', iff(NodeProps.azureResourceId == '', 'Non-Azure Virtual Machine', 'Azure Virtual Machine'), NodeProps.type),      ResourceId = iff(NodeProps.type == 'AzureScaleSetNode', NodeProps.vmScaleSetResourceId,          iff(NodeProps.type == 'AzureCloudServiceNode', NodeProps.cloudServiceDeploymentId, Computer)),     ResourceName = iff(NodeProps.type == 'AzureScaleSetNode', strcat(NodeProps.vmScaleSetName, ' | ', NodeProps.scaleSetInstanceId),          iff(NodeProps.type == 'AzureCloudServiceNode', strcat(NodeProps.cloudServiceRoleName, ' | ', NodeProps.cloudServiceInstanceId), Computer))     | project Computer, Type, ResourceId, ResourceName; let trend = Perf          | where TimeGenerated {TimeRange}         | where Computer in (computerList)          | where ObjectName == metric.object and CounterName == metric.counter        | make-series {TableTrend} default = 0 on TimeGenerated in range(datetime('\", timeRangeStart,\"'), datetime('\", timeRangeEnd ,\"'), totimespan('\", timeRangeGrain, \"')) by Computer     | project Computer, ['Trend ({TableTrend:label})'] = {TableTrend:label}; summaryPerComputer     | join kind=leftouter (trend) on Computer     | join kind=leftouter (NodeIdentityAndProps) on Computer     | join kind=leftouter (NodeIdentityAndPropsMin) on Computer     | join kind=leftouter (MachineSummary) on Computer     | project ResourceName, Type, {mergedAggregators}, ['Trend ({TableTrend:label})'], Properties = MachineSummary     | sort by {TableTrend:label} {tableTrendOrder}\"), ''));",
-            "crossComponentResources": [
-              "{Resource}"
-            ],
-            "isHiddenWhenLocked": true,
-            "queryType": 0,
-            "resourceType": "microsoft.compute/virtualmachinescalesets"
-          },
-          {
-            "id": "6e392933-2f72-45a6-889b-90351f9130db",
-            "version": "KqlParameterItem/1.0",
-            "name": "NetworkQuery",
-            "type": 1,
-            "query": "let metric = dynamic({Counter});\r\nlet timeRangeStart = {TimeRange:start};\r\nlet timeRangeEnd = {TimeRange:end};\r\nlet timeRangeGrain = {TimeRange:grain};\r\nprint(iff({IsNetworkCounter} == 'True', strcat(\"let metric = dynamic(\", metric, \"); let linux = iff(metric.counter == 'Bytes Received/sec', dynamic({'object': 'Network', 'counter': 'Total Bytes Received'}), dynamic({'object': 'Network', 'counter': 'Total Bytes Transmitted'})); let maxResultCount = 100; let windowsNetworkRaw = Perf | where TimeGenerated {TimeRange} | where ObjectName == metric.object and CounterName == metric.couter; let windowsNetworkSum = windowsNetworkRaw | summarize hint.shufflekey=Computer CounterValue=sum(CounterValue) by Computer, TimeGenerated; let windowsNetworkPctl = windowsNetworkRaw | summarize hint.shufflekey=Computer Average = avg(CounterValue), Max = max(CounterValue), Min = min(CounterValue), percentiles(CounterValue, 5, 10, 50, 80, 90, 95) by Computer, TimeGenerated | project TimeGenerated, Computer, Average, Max, Min, P5th = percentile_CounterValue_5, P10th = percentile_CounterValue_10, P50th = percentile_CounterValue_50, P80th = percentile_CounterValue_80, P90th = percentile_CounterValue_90, P95th = percentile_CounterValue_95; let linuxNetworkRaw = Perf | where TimeGenerated {TimeRange} | where ObjectName == linux.object and CounterName == linux.counter | order by InstanceName, TimeGenerated asc | extend prev_Value = prev(CounterValue), prev_t = prev(TimeGenerated), prev_instance = prev(InstanceName) | project TimeGenerated, Computer, CounterValue = iff(prev_instance == InstanceName and CounterValue >= prev_Value and TimeGenerated > prev_t, (CounterValue - prev_Value) / ((TimeGenerated - prev_t) / 1s), real(0)); let linuxNetworkSum = linuxNetworkRaw | summarize hint.shufflekey=Computer CounterValue=sum(CounterValue) by Computer, TimeGenerated; let linuxNetworkPctl = linuxNetworkRaw | summarize hint.shufflekey=Computer Average = avg(CounterValue), Max = max(CounterValue), Min = min(CounterValue), percentiles(CounterValue, 5, 10, 50, 80, 90, 95) by Computer, TimeGenerated | project TimeGenerated, Computer, Average, Max, Min, P5th = percentile_CounterValue_5, P10th = percentile_CounterValue_10, P50th = percentile_CounterValue_50, P80th = percentile_CounterValue_80, P90th = percentile_CounterValue_90, P95th = percentile_CounterValue_95; let networkDataSum = union windowsNetworkSum, linuxNetworkSum; let networkDataPctl = union windowsNetworkPctl, linuxNetworkPctl; let computerList = Perf  | project Computer; let EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) []; let OmsNodeIdentityAndProps = computerList | extend NodeId = Computer | extend Priority = 1 | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer); let ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL | where TimeGenerated {TimeRange} | where Computer in (computerList) | summarize hint.shufflekey=Computer arg_max(TimeGenerated, *) by Computer | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|', columnifexists('AzureCloudServiceDeployment_g', '')), ''), AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')), strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|', columnifexists('AzureVmScaleSetDeployment_g', '')), ''), ComputerProps = pack('type', 'StandAloneNode', 'name', ComputerName_s, 'mappingResourceId', ResourceId, 'subscriptionId', AzureSubscriptionId_g, 'resourceGroup', AzureResourceGroup_s, 'azureResourceId', columnifexists('AzureResourceId_s', '')), AzureCloudServiceNodeProps = pack('type', 'AzureCloudServiceNode', 'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''), 'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''), 'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''), 'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''), 'mappingResourceId', ResourceId), AzureScaleSetNodeProps = pack('type', 'AzureScaleSetNode', 'scaleSetInstanceId', columnifexists('AzureName_s', ''), 'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''), 'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''), 'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''), 'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''), 'resourceGroupName', columnifexists('AzureResourceGroup_s', ''), 'subscriptionId', columnifexists('AzureSubscriptionId_g', ''), 'mappingResourceId', ResourceId)| project   Computer, NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity, isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer), NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps, isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps), Priority = 2; let NodeIdentityAndProps = union kind=inner isfuzzy = true EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps | summarize hint.shufflekey=Computer arg_max(Priority, *) by Computer; let NodeIdentityAndPropsMin = NodeIdentityAndProps | extend Type = iff(NodeProps.type == 'StandAloneNode', iff(NodeProps.azureResourceId == '', 'Non-Azure Virtual Machine', 'Azure Virtual Machine'), NodeProps.type), ResourceId = iff(NodeProps.type == 'AzureScaleSetNode', NodeProps.vmScaleSetResourceId, iff(NodeProps.type == 'AzureCloudServiceNode', NodeProps.cloudServiceDeploymentId, Computer)), ResourceName = iff(NodeProps.type == 'AzureScaleSetNode', strcat(NodeProps.vmScaleSetName, ' | ', NodeProps.scaleSetInstanceId), iff(NodeProps.type == 'AzureCloudServiceNode', strcat(NodeProps.cloudServiceRoleName, ' | ', NodeProps.cloudServiceInstanceId), Computer)) | project Computer, Type, ResourceId, ResourceName; let MachineSummary = ServiceMapComputer_CL | where TimeGenerated {TimeRange} | where Computer in (computerList) | summarize hint.shufflekey=Computer arg_max(TimeGenerated, *) by Computer | project Computer, MachineSummary = pack('Fully Qualified Domain Name', Computer, 'OS Type', OperatingSystemFamily_s, 'Operating System', OperatingSystemFullName_s, 'Ipv4 Addresses', Ipv4Addresses_s, 'Ipv6 Addresses', Ipv6Addresses_s, 'Mac Addresses', MacAddresses_s, 'DNS Names', DnsNames_s, 'CPUs', strcat(Cpus_d, ' @ ', CpuSpeed_d, ' MHz'), 'Bitness', Bitness_s, 'Physcial Memory', strcat(PhysicalMemory_d, ' MB'), 'Virtualization State', VirtualizationState_s, 'VM Type', VirtualMachineType_s, 'OMS Agent', split(ResourceName_s, 'm-')[1]); let trend = networkDataSum | make-series {TableTrend} default=0 on TimeGenerated in range(datetime('\", timeRangeStart,\"'), datetime('\", timeRangeEnd ,\"'), totimespan('\", timeRangeGrain, \"')) by Computer | project Computer, ['Trend ({TableTrend:label})'] = {TableTrend:label}; networkDataPctl | join kind=leftouter hint.shufflekey=Computer (trend) on Computer | join kind=leftouter hint.shufflekey=Computer (NodeIdentityAndPropsMin) on Computer | join kind=leftouter hint.shufflekey=Computer (MachineSummary) on Computer | project ResourceName, Type, {mergedAggregators}, ['Trend ({TableTrend:label})'], Properties = MachineSummary | sort by {TableTrend:label} {tableTrendOrder} | limit maxResultCount\"), ''));",
+            "query": "let metric = dynamic({Counter}); \r\nlet timeRangeStart = {TimeRange:start};\r\nlet timeRangeEnd = {TimeRange:end};\r\nlet timeRangeGrain = {TimeRange:grain};\r\nprint(strcat(\"let maxResultCount = 100; let metric = dynamic(\", metric, \"); let summaryPerComputer = totable(InsightsMetrics      | where TimeGenerated {TimeRange}   {ComputerFilter}    | where Namespace == metric.object and Name == metric.counter     | summarize hint.shufflekey = Computer Average = avg(Val), Max = max(Val), Min = min(Val), percentiles(Val, 5, 10, 50, 80, 90, 95) by Computer      | project Computer, Average, Max, Min, P5th = percentile_Val_5, P10th = percentile_Val_10, P50th = percentile_Val_50, P80th = percentile_Val_80, P90th = percentile_Val_90, P95th = percentile_Val_95      | order by {TableTrend:label} {tableTrendOrder}, Computer      | limit maxResultCount);  let computerList = summaryPerComputer      | project Computer;  let MachineSummary = ServiceMapComputer_CL     | where TimeGenerated {TimeRange}     | where Computer in (computerList)     | summarize arg_max(TimeGenerated, *) by Computer     | project Computer, MachineSummary = pack('Fully Qualified Domain Name', Computer, 'OS Type', OperatingSystemFamily_s, 'Operating System', OperatingSystemFullName_s, 'Ipv4 Addresses', Ipv4Addresses_s,         'Ipv6 Addresses', Ipv6Addresses_s, 'Mac Addresses', MacAddresses_s, 'DNS Names', DnsNames_s, 'CPUs', strcat(Cpus_d, ' @ ', CpuSpeed_d, ' MHz'), 'Bitness', Bitness_s,         'Physcial Memory', strcat(PhysicalMemory_d, ' MB'), 'Virtualization State', VirtualizationState_s, 'VM Type', VirtualMachineType_s, 'OMS Agent', split(ResourceName_s, 'm-')[1]); let EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) []; let OmsNodeIdentityAndProps = computerList     | extend NodeId = Computer     | extend Priority = 1     | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer); let ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL     | where TimeGenerated {TimeRange}     | where Computer in (computerList)     | summarize arg_max(TimeGenerated, *) by Computer     | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2; let NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                                 | summarize arg_max(Priority, *) by Computer;  let NodeIdentityAndPropsMin = NodeIdentityAndProps     | extend Type = iff(NodeProps.type == 'StandAloneNode', iff(NodeProps.azureResourceId == '', 'Non-Azure Virtual Machine', 'Azure Virtual Machine'), NodeProps.type),      ResourceId = iff(NodeProps.type == 'AzureScaleSetNode', NodeProps.vmScaleSetResourceId,          iff(NodeProps.type == 'AzureCloudServiceNode', NodeProps.cloudServiceDeploymentId, Computer)),     ResourceName = iff(NodeProps.type == 'AzureScaleSetNode', strcat(NodeProps.vmScaleSetName, ' | ', NodeProps.scaleSetInstanceId),          iff(NodeProps.type == 'AzureCloudServiceNode', strcat(NodeProps.cloudServiceRoleName, ' | ', NodeProps.cloudServiceInstanceId), Computer))     | project Computer, Type, ResourceId, ResourceName; let trend = InsightsMetrics          | where TimeGenerated {TimeRange}         | where Computer in (computerList)          | where Namespace == metric.object and Name == metric.counter        | make-series {TableTrend} default = 0 on TimeGenerated in range(datetime('\", timeRangeStart,\"'), datetime('\", timeRangeEnd ,\"'), totimespan('\", timeRangeGrain, \"')) by Computer     | project Computer, ['Trend ({TableTrend:label})'] = {TableTrend:label}; summaryPerComputer     | join kind=leftouter (trend) on Computer     | join kind=leftouter (NodeIdentityAndProps) on Computer     | join kind=leftouter (NodeIdentityAndPropsMin) on Computer     | join kind=leftouter (MachineSummary) on Computer     | project ResourceName, Type, {mergedAggregators}, ['Trend ({TableTrend:label})'], Properties = MachineSummary     | sort by {TableTrend:label} {tableTrendOrder}\"));\r\n",
             "crossComponentResources": [
               "{Resource}"
             ],
@@ -374,33 +475,7 @@
             "version": "KqlParameterItem/1.0",
             "name": "ShowTable",
             "type": 1,
-            "query": "print iff(\"{Test:value}\" == \"\", \"False\", iff(\"{IsNetworkCounter:value}\" == \"False\", \"True\", \"False\"))",
-            "crossComponentResources": [
-              "{Resource}"
-            ],
-            "isHiddenWhenLocked": true,
-            "queryType": 0,
-            "resourceType": "microsoft.compute/virtualmachinescalesets"
-          },
-          {
-            "id": "6b664a24-d9a3-47b0-9d94-9cada9ddb8ce",
-            "version": "KqlParameterItem/1.0",
-            "name": "ShowNetworkTable",
-            "type": 1,
-            "query": "print iff(\"{Test:value}\" == \"\", \"False\", \"{IsNetworkCounter:value}\")",
-            "crossComponentResources": [
-              "{Resource}"
-            ],
-            "isHiddenWhenLocked": true,
-            "queryType": 0,
-            "resourceType": "microsoft.compute/virtualmachinescalesets"
-          },
-          {
-            "id": "343c4eae-e482-4678-a936-c4ad43b2ec19",
-            "version": "KqlParameterItem/1.0",
-            "name": "CounterTest",
-            "type": 1,
-            "query": "Perf\r\n| take 1",
+            "query": "print iff(\"{Test:value}\" == \"\", \"False\", \"True\")",
             "crossComponentResources": [
               "{Resource}"
             ],
@@ -422,7 +497,7 @@
         {
           "parameterName": "tab",
           "comparison": "isEqualTo",
-          "value": "100"
+          "value": "top100"
         }
       ],
       "conditionalVisibility": {
@@ -433,25 +508,12 @@
       "name": "parameters - 6"
     },
     {
-      "type": 1,
-      "content": {
-        "json": "There are no performance counters, either onboard machines to this workspace or enable performance counters."
-      },
-      "conditionalVisibility": {
-        "parameterName": "CounterTest",
-        "comparison": "isEqualTo",
-        "value": ""
-      },
-      "name": "text - 7"
-    },
-    {
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "// {Resource} {Test}\r\n{StandardQuery}",
+        "query": "{StandardQuery}",
         "size": 0,
         "noDataMessage": "There is no data for this counter, either enable the counter or onboard machines to this workspace",
-        "exportToExcelOptions": "visible",
         "queryType": 0,
         "resourceType": "microsoft.compute/virtualmachinescalesets",
         "crossComponentResources": [
@@ -639,36 +701,6 @@
                 "palette": "blue"
               }
             }
-          ],
-          "labelSettings": [
-            {
-              "columnId": "ResourceName",
-              "label": "ResourceName"
-            },
-            {
-              "columnId": "Type",
-              "label": "Type"
-            },
-            {
-              "columnId": "Average",
-              "label": "Average"
-            },
-            {
-              "columnId": "P95th",
-              "label": "P95th"
-            },
-            {
-              "columnId": "Max",
-              "label": "Max"
-            },
-            {
-              "columnId": "Trend (Average)",
-              "label": "Trend (Average)"
-            },
-            {
-              "columnId": "Properties",
-              "label": "Properties"
-            }
           ]
         }
       },
@@ -681,7 +713,7 @@
         {
           "parameterName": "tab",
           "comparison": "isEqualTo",
-          "value": "100"
+          "value": "top100"
         }
       ],
       "conditionalVisibility": {
@@ -694,237 +726,12 @@
     {
       "type": 1,
       "content": {
-        "json": "#### ℹ `Total Bytes {NetworkDirection}` counters are also being utilized to display the network table. The delta of `Total Bytes {NetworkDirection}` over a time period is being calculated to match up with the `Bytes {NetworkDirection}/sec` counter to display an accurate representation of network activity over all machines"
-      },
-      "conditionalVisibility": {
-        "parameterName": "ShowNetworkTable",
-        "comparison": "isEqualTo",
-        "value": "True"
-      },
-      "name": "text - 9"
-    },
-    {
-      "type": 3,
-      "content": {
-        "version": "KqlItem/1.0",
-        "query": "// {Resource} {Test}\r\n{NetworkQuery}",
-        "size": 0,
-        "noDataMessage": "There is no data for this counter, either enable the counter or onboard machines to this workspace",
-        "exportToExcelOptions": "visible",
-        "queryType": 0,
-        "resourceType": "microsoft.compute/virtualmachinescalesets",
-        "crossComponentResources": [
-          "{Resource}"
-        ],
-        "visualization": "table",
-        "gridSettings": {
-          "formatters": [
-            {
-              "columnMatch": "Type",
-              "formatter": 1,
-              "formatOptions": {}
-            },
-            {
-              "columnMatch": "P95th",
-              "formatter": 8,
-              "formatOptions": {
-                "palette": "blue"
-              },
-              "numberFormat": {
-                "unit": 2,
-                "options": {
-                  "style": "decimal"
-                }
-              }
-            },
-            {
-              "columnMatch": "Average",
-              "formatter": 1,
-              "formatOptions": {
-                "palette": "greenRed"
-              },
-              "numberFormat": {
-                "unit": 2,
-                "options": {
-                  "style": "decimal"
-                }
-              }
-            },
-            {
-              "columnMatch": "P10th",
-              "formatter": 1,
-              "formatOptions": {},
-              "numberFormat": {
-                "unit": 2,
-                "options": {
-                  "style": "decimal"
-                }
-              }
-            },
-            {
-              "columnMatch": "P50th",
-              "formatter": 1,
-              "formatOptions": {
-                "palette": "greenRed"
-              },
-              "numberFormat": {
-                "unit": 2,
-                "options": {
-                  "style": "decimal"
-                }
-              }
-            },
-            {
-              "columnMatch": "Trend (P95th)",
-              "formatter": 10,
-              "formatOptions": {
-                "palette": "blue"
-              }
-            },
-            {
-              "columnMatch": "Properties",
-              "formatter": 7,
-              "formatOptions": {
-                "linkTarget": "CellDetails",
-                "linkLabel": "️️️ℹ Info"
-              }
-            },
-            {
-              "columnMatch": "P5th",
-              "formatter": 8,
-              "formatOptions": {
-                "palette": "blue"
-              },
-              "numberFormat": {
-                "unit": 2,
-                "options": {
-                  "style": "decimal"
-                }
-              }
-            },
-            {
-              "columnMatch": "P80th",
-              "formatter": 1,
-              "formatOptions": {
-                "palette": "greenRed"
-              },
-              "numberFormat": {
-                "unit": 2,
-                "options": {
-                  "style": "decimal"
-                }
-              }
-            },
-            {
-              "columnMatch": "P90th",
-              "formatter": 1,
-              "formatOptions": {
-                "palette": "greenRed"
-              },
-              "numberFormat": {
-                "unit": 2,
-                "options": {
-                  "style": "decimal"
-                }
-              }
-            },
-            {
-              "columnMatch": "Min",
-              "formatter": 1,
-              "formatOptions": {},
-              "numberFormat": {
-                "unit": 2,
-                "options": {
-                  "style": "decimal"
-                }
-              }
-            },
-            {
-              "columnMatch": "Max",
-              "formatter": 1,
-              "formatOptions": {
-                "palette": "greenRed"
-              },
-              "numberFormat": {
-                "unit": 2,
-                "options": {
-                  "style": "decimal"
-                }
-              }
-            },
-            {
-              "columnMatch": "Trend (P5th)",
-              "formatter": 10,
-              "formatOptions": {
-                "palette": "blue"
-              }
-            },
-            {
-              "columnMatch": "Trend (P90th)",
-              "formatter": 10,
-              "formatOptions": {
-                "palette": "blue"
-              }
-            },
-            {
-              "columnMatch": "Trend (P80th)",
-              "formatter": 10,
-              "formatOptions": {
-                "palette": "blue"
-              }
-            },
-            {
-              "columnMatch": "Trend (P50th)",
-              "formatter": 10,
-              "formatOptions": {
-                "palette": "blue"
-              }
-            },
-            {
-              "columnMatch": "Trend (P10th)",
-              "formatter": 10,
-              "formatOptions": {
-                "palette": "blue"
-              }
-            },
-            {
-              "columnMatch": "Trend (Average)",
-              "formatter": 10,
-              "formatOptions": {
-                "palette": "blue"
-              }
-            }
-          ]
-        }
-      },
-      "conditionalVisibilities": [
-        {
-          "parameterName": "ShowNetworkTable",
-          "comparison": "isEqualTo",
-          "value": "True"
-        },
-        {
-          "parameterName": "tab",
-          "comparison": "isEqualTo",
-          "value": "100"
-        }
-      ],
-      "conditionalVisibility": {
-        "parameterName": "ShowNetworkTable",
-        "comparison": "isEqualTo",
-        "value": "True"
-      },
-      "name": "query - 10"
-    },
-    {
-      "type": 1,
-      "content": {
         "json": "### CPU Utilization %"
       },
       "conditionalVisibility": {
         "parameterName": "tab",
         "comparison": "isEqualTo",
-        "value": "10"
+        "value": "top10"
       },
       "customWidth": "50",
       "name": "text - 12"
@@ -937,7 +744,7 @@
       "conditionalVisibility": {
         "parameterName": "tab",
         "comparison": "isEqualTo",
-        "value": "10"
+        "value": "top10"
       },
       "customWidth": "50",
       "name": "text - 13"
@@ -1008,7 +815,7 @@
       "conditionalVisibility": {
         "parameterName": "tab",
         "comparison": "isEqualTo",
-        "value": "10"
+        "value": "top10"
       },
       "customWidth": "50",
       "name": "parameters - 14"
@@ -1079,7 +886,7 @@
       "conditionalVisibility": {
         "parameterName": "tab",
         "comparison": "isEqualTo",
-        "value": "10"
+        "value": "top10"
       },
       "customWidth": "50",
       "name": "parameters - 15"
@@ -1088,12 +895,11 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let cpuSummary=totable(InsightsMetrics\r\n    | where TimeGenerated {TimeRange} \r\n    | where (Namespace == 'Processor' and Name == 'UtilizationPercentage')\r\n    | where Origin == 'vm.azm.ms'\r\n    | summarize hint.shufflekey=Computer {aggregateLeftValue} by Computer, Name\r\n    | top 10 by {aggregateLeftLabel} {aggregateOrderLeft});\r\nlet computerList=(cpuSummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nInsightsMetrics\r\n    | where TimeGenerated {TimeRange}\r\n    | where (Namespace == 'Processor' and Name == 'UtilizationPercentage')\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {aggregateLeftValue} by bin(TimeGenerated, ({TimeRange:end} - {TimeRange:start})/100), ResourceName",
+        "query": "let cpuSummary=totable(InsightsMetrics\r\n    | where TimeGenerated {TimeRange} \r\n    | where (Namespace == 'Processor' and Name == 'UtilizationPercentage')\r\n    | summarize hint.shufflekey=Computer {aggregateLeftValue} by Computer, Name\r\n    | top 10 by {aggregateLeftLabel} {aggregateOrderLeft});\r\nlet computerList=(cpuSummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nInsightsMetrics\r\n    | where TimeGenerated {TimeRange}\r\n    | where (Namespace == 'Processor' and Name == 'UtilizationPercentage')\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {aggregateLeftValue} by bin(TimeGenerated, ({TimeRange:end} - {TimeRange:start})/100), ResourceName",
         "size": 0,
         "aggregation": 3,
         "showAnnotations": true,
         "noDataMessage": "There is no data for this counter, either enable the counter or onboard machines to this workspace",
-        "exportToExcelOptions": "visible",
         "queryType": 0,
         "resourceType": "microsoft.compute/virtualmachinescalesets",
         "crossComponentResources": [
@@ -1132,7 +938,7 @@
       "conditionalVisibility": {
         "parameterName": "tab",
         "comparison": "isEqualTo",
-        "value": "10"
+        "value": "top10"
       },
       "customWidth": "50",
       "name": "query - 16"
@@ -1141,12 +947,11 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let memorySummary=totable(InsightsMetrics\r\n    | where TimeGenerated {TimeRange} \r\n    | where Namespace == 'Memory' and Name == 'AvailableMB'\r\n    | where Origin == 'vm.azm.ms'\r\n    | summarize hint.shufflekey=Computer {aggregateRightValue} by Computer, Name\r\n    | top 10 by {aggregateRightLabel} {aggregateOrderRight});\r\nlet computerList=(memorySummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nInsightsMetrics\r\n    | where TimeGenerated {TimeRange}\r\n    | where Namespace == 'Memory' and Name == 'AvailableMB'\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {aggregateRightValue} by bin(TimeGenerated, ({TimeRange:end} - {TimeRange:start})/100), ResourceName",
+        "query": "let memorySummary=totable(InsightsMetrics\r\n    | where TimeGenerated {TimeRange} \r\n    | where Namespace == 'Memory' and Name == 'AvailableMB'\r\n    | summarize hint.shufflekey=Computer {aggregateRightValue} by Computer, Name\r\n    | top 10 by {aggregateRightLabel} {aggregateOrderRight});\r\nlet computerList=(memorySummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nInsightsMetrics\r\n    | where TimeGenerated {TimeRange}\r\n    | where Namespace == 'Memory' and Name == 'AvailableMB'\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {aggregateRightValue} by bin(TimeGenerated, ({TimeRange:end} - {TimeRange:start})/100), ResourceName",
         "size": 0,
         "aggregation": 3,
         "showAnnotations": true,
         "noDataMessage": "There is no data for this counter, either enable the counter or onboard machines to this workspace",
-        "exportToExcelOptions": "visible",
         "queryType": 0,
         "resourceType": "microsoft.compute/virtualmachinescalesets",
         "crossComponentResources": [
@@ -1176,7 +981,7 @@
         },
         "chartSettings": {
           "ySettings": {
-            "unit": 2,
+            "unit": 4,
             "min": 0,
             "max": null
           }
@@ -1185,7 +990,7 @@
       "conditionalVisibility": {
         "parameterName": "tab",
         "comparison": "isEqualTo",
-        "value": "10"
+        "value": "top10"
       },
       "customWidth": "50",
       "name": "query - 17"
@@ -1198,7 +1003,7 @@
       "conditionalVisibility": {
         "parameterName": "tab",
         "comparison": "isEqualTo",
-        "value": "10"
+        "value": "top10"
       },
       "customWidth": "50",
       "name": "text - 18"
@@ -1211,7 +1016,7 @@
       "conditionalVisibility": {
         "parameterName": "tab",
         "comparison": "isEqualTo",
-        "value": "10"
+        "value": "top10"
       },
       "customWidth": "50",
       "name": "text - 19"
@@ -1282,7 +1087,7 @@
       "conditionalVisibility": {
         "parameterName": "tab",
         "comparison": "isEqualTo",
-        "value": "10"
+        "value": "top10"
       },
       "customWidth": "50",
       "name": "parameters - 20"
@@ -1353,7 +1158,7 @@
       "conditionalVisibility": {
         "parameterName": "tab",
         "comparison": "isEqualTo",
-        "value": "10"
+        "value": "top10"
       },
       "customWidth": "50",
       "name": "parameters - 21"
@@ -1362,11 +1167,10 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let networkSendSummary = totable(InsightsMetrics\r\n    | where TimeGenerated {TimeRange}\r\n    | where Namespace == 'Network' and Name == 'WriteBytesPerSecond'\r\n    | where Origin == 'vm.azm.ms'\r\n    | summarize hint.shufflekey=Computer {aggregateLeftValue} by Computer, Name\r\n    | top 10 by {aggregateLeftLabel} {aggregateOrderLeft});\r\nlet computerList=(networkSendSummary | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nInsightsMetrics\r\n    | where TimeGenerated {TimeRange}\r\n    | where Namespace == 'Network' and Name == 'WriteBytesPerSecond'\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {aggregateLeftValue} by bin(TimeGenerated, ({TimeRange:end} - {TimeRange:start})/100), ResourceName",
+        "query": "let memorySummary=totable(InsightsMetrics\r\n    | where TimeGenerated {TimeRange} \r\n    | where Namespace == 'Network' and Name == 'WriteBytesPerSecond'\r\n    | summarize hint.shufflekey=Computer {aggregateLeftValue} by Computer, Name\r\n    | top 10 by {aggregateLeftLabel} {aggregateOrderLeft});\r\nlet computerList=(memorySummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nInsightsMetrics\r\n    | where TimeGenerated {TimeRange}\r\n    | where Namespace == 'Network' and Name == 'WriteBytesPerSecond'\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {aggregateLeftValue} by bin(TimeGenerated, ({TimeRange:end} - {TimeRange:start})/100), ResourceName",
         "size": 0,
         "showAnnotations": true,
         "noDataMessage": "There is no data for this counter, either enable the counter or onboard machines to this workspace",
-        "exportToExcelOptions": "visible",
         "queryType": 0,
         "resourceType": "microsoft.compute/virtualmachinescalesets",
         "crossComponentResources": [
@@ -1396,7 +1200,7 @@
         },
         "chartSettings": {
           "ySettings": {
-            "unit": 11,
+            "unit": 2,
             "min": 0,
             "max": null
           }
@@ -1405,7 +1209,7 @@
       "conditionalVisibility": {
         "parameterName": "tab",
         "comparison": "isEqualTo",
-        "value": "10"
+        "value": "top10"
       },
       "customWidth": "50",
       "name": "query - 22"
@@ -1414,11 +1218,10 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let networkReceiveSummary = totable(InsightsMetrics\r\n    | where TimeGenerated {TimeRange}\r\n    | where Namespace == 'Network' and Name == 'ReadBytesPerSecond'\r\n    | where Origin == 'vm.azm.ms'\r\n    | summarize hint.shufflekey=Computer {aggregateRightValue} by Computer, Name\r\n    | top 10 by {aggregateRightLabel} {aggregateOrderRight});\r\nlet computerList=(networkReceiveSummary | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nInsightsMetrics\r\n    | where TimeGenerated {TimeRange}\r\n    | where Namespace == 'Network' and Name == 'ReadBytesPerSecond'\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {aggregateRightValue} by bin(TimeGenerated, ({TimeRange:end} - {TimeRange:start})/100), ResourceName",
+        "query": "let memorySummary=totable(InsightsMetrics\r\n    | where TimeGenerated {TimeRange} \r\n    | where Namespace == 'Network' and Name == 'ReadBytesPerSecond'\r\n    | summarize hint.shufflekey=Computer {aggregateRightValue} by Computer, Name\r\n    | top 10 by {aggregateRightLabel} {aggregateOrderRight});\r\nlet computerList=(memorySummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nInsightsMetrics\r\n    | where TimeGenerated {TimeRange}\r\n    | where Namespace == 'Network' and Name == 'ReadBytesPerSecond'\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {aggregateRightValue} by bin(TimeGenerated, ({TimeRange:end} - {TimeRange:start})/100), ResourceName",
         "size": 0,
         "showAnnotations": true,
         "noDataMessage": "There is no data for this counter, either enable the counter or onboard machines to this workspace",
-        "exportToExcelOptions": "visible",
         "queryType": 0,
         "resourceType": "microsoft.compute/virtualmachinescalesets",
         "crossComponentResources": [
@@ -1448,7 +1251,7 @@
         },
         "chartSettings": {
           "ySettings": {
-            "unit": 11,
+            "unit": 2,
             "min": 0,
             "max": null
           }
@@ -1457,7 +1260,7 @@
       "conditionalVisibility": {
         "parameterName": "tab",
         "comparison": "isEqualTo",
-        "value": "10"
+        "value": "top10"
       },
       "customWidth": "50",
       "name": "query - 23"
@@ -1470,7 +1273,7 @@
       "conditionalVisibility": {
         "parameterName": "tab",
         "comparison": "isEqualTo",
-        "value": "10"
+        "value": "top10"
       },
       "customWidth": "50",
       "name": "text - 24"
@@ -1479,6 +1282,11 @@
       "type": 1,
       "content": {
         "json": ""
+      },
+      "conditionalVisibility": {
+        "parameterName": "tab",
+        "comparison": "isEqualTo",
+        "value": "top10"
       },
       "customWidth": "50",
       "name": "text - 25"
@@ -1521,7 +1329,7 @@
       "conditionalVisibility": {
         "parameterName": "tab",
         "comparison": "isEqualTo",
-        "value": "10"
+        "value": "top10"
       },
       "customWidth": "50",
       "name": "parameters - 26"
@@ -1531,6 +1339,11 @@
       "content": {
         "json": ""
       },
+      "conditionalVisibility": {
+        "parameterName": "tab",
+        "comparison": "isEqualTo",
+        "value": "top10"
+      },
       "customWidth": "50",
       "name": "text - 27"
     },
@@ -1538,12 +1351,11 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let memorySummary=totable(InsightsMetrics\r\n    | where TimeGenerated {TimeRange} \r\n    | where Namespace == 'LogicalDisk' and Name == 'FreeSpacePercentage'\r\n    | where Origin == 'vm.azm.ms'\r\n\t| extend Val = 100 - Val\r\n    | summarize hint.shufflekey=Computer {aggregateLeftValue} by Computer, Name\r\n    | top 10 by {aggregateLeftLabel} {aggregateOrderLeft});\r\nlet computerList=(memorySummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nInsightsMetrics\r\n    | where TimeGenerated {TimeRange}\r\n    | where Namespace == 'LogicalDisk' and Name == 'FreeSpacePercentage'\r\n\t| extend Val = 100 - Val\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {aggregateLeftValue} by bin(TimeGenerated, ({TimeRange:end} - {TimeRange:start})/100), ResourceName",
+        "query": "let memorySummary=totable(InsightsMetrics\r\n    | where TimeGenerated {TimeRange} \r\n    | where Namespace == 'LogicalDisk' and Name == 'FreeSpacePercentage'\r\n\t| extend Val = 100 - Val\r\n    | summarize hint.shufflekey=Computer {aggregateLeftValue} by Computer, Name\r\n    | top 10 by {aggregateLeftLabel} {aggregateOrderLeft});\r\nlet computerList=(memorySummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nInsightsMetrics\r\n    | where TimeGenerated {TimeRange}\r\n    | where Namespace == 'LogicalDisk' and Name == 'FreeSpacePercentage'\r\n\t| extend Val = 100 - Val\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {aggregateLeftValue} by bin(TimeGenerated, ({TimeRange:end} - {TimeRange:start})/100), ResourceName",
         "size": 0,
         "aggregation": 3,
         "showAnnotations": true,
         "noDataMessage": "There is no data for this counter, either enable the counter or onboard machines to this workspace",
-        "exportToExcelOptions": "visible",
         "queryType": 0,
         "resourceType": "microsoft.compute/virtualmachinescalesets",
         "crossComponentResources": [
@@ -1582,12 +1394,11 @@
       "conditionalVisibility": {
         "parameterName": "tab",
         "comparison": "isEqualTo",
-        "value": "10"
+        "value": "top10"
       },
       "customWidth": "50",
       "name": "query - 28"
     }
   ],
-  "styleSettings": {},
   "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
 }

--- a/Workbooks/Virtual Machine Scale Sets - Performance Analysis/Performance Analysis/Performance Analysis.workbook
+++ b/Workbooks/Virtual Machine Scale Sets - Performance Analysis/Performance Analysis/Performance Analysis.workbook
@@ -5,15 +5,14 @@
       "type": 9,
       "content": {
         "version": "KqlParameterItem/1.0",
-        "query": "",
         "crossComponentResources": [
-          "value::selected"
+          "value::all"
         ],
         "parameters": [
           {
             "id": "688dc7cb-bea3-41ae-ae94-32d22e09568c",
             "version": "KqlParameterItem/1.0",
-            "name": "Resource",
+            "name": "DefaultResource",
             "type": 5,
             "isRequired": true,
             "value": "value::1",
@@ -25,8 +24,20 @@
               "additionalResourceOptions": [
                 "value::1"
               ]
-            },
-            "timeContextFromParameter": null
+            }
+          },
+          {
+            "id": "bbbc300a-6f91-4b2b-b4b5-842b4bf8577a",
+            "version": "KqlParameterItem/1.0",
+            "name": "Selection",
+            "type": 1,
+            "query": "where type =~ 'microsoft.compute/virtualmachinescalesets'\r\n| extend match = id =~ \"{DefaultResource}\"\r\n| order by match desc, name asc\r\n| take 1\r\n| project value = tostring(pack('sub', subscriptionId, 'rg', resourceGroup, 'ws', id))",
+            "crossComponentResources": [
+              "value::all"
+            ],
+            "isHiddenWhenLocked": true,
+            "queryType": 1,
+            "resourceType": "microsoft.resourcegraph/resources"
           }
         ],
         "style": "above",
@@ -56,21 +67,57 @@
       "type": 9,
       "content": {
         "version": "KqlParameterItem/1.0",
-        "query": "",
         "crossComponentResources": [
           "{Resource}"
         ],
         "parameters": [
           {
+            "id": "1db5ee15-fe52-458b-91d1-7ee39d8c2cd3",
+            "version": "KqlParameterItem/1.0",
+            "name": "Subscriptions",
+            "type": 6,
+            "isRequired": true,
+            "multiSelect": true,
+            "quote": "'",
+            "delimiter": ",",
+            "query": "summarize by subscriptionId\r\n| project value = strcat('/subscriptions/', subscriptionId), label = subscriptionId, selected = iff(subscriptionId =~ todynamic('{Selection}').sub, true, false)",
+            "crossComponentResources": [
+              "value::all"
+            ],
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "queryType": 1,
+            "resourceType": "microsoft.resourcegraph/resources"
+          },
+          {
+            "id": "9732eff8-fb57-4cbd-8ade-5ae746f33760",
+            "version": "KqlParameterItem/1.0",
+            "name": "Resource",
+            "label": "Virtual Machine Scale Set",
+            "type": 5,
+            "isRequired": true,
+            "multiSelect": true,
+            "quote": "'",
+            "delimiter": ",",
+            "query": "where type =~ 'microsoft.compute/virtualmachinescalesets'\r\n| summarize by id, name\r\n| project id, selected = iff(id =~ todynamic('{Selection}').ws, true, false)",
+            "crossComponentResources": [
+              "{Subscriptions}"
+            ],
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "queryType": 1,
+            "resourceType": "microsoft.resourcegraph/resources"
+          },
+          {
             "id": "5f8cce4b-9c4c-47da-8683-7e5ccc9faed3",
             "version": "KqlParameterItem/1.0",
             "name": "TimeRange",
             "type": 4,
-            "isRequired": false,
             "value": {
-              "durationMs": 1800000
+              "durationMs": 14400000
             },
-            "isHiddenWhenLocked": false,
             "typeSettings": {
               "selectableValues": [
                 {
@@ -173,20 +220,19 @@
                 }
               ],
               "allowCustom": true
-            }
+            },
+            "label": "Time Range"
           },
           {
             "id": "d6de19ff-cde4-41c2-9fba-b441312ea5c9",
             "version": "KqlParameterItem/1.0",
             "name": "Test",
             "type": 1,
-            "isRequired": false,
-            "query": "// {Resource}\r\nPerf\r\n| take 1",
+            "query": "InsightsMetrics\r\n| where TimeGenerated {TimeRange}\r\n| take 1",
             "crossComponentResources": [
               "{Resource}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
             "queryType": 0,
             "resourceType": "microsoft.compute/virtualmachinescalesets"
           }
@@ -195,13 +241,24 @@
         "queryType": 0,
         "resourceType": "microsoft.compute/virtualmachinescalesets"
       },
-      "conditionalVisibility": null,
       "name": "parameters - 2"
     },
     {
       "type": 1,
       "content": {
-        "json": "⚠ This workbook requires [Azure Monitor for VMs (preview)](https://docs.microsoft.com/en-us/azure/azure-monitor/insights/vminsights-overview) enabled in order to show accurate and complete information for your VMs. Follow the link to onboard machines or select a different workspace."
+        "json": "⚠ A subscription has not yet been selected. Select a subscription under the `Subscriptions` dropdown or refresh the workbook."
+      },
+      "conditionalVisibility": {
+        "parameterName": "Subscriptions",
+        "comparison": "isEqualTo",
+        "value": null
+      },
+      "name": "text - 29"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "⚠ No performance counters were detected in the selected workspace for the specified time period (`{TimeRange:label}`). Either try a broader time range, select a different workspace, or onboard virtual machines to the selected workspace `{Workspaces:label}`.\r\n\r\nIf you choose to onboard virtual machines to workspace `{Workspaces:label}`, follow the instruction in the following link: [Azure Monitor for VMs (preview)](https://docs.microsoft.com/en-us/azure/azure-monitor/insights/vminsights-overview)."
       },
       "conditionalVisibility": {
         "parameterName": "Test",
@@ -211,46 +268,71 @@
       "name": "text - 3"
     },
     {
-      "type": 1,
+      "type": 11,
       "content": {
-        "json": "---"
+        "version": "LinkItem/1.0",
+        "style": "tabs",
+        "links": [
+          {
+            "cellValue": "tab",
+            "linkTarget": "parameter",
+            "linkLabel": "Top 100 Machines",
+            "subTarget": "top100",
+            "style": "link"
+          },
+          {
+            "cellValue": "tab",
+            "linkTarget": "parameter",
+            "linkLabel": "Top 10 Machines",
+            "subTarget": "top10",
+            "style": "link"
+          }
+        ]
       },
-      "conditionalVisibility": null,
-      "name": "text - 4"
-    },
-    {
-      "type": 1,
-      "content": {
-        "json": "<h2 style=\"margin-bottom:0;padding-bottom:0;\">Top 100 Machines</h2>"
-      },
-      "conditionalVisibility": null,
-      "name": "text - 5"
+      "name": "links - 28"
     },
     {
       "type": 9,
       "content": {
         "version": "KqlParameterItem/1.0",
-        "query": "",
         "crossComponentResources": [
           "{Resource}"
         ],
         "parameters": [
+          {
+            "id": "41bb3710-5e9e-4b66-91fd-e11435899880",
+            "version": "KqlParameterItem/1.0",
+            "name": "ComputerNameContains",
+            "label": "Computer Name Contains",
+            "type": 1,
+            "description": "This will filter the computers whose name contains the keyword. This will query all the machines in the workspace.",
+            "value": ""
+          },
+          {
+            "id": "b533865a-3539-42b1-8dcd-33ca0d481c2a",
+            "version": "KqlParameterItem/1.0",
+            "name": "ComputerFilter",
+            "type": 1,
+            "query": "{\"version\":\"1.0.0\",\"content\":\"{\\\"snippet\\\": \\\"| where Computer contains '{ComputerNameContains}'\\\"}\"}",
+            "crossComponentResources": [
+              "{Resource}"
+            ],
+            "isHiddenWhenLocked": true,
+            "queryType": 8
+          },
           {
             "id": "aa2368fc-ad30-4608-b96a-72abf7b1e1af",
             "version": "KqlParameterItem/1.0",
             "name": "Counter",
             "type": 2,
             "description": "Select a VM performance counter for the table below",
-            "isRequired": false,
-            "query": "// {Resource} {Test}\r\nPerf\r\n| where TimeGenerated {TimeRange}\r\n| where ObjectName != 'Network' and ObjectName != 'Network Interface'\r\n| summarize by CounterName, ObjectName, CounterText = CounterName\r\n| order by ObjectName asc, CounterText asc\r\n| project Counter = pack('counter', CounterName, 'object', ObjectName), CounterText, group = ObjectName",
+            "query": "InsightsMetrics\r\n| where TimeGenerated {TimeRange}\r\n| summarize by Namespace, Name, CounterText = Name\r\n| order by Name asc, Namespace asc\r\n| project Counter = pack('counter', Name, 'object', Namespace), CounterText, group = Namespace",
             "crossComponentResources": [
               "{Resource}"
             ],
-            "isHiddenWhenLocked": false,
             "typeSettings": {
               "additionalResourceOptions": []
             },
-            "timeContextFromParameter": null,
             "queryType": 0,
             "resourceType": "microsoft.compute/virtualmachinescalesets"
           },
@@ -259,43 +341,11 @@
             "version": "KqlParameterItem/1.0",
             "name": "CounterText",
             "type": 1,
-            "isRequired": false,
             "query": "let metric = dynamic({Counter});\r\nrange Steps from 1 to 1 step 1\r\n| project strcat(metric.object, \" > \", metric.counter)",
             "crossComponentResources": [
               "{Resource}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
-            "queryType": 0,
-            "resourceType": "microsoft.compute/virtualmachinescalesets"
-          },
-          {
-            "id": "ce228deb-88eb-4438-9dce-6c6d1972ff09",
-            "version": "KqlParameterItem/1.0",
-            "name": "IsNetworkCounter",
-            "type": 1,
-            "isRequired": false,
-            "query": "let counter = dynamic({Counter});\r\nprint tostring(counter.object == 'Network Adapter')",
-            "crossComponentResources": [
-              "{Resource}"
-            ],
-            "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
-            "queryType": 0,
-            "resourceType": "microsoft.compute/virtualmachinescalesets"
-          },
-          {
-            "id": "3b23aa7a-2afd-40ba-a710-0e2cc73c764b",
-            "version": "KqlParameterItem/1.0",
-            "name": "NetworkDirection",
-            "type": 1,
-            "isRequired": false,
-            "query": "let metric = dynamic({Counter});\r\nprint(iff(metric.counter == 'Bytes Received/sec', 'Received', 'Sent'))",
-            "crossComponentResources": [
-              "{Resource}"
-            ],
-            "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
             "queryType": 0,
             "resourceType": "microsoft.compute/virtualmachinescalesets"
           },
@@ -309,12 +359,10 @@
             "multiSelect": true,
             "quote": "",
             "delimiter": ",",
-            "isHiddenWhenLocked": false,
             "typeSettings": {
               "additionalResourceOptions": []
             },
-            "jsonData": "[\r\n    { \"value\":\"Average\", \"label\":\"Average\", \"selected\": true },\r\n    { \"value\":\"P5th\", \"label\":\"P5th\", \"selected\": false },\r\n    { \"value\":\"P10th\", \"label\":\"P10th\", \"selected\": false },\r\n    { \"value\":\"P50th\", \"label\":\"P50th\", \"selected\": false },\r\n    { \"value\":\"P80th\", \"label\":\"P80th\", \"selected\": false },\r\n    { \"value\":\"P90th\", \"label\":\"P90th\", \"selected\": false },\r\n    { \"value\":\"P95th\", \"label\":\"P95th\", \"selected\": true },\r\n    { \"value\":\"Min\", \"label\":\"Min\", \"selected\": false },\r\n    { \"value\":\"Max\", \"label\":\"Max\", \"selected\": true }\r\n]",
-            "timeContextFromParameter": null
+            "jsonData": "[\r\n    { \"value\":\"Average\", \"label\":\"Average\", \"selected\": true },\r\n    { \"value\":\"P5th\", \"label\":\"P5th\", \"selected\": false },\r\n    { \"value\":\"P10th\", \"label\":\"P10th\", \"selected\": false },\r\n    { \"value\":\"P50th\", \"label\":\"P50th\", \"selected\": false },\r\n    { \"value\":\"P80th\", \"label\":\"P80th\", \"selected\": false },\r\n    { \"value\":\"P90th\", \"label\":\"P90th\", \"selected\": false },\r\n    { \"value\":\"P95th\", \"label\":\"P95th\", \"selected\": true },\r\n    { \"value\":\"Min\", \"label\":\"Min\", \"selected\": false },\r\n    { \"value\":\"Max\", \"label\":\"Max\", \"selected\": true }\r\n]"
           },
           {
             "id": "6a7306ea-247f-46ca-abca-501911f9e9d3",
@@ -323,26 +371,60 @@
             "type": 2,
             "description": "Select a percentile to display in the Trend column in the table below",
             "isRequired": true,
-            "isHiddenWhenLocked": false,
             "typeSettings": {
               "additionalResourceOptions": []
             },
-            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\", \"selected\": true },\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\", \"selected\": false },\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\", \"selected\": false },\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\", \"selected\": false },\r\n    { \"value\":\"P80th = round(percentile(CounterValue, 80), 2)\", \"label\":\"P80th\", \"selected\": false },\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\", \"selected\": false },\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\", \"selected\": false }\r\n]",
-            "timeContextFromParameter": null
+            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(Val), 2)\", \"label\":\"Average\", \"selected\": true },\r\n    { \"value\":\"P5th = round(percentile(Val, 5), 2)\", \"label\":\"P5th\", \"selected\": false },\r\n    { \"value\":\"P10th = round(percentile(Val, 10), 2)\", \"label\":\"P10th\", \"selected\": false },\r\n    { \"value\":\"P50th = round(percentile(Val, 50), 2)\", \"label\":\"P50th\", \"selected\": false },\r\n    { \"value\":\"P80th = round(percentile(Val, 80), 2)\", \"label\":\"P80th\", \"selected\": false },\r\n    { \"value\":\"P90th = round(percentile(Val, 90), 2)\", \"label\":\"P90th\", \"selected\": false },\r\n    { \"value\":\"P95th = round(percentile(Val, 95), 2)\", \"label\":\"P95th\", \"selected\": false }\r\n]"
           },
           {
             "id": "0327f26e-cdde-4b48-b512-6c35f06ad1d0",
             "version": "KqlParameterItem/1.0",
             "name": "tableTrendOrder",
             "type": 1,
-            "isRequired": false,
-            "query": "range Steps from 1 to 1 step 1\r\n| project value = iff('{TableTrend}' contains 'P5th'  or '{TableTrend}' contains 'P10th', 'asc', 'desc')",
-            "crossComponentResources": [
-              "{Resource}"
-            ],
+            "value": "desc",
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
-            "queryType": 0,
+            "criteriaData": [
+              {
+                "condition": "if (TableTrend contains 'P5th'), result = 'asc'",
+                "criteriaContext": {
+                  "leftOperand": "TableTrend",
+                  "operator": "contains",
+                  "rightValType": "static",
+                  "rightVal": "P5th",
+                  "resultValType": "static",
+                  "resultVal": "asc"
+                }
+              },
+              {
+                "condition": "if (TableTrend contains 'P10th'), result = 'asc'",
+                "criteriaContext": {
+                  "leftOperand": "TableTrend",
+                  "operator": "contains",
+                  "rightValType": "static",
+                  "rightVal": "P10th",
+                  "resultValType": "static",
+                  "resultVal": "asc"
+                }
+              },
+              {
+                "condition": "else result = 'desc'",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "static",
+                  "resultVal": "desc"
+                }
+              }
+            ]
+          },
+          {
+            "id": "6868a13a-498e-4c1b-80c2-8c44b3427126",
+            "version": "KqlParameterItem/1.0",
+            "name": "tableTrendLabel",
+            "type": 1,
+            "query": "{\"version\":\"1.0.0\",\"content\":\"\\\"{TableTrend:label}\\\"\",\"transformers\":null}",
+            "isHiddenWhenLocked": true,
+            "queryType": 8,
             "resourceType": "microsoft.compute/virtualmachinescalesets"
           },
           {
@@ -350,43 +432,41 @@
             "version": "KqlParameterItem/1.0",
             "name": "mergedAggregators",
             "type": 1,
-            "isRequired": false,
-            "query": "let aggregators = iff('{Aggregators}' contains '{TableTrend:label}', '{Aggregators}', '{Aggregators},{TableTrend:label}');\r\nrange Steps from 1 to 1 step 1\r\n| project aggregators",
-            "crossComponentResources": [
-              "{Resource}"
-            ],
+            "value": "Average",
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
-            "queryType": 0,
-            "resourceType": "microsoft.compute/virtualmachinescalesets"
+            "criteriaData": [
+              {
+                "condition": "if (Aggregators contains tableTrendLabel), result = Aggregators",
+                "criteriaContext": {
+                  "leftOperand": "Aggregators",
+                  "operator": "contains",
+                  "rightValType": "param",
+                  "rightVal": "tableTrendLabel",
+                  "resultValType": "param",
+                  "resultVal": "Aggregators"
+                }
+              },
+              {
+                "condition": "else result = '{Aggregators},{tableTrendLabel}'",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "static",
+                  "resultVal": "{Aggregators},{tableTrendLabel}"
+                }
+              }
+            ]
           },
           {
             "id": "27faa340-a75f-4ae1-a43a-1aa6ece37cff",
             "version": "KqlParameterItem/1.0",
             "name": "StandardQuery",
             "type": 1,
-            "isRequired": false,
-            "query": "// {Resource} {Test}\r\nlet metric = dynamic({Counter}); \r\nlet timeRangeStart = {TimeRange:start};\r\nlet timeRangeEnd = {TimeRange:end};\r\nlet timeRangeGrain = {TimeRange:grain};\r\nprint(iff({IsNetworkCounter} == 'False', strcat(\"let maxResultCount = 100; let metric = dynamic(\", metric, \"); let summaryPerComputer = totable(Perf      | where TimeGenerated {TimeRange}       | where ObjectName == metric.object and CounterName == metric.counter     | summarize hint.shufflekey = Computer Average = avg(CounterValue), Max = max(CounterValue), Min = min(CounterValue), percentiles(CounterValue, 5, 10, 50, 80, 90, 95) by Computer      | project Computer, Average, Max, Min, P5th = percentile_CounterValue_5, P10th = percentile_CounterValue_10, P50th = percentile_CounterValue_50, P80th = percentile_CounterValue_80, P90th = percentile_CounterValue_90, P95th = percentile_CounterValue_95      | order by {TableTrend:label} {tableTrendOrder}, Computer      | limit maxResultCount);  let computerList = summaryPerComputer      | project Computer;  let MachineSummary = ServiceMapComputer_CL     | where TimeGenerated {TimeRange}     | where Computer in (computerList)     | summarize arg_max(TimeGenerated, *) by Computer     | project Computer, MachineSummary = pack('Fully Qualified Domain Name', Computer, 'OS Type', OperatingSystemFamily_s, 'Operating System', OperatingSystemFullName_s, 'Ipv4 Addresses', Ipv4Addresses_s,         'Ipv6 Addresses', Ipv6Addresses_s, 'Mac Addresses', MacAddresses_s, 'DNS Names', DnsNames_s, 'CPUs', strcat(Cpus_d, ' @ ', CpuSpeed_d, ' MHz'), 'Bitness', Bitness_s,         'Physcial Memory', strcat(PhysicalMemory_d, ' MB'), 'Virtualization State', VirtualizationState_s, 'VM Type', VirtualMachineType_s, 'OMS Agent', split(ResourceName_s, 'm-')[1]); let EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) []; let OmsNodeIdentityAndProps = computerList     | extend NodeId = Computer     | extend Priority = 1     | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer); let ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL     | where TimeGenerated {TimeRange}     | where Computer in (computerList)     | summarize arg_max(TimeGenerated, *) by Computer     | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2; let NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                                 | summarize arg_max(Priority, *) by Computer;  let NodeIdentityAndPropsMin = NodeIdentityAndProps     | extend Type = iff(NodeProps.type == 'StandAloneNode', iff(NodeProps.azureResourceId == '', 'Non-Azure Virtual Machine', 'Azure Virtual Machine'), NodeProps.type),      ResourceId = iff(NodeProps.type == 'AzureScaleSetNode', NodeProps.vmScaleSetResourceId,          iff(NodeProps.type == 'AzureCloudServiceNode', NodeProps.cloudServiceDeploymentId, Computer)),     ResourceName = iff(NodeProps.type == 'AzureScaleSetNode', strcat(NodeProps.vmScaleSetName, ' | ', NodeProps.scaleSetInstanceId),          iff(NodeProps.type == 'AzureCloudServiceNode', strcat(NodeProps.cloudServiceRoleName, ' | ', NodeProps.cloudServiceInstanceId), Computer))     | project Computer, Type, ResourceId, ResourceName; let trend = Perf          | where TimeGenerated {TimeRange}         | where Computer in (computerList)          | where ObjectName == metric.object and CounterName == metric.counter        | make-series {TableTrend} default = 0 on TimeGenerated in range(datetime('\", timeRangeStart,\"'), datetime('\", timeRangeEnd ,\"'), totimespan('\", timeRangeGrain, \"')) by Computer     | project Computer, ['Trend ({TableTrend:label})'] = {TableTrend:label}; summaryPerComputer     | join kind=leftouter (trend) on Computer     | join kind=leftouter (NodeIdentityAndProps) on Computer     | join kind=leftouter (NodeIdentityAndPropsMin) on Computer     | join kind=leftouter (MachineSummary) on Computer     | project ResourceName, Type, {mergedAggregators}, ['Trend ({TableTrend:label})'], Properties = MachineSummary     | sort by {TableTrend:label} {tableTrendOrder}\"), ''));",
+            "query": "let metric = dynamic({Counter}); \r\nlet timeRangeStart = {TimeRange:start};\r\nlet timeRangeEnd = {TimeRange:end};\r\nlet timeRangeGrain = {TimeRange:grain};\r\nprint(strcat(\"let maxResultCount = 100; let metric = dynamic(\", metric, \"); let summaryPerComputer = totable(InsightsMetrics      | where TimeGenerated {TimeRange}   {ComputerFilter}    | where Namespace == metric.object and Name == metric.counter     | summarize hint.shufflekey = Computer Average = avg(Val), Max = max(Val), Min = min(Val), percentiles(Val, 5, 10, 50, 80, 90, 95) by Computer      | project Computer, Average, Max, Min, P5th = percentile_Val_5, P10th = percentile_Val_10, P50th = percentile_Val_50, P80th = percentile_Val_80, P90th = percentile_Val_90, P95th = percentile_Val_95      | order by {TableTrend:label} {tableTrendOrder}, Computer      | limit maxResultCount);  let computerList = summaryPerComputer      | project Computer;  let MachineSummary = ServiceMapComputer_CL     | where TimeGenerated {TimeRange}     | where Computer in (computerList)     | summarize arg_max(TimeGenerated, *) by Computer     | project Computer, MachineSummary = pack('Fully Qualified Domain Name', Computer, 'OS Type', OperatingSystemFamily_s, 'Operating System', OperatingSystemFullName_s, 'Ipv4 Addresses', Ipv4Addresses_s,         'Ipv6 Addresses', Ipv6Addresses_s, 'Mac Addresses', MacAddresses_s, 'DNS Names', DnsNames_s, 'CPUs', strcat(Cpus_d, ' @ ', CpuSpeed_d, ' MHz'), 'Bitness', Bitness_s,         'Physcial Memory', strcat(PhysicalMemory_d, ' MB'), 'Virtualization State', VirtualizationState_s, 'VM Type', VirtualMachineType_s, 'OMS Agent', split(ResourceName_s, 'm-')[1]); let EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) []; let OmsNodeIdentityAndProps = computerList     | extend NodeId = Computer     | extend Priority = 1     | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer); let ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL     | where TimeGenerated {TimeRange}     | where Computer in (computerList)     | summarize arg_max(TimeGenerated, *) by Computer     | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2; let NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                                 | summarize arg_max(Priority, *) by Computer;  let NodeIdentityAndPropsMin = NodeIdentityAndProps     | extend Type = iff(NodeProps.type == 'StandAloneNode', iff(NodeProps.azureResourceId == '', 'Non-Azure Virtual Machine', 'Azure Virtual Machine'), NodeProps.type),      ResourceId = iff(NodeProps.type == 'AzureScaleSetNode', NodeProps.vmScaleSetResourceId,          iff(NodeProps.type == 'AzureCloudServiceNode', NodeProps.cloudServiceDeploymentId, Computer)),     ResourceName = iff(NodeProps.type == 'AzureScaleSetNode', strcat(NodeProps.vmScaleSetName, ' | ', NodeProps.scaleSetInstanceId),          iff(NodeProps.type == 'AzureCloudServiceNode', strcat(NodeProps.cloudServiceRoleName, ' | ', NodeProps.cloudServiceInstanceId), Computer))     | project Computer, Type, ResourceId, ResourceName; let trend = InsightsMetrics          | where TimeGenerated {TimeRange}         | where Computer in (computerList)          | where Namespace == metric.object and Name == metric.counter        | make-series {TableTrend} default = 0 on TimeGenerated in range(datetime('\", timeRangeStart,\"'), datetime('\", timeRangeEnd ,\"'), totimespan('\", timeRangeGrain, \"')) by Computer     | project Computer, ['Trend ({TableTrend:label})'] = {TableTrend:label}; summaryPerComputer     | join kind=leftouter (trend) on Computer     | join kind=leftouter (NodeIdentityAndProps) on Computer     | join kind=leftouter (NodeIdentityAndPropsMin) on Computer     | join kind=leftouter (MachineSummary) on Computer     | project ResourceName, Type, {mergedAggregators}, ['Trend ({TableTrend:label})'], Properties = MachineSummary     | sort by {TableTrend:label} {tableTrendOrder}\"));\r\n",
             "crossComponentResources": [
               "{Resource}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
-            "queryType": 0,
-            "resourceType": "microsoft.compute/virtualmachinescalesets"
-          },
-          {
-            "id": "6e392933-2f72-45a6-889b-90351f9130db",
-            "version": "KqlParameterItem/1.0",
-            "name": "NetworkQuery",
-            "type": 1,
-            "isRequired": false,
-            "query": "let metric = dynamic({Counter});\r\nlet timeRangeStart = {TimeRange:start};\r\nlet timeRangeEnd = {TimeRange:end};\r\nlet timeRangeGrain = {TimeRange:grain};\r\nprint(iff({IsNetworkCounter} == 'True', strcat(\"let metric = dynamic(\", metric, \"); let linux = iff(metric.counter == 'Bytes Received/sec', dynamic({'object': 'Network', 'counter': 'Total Bytes Received'}), dynamic({'object': 'Network', 'counter': 'Total Bytes Transmitted'})); let maxResultCount = 100; let windowsNetworkRaw = Perf | where TimeGenerated {TimeRange} | where ObjectName == metric.object and CounterName == metric.couter; let windowsNetworkSum = windowsNetworkRaw | summarize hint.shufflekey=Computer CounterValue=sum(CounterValue) by Computer, TimeGenerated; let windowsNetworkPctl = windowsNetworkRaw | summarize hint.shufflekey=Computer Average = avg(CounterValue), Max = max(CounterValue), Min = min(CounterValue), percentiles(CounterValue, 5, 10, 50, 80, 90, 95) by Computer, TimeGenerated | project TimeGenerated, Computer, Average, Max, Min, P5th = percentile_CounterValue_5, P10th = percentile_CounterValue_10, P50th = percentile_CounterValue_50, P80th = percentile_CounterValue_80, P90th = percentile_CounterValue_90, P95th = percentile_CounterValue_95; let linuxNetworkRaw = Perf | where TimeGenerated {TimeRange} | where ObjectName == linux.object and CounterName == linux.counter | order by InstanceName, TimeGenerated asc | extend prev_Value = prev(CounterValue), prev_t = prev(TimeGenerated), prev_instance = prev(InstanceName) | project TimeGenerated, Computer, CounterValue = iff(prev_instance == InstanceName and CounterValue >= prev_Value and TimeGenerated > prev_t, (CounterValue - prev_Value) / ((TimeGenerated - prev_t) / 1s), real(0)); let linuxNetworkSum = linuxNetworkRaw | summarize hint.shufflekey=Computer CounterValue=sum(CounterValue) by Computer, TimeGenerated; let linuxNetworkPctl = linuxNetworkRaw | summarize hint.shufflekey=Computer Average = avg(CounterValue), Max = max(CounterValue), Min = min(CounterValue), percentiles(CounterValue, 5, 10, 50, 80, 90, 95) by Computer, TimeGenerated | project TimeGenerated, Computer, Average, Max, Min, P5th = percentile_CounterValue_5, P10th = percentile_CounterValue_10, P50th = percentile_CounterValue_50, P80th = percentile_CounterValue_80, P90th = percentile_CounterValue_90, P95th = percentile_CounterValue_95; let networkDataSum = union windowsNetworkSum, linuxNetworkSum; let networkDataPctl = union windowsNetworkPctl, linuxNetworkPctl; let computerList = Perf  | project Computer; let EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) []; let OmsNodeIdentityAndProps = computerList | extend NodeId = Computer | extend Priority = 1 | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer); let ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL | where TimeGenerated {TimeRange} | where Computer in (computerList) | summarize hint.shufflekey=Computer arg_max(TimeGenerated, *) by Computer | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|', columnifexists('AzureCloudServiceDeployment_g', '')), ''), AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')), strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|', columnifexists('AzureVmScaleSetDeployment_g', '')), ''), ComputerProps = pack('type', 'StandAloneNode', 'name', ComputerName_s, 'mappingResourceId', ResourceId, 'subscriptionId', AzureSubscriptionId_g, 'resourceGroup', AzureResourceGroup_s, 'azureResourceId', columnifexists('AzureResourceId_s', '')), AzureCloudServiceNodeProps = pack('type', 'AzureCloudServiceNode', 'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''), 'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''), 'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''), 'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''), 'mappingResourceId', ResourceId), AzureScaleSetNodeProps = pack('type', 'AzureScaleSetNode', 'scaleSetInstanceId', columnifexists('AzureName_s', ''), 'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''), 'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''), 'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''), 'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''), 'resourceGroupName', columnifexists('AzureResourceGroup_s', ''), 'subscriptionId', columnifexists('AzureSubscriptionId_g', ''), 'mappingResourceId', ResourceId)| project   Computer, NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity, isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer), NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps, isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps), Priority = 2; let NodeIdentityAndProps = union kind=inner isfuzzy = true EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps | summarize hint.shufflekey=Computer arg_max(Priority, *) by Computer; let NodeIdentityAndPropsMin = NodeIdentityAndProps | extend Type = iff(NodeProps.type == 'StandAloneNode', iff(NodeProps.azureResourceId == '', 'Non-Azure Virtual Machine', 'Azure Virtual Machine'), NodeProps.type), ResourceId = iff(NodeProps.type == 'AzureScaleSetNode', NodeProps.vmScaleSetResourceId, iff(NodeProps.type == 'AzureCloudServiceNode', NodeProps.cloudServiceDeploymentId, Computer)), ResourceName = iff(NodeProps.type == 'AzureScaleSetNode', strcat(NodeProps.vmScaleSetName, ' | ', NodeProps.scaleSetInstanceId), iff(NodeProps.type == 'AzureCloudServiceNode', strcat(NodeProps.cloudServiceRoleName, ' | ', NodeProps.cloudServiceInstanceId), Computer)) | project Computer, Type, ResourceId, ResourceName; let MachineSummary = ServiceMapComputer_CL | where TimeGenerated {TimeRange} | where Computer in (computerList) | summarize hint.shufflekey=Computer arg_max(TimeGenerated, *) by Computer | project Computer, MachineSummary = pack('Fully Qualified Domain Name', Computer, 'OS Type', OperatingSystemFamily_s, 'Operating System', OperatingSystemFullName_s, 'Ipv4 Addresses', Ipv4Addresses_s, 'Ipv6 Addresses', Ipv6Addresses_s, 'Mac Addresses', MacAddresses_s, 'DNS Names', DnsNames_s, 'CPUs', strcat(Cpus_d, ' @ ', CpuSpeed_d, ' MHz'), 'Bitness', Bitness_s, 'Physcial Memory', strcat(PhysicalMemory_d, ' MB'), 'Virtualization State', VirtualizationState_s, 'VM Type', VirtualMachineType_s, 'OMS Agent', split(ResourceName_s, 'm-')[1]); let trend = networkDataSum | make-series {TableTrend} default=0 on TimeGenerated in range(datetime('\", timeRangeStart,\"'), datetime('\", timeRangeEnd ,\"'), totimespan('\", timeRangeGrain, \"')) by Computer | project Computer, ['Trend ({TableTrend:label})'] = {TableTrend:label}; networkDataPctl | join kind=leftouter hint.shufflekey=Computer (trend) on Computer | join kind=leftouter hint.shufflekey=Computer (NodeIdentityAndPropsMin) on Computer | join kind=leftouter hint.shufflekey=Computer (MachineSummary) on Computer | project ResourceName, Type, {mergedAggregators}, ['Trend ({TableTrend:label})'], Properties = MachineSummary | sort by {TableTrend:label} {tableTrendOrder} | limit maxResultCount\"), ''));",
-            "crossComponentResources": [
-              "{Resource}"
-            ],
-            "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
             "queryType": 0,
             "resourceType": "microsoft.compute/virtualmachinescalesets"
           },
@@ -395,43 +475,11 @@
             "version": "KqlParameterItem/1.0",
             "name": "ShowTable",
             "type": 1,
-            "isRequired": false,
-            "query": "print iff(\"{Test:value}\" == \"\", \"False\", iff(\"{IsNetworkCounter:value}\" == \"False\", \"True\", \"False\"))",
+            "query": "print iff(\"{Test:value}\" == \"\", \"False\", \"True\")",
             "crossComponentResources": [
               "{Resource}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
-            "queryType": 0,
-            "resourceType": "microsoft.compute/virtualmachinescalesets"
-          },
-          {
-            "id": "6b664a24-d9a3-47b0-9d94-9cada9ddb8ce",
-            "version": "KqlParameterItem/1.0",
-            "name": "ShowNetworkTable",
-            "type": 1,
-            "isRequired": false,
-            "query": "print iff(\"{Test:value}\" == \"\", \"False\", \"{IsNetworkCounter:value}\")",
-            "crossComponentResources": [
-              "{Resource}"
-            ],
-            "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
-            "queryType": 0,
-            "resourceType": "microsoft.compute/virtualmachinescalesets"
-          },
-          {
-            "id": "343c4eae-e482-4678-a936-c4ad43b2ec19",
-            "version": "KqlParameterItem/1.0",
-            "name": "CounterTest",
-            "type": 1,
-            "isRequired": false,
-            "query": "Perf\r\n| take 1",
-            "crossComponentResources": [
-              "{Resource}"
-            ],
-            "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
             "queryType": 0,
             "resourceType": "microsoft.compute/virtualmachinescalesets"
           }
@@ -440,6 +488,18 @@
         "queryType": 0,
         "resourceType": "microsoft.compute/virtualmachinescalesets"
       },
+      "conditionalVisibilities": [
+        {
+          "parameterName": "Test",
+          "comparison": "isNotEqualTo",
+          "value": null
+        },
+        {
+          "parameterName": "tab",
+          "comparison": "isEqualTo",
+          "value": "top100"
+        }
+      ],
       "conditionalVisibility": {
         "parameterName": "Test",
         "comparison": "isNotEqualTo",
@@ -448,22 +508,10 @@
       "name": "parameters - 6"
     },
     {
-      "type": 1,
-      "content": {
-        "json": "There are no performance counters, either onboard machines to this workspace or enable performance counters."
-      },
-      "conditionalVisibility": {
-        "parameterName": "CounterTest",
-        "comparison": "isEqualTo",
-        "value": ""
-      },
-      "name": "text - 7"
-    },
-    {
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "// {Resource} {Test}\r\n{StandardQuery}",
+        "query": "{StandardQuery}",
         "size": 0,
         "noDataMessage": "There is no data for this counter, either enable the counter or onboard machines to this workspace",
         "queryType": 0,
@@ -656,6 +704,18 @@
           ]
         }
       },
+      "conditionalVisibilities": [
+        {
+          "parameterName": "ShowTable",
+          "comparison": "isEqualTo",
+          "value": "True"
+        },
+        {
+          "parameterName": "tab",
+          "comparison": "isEqualTo",
+          "value": "top100"
+        }
+      ],
       "conditionalVisibility": {
         "parameterName": "ShowTable",
         "comparison": "isEqualTo",
@@ -666,229 +726,13 @@
     {
       "type": 1,
       "content": {
-        "json": "#### ℹ `Total Bytes {NetworkDirection}` counters are also being utilized to display the network table. The delta of `Total Bytes {NetworkDirection}` over a time period is being calculated to match up with the `Bytes {NetworkDirection}/sec` counter to display an accurate representation of network activity over all machines"
-      },
-      "conditionalVisibility": {
-        "parameterName": "ShowNetworkTable",
-        "comparison": "isEqualTo",
-        "value": "True"
-      },
-      "name": "text - 9"
-    },
-    {
-      "type": 3,
-      "content": {
-        "version": "KqlItem/1.0",
-        "query": "// {Resource} {Test}\r\n{NetworkQuery}",
-        "size": 0,
-        "noDataMessage": "There is no data for this counter, either enable the counter or onboard machines to this workspace",
-        "queryType": 0,
-        "resourceType": "microsoft.compute/virtualmachinescalesets",
-        "crossComponentResources": [
-          "{Resource}"
-        ],
-        "visualization": "table",
-        "gridSettings": {
-          "formatters": [
-            {
-              "columnMatch": "Type",
-              "formatter": 1,
-              "formatOptions": {}
-            },
-            {
-              "columnMatch": "P95th",
-              "formatter": 8,
-              "formatOptions": {
-                "palette": "blue"
-              },
-              "numberFormat": {
-                "unit": 2,
-                "options": {
-                  "style": "decimal"
-                }
-              }
-            },
-            {
-              "columnMatch": "Average",
-              "formatter": 1,
-              "formatOptions": {
-                "palette": "greenRed"
-              },
-              "numberFormat": {
-                "unit": 2,
-                "options": {
-                  "style": "decimal"
-                }
-              }
-            },
-            {
-              "columnMatch": "P10th",
-              "formatter": 1,
-              "formatOptions": {},
-              "numberFormat": {
-                "unit": 2,
-                "options": {
-                  "style": "decimal"
-                }
-              }
-            },
-            {
-              "columnMatch": "P50th",
-              "formatter": 1,
-              "formatOptions": {
-                "palette": "greenRed"
-              },
-              "numberFormat": {
-                "unit": 2,
-                "options": {
-                  "style": "decimal"
-                }
-              }
-            },
-            {
-              "columnMatch": "Trend (P95th)",
-              "formatter": 10,
-              "formatOptions": {
-                "palette": "blue"
-              }
-            },
-            {
-              "columnMatch": "Properties",
-              "formatter": 7,
-              "formatOptions": {
-                "linkTarget": "CellDetails",
-                "linkLabel": "️️️ℹ Info"
-              }
-            },
-            {
-              "columnMatch": "P5th",
-              "formatter": 8,
-              "formatOptions": {
-                "palette": "blue"
-              },
-              "numberFormat": {
-                "unit": 2,
-                "options": {
-                  "style": "decimal"
-                }
-              }
-            },
-            {
-              "columnMatch": "P80th",
-              "formatter": 1,
-              "formatOptions": {
-                "palette": "greenRed"
-              },
-              "numberFormat": {
-                "unit": 2,
-                "options": {
-                  "style": "decimal"
-                }
-              }
-            },
-            {
-              "columnMatch": "P90th",
-              "formatter": 1,
-              "formatOptions": {
-                "palette": "greenRed"
-              },
-              "numberFormat": {
-                "unit": 2,
-                "options": {
-                  "style": "decimal"
-                }
-              }
-            },
-            {
-              "columnMatch": "Min",
-              "formatter": 1,
-              "formatOptions": {},
-              "numberFormat": {
-                "unit": 2,
-                "options": {
-                  "style": "decimal"
-                }
-              }
-            },
-            {
-              "columnMatch": "Max",
-              "formatter": 1,
-              "formatOptions": {
-                "palette": "greenRed"
-              },
-              "numberFormat": {
-                "unit": 2,
-                "options": {
-                  "style": "decimal"
-                }
-              }
-            },
-            {
-              "columnMatch": "Trend (P5th)",
-              "formatter": 10,
-              "formatOptions": {
-                "palette": "blue"
-              }
-            },
-            {
-              "columnMatch": "Trend (P90th)",
-              "formatter": 10,
-              "formatOptions": {
-                "palette": "blue"
-              }
-            },
-            {
-              "columnMatch": "Trend (P80th)",
-              "formatter": 10,
-              "formatOptions": {
-                "palette": "blue"
-              }
-            },
-            {
-              "columnMatch": "Trend (P50th)",
-              "formatter": 10,
-              "formatOptions": {
-                "palette": "blue"
-              }
-            },
-            {
-              "columnMatch": "Trend (P10th)",
-              "formatter": 10,
-              "formatOptions": {
-                "palette": "blue"
-              }
-            },
-            {
-              "columnMatch": "Trend (Average)",
-              "formatter": 10,
-              "formatOptions": {
-                "palette": "blue"
-              }
-            }
-          ]
-        }
-      },
-      "conditionalVisibility": {
-        "parameterName": "ShowNetworkTable",
-        "comparison": "isEqualTo",
-        "value": "True"
-      },
-      "name": "query - 10"
-    },
-    {
-      "type": 1,
-      "content": {
-        "json": "---\r\n## Top 10 Machines"
-      },
-      "conditionalVisibility": null,
-      "name": "text - 11"
-    },
-    {
-      "type": 1,
-      "content": {
         "json": "### CPU Utilization %"
       },
-      "conditionalVisibility": null,
+      "conditionalVisibility": {
+        "parameterName": "tab",
+        "comparison": "isEqualTo",
+        "value": "top10"
+      },
       "customWidth": "50",
       "name": "text - 12"
     },
@@ -897,7 +741,11 @@
       "content": {
         "json": "### Available Memory"
       },
-      "conditionalVisibility": null,
+      "conditionalVisibility": {
+        "parameterName": "tab",
+        "comparison": "isEqualTo",
+        "value": "top10"
+      },
       "customWidth": "50",
       "name": "text - 13"
     },
@@ -905,10 +753,6 @@
       "type": 9,
       "content": {
         "version": "KqlParameterItem/1.0",
-        "query": "",
-        "crossComponentResources": [
-          "{Resource}"
-        ],
         "parameters": [
           {
             "id": "92358ae0-d5e1-494b-b65b-6d904f1325c5",
@@ -916,26 +760,22 @@
             "name": "Aggregate",
             "type": 2,
             "isRequired": true,
-            "value": "P95th = round(percentile(CounterValue, 95), 2)",
-            "isHiddenWhenLocked": false,
+            "value": "P95th = round(percentile(Val, 95), 2)",
             "typeSettings": {
               "additionalResourceOptions": []
             },
-            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\"},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\"},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\"},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\"},\r\n    { \"value\":\"P80th = round(percentile(CounterValue, 80), 2)\", \"label\":\"P80th\"},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\"},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\"}\r\n]",
-            "timeContextFromParameter": null
+            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(Val), 2)\", \"label\":\"Average\"},\r\n    { \"value\":\"P5th = round(percentile(Val, 5), 2)\", \"label\":\"P5th\"},\r\n    { \"value\":\"P10th = round(percentile(Val, 10), 2)\", \"label\":\"P10th\"},\r\n    { \"value\":\"P50th = round(percentile(Val, 50), 2)\", \"label\":\"P50th\"},\r\n    { \"value\":\"P80th = round(percentile(Val, 80), 2)\", \"label\":\"P80th\"},\r\n    { \"value\":\"P90th = round(percentile(Val, 90), 2)\", \"label\":\"P90th\"},\r\n    { \"value\":\"P95th = round(percentile(Val, 95), 2)\", \"label\":\"P95th\"}\r\n]"
           },
           {
             "id": "27345375-4376-4e2f-8ac4-59d4eab9d235",
             "version": "KqlParameterItem/1.0",
             "name": "aggregateOrderLeft",
             "type": 1,
-            "isRequired": false,
             "query": "range Steps from 1 to 1 step 1\r\n| project value = iff('{Aggregate}' contains 'P5th'  or '{Aggregate}' contains 'P10th', 'asc', 'desc')",
             "crossComponentResources": [
               "{Resource}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
             "queryType": 0,
             "resourceType": "microsoft.compute/virtualmachinescalesets"
           },
@@ -950,7 +790,6 @@
               "{Resource}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
             "queryType": 0,
             "resourceType": "microsoft.compute/virtualmachinescalesets"
           },
@@ -965,7 +804,6 @@
               "{Resource}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
             "queryType": 0,
             "resourceType": "microsoft.compute/virtualmachinescalesets"
           }
@@ -974,7 +812,11 @@
         "queryType": 0,
         "resourceType": "microsoft.compute/virtualmachinescalesets"
       },
-      "conditionalVisibility": null,
+      "conditionalVisibility": {
+        "parameterName": "tab",
+        "comparison": "isEqualTo",
+        "value": "top10"
+      },
       "customWidth": "50",
       "name": "parameters - 14"
     },
@@ -982,10 +824,6 @@
       "type": 9,
       "content": {
         "version": "KqlParameterItem/1.0",
-        "query": "",
-        "crossComponentResources": [
-          "{Resource}"
-        ],
         "parameters": [
           {
             "id": "333837c2-d5a4-4173-9aad-3db1dca17e2a",
@@ -993,26 +831,22 @@
             "name": "Aggregate",
             "type": 2,
             "isRequired": true,
-            "value": "P95th = round(percentile(CounterValue, 95), 2)",
-            "isHiddenWhenLocked": false,
+            "value": "P5th = round(percentile(Val, 5), 2)",
             "typeSettings": {
               "additionalResourceOptions": []
             },
-            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\"},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\"},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\"},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\"},\r\n    { \"value\":\"P80th = round(percentile(CounterValue, 80), 2)\", \"label\":\"P80th\"},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\"},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\"}\r\n]",
-            "timeContextFromParameter": null
+            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(Val), 2)\", \"label\":\"Average\"},\r\n    { \"value\":\"P5th = round(percentile(Val, 5), 2)\", \"label\":\"P5th\"},\r\n    { \"value\":\"P10th = round(percentile(Val, 10), 2)\", \"label\":\"P10th\"},\r\n    { \"value\":\"P50th = round(percentile(Val, 50), 2)\", \"label\":\"P50th\"},\r\n    { \"value\":\"P80th = round(percentile(Val, 80), 2)\", \"label\":\"P80th\"},\r\n    { \"value\":\"P90th = round(percentile(Val, 90), 2)\", \"label\":\"P90th\"},\r\n    { \"value\":\"P95th = round(percentile(Val, 95), 2)\", \"label\":\"P95th\"}\r\n]"
           },
           {
             "id": "a23b29a5-5e4a-4d8e-ba73-bfdf27b2980e",
             "version": "KqlParameterItem/1.0",
             "name": "aggregateOrderRight",
             "type": 1,
-            "isRequired": false,
             "query": "range Steps from 1 to 1 step 1\r\n| project value = iff('{Aggregate}' contains 'P5th'  or '{Aggregate}' contains 'P10th', 'asc', 'desc')",
             "crossComponentResources": [
               "{Resource}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
             "queryType": 0,
             "resourceType": "microsoft.compute/virtualmachinescalesets"
           },
@@ -1027,7 +861,6 @@
               "{Resource}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
             "queryType": 0,
             "resourceType": "microsoft.compute/virtualmachinescalesets"
           },
@@ -1042,7 +875,6 @@
               "{Resource}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
             "queryType": 0,
             "resourceType": "microsoft.compute/virtualmachinescalesets"
           }
@@ -1051,7 +883,11 @@
         "queryType": 0,
         "resourceType": "microsoft.compute/virtualmachinescalesets"
       },
-      "conditionalVisibility": null,
+      "conditionalVisibility": {
+        "parameterName": "tab",
+        "comparison": "isEqualTo",
+        "value": "top10"
+      },
       "customWidth": "50",
       "name": "parameters - 15"
     },
@@ -1059,7 +895,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let cpuSummary=totable(Perf\r\n    | where TimeGenerated {TimeRange} \r\n    | where (ObjectName == 'Processor' and InstanceName == '_Total' and CounterName == '% Processor Time')\r\n    | summarize hint.shufflekey=Computer {aggregateLeftValue} by Computer, CounterName\r\n    | top 10 by {aggregateLeftLabel} {aggregateOrderLeft});\r\nlet computerList=(cpuSummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nPerf\r\n    | where TimeGenerated {TimeRange}\r\n    | where (ObjectName == 'Processor' and InstanceName == '_Total' and CounterName == '% Processor Time')\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {aggregateLeftValue} by bin(TimeGenerated, ({TimeRange:end} - {TimeRange:start})/100), ResourceName",
+        "query": "let cpuSummary=totable(InsightsMetrics\r\n    | where TimeGenerated {TimeRange} \r\n    | where (Namespace == 'Processor' and Name == 'UtilizationPercentage')\r\n    | summarize hint.shufflekey=Computer {aggregateLeftValue} by Computer, Name\r\n    | top 10 by {aggregateLeftLabel} {aggregateOrderLeft});\r\nlet computerList=(cpuSummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nInsightsMetrics\r\n    | where TimeGenerated {TimeRange}\r\n    | where (Namespace == 'Processor' and Name == 'UtilizationPercentage')\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {aggregateLeftValue} by bin(TimeGenerated, ({TimeRange:end} - {TimeRange:start})/100), ResourceName",
         "size": 0,
         "aggregation": 3,
         "showAnnotations": true,
@@ -1090,9 +926,20 @@
               }
             }
           }
+        },
+        "chartSettings": {
+          "ySettings": {
+            "unit": 1,
+            "min": 0,
+            "max": 100
+          }
         }
       },
-      "conditionalVisibility": null,
+      "conditionalVisibility": {
+        "parameterName": "tab",
+        "comparison": "isEqualTo",
+        "value": "top10"
+      },
       "customWidth": "50",
       "name": "query - 16"
     },
@@ -1100,7 +947,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let memorySummary=totable(Perf\r\n    | where TimeGenerated {TimeRange} \r\n    | where ObjectName == 'Memory' and CounterName in ('Available MBytes', 'Available MBytes Memory')\r\n    | summarize hint.shufflekey=Computer {aggregateRightValue} by Computer, CounterName\r\n    | top 10 by {aggregateRightLabel} {aggregateOrderRight});\r\nlet computerList=(memorySummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nPerf\r\n    | where TimeGenerated {TimeRange}\r\n    | where ObjectName == 'Memory' and CounterName in ('Available MBytes', 'Available MBytes Memory')\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {aggregateRightValue} by bin(TimeGenerated, ({TimeRange:end} - {TimeRange:start})/100), ResourceName",
+        "query": "let memorySummary=totable(InsightsMetrics\r\n    | where TimeGenerated {TimeRange} \r\n    | where Namespace == 'Memory' and Name == 'AvailableMB'\r\n    | summarize hint.shufflekey=Computer {aggregateRightValue} by Computer, Name\r\n    | top 10 by {aggregateRightLabel} {aggregateOrderRight});\r\nlet computerList=(memorySummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nInsightsMetrics\r\n    | where TimeGenerated {TimeRange}\r\n    | where Namespace == 'Memory' and Name == 'AvailableMB'\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {aggregateRightValue} by bin(TimeGenerated, ({TimeRange:end} - {TimeRange:start})/100), ResourceName",
         "size": 0,
         "aggregation": 3,
         "showAnnotations": true,
@@ -1131,9 +978,20 @@
               }
             }
           }
+        },
+        "chartSettings": {
+          "ySettings": {
+            "unit": 4,
+            "min": 0,
+            "max": null
+          }
         }
       },
-      "conditionalVisibility": null,
+      "conditionalVisibility": {
+        "parameterName": "tab",
+        "comparison": "isEqualTo",
+        "value": "top10"
+      },
       "customWidth": "50",
       "name": "query - 17"
     },
@@ -1142,7 +1000,11 @@
       "content": {
         "json": "### Bytes Sent Rate"
       },
-      "conditionalVisibility": null,
+      "conditionalVisibility": {
+        "parameterName": "tab",
+        "comparison": "isEqualTo",
+        "value": "top10"
+      },
       "customWidth": "50",
       "name": "text - 18"
     },
@@ -1151,7 +1013,11 @@
       "content": {
         "json": "### Bytes Received Rate"
       },
-      "conditionalVisibility": null,
+      "conditionalVisibility": {
+        "parameterName": "tab",
+        "comparison": "isEqualTo",
+        "value": "top10"
+      },
       "customWidth": "50",
       "name": "text - 19"
     },
@@ -1159,10 +1025,6 @@
       "type": 9,
       "content": {
         "version": "KqlParameterItem/1.0",
-        "query": "",
-        "crossComponentResources": [
-          "{Resource}"
-        ],
         "parameters": [
           {
             "id": "360da4c1-97fa-4b15-a008-33a6110d0acd",
@@ -1170,26 +1032,22 @@
             "name": "Aggregate",
             "type": 2,
             "isRequired": true,
-            "value": "P95th = round(percentile(CounterValue, 95), 2)",
-            "isHiddenWhenLocked": false,
+            "value": "P95th = round(percentile(Val, 95), 2)",
             "typeSettings": {
               "additionalResourceOptions": []
             },
-            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\"},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\"},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\"},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\"},\r\n    { \"value\":\"P80th = round(percentile(CounterValue, 80), 2)\", \"label\":\"P80th\"},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\"},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\"}\r\n]",
-            "timeContextFromParameter": null
+            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(Val), 2)\", \"label\":\"Average\"},\r\n    { \"value\":\"P5th = round(percentile(Val, 5), 2)\", \"label\":\"P5th\"},\r\n    { \"value\":\"P10th = round(percentile(Val, 10), 2)\", \"label\":\"P10th\"},\r\n    { \"value\":\"P50th = round(percentile(Val, 50), 2)\", \"label\":\"P50th\"},\r\n    { \"value\":\"P80th = round(percentile(Val, 80), 2)\", \"label\":\"P80th\"},\r\n    { \"value\":\"P90th = round(percentile(Val, 90), 2)\", \"label\":\"P90th\"},\r\n    { \"value\":\"P95th = round(percentile(Val, 95), 2)\", \"label\":\"P95th\"}\r\n]"
           },
           {
             "id": "31ccd4a1-d626-44bb-a5de-1780a33b37a5",
             "version": "KqlParameterItem/1.0",
             "name": "aggregateOrderLeft",
             "type": 1,
-            "isRequired": false,
             "query": "range Steps from 1 to 1 step 1\r\n| project value = iff('{Aggregate}' contains 'P5th'  or '{Aggregate}' contains 'P10th', 'asc', 'desc')",
             "crossComponentResources": [
               "{Resource}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
             "queryType": 0,
             "resourceType": "microsoft.compute/virtualmachinescalesets"
           },
@@ -1204,7 +1062,6 @@
               "{Resource}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
             "queryType": 0,
             "resourceType": "microsoft.compute/virtualmachinescalesets"
           },
@@ -1219,7 +1076,6 @@
               "{Resource}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
             "queryType": 0,
             "resourceType": "microsoft.compute/virtualmachinescalesets"
           }
@@ -1228,7 +1084,11 @@
         "queryType": 0,
         "resourceType": "microsoft.compute/virtualmachinescalesets"
       },
-      "conditionalVisibility": null,
+      "conditionalVisibility": {
+        "parameterName": "tab",
+        "comparison": "isEqualTo",
+        "value": "top10"
+      },
       "customWidth": "50",
       "name": "parameters - 20"
     },
@@ -1236,10 +1096,6 @@
       "type": 9,
       "content": {
         "version": "KqlParameterItem/1.0",
-        "query": "",
-        "crossComponentResources": [
-          "{Resource}"
-        ],
         "parameters": [
           {
             "id": "6772b281-d17d-4293-a227-1b2ed67f399e",
@@ -1247,26 +1103,22 @@
             "name": "Aggregate",
             "type": 2,
             "isRequired": true,
-            "value": "P95th = round(percentile(CounterValue, 95), 2)",
-            "isHiddenWhenLocked": false,
+            "value": "P95th = round(percentile(Val, 95), 2)",
             "typeSettings": {
               "additionalResourceOptions": []
             },
-            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\"},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\"},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\"},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\"},\r\n    { \"value\":\"P80th = round(percentile(CounterValue, 80), 2)\", \"label\":\"P80th\"},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\"},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\"}\r\n]",
-            "timeContextFromParameter": null
+            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(Val), 2)\", \"label\":\"Average\"},\r\n    { \"value\":\"P5th = round(percentile(Val, 5), 2)\", \"label\":\"P5th\"},\r\n    { \"value\":\"P10th = round(percentile(Val, 10), 2)\", \"label\":\"P10th\"},\r\n    { \"value\":\"P50th = round(percentile(Val, 50), 2)\", \"label\":\"P50th\"},\r\n    { \"value\":\"P80th = round(percentile(Val, 80), 2)\", \"label\":\"P80th\"},\r\n    { \"value\":\"P90th = round(percentile(Val, 90), 2)\", \"label\":\"P90th\"},\r\n    { \"value\":\"P95th = round(percentile(Val, 95), 2)\", \"label\":\"P95th\"}\r\n]"
           },
           {
             "id": "5e2eef28-0528-406f-86b5-ceae535455f9",
             "version": "KqlParameterItem/1.0",
             "name": "aggregateOrderRight",
             "type": 1,
-            "isRequired": false,
             "query": "range Steps from 1 to 1 step 1\r\n| project value = iff('{Aggregate}' contains 'P5th'  or '{Aggregate}' contains 'P10th', 'asc', 'desc')",
             "crossComponentResources": [
               "{Resource}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
             "queryType": 0,
             "resourceType": "microsoft.compute/virtualmachinescalesets"
           },
@@ -1281,7 +1133,6 @@
               "{Resource}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
             "queryType": 0,
             "resourceType": "microsoft.compute/virtualmachinescalesets"
           },
@@ -1296,7 +1147,6 @@
               "{Resource}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
             "queryType": 0,
             "resourceType": "microsoft.compute/virtualmachinescalesets"
           }
@@ -1305,7 +1155,11 @@
         "queryType": 0,
         "resourceType": "microsoft.compute/virtualmachinescalesets"
       },
-      "conditionalVisibility": null,
+      "conditionalVisibility": {
+        "parameterName": "tab",
+        "comparison": "isEqualTo",
+        "value": "top10"
+      },
       "customWidth": "50",
       "name": "parameters - 21"
     },
@@ -1313,7 +1167,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let linuxNetworkSend=Perf \r\n    | where TimeGenerated {TimeRange} \r\n    | where ObjectName == 'Network' and CounterName == 'Total Bytes Transmitted'\r\n    | order by CounterName asc, InstanceName, Computer asc, TimeGenerated asc\r\n    | extend prev_Computer=prev(Computer), prev_Value=prev(CounterValue), prev_t=prev(TimeGenerated), prev_counter=prev(CounterName), prev_instance=prev(InstanceName)\r\n    | project   TimeGenerated,            Computer,            CounterValue = iff(prev_Computer == Computer and prev_instance == InstanceName and prev_counter == CounterName and CounterValue >= prev_Value and TimeGenerated > prev_t, (CounterValue-prev_Value)/((TimeGenerated-prev_t)/1s), real(0))\r\n    | summarize hint.shufflekey=Computer CounterValue = sum(CounterValue) by Computer, bin(TimeGenerated, 2s);\r\nlet windowsNetworkSend = Perf \r\n    | where TimeGenerated {TimeRange} \r\n    | where ObjectName == 'Network Adapter' and CounterName == 'Bytes Sent/sec'\r\n    | summarize hint.shufflekey=Computer CounterValue = sum(CounterValue) by Computer, bin(TimeGenerated, 2s);\r\nlet networkDataSend = union linuxNetworkSend, windowsNetworkSend;\r\nlet networkSendSummary = totable(networkDataSend\r\n    | where TimeGenerated {TimeRange}\r\n    | summarize hint.shufflekey=Computer {aggregateLeftValue} by Computer\r\n    | top 10 by {aggregateLeftLabel} {aggregateOrderLeft});\r\nlet computerList=(networkSendSummary | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nnetworkDataSend\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {aggregateLeftValue} by bin(TimeGenerated, ({TimeRange:end} - {TimeRange:start})/100), ResourceName",
+        "query": "let memorySummary=totable(InsightsMetrics\r\n    | where TimeGenerated {TimeRange} \r\n    | where Namespace == 'Network' and Name == 'WriteBytesPerSecond'\r\n    | summarize hint.shufflekey=Computer {aggregateLeftValue} by Computer, Name\r\n    | top 10 by {aggregateLeftLabel} {aggregateOrderLeft});\r\nlet computerList=(memorySummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nInsightsMetrics\r\n    | where TimeGenerated {TimeRange}\r\n    | where Namespace == 'Network' and Name == 'WriteBytesPerSecond'\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {aggregateLeftValue} by bin(TimeGenerated, ({TimeRange:end} - {TimeRange:start})/100), ResourceName",
         "size": 0,
         "showAnnotations": true,
         "noDataMessage": "There is no data for this counter, either enable the counter or onboard machines to this workspace",
@@ -1343,9 +1197,20 @@
               }
             }
           }
+        },
+        "chartSettings": {
+          "ySettings": {
+            "unit": 2,
+            "min": 0,
+            "max": null
+          }
         }
       },
-      "conditionalVisibility": null,
+      "conditionalVisibility": {
+        "parameterName": "tab",
+        "comparison": "isEqualTo",
+        "value": "top10"
+      },
       "customWidth": "50",
       "name": "query - 22"
     },
@@ -1353,7 +1218,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let linuxNetworkReceive=Perf \r\n    | where TimeGenerated {TimeRange} \r\n    | where ObjectName == 'Network' and CounterName == 'Total Bytes Received'\r\n    | order by CounterName asc, InstanceName, Computer asc, TimeGenerated asc\r\n    | extend prev_Computer=prev(Computer), prev_Value=prev(CounterValue), prev_t=prev(TimeGenerated), prev_counter=prev(CounterName), prev_instance=prev(InstanceName)\r\n    | project   TimeGenerated,            Computer,            CounterValue = iff(prev_Computer == Computer and prev_instance == InstanceName and prev_counter == CounterName and CounterValue >= prev_Value and TimeGenerated > prev_t, (CounterValue-prev_Value)/((TimeGenerated-prev_t)/1s), real(0))\r\n    | summarize hint.shufflekey=Computer CounterValue = sum(CounterValue) by Computer, bin(TimeGenerated, 2s);\r\nlet windowsNetworkReceive = Perf \r\n    | where TimeGenerated {TimeRange} \r\n    | where ObjectName == 'Network Adapter' and CounterName == 'Bytes Received/sec'\r\n    | summarize hint.shufflekey=Computer CounterValue = sum(CounterValue) by Computer, bin(TimeGenerated, 2s);\r\nlet networkDataReceive = union linuxNetworkReceive, windowsNetworkReceive;\r\nlet networkReceiveSummary = totable(networkDataReceive\r\n    | where TimeGenerated {TimeRange}\r\n    | summarize hint.shufflekey=Computer {aggregateRightValue} by Computer\r\n    | top 10 by {aggregateRightLabel} {aggregateOrderRight});\r\nlet computerList=(networkReceiveSummary | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nnetworkDataReceive\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {aggregateRightValue} by bin(TimeGenerated, ({TimeRange:end} - {TimeRange:start})/100), ResourceName",
+        "query": "let memorySummary=totable(InsightsMetrics\r\n    | where TimeGenerated {TimeRange} \r\n    | where Namespace == 'Network' and Name == 'ReadBytesPerSecond'\r\n    | summarize hint.shufflekey=Computer {aggregateRightValue} by Computer, Name\r\n    | top 10 by {aggregateRightLabel} {aggregateOrderRight});\r\nlet computerList=(memorySummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nInsightsMetrics\r\n    | where TimeGenerated {TimeRange}\r\n    | where Namespace == 'Network' and Name == 'ReadBytesPerSecond'\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {aggregateRightValue} by bin(TimeGenerated, ({TimeRange:end} - {TimeRange:start})/100), ResourceName",
         "size": 0,
         "showAnnotations": true,
         "noDataMessage": "There is no data for this counter, either enable the counter or onboard machines to this workspace",
@@ -1383,9 +1248,20 @@
               }
             }
           }
+        },
+        "chartSettings": {
+          "ySettings": {
+            "unit": 2,
+            "min": 0,
+            "max": null
+          }
         }
       },
-      "conditionalVisibility": null,
+      "conditionalVisibility": {
+        "parameterName": "tab",
+        "comparison": "isEqualTo",
+        "value": "top10"
+      },
       "customWidth": "50",
       "name": "query - 23"
     },
@@ -1394,7 +1270,11 @@
       "content": {
         "json": "### Logical Disk Space Used %"
       },
-      "conditionalVisibility": null,
+      "conditionalVisibility": {
+        "parameterName": "tab",
+        "comparison": "isEqualTo",
+        "value": "top10"
+      },
       "customWidth": "50",
       "name": "text - 24"
     },
@@ -1403,7 +1283,11 @@
       "content": {
         "json": ""
       },
-      "conditionalVisibility": null,
+      "conditionalVisibility": {
+        "parameterName": "tab",
+        "comparison": "isEqualTo",
+        "value": "top10"
+      },
       "customWidth": "50",
       "name": "text - 25"
     },
@@ -1411,10 +1295,6 @@
       "type": 9,
       "content": {
         "version": "KqlParameterItem/1.0",
-        "query": "",
-        "crossComponentResources": [
-          "{Resource}"
-        ],
         "parameters": [
           {
             "id": "5d6afbec-79f6-4cd1-b3a1-361503478304",
@@ -1422,26 +1302,22 @@
             "name": "Aggregate",
             "type": 2,
             "isRequired": true,
-            "value": "P95th = round(percentile(CounterValue, 95), 2)",
-            "isHiddenWhenLocked": false,
+            "value": "P95th = round(percentile(Val, 95), 2)",
             "typeSettings": {
               "additionalResourceOptions": []
             },
-            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\"},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\"},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\"},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\"},\r\n    { \"value\":\"P80th = round(percentile(CounterValue, 80), 2)\", \"label\":\"P80th\"},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\"},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\"}\r\n]",
-            "timeContextFromParameter": null
+            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(Val), 2)\", \"label\":\"Average\"},\r\n    { \"value\":\"P5th = round(percentile(Val, 5), 2)\", \"label\":\"P5th\"},\r\n    { \"value\":\"P10th = round(percentile(Val, 10), 2)\", \"label\":\"P10th\"},\r\n    { \"value\":\"P50th = round(percentile(Val, 50), 2)\", \"label\":\"P50th\"},\r\n    { \"value\":\"P80th = round(percentile(Val, 80), 2)\", \"label\":\"P80th\"},\r\n    { \"value\":\"P90th = round(percentile(Val, 90), 2)\", \"label\":\"P90th\"},\r\n    { \"value\":\"P95th = round(percentile(Val, 95), 2)\", \"label\":\"P95th\"}\r\n]"
           },
           {
             "id": "1d5a805c-acce-4afe-a38b-c2740fb3ff26",
             "version": "KqlParameterItem/1.0",
             "name": "aggregateOrder",
             "type": 1,
-            "isRequired": false,
             "query": "range Steps from 1 to 1 step 1\r\n| project value = iff('{Aggregate}' contains 'P5th'  or '{Aggregate}' contains 'P10th', 'asc', 'desc')",
             "crossComponentResources": [
               "{Resource}"
             ],
             "isHiddenWhenLocked": true,
-            "timeContextFromParameter": null,
             "queryType": 0,
             "resourceType": "microsoft.compute/virtualmachinescalesets"
           }
@@ -1450,7 +1326,11 @@
         "queryType": 0,
         "resourceType": "microsoft.compute/virtualmachinescalesets"
       },
-      "conditionalVisibility": null,
+      "conditionalVisibility": {
+        "parameterName": "tab",
+        "comparison": "isEqualTo",
+        "value": "top10"
+      },
       "customWidth": "50",
       "name": "parameters - 26"
     },
@@ -1459,7 +1339,11 @@
       "content": {
         "json": ""
       },
-      "conditionalVisibility": null,
+      "conditionalVisibility": {
+        "parameterName": "tab",
+        "comparison": "isEqualTo",
+        "value": "top10"
+      },
       "customWidth": "50",
       "name": "text - 27"
     },
@@ -1467,7 +1351,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let diskSummary=totable(Perf\r\n    | where TimeGenerated {TimeRange} \r\n    | where (ObjectName == 'LogicalDisk' and InstanceName != '_Total' and CounterName in ('% Free Space')) or        (ObjectName == 'Logical Disk' and InstanceName != '_Total' and CounterName in ('% Used Space'))\r\n    | project TimeGenerated, Computer,    CounterName = '% Used Space',    CounterValue = case(ObjectName == 'LogicalDisk' and CounterName == '% Free Space', 100 - CounterValue,                CounterValue < 0, real(0),                CounterValue)\r\n    | summarize hint.shufflekey=Computer {Aggregate} by Computer, CounterName\r\n    | top 10 by {Aggregate:label} {aggregateOrder});\r\nlet computerList=(diskSummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nPerf\r\n    | where TimeGenerated {TimeRange}\r\n    | where (ObjectName == 'LogicalDisk' and InstanceName != '_Total' and CounterName in ('% Free Space')) or        (ObjectName == 'Logical Disk' and InstanceName != '_Total' and CounterName in ('% Used Space'))\r\n    | where Computer in (computerList)\r\n    | project TimeGenerated, Computer,    CounterName = '% Used Space',    CounterValue = case(ObjectName == 'LogicalDisk' and CounterName == '% Free Space', 100 - CounterValue,                CounterValue < 0, real(0),                CounterValue)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {Aggregate} by bin(TimeGenerated, ({TimeRange:end} - {TimeRange:start})/100), ResourceName",
+        "query": "let memorySummary=totable(InsightsMetrics\r\n    | where TimeGenerated {TimeRange} \r\n    | where Namespace == 'LogicalDisk' and Name == 'FreeSpacePercentage'\r\n\t| extend Val = 100 - Val\r\n    | summarize hint.shufflekey=Computer {aggregateLeftValue} by Computer, Name\r\n    | top 10 by {aggregateLeftLabel} {aggregateOrderLeft});\r\nlet computerList=(memorySummary \r\n    | project Computer);\r\nlet EmptyNodeIdentityAndProps = datatable(Computer:string, NodeId:string, NodeProps:dynamic, Priority: long) [];\r\nlet OmsNodeIdentityAndProps = computerList\r\n    | extend NodeId = Computer\r\n    | extend Priority = 1\r\n    | extend NodeProps = pack('type', 'StandAloneNode', 'name', Computer);\r\nlet ServiceMapNodeIdentityAndProps = ServiceMapComputer_CL\r\n    | where TimeGenerated {TimeRange}\r\n    | where Computer in (computerList)\r\n    | summarize arg_max(TimeGenerated, *) by Computer\r\n    | extend Computer = ComputerName_s, AzureCloudServiceNodeIdentity = iif(isnotempty(columnifexists('AzureCloudServiceName_s', '')), strcat(columnifexists('AzureCloudServiceInstanceId_s', ''), '|',                     columnifexists('AzureCloudServiceDeployment_g', '')), ''),          AzureScaleSetNodeIdentity = iif(isnotempty(columnifexists('AzureVmScaleSetName_s', '')),              strcat(columnifexists('AzureVmScaleSetInstanceId_s', ''), '|',                     columnifexists('AzureVmScaleSetDeployment_g', '')), ''),          ComputerProps =              pack('type', 'StandAloneNode',                   'name', ComputerName_s,                   'mappingResourceId', ResourceId,                   'subscriptionId', AzureSubscriptionId_g,                   'resourceGroup', AzureResourceGroup_s,                   'azureResourceId', columnifexists('AzureResourceId_s', '')),          AzureCloudServiceNodeProps =              pack('type', 'AzureCloudServiceNode',                   'cloudServiceInstanceId', columnifexists('AzureCloudServiceInstanceId_s', ''),                   'cloudServiceRoleName', columnifexists('AzureCloudServiceRoleName_s', ''),                   'cloudServiceDeploymentId', columnifexists('AzureCloudServiceDeployment_g', ''),                   'cloudServiceName', columnifexists('AzureCloudServiceName_s', ''),                   'mappingResourceId', ResourceId),          AzureScaleSetNodeProps =               pack('type', 'AzureScaleSetNode',                   'scaleSetInstanceId', columnifexists('AzureName_s', ''),                   'vmScaleSetDeploymentId', columnifexists('AzureVmScaleSetDeployment_g', ''),                   'vmScaleSetName', columnifexists('AzureVmScaleSetName_s', ''),                   'serviceFabricClusterName', columnifexists('AzureServiceFabricClusterName_s', ''),                   'vmScaleSetResourceId', columnifexists('AzureVmScaleSetResourceId_s', ''),                   'resourceGroupName', columnifexists('AzureResourceGroup_s', ''),                   'subscriptionId', columnifexists('AzureSubscriptionId_g', ''),                   'mappingResourceId', ResourceId)| project   Computer,            NodeId = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeIdentity,                       isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeIdentity, Computer),            NodeProps = case(isnotempty(AzureCloudServiceNodeIdentity), AzureCloudServiceNodeProps,                          isnotempty(AzureScaleSetNodeIdentity), AzureScaleSetNodeProps, ComputerProps),            Priority = 2;\r\nlet NodeIdentityAndProps = union kind=inner isfuzzy = true                                  EmptyNodeIdentityAndProps, OmsNodeIdentityAndProps, ServiceMapNodeIdentityAndProps                            \r\n    | summarize arg_max(Priority, *) by Computer; \r\nlet NodeIdentityAndPropsMin = NodeIdentityAndProps\r\n    | extend Kind = iff(NodeProps.type == \"StandAloneNode\", iff(NodeProps.azureResourceId == \"\", \"Non-Azure Virtual Machine\", \"Azure Virtual Machine\"), NodeProps.type), \r\n    ResourceId = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.vmScaleSetResourceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceDeploymentId, Computer)),\r\n    ResourceName = iff(NodeProps.type == \"AzureScaleSetNode\", NodeProps.scaleSetInstanceId, \r\n        iff(NodeProps.type == \"AzureCloudServiceNode\", NodeProps.cloudServiceInstanceId, Computer))\r\n    | project Computer, Kind, ResourceId, ResourceName;\r\nInsightsMetrics\r\n    | where TimeGenerated {TimeRange}\r\n    | where Namespace == 'LogicalDisk' and Name == 'FreeSpacePercentage'\r\n\t| extend Val = 100 - Val\r\n    | where Computer in (computerList)\r\n    | join kind=leftouter (NodeIdentityAndPropsMin) on Computer\r\n    | summarize {aggregateLeftValue} by bin(TimeGenerated, ({TimeRange:end} - {TimeRange:start})/100), ResourceName",
         "size": 0,
         "aggregation": 3,
         "showAnnotations": true,
@@ -1498,9 +1382,20 @@
               }
             }
           }
+        },
+        "chartSettings": {
+          "ySettings": {
+            "unit": 1,
+            "min": 0,
+            "max": 100
+          }
         }
       },
-      "conditionalVisibility": null,
+      "conditionalVisibility": {
+        "parameterName": "tab",
+        "comparison": "isEqualTo",
+        "value": "top10"
+      },
       "customWidth": "50",
       "name": "query - 28"
     }

--- a/Workbooks/Virtual Machine Scale Sets - Performance Analysis/Performance Analysis/settings.json
+++ b/Workbooks/Virtual Machine Scale Sets - Performance Analysis/Performance Analysis/settings.json
@@ -3,7 +3,6 @@
     "name":"Performance",
     "author": "Microsoft",
     "galleries": [
-        { "type": "workbook", "resourceType": "microsoft.compute/virtualmachinescalesets", "order": 175 },
-        { "type": "insights", "resourceType": "microsoft.compute/virtualmachinescalesets", "order": 175 }
+        { "type": "insights", "resourceType": "microsoft.compute/virtualmachinescalesets", "categoryKey": "vmInsightsVirtualMachinesInsightsMetrics", "order": 175 }
     ]
 }


### PR DESCRIPTION
Update VMSS Perf workbooks to use InsightsMetrics. The regular and preview templates are the same, the preview will eventually be deprecated as with the other VM Insights templates. The Perf based iteration was copied over with the Perf suffix.

Signed-off-by: andrewki-msft <43890980+andrewki-msft@users.noreply.github.com>

Test
-

VMSS Perf
![image](https://user-images.githubusercontent.com/43890980/76695091-11241300-6638-11ea-8290-c7e49af5a642.png)

VMSS InsightsMetrics
![image](https://user-images.githubusercontent.com/43890980/76695095-2a2cc400-6638-11ea-9bb8-1842b2090f5a.png)
