### PR TITLE
Adding storage-account-insights type

### DIFF
--- a/Workbooks/Individual Storage/Availability/settings.json
+++ b/Workbooks/Individual Storage/Availability/settings.json
@@ -2,5 +2,8 @@
     "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/settings.json",
     "name":"Availability",
     "author": "Microsoft",
-    "galleries": [{ "type": "workbook", "resourceType": "microsoft.storage/storageaccounts", "order": 400 }]
+    "galleries": [
+        { "type": "workbook", "resourceType": "microsoft.storage/storageaccounts", "order": 400 },
+        { "type": "storage-account-insights", "resourceType": "microsoft.storage/storageaccounts", "order": 400 }
+    ]
 }

--- a/Workbooks/Individual Storage/Capacity/settings.json
+++ b/Workbooks/Individual Storage/Capacity/settings.json
@@ -2,5 +2,8 @@
     "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/settings.json",
     "name":"Capacity",
     "author": "Microsoft",
-    "galleries": [{ "type": "workbook", "resourceType": "microsoft.storage/storageaccounts", "order": 500 }]
+    "galleries": [
+        { "type": "workbook", "resourceType": "microsoft.storage/storageaccounts", "order": 500 },
+        { "type": "storage-account-insights", "resourceType": "microsoft.storage/storageaccounts", "order": 500 }
+    ]
 }

--- a/Workbooks/Individual Storage/Failures/settings.json
+++ b/Workbooks/Individual Storage/Failures/settings.json
@@ -2,5 +2,8 @@
     "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/settings.json",
     "name":"Failures",
     "author": "Microsoft",
-    "galleries": [{ "type": "workbook", "resourceType": "microsoft.storage/storageaccounts", "order": 200 }]
+    "galleries": [
+        { "type": "workbook", "resourceType": "microsoft.storage/storageaccounts", "order": 200 },
+        { "type": "storage-account-insights", "resourceType": "microsoft.storage/storageaccounts", "order": 200 }
+    ]
 }

--- a/Workbooks/Individual Storage/Overview/settings.json
+++ b/Workbooks/Individual Storage/Overview/settings.json
@@ -2,5 +2,8 @@
     "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/settings.json",
     "name":"Storage Account Overview",
     "author": "Microsoft",
-    "galleries": [{ "type": "workbook", "resourceType": "microsoft.storage/storageaccounts", "order": 100 }]
+    "galleries": [
+        { "type": "workbook", "resourceType": "microsoft.storage/storageaccounts", "order": 100 },
+        { "type": "storage-account-insights", "resourceType": "microsoft.storage/storageaccounts", "order": 100 }
+    ]
 }

--- a/Workbooks/Individual Storage/Performance/settings.json
+++ b/Workbooks/Individual Storage/Performance/settings.json
@@ -2,5 +2,7 @@
     "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/settings.json",
     "name":"Performance",
     "author": "Microsoft",
-    "galleries": [{ "type": "workbook", "resourceType": "microsoft.storage/storageaccounts", "order": 300 }]
-}
+    "galleries": [
+        { "type": "workbook", "resourceType": "microsoft.storage/storageaccounts", "order": 300 },
+        { "type": "storage-account-insights", "resourceType": "microsoft.storage/storageaccounts", "order": 300 }
+    ]}


### PR DESCRIPTION
Currently all the storage account workbooks are of type 'Workbook'. When switching to the WorkbookViewerBlades, they aren't recognized as insightsMode and the tool bar just becomes a refresh symbol. 

Looks like we need to create the 'storage-account-insights' workbook type and change all storage account workbook types to 'storage-account'. The development process will be similar to storage insights migration.

This PR is to copy the templates over to the storage account gallery with the type 'storage-account-insights'.

## PR Checklist

* [ ] Explain your changes, so people looking at the PR know *what* and *why*, the code changes are the *how*.
* [ ] *if updating templates, it is helpful to post a screenshot of what the changes look like.*
* [ ] *if updating templates, ensure that your parameters and steps have meaningful names.*
* [ ] *if adding new templates, or changing items in a gallery, it's helpful to post a screenshot of what the gallery looks like now*
