### PR TITLE
Optimize Performance Counters templates

### DIFF
--- a/Workbooks/Virtual Machines - Performance Analysis/Performance Counters (Perf)/Performance Counters (Perf).workbook
+++ b/Workbooks/Virtual Machines - Performance Analysis/Performance Counters (Perf)/Performance Counters (Perf).workbook
@@ -47,7 +47,7 @@
             "version": "KqlParameterItem/1.0",
             "name": "ContextSelection",
             "type": 1,
-            "query": "// {DefaultWorkspace}\r\nwhere strcat(\"'\", id, \"'\") =~ \"{DefaultWorkspace:value}\"\r\n| project value = tostring(pack('sub', subscriptionId, 'rg', resourceGroup, 'ws', id))",
+            "query": "where strcat(\"'\", id, \"'\") =~ \"{DefaultWorkspace:value}\"\r\n| project value = tostring(pack('sub', subscriptionId, 'rg', resourceGroup, 'ws', id))",
             "crossComponentResources": [
               "value::all"
             ],
@@ -60,7 +60,7 @@
             "version": "KqlParameterItem/1.0",
             "name": "HybridMode",
             "type": 1,
-            "value": null,
+            "value": "true",
             "isHiddenWhenLocked": true,
             "criteriaData": [
               {
@@ -93,7 +93,7 @@
             "multiSelect": true,
             "quote": "'",
             "delimiter": ",",
-            "query": "// {DefaultWorkspace} {ContextSelection} {DefaultSubscription}\r\nsummarize by subscriptionId\r\n| project strcat('/subscriptions/', subscriptionId), selected = iff({HybridMode} == true, iff(subscriptionId == todynamic('{ContextSelection}').sub, true, false), iff(strcat('/subscriptions/', subscriptionId) == '{DefaultSubscription}', true, false))",
+            "query": "summarize by subscriptionId\r\n| project strcat('/subscriptions/', subscriptionId), selected = iff({HybridMode} == true, iff(subscriptionId == todynamic('{ContextSelection}').sub, true, false), iff(strcat('/subscriptions/', subscriptionId) == '{DefaultSubscription}', true, false))",
             "crossComponentResources": [
               "value::all"
             ],
@@ -112,7 +112,7 @@
             "multiSelect": true,
             "quote": "'",
             "delimiter": ",",
-            "query": "// {DefaultWorkspace} {ContextSelection} {Subscriptions}\r\nwhere type =~ 'microsoft.operationalinsights/workspaces'\r\n| summarize by id, name\r\n| order by tolower(name) asc\r\n| extend Row = row_number()\r\n| project id, selected = iff({HybridMode} == 'true', iff(id == todynamic('{ContextSelection}').ws, true, false), Row == 1)",
+            "query": "where type =~ 'microsoft.operationalinsights/workspaces'\r\n| summarize by id, name\r\n| order by tolower(name) asc\r\n| extend Row = row_number()\r\n| project id, selected = iff({HybridMode} == 'true', iff(id == todynamic('{ContextSelection}').ws, true, false), Row == 1)",
             "crossComponentResources": [
               "{Subscriptions}"
             ],
@@ -255,12 +255,9 @@
             "version": "KqlParameterItem/1.0",
             "name": "LineChartQuerySnippet",
             "type": 1,
-            "query": "print(\"bin(TimeGenerated, {TimeGrain}), ResourceName | render linechart\")",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
+            "query": "{\"version\":\"1.0.0\",\"content\":\"\\\"bin(TimeGenerated, {TimeGrain}), ResourceName | render linechart\\\"\",\"transformers\":null}",
             "isHiddenWhenLocked": true,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "queryType": 8
           },
           {
             "id": "7055a395-0d53-4724-93ad-15e03d4e2ffa",
@@ -306,6 +303,7 @@
             "typeSettings": {
               "additionalResourceOptions": []
             },
+            "queryType": 0,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
           {
@@ -313,12 +311,30 @@
             "version": "KqlParameterItem/1.0",
             "name": "ComputerFilter",
             "type": 1,
-            "query": "let computerFilter = iff('*' in ({Computers}), \"{CustomComputerQuery}\", \"| where Computer in ({Computers})\");\r\nprint(computerFilter)",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
+            "value": null,
             "isHiddenWhenLocked": true,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "criteriaData": [
+              {
+                "condition": "if (Computers contains '*'), result = CustomComputerQuery",
+                "criteriaContext": {
+                  "leftOperand": "Computers",
+                  "operator": "contains",
+                  "rightValType": "static",
+                  "rightVal": "*",
+                  "resultValType": "param",
+                  "resultVal": "CustomComputerQuery"
+                }
+              },
+              {
+                "condition": "else result = '| where Computer in ({Computers})'",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "static",
+                  "resultVal": "| where Computer in ({Computers})"
+                }
+              }
+            ]
           },
           {
             "id": "9c56155c-9a7e-41db-ac56-40cabb7d7ddf",
@@ -326,11 +342,7 @@
             "name": "TopN",
             "type": 1,
             "isRequired": true,
-            "query": "print 5",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "value": "5"
           },
           {
             "id": "4261aa48-5274-47a9-8642-1618c8aa7a95",
@@ -350,11 +362,14 @@
             "name": "Test",
             "label": "Not Onboarded",
             "type": 1,
-            "query": "VMConnection\r\n| take 1\r\n| summarize count()",
+            "query": "Perf\r\n| take 1\r\n| summarize count()",
             "crossComponentResources": [
               "{Workspaces}"
             ],
             "isHiddenWhenLocked": true,
+            "timeContext": {
+              "durationMs": 0
+            },
             "timeContextFromParameter": "TimeRange",
             "queryType": 0,
             "resourceType": "microsoft.operationalinsights/workspaces"
@@ -399,15 +414,20 @@
             "name": "Counter",
             "type": 2,
             "isRequired": true,
-            "query": "// {Workspaces}\r\nPerf\r\n| where TimeGenerated {TimeRange}\r\n| summarize by CounterName, ObjectName, CounterText = CounterName\r\n| order by ObjectName asc, CounterText asc\r\n| project Counter = pack('counter', CounterName, 'object', ObjectName), CounterText, group = ObjectName",
+            "query": "Perf\r\n| where TimeGenerated {TimeRange}\r\n| summarize by CounterName, ObjectName, CounterText = CounterName\r\n| order by ObjectName asc, CounterText asc\r\n| project Counter = pack('counter', CounterName, 'object', ObjectName), CounterText, group = ObjectName",
             "crossComponentResources": [
               "{Workspaces}"
             ],
             "typeSettings": {
               "additionalResourceOptions": []
             },
+            "timeContext": {
+              "durationMs": 0
+            },
+            "timeContextFromParameter": "TimeRange",
+            "queryType": 0,
             "resourceType": "microsoft.operationalinsights/workspaces",
-            "value": "{\"counter\":\"% Processor Time\",\"object\":\"Processor\"}"
+            "value": "{\"counter\":\"% Processor Time\",\"object\":\"Process\"}"
           },
           {
             "id": "6a7306ea-247f-46ca-abca-501911f9e9d3",
@@ -425,12 +445,41 @@
             "version": "KqlParameterItem/1.0",
             "name": "TrendAggregatorOrder1",
             "type": 1,
-            "query": "print(iff('{TrendAggregator:label}' == 'P5th'  or '{TrendAggregator:label}' == 'P10th', 'asc', 'desc'))",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
+            "value": "desc",
             "isHiddenWhenLocked": true,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "criteriaData": [
+              {
+                "condition": "if (TrendAggregator contains 'P5th'), result = 'asc'",
+                "criteriaContext": {
+                  "leftOperand": "TrendAggregator",
+                  "operator": "contains",
+                  "rightValType": "static",
+                  "rightVal": "P5th",
+                  "resultValType": "static",
+                  "resultVal": "asc"
+                }
+              },
+              {
+                "condition": "if (TrendAggregator contains 'P10th'), result = 'asc'",
+                "criteriaContext": {
+                  "leftOperand": "TrendAggregator",
+                  "operator": "contains",
+                  "rightValType": "static",
+                  "rightVal": "P10th",
+                  "resultValType": "static",
+                  "resultVal": "asc"
+                }
+              },
+              {
+                "condition": "else result = 'desc'",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "static",
+                  "resultVal": "desc"
+                }
+              }
+            ]
           },
           {
             "id": "d026cf36-d22e-4f92-a577-94220726ba3f",
@@ -438,14 +487,10 @@
             "name": "Visualization",
             "type": 2,
             "isRequired": true,
-            "query": "datatable (value:long, Display:string, isSelected:boolean)\r\n    [0, \"Line Chart\", true,\r\n     1, \"Grid\", false]",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
             "typeSettings": {
               "additionalResourceOptions": []
             },
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "jsonData": "[\r\n    {\r\n        \"value\": \"0\",\r\n        \"label\": \"Line Chart\",\r\n        \"selected\": true\r\n    },\r\n    {\r\n        \"value\": \"1\",\r\n        \"label\": \"Grid\",\r\n        \"selected\": false\r\n    }\r\n]"
           },
           {
             "id": "a9ac011f-176f-4c31-b82e-139aba93a426",
@@ -453,60 +498,76 @@
             "name": "Snippet1",
             "type": 1,
             "isRequired": true,
-            "query": "print(iff({Visualization} == 0, \"{LineChartQuerySnippet}\", \"{GridQuerySnippet}\") )",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
+            "value": "bin(TimeGenerated, 15m), ResourceName | render linechart",
             "isHiddenWhenLocked": true,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "criteriaData": [
+              {
+                "condition": "if (Visualization == '0'), result = LineChartQuerySnippet",
+                "criteriaContext": {
+                  "leftOperand": "Visualization",
+                  "operator": "==",
+                  "rightValType": "static",
+                  "rightVal": "0",
+                  "resultValType": "param",
+                  "resultVal": "LineChartQuerySnippet"
+                }
+              },
+              {
+                "condition": "else result = GridQuerySnippet",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "param",
+                  "resultVal": "GridQuerySnippet"
+                }
+              }
+            ]
           },
           {
             "id": "2c9b88ba-fba2-41cf-b10d-8369f2b00377",
             "version": "KqlParameterItem/1.0",
             "name": "Counter1",
             "type": 1,
-            "query": "print '{Counter}'",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
+            "value": "{\"counter\":\"% Processor Time\",\"object\":\"Process\"}",
             "isHiddenWhenLocked": true,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "criteriaData": [
+              {
+                "condition": "else result = Counter",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "param",
+                  "resultVal": "Counter"
+                }
+              }
+            ]
           },
           {
             "id": "028cfd79-33d7-4d82-be4d-348d17488ca1",
             "version": "KqlParameterItem/1.0",
             "name": "CounterLabel1",
             "type": 1,
-            "query": "print '{Counter:label}'",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
+            "query": "{\"version\":\"1.0.0\",\"content\":\"\\\"{Counter:label}\\\"\",\"transformers\":null}",
             "isHiddenWhenLocked": true,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "queryType": 8
           },
           {
             "id": "41eb7c98-b679-42b9-8454-432a4b8fff48",
             "version": "KqlParameterItem/1.0",
             "name": "TrendAggregatorValue1",
             "type": 1,
-            "query": "print '{TrendAggregator}'",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
+            "query": "{\"version\":\"1.0.0\",\"content\":\"\\\"{TrendAggregator}\\\"\",\"transformers\":null}",
             "isHiddenWhenLocked": true,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "queryType": 8
           },
           {
             "id": "5c8cbc8c-1776-42fd-9291-2fc4f0e0558b",
             "version": "KqlParameterItem/1.0",
             "name": "TrendAggregatorLabel1",
             "type": 1,
-            "query": "print '{TrendAggregator:label}'",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
+            "query": "{\"version\":\"1.0.0\",\"content\":\"\\\"{TrendAggregator:label}\\\"\",\"transformers\":null}",
             "isHiddenWhenLocked": true,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "queryType": 8
           },
           {
             "id": "26106dfe-4e33-4c7c-b4b6-2eff5cc76476",
@@ -555,13 +616,18 @@
             "name": "Counter2",
             "type": 2,
             "isRequired": true,
-            "query": "// {Workspaces}\r\nPerf\r\n| where TimeGenerated {TimeRange}\r\n| summarize by CounterName, ObjectName, CounterText = CounterName\r\n| order by ObjectName asc, CounterText asc\r\n| project Counter = pack('counter', CounterName, 'object', ObjectName), CounterText, group = ObjectName",
+            "query": "Perf\r\n| where TimeGenerated {TimeRange}\r\n| summarize by CounterName, ObjectName, CounterText = CounterName\r\n| order by ObjectName asc, CounterText asc\r\n| project Counter = pack('counter', CounterName, 'object', ObjectName), CounterText, group = ObjectName",
             "crossComponentResources": [
               "{Workspaces}"
             ],
             "typeSettings": {
               "additionalResourceOptions": []
             },
+            "timeContext": {
+              "durationMs": 0
+            },
+            "timeContextFromParameter": "TimeRange",
+            "queryType": 0,
             "resourceType": "microsoft.operationalinsights/workspaces",
             "value": "{\"counter\":\"% Available Memory\",\"object\":\"Memory\"}"
           },
@@ -571,6 +637,9 @@
             "name": "TrendAggregator2",
             "type": 2,
             "isRequired": true,
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
             "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\", \"selected\":false},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\", \"selected\":false},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P80th = round(percentile(CounterValue, 80), 2)\", \"label\":\"P80th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\", \"selected\":true}    \r\n]"
           },
           {
@@ -578,43 +647,113 @@
             "version": "KqlParameterItem/1.0",
             "name": "TrendAggregatorOrder2",
             "type": 1,
-            "query": "print(iff('{TrendAggregator2:label}' == 'P5th'  or '{TrendAggregator2:label}' == 'P10th', 'asc', 'desc'))",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
+            "value": "desc",
             "isHiddenWhenLocked": true,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "criteriaData": [
+              {
+                "condition": "if (TrendAggregator2 contains 'P5th'), result = 'asc'",
+                "criteriaContext": {
+                  "leftOperand": "TrendAggregator2",
+                  "operator": "contains",
+                  "rightValType": "static",
+                  "rightVal": "P5th",
+                  "resultValType": "static",
+                  "resultVal": "asc"
+                }
+              },
+              {
+                "condition": "if (TrendAggregator2 contains 'P10th'), result = 'asc'",
+                "criteriaContext": {
+                  "leftOperand": "TrendAggregator2",
+                  "operator": "contains",
+                  "rightValType": "static",
+                  "rightVal": "P10th",
+                  "resultValType": "static",
+                  "resultVal": "asc"
+                }
+              },
+              {
+                "condition": "else result = 'desc'",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "static",
+                  "resultVal": "desc"
+                }
+              }
+            ]
           },
           {
-            "id": "bf55b759-7b6a-4ea6-8040-e3e6cc2ffe25",
+            "id": "d026cf36-d22e-4f92-a577-94220726ba3f",
             "version": "KqlParameterItem/1.0",
             "name": "Visualization2",
             "type": 2,
             "isRequired": true,
-            "query": "datatable (value:long, Display:string, isSelected:boolean)\r\n    [0, \"Line Chart\", true,\r\n     1, \"Grid\", false]",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
             "typeSettings": {
               "additionalResourceOptions": []
             },
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "jsonData": "[\r\n    {\r\n        \"value\": \"0\",\r\n        \"label\": \"Line Chart\",\r\n        \"selected\": true\r\n    },\r\n    {\r\n        \"value\": \"1\",\r\n        \"label\": \"Grid\",\r\n        \"selected\": false\r\n    }\r\n]"
           },
           {
-            "id": "de7bf116-f413-457b-8c71-fb95cc6adc87",
+            "id": "a9ac011f-176f-4c31-b82e-139aba93a426",
             "version": "KqlParameterItem/1.0",
             "name": "Snippet2",
             "type": 1,
             "isRequired": true,
-            "query": "print(iff({Visualization2} == 0, \"{LineChartQuerySnippet}\", \"{GridQuerySnippet}\") )",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
+            "value": "bin(TimeGenerated, 15m), ResourceName | render linechart",
             "isHiddenWhenLocked": true,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "criteriaData": [
+              {
+                "condition": "if (Visualization2 == '0'), result = LineChartQuerySnippet",
+                "criteriaContext": {
+                  "leftOperand": "Visualization2",
+                  "operator": "==",
+                  "rightValType": "static",
+                  "rightVal": "0",
+                  "resultValType": "param",
+                  "resultVal": "LineChartQuerySnippet"
+                }
+              },
+              {
+                "condition": "else result = GridQuerySnippet",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "param",
+                  "resultVal": "GridQuerySnippet"
+                }
+              }
+            ]
           },
           {
-            "id": "2ce20c70-a462-4c7d-b5af-7f3b4cc27511",
+            "id": "028cfd79-33d7-4d82-be4d-348d17488ca1",
+            "version": "KqlParameterItem/1.0",
+            "name": "CounterLabel2",
+            "type": 1,
+            "query": "{\"version\":\"1.0.0\",\"content\":\"\\\"{Counter2:label}\\\"\",\"transformers\":null}",
+            "isHiddenWhenLocked": true,
+            "queryType": 8
+          },
+          {
+            "id": "41eb7c98-b679-42b9-8454-432a4b8fff48",
+            "version": "KqlParameterItem/1.0",
+            "name": "TrendAggregatorValue2",
+            "type": 1,
+            "query": "{\"version\":\"1.0.0\",\"content\":\"\\\"{TrendAggregator2}\\\"\",\"transformers\":null}",
+            "isHiddenWhenLocked": true,
+            "queryType": 8
+          },
+          {
+            "id": "5c8cbc8c-1776-42fd-9291-2fc4f0e0558b",
+            "version": "KqlParameterItem/1.0",
+            "name": "TrendAggregatorLabel2",
+            "type": 1,
+            "query": "{\"version\":\"1.0.0\",\"content\":\"\\\"{TrendAggregator2:label}\\\"\",\"transformers\":null}",
+            "isHiddenWhenLocked": true,
+            "queryType": 8
+          },
+          {
+            "id": "26106dfe-4e33-4c7c-b4b6-2eff5cc76476",
             "version": "KqlParameterItem/1.0",
             "name": "Unit2",
             "type": 2,
@@ -660,15 +799,18 @@
             "name": "Counter3",
             "type": 2,
             "isRequired": true,
-            "query": "// {Workspaces}\r\nPerf\r\n| where TimeGenerated {TimeRange}\r\n| summarize by CounterName, ObjectName, CounterText = CounterName\r\n| order by ObjectName asc, CounterText asc\r\n| project Counter = pack('counter', CounterName, 'object', ObjectName), CounterText, group = ObjectName",
+            "query": "Perf\r\n| where TimeGenerated {TimeRange}\r\n| summarize by CounterName, ObjectName, CounterText = CounterName\r\n| order by ObjectName asc, CounterText asc\r\n| project Counter = pack('counter', CounterName, 'object', ObjectName), CounterText, group = ObjectName",
             "crossComponentResources": [
               "{Workspaces}"
             ],
             "typeSettings": {
-              "additionalResourceOptions": [
-                "value::1"
-              ]
+              "additionalResourceOptions": []
             },
+            "timeContext": {
+              "durationMs": 0
+            },
+            "timeContextFromParameter": "TimeRange",
+            "queryType": 0,
             "resourceType": "microsoft.operationalinsights/workspaces",
             "value": "{\"counter\":\"Bytes Sent/sec\",\"object\":\"Network Adapter\"}"
           },
@@ -678,6 +820,9 @@
             "name": "TrendAggregator3",
             "type": 2,
             "isRequired": true,
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
             "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\", \"selected\":false},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\", \"selected\":false},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P80th = round(percentile(CounterValue, 80), 2)\", \"label\":\"P80th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\", \"selected\":true}    \r\n]"
           },
           {
@@ -685,43 +830,113 @@
             "version": "KqlParameterItem/1.0",
             "name": "TrendAggregatorOrder3",
             "type": 1,
-            "query": "print(iff('{TrendAggregator3:label}' == 'P5th'  or '{TrendAggregator3:label}' == 'P10th', 'asc', 'desc'))",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
+            "value": "desc",
             "isHiddenWhenLocked": true,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "criteriaData": [
+              {
+                "condition": "if (TrendAggregator3 contains 'P5th'), result = 'asc'",
+                "criteriaContext": {
+                  "leftOperand": "TrendAggregator3",
+                  "operator": "contains",
+                  "rightValType": "static",
+                  "rightVal": "P5th",
+                  "resultValType": "static",
+                  "resultVal": "asc"
+                }
+              },
+              {
+                "condition": "if (TrendAggregator3 contains 'P10th'), result = 'asc'",
+                "criteriaContext": {
+                  "leftOperand": "TrendAggregator3",
+                  "operator": "contains",
+                  "rightValType": "static",
+                  "rightVal": "P10th",
+                  "resultValType": "static",
+                  "resultVal": "asc"
+                }
+              },
+              {
+                "condition": "else result = 'desc'",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "static",
+                  "resultVal": "desc"
+                }
+              }
+            ]
           },
           {
-            "id": "db1c9737-0d87-41ad-8f3c-f22c853be400",
+            "id": "d026cf36-d22e-4f92-a577-94220726ba3f",
             "version": "KqlParameterItem/1.0",
             "name": "Visualization3",
             "type": 2,
             "isRequired": true,
-            "query": "datatable (value:long, Display:string, isSelected:boolean)\r\n    [0, \"Line Chart\", true,\r\n     1, \"Grid\", false]",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
             "typeSettings": {
               "additionalResourceOptions": []
             },
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "jsonData": "[\r\n    {\r\n        \"value\": \"0\",\r\n        \"label\": \"Line Chart\",\r\n        \"selected\": true\r\n    },\r\n    {\r\n        \"value\": \"1\",\r\n        \"label\": \"Grid\",\r\n        \"selected\": false\r\n    }\r\n]"
           },
           {
-            "id": "82cef2b6-4ce0-4a64-bd64-017810211147",
+            "id": "a9ac011f-176f-4c31-b82e-139aba93a426",
             "version": "KqlParameterItem/1.0",
             "name": "Snippet3",
             "type": 1,
             "isRequired": true,
-            "query": "print(iff({Visualization3} == 0, \"{LineChartQuerySnippet}\", \"{GridQuerySnippet}\") )",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
+            "value": "bin(TimeGenerated, 15m), ResourceName | render linechart",
             "isHiddenWhenLocked": true,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "criteriaData": [
+              {
+                "condition": "if (Visualization3 == '0'), result = LineChartQuerySnippet",
+                "criteriaContext": {
+                  "leftOperand": "Visualization3",
+                  "operator": "==",
+                  "rightValType": "static",
+                  "rightVal": "0",
+                  "resultValType": "param",
+                  "resultVal": "LineChartQuerySnippet"
+                }
+              },
+              {
+                "condition": "else result = GridQuerySnippet",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "param",
+                  "resultVal": "GridQuerySnippet"
+                }
+              }
+            ]
           },
           {
-            "id": "def72a65-f496-4619-8fcb-85c338641907",
+            "id": "028cfd79-33d7-4d82-be4d-348d17488ca1",
+            "version": "KqlParameterItem/1.0",
+            "name": "CounterLabel3",
+            "type": 1,
+            "query": "{\"version\":\"1.0.0\",\"content\":\"\\\"{Counter3:label}\\\"\",\"transformers\":null}",
+            "isHiddenWhenLocked": true,
+            "queryType": 8
+          },
+          {
+            "id": "41eb7c98-b679-42b9-8454-432a4b8fff48",
+            "version": "KqlParameterItem/1.0",
+            "name": "TrendAggregatorValue3",
+            "type": 1,
+            "query": "{\"version\":\"1.0.0\",\"content\":\"\\\"{TrendAggregator3}\\\"\",\"transformers\":null}",
+            "isHiddenWhenLocked": true,
+            "queryType": 8
+          },
+          {
+            "id": "5c8cbc8c-1776-42fd-9291-2fc4f0e0558b",
+            "version": "KqlParameterItem/1.0",
+            "name": "TrendAggregatorLabel3",
+            "type": 1,
+            "query": "{\"version\":\"1.0.0\",\"content\":\"\\\"{TrendAggregator3:label}\\\"\",\"transformers\":null}",
+            "isHiddenWhenLocked": true,
+            "queryType": 8
+          },
+          {
+            "id": "26106dfe-4e33-4c7c-b4b6-2eff5cc76476",
             "version": "KqlParameterItem/1.0",
             "name": "Unit3",
             "type": 2,
@@ -767,13 +982,18 @@
             "name": "Counter4",
             "type": 2,
             "isRequired": true,
-            "query": "// {Workspaces}\r\nPerf\r\n| where TimeGenerated {TimeRange}\r\n| summarize by CounterName, ObjectName, CounterText = CounterName\r\n| order by ObjectName asc, CounterText asc\r\n| project Counter = pack('counter', CounterName, 'object', ObjectName), CounterText, group = ObjectName",
+            "query": "Perf\r\n| where TimeGenerated {TimeRange}\r\n| summarize by CounterName, ObjectName, CounterText = CounterName\r\n| order by ObjectName asc, CounterText asc\r\n| project Counter = pack('counter', CounterName, 'object', ObjectName), CounterText, group = ObjectName",
             "crossComponentResources": [
               "{Workspaces}"
             ],
             "typeSettings": {
               "additionalResourceOptions": []
             },
+            "timeContext": {
+              "durationMs": 0
+            },
+            "timeContextFromParameter": "TimeRange",
+            "queryType": 0,
             "resourceType": "microsoft.operationalinsights/workspaces",
             "value": "{\"counter\":\"Bytes Received/sec\",\"object\":\"Network Adapter\"}"
           },
@@ -783,6 +1003,9 @@
             "name": "TrendAggregator4",
             "type": 2,
             "isRequired": true,
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
             "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\", \"selected\":false},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\", \"selected\":false},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P80th = round(percentile(CounterValue, 80), 2)\", \"label\":\"P80th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\", \"selected\":true}    \r\n]"
           },
           {
@@ -790,43 +1013,113 @@
             "version": "KqlParameterItem/1.0",
             "name": "TrendAggregatorOrder4",
             "type": 1,
-            "query": "print(iff('{TrendAggregator4:label}' == 'P5th'  or '{TrendAggregator4:label}' == 'P10th', 'asc', 'desc'))",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
+            "value": "desc",
             "isHiddenWhenLocked": true,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "criteriaData": [
+              {
+                "condition": "if (TrendAggregator4 contains 'P5th'), result = 'asc'",
+                "criteriaContext": {
+                  "leftOperand": "TrendAggregator4",
+                  "operator": "contains",
+                  "rightValType": "static",
+                  "rightVal": "P5th",
+                  "resultValType": "static",
+                  "resultVal": "asc"
+                }
+              },
+              {
+                "condition": "if (TrendAggregator4 contains 'P10th'), result = 'asc'",
+                "criteriaContext": {
+                  "leftOperand": "TrendAggregator4",
+                  "operator": "contains",
+                  "rightValType": "static",
+                  "rightVal": "P10th",
+                  "resultValType": "static",
+                  "resultVal": "asc"
+                }
+              },
+              {
+                "condition": "else result = 'desc'",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "static",
+                  "resultVal": "desc"
+                }
+              }
+            ]
           },
           {
-            "id": "16d42161-ad5d-4bd8-9b2a-8e834e3b8fed",
+            "id": "d026cf36-d22e-4f92-a577-94220726ba3f",
             "version": "KqlParameterItem/1.0",
             "name": "Visualization4",
             "type": 2,
             "isRequired": true,
-            "query": "datatable (value:long, Display:string, isSelected:boolean)\r\n    [0, \"Line Chart\", true,\r\n     1, \"Grid\", false]",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
             "typeSettings": {
               "additionalResourceOptions": []
             },
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "jsonData": "[\r\n    {\r\n        \"value\": \"0\",\r\n        \"label\": \"Line Chart\",\r\n        \"selected\": true\r\n    },\r\n    {\r\n        \"value\": \"1\",\r\n        \"label\": \"Grid\",\r\n        \"selected\": false\r\n    }\r\n]"
           },
           {
-            "id": "d768c009-20aa-4476-83cd-afacf4694818",
+            "id": "a9ac011f-176f-4c31-b82e-139aba93a426",
             "version": "KqlParameterItem/1.0",
             "name": "Snippet4",
             "type": 1,
             "isRequired": true,
-            "query": "print(iff({Visualization4} == 0, \"{LineChartQuerySnippet}\", \"{GridQuerySnippet}\") )",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
+            "value": "bin(TimeGenerated, 15m), ResourceName | render linechart",
             "isHiddenWhenLocked": true,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "criteriaData": [
+              {
+                "condition": "if (Visualization4 == '0'), result = LineChartQuerySnippet",
+                "criteriaContext": {
+                  "leftOperand": "Visualization4",
+                  "operator": "==",
+                  "rightValType": "static",
+                  "rightVal": "0",
+                  "resultValType": "param",
+                  "resultVal": "LineChartQuerySnippet"
+                }
+              },
+              {
+                "condition": "else result = GridQuerySnippet",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "param",
+                  "resultVal": "GridQuerySnippet"
+                }
+              }
+            ]
           },
           {
-            "id": "eb3e4d65-ee3c-481c-af2e-8b41e4049bf8",
+            "id": "028cfd79-33d7-4d82-be4d-348d17488ca1",
+            "version": "KqlParameterItem/1.0",
+            "name": "CounterLabel4",
+            "type": 1,
+            "query": "{\"version\":\"1.0.0\",\"content\":\"\\\"{Counter4:label}\\\"\",\"transformers\":null}",
+            "isHiddenWhenLocked": true,
+            "queryType": 8
+          },
+          {
+            "id": "41eb7c98-b679-42b9-8454-432a4b8fff48",
+            "version": "KqlParameterItem/1.0",
+            "name": "TrendAggregatorValue4",
+            "type": 1,
+            "query": "{\"version\":\"1.0.0\",\"content\":\"\\\"{TrendAggregator4}\\\"\",\"transformers\":null}",
+            "isHiddenWhenLocked": true,
+            "queryType": 8
+          },
+          {
+            "id": "5c8cbc8c-1776-42fd-9291-2fc4f0e0558b",
+            "version": "KqlParameterItem/1.0",
+            "name": "TrendAggregatorLabel4",
+            "type": 1,
+            "query": "{\"version\":\"1.0.0\",\"content\":\"\\\"{TrendAggregator4:label}\\\"\",\"transformers\":null}",
+            "isHiddenWhenLocked": true,
+            "queryType": 8
+          },
+          {
+            "id": "26106dfe-4e33-4c7c-b4b6-2eff5cc76476",
             "version": "KqlParameterItem/1.0",
             "name": "Unit4",
             "type": 2,
@@ -1100,15 +1393,18 @@
             "name": "Counter5",
             "type": 2,
             "isRequired": true,
-            "query": "// {Workspaces}\r\nPerf\r\n| where TimeGenerated {TimeRange}\r\n| summarize by CounterName, ObjectName, CounterText = CounterName\r\n| order by ObjectName asc, CounterText asc\r\n| project Counter = pack('counter', CounterName, 'object', ObjectName), CounterText, group = ObjectName",
+            "query": "Perf\r\n| where TimeGenerated {TimeRange}\r\n| summarize by CounterName, ObjectName, CounterText = CounterName\r\n| order by ObjectName asc, CounterText asc\r\n| project Counter = pack('counter', CounterName, 'object', ObjectName), CounterText, group = ObjectName",
             "crossComponentResources": [
               "{Workspaces}"
             ],
             "typeSettings": {
-              "additionalResourceOptions": [
-                "value::1"
-              ]
+              "additionalResourceOptions": []
             },
+            "timeContext": {
+              "durationMs": 0
+            },
+            "timeContextFromParameter": "TimeRange",
+            "queryType": 0,
             "resourceType": "microsoft.operationalinsights/workspaces",
             "value": "{\"counter\":\"% Used Space\",\"object\":\"Logical Disk\"}"
           },
@@ -1118,6 +1414,9 @@
             "name": "TrendAggregator5",
             "type": 2,
             "isRequired": true,
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
             "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\", \"selected\":false},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\", \"selected\":false},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P80th = round(percentile(CounterValue, 80), 2)\", \"label\":\"P80th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\", \"selected\":true}    \r\n]"
           },
           {
@@ -1125,43 +1424,113 @@
             "version": "KqlParameterItem/1.0",
             "name": "TrendAggregatorOrder5",
             "type": 1,
-            "query": "print(iff('{TrendAggregator5:label}' == 'P5th'  or '{TrendAggregator5:label}' == 'P10th', 'asc', 'desc'))",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
+            "value": "desc",
             "isHiddenWhenLocked": true,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "criteriaData": [
+              {
+                "condition": "if (TrendAggregator5 contains 'P5th'), result = 'asc'",
+                "criteriaContext": {
+                  "leftOperand": "TrendAggregator5",
+                  "operator": "contains",
+                  "rightValType": "static",
+                  "rightVal": "P5th",
+                  "resultValType": "static",
+                  "resultVal": "asc"
+                }
+              },
+              {
+                "condition": "if (TrendAggregator5 contains 'P10th'), result = 'asc'",
+                "criteriaContext": {
+                  "leftOperand": "TrendAggregator5",
+                  "operator": "contains",
+                  "rightValType": "static",
+                  "rightVal": "P10th",
+                  "resultValType": "static",
+                  "resultVal": "asc"
+                }
+              },
+              {
+                "condition": "else result = 'desc'",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "static",
+                  "resultVal": "desc"
+                }
+              }
+            ]
           },
           {
-            "id": "b75e4ca5-7d71-4d29-b69e-9104934905ba",
+            "id": "d026cf36-d22e-4f92-a577-94220726ba3f",
             "version": "KqlParameterItem/1.0",
             "name": "Visualization5",
             "type": 2,
             "isRequired": true,
-            "query": "datatable (value:long, Display:string, isSelected:boolean)\r\n    [0, \"Line Chart\", true,\r\n     1, \"Grid\", false]",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
             "typeSettings": {
               "additionalResourceOptions": []
             },
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "jsonData": "[\r\n    {\r\n        \"value\": \"0\",\r\n        \"label\": \"Line Chart\",\r\n        \"selected\": true\r\n    },\r\n    {\r\n        \"value\": \"1\",\r\n        \"label\": \"Grid\",\r\n        \"selected\": false\r\n    }\r\n]"
           },
           {
-            "id": "7df7ee71-c054-4a88-b8b1-33ba6dd9d70d",
+            "id": "a9ac011f-176f-4c31-b82e-139aba93a426",
             "version": "KqlParameterItem/1.0",
             "name": "Snippet5",
             "type": 1,
             "isRequired": true,
-            "query": "print(iff({Visualization5} == 0, \"{LineChartQuerySnippet}\", \"{GridQuerySnippet}\") )",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
+            "value": "bin(TimeGenerated, 15m), ResourceName | render linechart",
             "isHiddenWhenLocked": true,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "criteriaData": [
+              {
+                "condition": "if (Visualization5 == '0'), result = LineChartQuerySnippet",
+                "criteriaContext": {
+                  "leftOperand": "Visualization5",
+                  "operator": "==",
+                  "rightValType": "static",
+                  "rightVal": "0",
+                  "resultValType": "param",
+                  "resultVal": "LineChartQuerySnippet"
+                }
+              },
+              {
+                "condition": "else result = GridQuerySnippet",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "param",
+                  "resultVal": "GridQuerySnippet"
+                }
+              }
+            ]
           },
           {
-            "id": "bb81032c-59e4-417f-a5e1-fc6552c3190f",
+            "id": "028cfd79-33d7-4d82-be4d-348d17488ca1",
+            "version": "KqlParameterItem/1.0",
+            "name": "CounterLabel5",
+            "type": 1,
+            "query": "{\"version\":\"1.0.0\",\"content\":\"\\\"{Counter5:label}\\\"\",\"transformers\":null}",
+            "isHiddenWhenLocked": true,
+            "queryType": 8
+          },
+          {
+            "id": "41eb7c98-b679-42b9-8454-432a4b8fff48",
+            "version": "KqlParameterItem/1.0",
+            "name": "TrendAggregatorValue5",
+            "type": 1,
+            "query": "{\"version\":\"1.0.0\",\"content\":\"\\\"{TrendAggregator5}\\\"\",\"transformers\":null}",
+            "isHiddenWhenLocked": true,
+            "queryType": 8
+          },
+          {
+            "id": "5c8cbc8c-1776-42fd-9291-2fc4f0e0558b",
+            "version": "KqlParameterItem/1.0",
+            "name": "TrendAggregatorLabel5",
+            "type": 1,
+            "query": "{\"version\":\"1.0.0\",\"content\":\"\\\"{TrendAggregator5:label}\\\"\",\"transformers\":null}",
+            "isHiddenWhenLocked": true,
+            "queryType": 8
+          },
+          {
+            "id": "26106dfe-4e33-4c7c-b4b6-2eff5cc76476",
             "version": "KqlParameterItem/1.0",
             "name": "Unit5",
             "type": 2,
@@ -1207,15 +1576,18 @@
             "name": "Counter6",
             "type": 2,
             "isRequired": true,
-            "query": "// {Workspaces}\r\nPerf\r\n| where TimeGenerated {TimeRange}\r\n| summarize by CounterName, ObjectName, CounterText = CounterName\r\n| order by ObjectName asc, CounterText asc\r\n| project Counter = pack('counter', CounterName, 'object', ObjectName), CounterText, group = ObjectName",
+            "query": "Perf\r\n| where TimeGenerated {TimeRange}\r\n| summarize by CounterName, ObjectName, CounterText = CounterName\r\n| order by ObjectName asc, CounterText asc\r\n| project Counter = pack('counter', CounterName, 'object', ObjectName), CounterText, group = ObjectName",
             "crossComponentResources": [
               "{Workspaces}"
             ],
             "typeSettings": {
-              "additionalResourceOptions": [
-                "value::1"
-              ]
+              "additionalResourceOptions": []
             },
+            "timeContext": {
+              "durationMs": 0
+            },
+            "timeContextFromParameter": "TimeRange",
+            "queryType": 0,
             "resourceType": "microsoft.operationalinsights/workspaces",
             "value": "{\"counter\":\"% Free Space\",\"object\":\"LogicalDisk\"}"
           },
@@ -1225,6 +1597,9 @@
             "name": "TrendAggregator6",
             "type": 2,
             "isRequired": true,
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
             "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\", \"selected\":false},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\", \"selected\":false},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P80th = round(percentile(CounterValue, 80), 2)\", \"label\":\"P80th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\", \"selected\":true}    \r\n]"
           },
           {
@@ -1232,43 +1607,113 @@
             "version": "KqlParameterItem/1.0",
             "name": "TrendAggregatorOrder6",
             "type": 1,
-            "query": "print(iff('{TrendAggregator6:label}' == 'P5th'  or '{TrendAggregator6:label}' == 'P10th', 'asc', 'desc'))",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
+            "value": "desc",
             "isHiddenWhenLocked": true,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "criteriaData": [
+              {
+                "condition": "if (TrendAggregator6 contains 'P5th'), result = 'asc'",
+                "criteriaContext": {
+                  "leftOperand": "TrendAggregator6",
+                  "operator": "contains",
+                  "rightValType": "static",
+                  "rightVal": "P5th",
+                  "resultValType": "static",
+                  "resultVal": "asc"
+                }
+              },
+              {
+                "condition": "if (TrendAggregator6 contains 'P10th'), result = 'asc'",
+                "criteriaContext": {
+                  "leftOperand": "TrendAggregator6",
+                  "operator": "contains",
+                  "rightValType": "static",
+                  "rightVal": "P10th",
+                  "resultValType": "static",
+                  "resultVal": "asc"
+                }
+              },
+              {
+                "condition": "else result = 'desc'",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "static",
+                  "resultVal": "desc"
+                }
+              }
+            ]
           },
           {
-            "id": "5b1ee58a-5d4d-4be8-b38c-3a8eb37a2f3e",
+            "id": "d026cf36-d22e-4f92-a577-94220726ba3f",
             "version": "KqlParameterItem/1.0",
             "name": "Visualization6",
             "type": 2,
             "isRequired": true,
-            "query": "datatable (value:long, Display:string, isSelected:boolean)\r\n    [0, \"Line Chart\", true,\r\n     1, \"Grid\", false]",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
             "typeSettings": {
               "additionalResourceOptions": []
             },
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "jsonData": "[\r\n    {\r\n        \"value\": \"0\",\r\n        \"label\": \"Line Chart\",\r\n        \"selected\": true\r\n    },\r\n    {\r\n        \"value\": \"1\",\r\n        \"label\": \"Grid\",\r\n        \"selected\": false\r\n    }\r\n]"
           },
           {
-            "id": "d931d741-2f83-4ca0-bc2b-5c0c13fe8058",
+            "id": "a9ac011f-176f-4c31-b82e-139aba93a426",
             "version": "KqlParameterItem/1.0",
             "name": "Snippet6",
             "type": 1,
             "isRequired": true,
-            "query": "print(iff({Visualization6} == 0, \"{LineChartQuerySnippet}\", \"{GridQuerySnippet}\") )",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
+            "value": "bin(TimeGenerated, 15m), ResourceName | render linechart",
             "isHiddenWhenLocked": true,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "criteriaData": [
+              {
+                "condition": "if (Visualization6 == '0'), result = LineChartQuerySnippet",
+                "criteriaContext": {
+                  "leftOperand": "Visualization6",
+                  "operator": "==",
+                  "rightValType": "static",
+                  "rightVal": "0",
+                  "resultValType": "param",
+                  "resultVal": "LineChartQuerySnippet"
+                }
+              },
+              {
+                "condition": "else result = GridQuerySnippet",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "param",
+                  "resultVal": "GridQuerySnippet"
+                }
+              }
+            ]
           },
           {
-            "id": "ab35d419-d8c1-45be-8885-e39a55c0648d",
+            "id": "028cfd79-33d7-4d82-be4d-348d17488ca1",
+            "version": "KqlParameterItem/1.0",
+            "name": "CounterLabel6",
+            "type": 1,
+            "query": "{\"version\":\"1.0.0\",\"content\":\"\\\"{Counter6:label}\\\"\",\"transformers\":null}",
+            "isHiddenWhenLocked": true,
+            "queryType": 8
+          },
+          {
+            "id": "41eb7c98-b679-42b9-8454-432a4b8fff48",
+            "version": "KqlParameterItem/1.0",
+            "name": "TrendAggregatorValue6",
+            "type": 1,
+            "query": "{\"version\":\"1.0.0\",\"content\":\"\\\"{TrendAggregator6}\\\"\",\"transformers\":null}",
+            "isHiddenWhenLocked": true,
+            "queryType": 8
+          },
+          {
+            "id": "5c8cbc8c-1776-42fd-9291-2fc4f0e0558b",
+            "version": "KqlParameterItem/1.0",
+            "name": "TrendAggregatorLabel6",
+            "type": 1,
+            "query": "{\"version\":\"1.0.0\",\"content\":\"\\\"{TrendAggregator6:label}\\\"\",\"transformers\":null}",
+            "isHiddenWhenLocked": true,
+            "queryType": 8
+          },
+          {
+            "id": "26106dfe-4e33-4c7c-b4b6-2eff5cc76476",
             "version": "KqlParameterItem/1.0",
             "name": "Unit6",
             "type": 2,
@@ -1314,17 +1759,20 @@
             "name": "Counter7",
             "type": 2,
             "isRequired": true,
-            "query": "// {Workspaces}\r\nPerf\r\n| where TimeGenerated {TimeRange}\r\n| summarize by CounterName, ObjectName, CounterText = CounterName\r\n| order by ObjectName asc, CounterText asc\r\n| project Counter = pack('counter', CounterName, 'object', ObjectName), CounterText, group = ObjectName",
+            "query": "Perf\r\n| where TimeGenerated {TimeRange}\r\n| summarize by CounterName, ObjectName, CounterText = CounterName\r\n| order by ObjectName asc, CounterText asc\r\n| project Counter = pack('counter', CounterName, 'object', ObjectName), CounterText, group = ObjectName",
             "crossComponentResources": [
               "{Workspaces}"
             ],
             "typeSettings": {
-              "additionalResourceOptions": [
-                "value::1"
-              ]
+              "additionalResourceOptions": []
             },
+            "timeContext": {
+              "durationMs": 0
+            },
+            "timeContextFromParameter": "TimeRange",
+            "queryType": 0,
             "resourceType": "microsoft.operationalinsights/workspaces",
-            "value": "{\"counter\":\"Disk Write Bytes/sec\",\"object\":\"LogicalDisk\"}"
+            "value": "{\"counter\":\"Disk Write Bytes/sec\",\"object\":\"Logical Disk\"}"
           },
           {
             "id": "6a7306ea-247f-46ca-abca-501911f9e9d3",
@@ -1332,6 +1780,9 @@
             "name": "TrendAggregator7",
             "type": 2,
             "isRequired": true,
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
             "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\", \"selected\":false},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\", \"selected\":false},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P80th = round(percentile(CounterValue, 80), 2)\", \"label\":\"P80th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\", \"selected\":true}    \r\n]"
           },
           {
@@ -1339,43 +1790,113 @@
             "version": "KqlParameterItem/1.0",
             "name": "TrendAggregatorOrder7",
             "type": 1,
-            "query": "print(iff('{TrendAggregator7:label}' == 'P5th'  or '{TrendAggregator7:label}' == 'P10th', 'asc', 'desc'))",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
+            "value": "desc",
             "isHiddenWhenLocked": true,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "criteriaData": [
+              {
+                "condition": "if (TrendAggregator7 contains 'P5th'), result = 'asc'",
+                "criteriaContext": {
+                  "leftOperand": "TrendAggregator7",
+                  "operator": "contains",
+                  "rightValType": "static",
+                  "rightVal": "P5th",
+                  "resultValType": "static",
+                  "resultVal": "asc"
+                }
+              },
+              {
+                "condition": "if (TrendAggregator7 contains 'P10th'), result = 'asc'",
+                "criteriaContext": {
+                  "leftOperand": "TrendAggregator7",
+                  "operator": "contains",
+                  "rightValType": "static",
+                  "rightVal": "P10th",
+                  "resultValType": "static",
+                  "resultVal": "asc"
+                }
+              },
+              {
+                "condition": "else result = 'desc'",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "static",
+                  "resultVal": "desc"
+                }
+              }
+            ]
           },
           {
-            "id": "bc1291ba-dd26-4224-9b25-3a1e7b3eb024",
+            "id": "d026cf36-d22e-4f92-a577-94220726ba3f",
             "version": "KqlParameterItem/1.0",
             "name": "Visualization7",
             "type": 2,
             "isRequired": true,
-            "query": "datatable (value:long, Display:string, isSelected:boolean)\r\n    [0, \"Line Chart\", true,\r\n     1, \"Grid\", false]",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
             "typeSettings": {
               "additionalResourceOptions": []
             },
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "jsonData": "[\r\n    {\r\n        \"value\": \"0\",\r\n        \"label\": \"Line Chart\",\r\n        \"selected\": true\r\n    },\r\n    {\r\n        \"value\": \"1\",\r\n        \"label\": \"Grid\",\r\n        \"selected\": false\r\n    }\r\n]"
           },
           {
-            "id": "6cc1a388-27c6-4cfe-a787-ff00cb8f4fae",
+            "id": "a9ac011f-176f-4c31-b82e-139aba93a426",
             "version": "KqlParameterItem/1.0",
             "name": "Snippet7",
             "type": 1,
             "isRequired": true,
-            "query": "print(iff({Visualization7} == 0, \"{LineChartQuerySnippet}\", \"{GridQuerySnippet}\") )",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
+            "value": "bin(TimeGenerated, 15m), ResourceName | render linechart",
             "isHiddenWhenLocked": true,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "criteriaData": [
+              {
+                "condition": "if (Visualization7 == '0'), result = LineChartQuerySnippet",
+                "criteriaContext": {
+                  "leftOperand": "Visualization7",
+                  "operator": "==",
+                  "rightValType": "static",
+                  "rightVal": "0",
+                  "resultValType": "param",
+                  "resultVal": "LineChartQuerySnippet"
+                }
+              },
+              {
+                "condition": "else result = GridQuerySnippet",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "param",
+                  "resultVal": "GridQuerySnippet"
+                }
+              }
+            ]
           },
           {
-            "id": "dce874fa-b71d-4a09-bcee-bd1b3f672f7f",
+            "id": "028cfd79-33d7-4d82-be4d-348d17488ca1",
+            "version": "KqlParameterItem/1.0",
+            "name": "CounterLabel7",
+            "type": 1,
+            "query": "{\"version\":\"1.0.0\",\"content\":\"\\\"{Counter7:label}\\\"\",\"transformers\":null}",
+            "isHiddenWhenLocked": true,
+            "queryType": 8
+          },
+          {
+            "id": "41eb7c98-b679-42b9-8454-432a4b8fff48",
+            "version": "KqlParameterItem/1.0",
+            "name": "TrendAggregatorValue7",
+            "type": 1,
+            "query": "{\"version\":\"1.0.0\",\"content\":\"\\\"{TrendAggregator7}\\\"\",\"transformers\":null}",
+            "isHiddenWhenLocked": true,
+            "queryType": 8
+          },
+          {
+            "id": "5c8cbc8c-1776-42fd-9291-2fc4f0e0558b",
+            "version": "KqlParameterItem/1.0",
+            "name": "TrendAggregatorLabel7",
+            "type": 1,
+            "query": "{\"version\":\"1.0.0\",\"content\":\"\\\"{TrendAggregator7:label}\\\"\",\"transformers\":null}",
+            "isHiddenWhenLocked": true,
+            "queryType": 8
+          },
+          {
+            "id": "26106dfe-4e33-4c7c-b4b6-2eff5cc76476",
             "version": "KqlParameterItem/1.0",
             "name": "Unit7",
             "type": 2,
@@ -1421,15 +1942,18 @@
             "name": "Counter8",
             "type": 2,
             "isRequired": true,
-            "query": "// {Workspaces}\r\nPerf\r\n| where TimeGenerated {TimeRange}\r\n| summarize by CounterName, ObjectName, CounterText = CounterName\r\n| order by ObjectName asc, CounterText asc\r\n| project Counter = pack('counter', CounterName, 'object', ObjectName), CounterText, group = ObjectName",
+            "query": "Perf\r\n| where TimeGenerated {TimeRange}\r\n| summarize by CounterName, ObjectName, CounterText = CounterName\r\n| order by ObjectName asc, CounterText asc\r\n| project Counter = pack('counter', CounterName, 'object', ObjectName), CounterText, group = ObjectName",
             "crossComponentResources": [
               "{Workspaces}"
             ],
             "typeSettings": {
-              "additionalResourceOptions": [
-                "value::1"
-              ]
+              "additionalResourceOptions": []
             },
+            "timeContext": {
+              "durationMs": 0
+            },
+            "timeContextFromParameter": "TimeRange",
+            "queryType": 0,
             "resourceType": "microsoft.operationalinsights/workspaces",
             "value": "{\"counter\":\"Disk Read Bytes/sec\",\"object\":\"Logical Disk\"}"
           },
@@ -1439,6 +1963,9 @@
             "name": "TrendAggregator8",
             "type": 2,
             "isRequired": true,
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
             "jsonData": "[\r\n    { \"value\":\"Average = round(avg(CounterValue), 2)\", \"label\":\"Average\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(CounterValue, 5), 2)\", \"label\":\"P5th\", \"selected\":false},\r\n    { \"value\":\"P10th = round(percentile(CounterValue, 10), 2)\", \"label\":\"P10th\", \"selected\":false},\r\n    { \"value\":\"P50th = round(percentile(CounterValue, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P80th = round(percentile(CounterValue, 80), 2)\", \"label\":\"P80th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(CounterValue, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(CounterValue, 95), 2)\", \"label\":\"P95th\", \"selected\":true}    \r\n]"
           },
           {
@@ -1446,43 +1973,113 @@
             "version": "KqlParameterItem/1.0",
             "name": "TrendAggregatorOrder8",
             "type": 1,
-            "query": "print(iff('{TrendAggregator8:label}' == 'P5th'  or '{TrendAggregator8:label}' == 'P10th', 'asc', 'desc'))",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
+            "value": "desc",
             "isHiddenWhenLocked": true,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "criteriaData": [
+              {
+                "condition": "if (TrendAggregator8 contains 'P5th'), result = 'asc'",
+                "criteriaContext": {
+                  "leftOperand": "TrendAggregator8",
+                  "operator": "contains",
+                  "rightValType": "static",
+                  "rightVal": "P5th",
+                  "resultValType": "static",
+                  "resultVal": "asc"
+                }
+              },
+              {
+                "condition": "if (TrendAggregator8 contains 'P10th'), result = 'asc'",
+                "criteriaContext": {
+                  "leftOperand": "TrendAggregator8",
+                  "operator": "contains",
+                  "rightValType": "static",
+                  "rightVal": "P10th",
+                  "resultValType": "static",
+                  "resultVal": "asc"
+                }
+              },
+              {
+                "condition": "else result = 'desc'",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "static",
+                  "resultVal": "desc"
+                }
+              }
+            ]
           },
           {
-            "id": "68468652-570f-4d77-af12-a59d463d5f02",
+            "id": "d026cf36-d22e-4f92-a577-94220726ba3f",
             "version": "KqlParameterItem/1.0",
             "name": "Visualization8",
             "type": 2,
             "isRequired": true,
-            "query": "datatable (value:long, Display:string, isSelected:boolean)\r\n    [0, \"Line Chart\", true,\r\n     1, \"Grid\", false]",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
             "typeSettings": {
               "additionalResourceOptions": []
             },
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "jsonData": "[\r\n    {\r\n        \"value\": \"0\",\r\n        \"label\": \"Line Chart\",\r\n        \"selected\": true\r\n    },\r\n    {\r\n        \"value\": \"1\",\r\n        \"label\": \"Grid\",\r\n        \"selected\": false\r\n    }\r\n]"
           },
           {
-            "id": "15738505-f7e6-446e-995d-280cf70dde93",
+            "id": "a9ac011f-176f-4c31-b82e-139aba93a426",
             "version": "KqlParameterItem/1.0",
             "name": "Snippet8",
             "type": 1,
             "isRequired": true,
-            "query": "print(iff({Visualization8} == 0, \"{LineChartQuerySnippet}\", \"{GridQuerySnippet}\") )",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
+            "value": "bin(TimeGenerated, 15m), ResourceName | render linechart",
             "isHiddenWhenLocked": true,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "criteriaData": [
+              {
+                "condition": "if (Visualization8 == '0'), result = LineChartQuerySnippet",
+                "criteriaContext": {
+                  "leftOperand": "Visualization8",
+                  "operator": "==",
+                  "rightValType": "static",
+                  "rightVal": "0",
+                  "resultValType": "param",
+                  "resultVal": "LineChartQuerySnippet"
+                }
+              },
+              {
+                "condition": "else result = GridQuerySnippet",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "param",
+                  "resultVal": "GridQuerySnippet"
+                }
+              }
+            ]
           },
           {
-            "id": "c78d15dd-79cb-4cd2-8749-df9d97625b31",
+            "id": "028cfd79-33d7-4d82-be4d-348d17488ca1",
+            "version": "KqlParameterItem/1.0",
+            "name": "CounterLabel8",
+            "type": 1,
+            "query": "{\"version\":\"1.0.0\",\"content\":\"\\\"{Counter8:label}\\\"\",\"transformers\":null}",
+            "isHiddenWhenLocked": true,
+            "queryType": 8
+          },
+          {
+            "id": "41eb7c98-b679-42b9-8454-432a4b8fff48",
+            "version": "KqlParameterItem/1.0",
+            "name": "TrendAggregatorValue8",
+            "type": 1,
+            "query": "{\"version\":\"1.0.0\",\"content\":\"\\\"{TrendAggregator8}\\\"\",\"transformers\":null}",
+            "isHiddenWhenLocked": true,
+            "queryType": 8
+          },
+          {
+            "id": "5c8cbc8c-1776-42fd-9291-2fc4f0e0558b",
+            "version": "KqlParameterItem/1.0",
+            "name": "TrendAggregatorLabel8",
+            "type": 1,
+            "query": "{\"version\":\"1.0.0\",\"content\":\"\\\"{TrendAggregator8:label}\\\"\",\"transformers\":null}",
+            "isHiddenWhenLocked": true,
+            "queryType": 8
+          },
+          {
+            "id": "26106dfe-4e33-4c7c-b4b6-2eff5cc76476",
             "version": "KqlParameterItem/1.0",
             "name": "Unit8",
             "type": 2,

--- a/Workbooks/Virtual Machines - Performance Analysis/Performance Counters (Preview)/Performance Counters (Preview).workbook
+++ b/Workbooks/Virtual Machines - Performance Analysis/Performance Counters (Preview)/Performance Counters (Preview).workbook
@@ -10,6 +10,17 @@
         ],
         "parameters": [
           {
+            "id": "2c4ef86b-c7cb-434e-9051-291940cb51bf",
+            "version": "KqlParameterItem/1.0",
+            "name": "Blank",
+            "type": 1,
+            "isHiddenWhenLocked": true,
+            "timeContext": {
+              "durationMs": 0
+            },
+            "timeContextFromParameter": "TimeRange"
+          },
+          {
             "id": "80a15801-7442-49f3-a82f-6e55849ec7fb",
             "version": "KqlParameterItem/1.0",
             "name": "DefaultWorkspace",
@@ -47,7 +58,7 @@
             "version": "KqlParameterItem/1.0",
             "name": "ContextSelection",
             "type": 1,
-            "query": "// {DefaultWorkspace}\r\nwhere strcat(\"'\", id, \"'\") =~ \"{DefaultWorkspace:value}\"\r\n| project value = tostring(pack('sub', subscriptionId, 'rg', resourceGroup, 'ws', id))",
+            "query": "where strcat(\"'\", id, \"'\") =~ \"{DefaultWorkspace:value}\"\r\n| project value = tostring(pack('sub', subscriptionId, 'rg', resourceGroup, 'ws', id))",
             "crossComponentResources": [
               "value::all"
             ],
@@ -92,7 +103,7 @@
             "multiSelect": true,
             "quote": "'",
             "delimiter": ",",
-            "query": "// {DefaultWorkspace} {ContextSelection} {DefaultSubscription}\r\nsummarize by subscriptionId\r\n| project strcat('/subscriptions/', subscriptionId), selected = iff({HybridMode} == true, iff(subscriptionId == todynamic('{ContextSelection}').sub, true, false), iff(strcat('/subscriptions/', subscriptionId) == '{DefaultSubscription}', true, false))",
+            "query": "summarize by subscriptionId\r\n| project strcat('/subscriptions/', subscriptionId), selected = iff({HybridMode} == true, iff(subscriptionId == todynamic('{ContextSelection}').sub, true, false), iff(strcat('/subscriptions/', subscriptionId) == '{DefaultSubscription}', true, false))",
             "crossComponentResources": [
               "value::all"
             ],
@@ -111,7 +122,7 @@
             "multiSelect": true,
             "quote": "'",
             "delimiter": ",",
-            "query": "// {DefaultWorkspace} {ContextSelection} {Subscriptions}\r\nwhere type =~ 'microsoft.operationalinsights/workspaces'\r\n| summarize by id, name\r\n| order by tolower(name) asc\r\n| extend Row = row_number()\r\n| project id, selected = iff({HybridMode} == 'true', iff(id == todynamic('{ContextSelection}').ws, true, false), Row == 1)",
+            "query": "where type =~ 'microsoft.operationalinsights/workspaces'\r\n| summarize by id, name\r\n| order by tolower(name) asc\r\n| extend Row = row_number()\r\n| project id, selected = iff({HybridMode} == 'true', iff(id == todynamic('{ContextSelection}').ws, true, false), Row == 1)",
             "crossComponentResources": [
               "{Subscriptions}"
             ],
@@ -255,12 +266,9 @@
             "version": "KqlParameterItem/1.0",
             "name": "LineChartQuerySnippet",
             "type": 1,
-            "query": "print(\"bin(TimeGenerated, {TimeGrain}), ResourceName | render linechart\")",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
+            "query": "{\"version\":\"1.0.0\",\"content\":\"\\\"bin(TimeGenerated, {TimeGrain}), ResourceName | render linechart\\\"\",\"transformers\":null}",
             "isHiddenWhenLocked": true,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "queryType": 8
           },
           {
             "id": "7055a395-0d53-4724-93ad-15e03d4e2ffa",
@@ -283,13 +291,28 @@
             "version": "KqlParameterItem/1.0",
             "name": "CustomComputerQuery",
             "type": 1,
-            "query": "let computerFilter = iff('{ComputerNameContains}' != '', \"| where Computer contains '{ComputerNameContains}'\", \"\");\r\nprint(computerFilter)",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
             "isHiddenWhenLocked": true,
-            "queryType": 0,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "criteriaData": [
+              {
+                "condition": "if (ComputerNameContains is not empty ), result = '| where Computer contains '{ComputerNameContains}''",
+                "criteriaContext": {
+                  "leftOperand": "ComputerNameContains",
+                  "operator": "isNotNull",
+                  "rightValType": "param",
+                  "resultValType": "static",
+                  "resultVal": "| where Computer contains '{ComputerNameContains}'"
+                }
+              },
+              {
+                "condition": "else result = Blank",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "param",
+                  "resultVal": "Blank"
+                }
+              }
+            ]
           },
           {
             "id": "3cd4c13e-bb7a-4b71-952e-ebf5779fba6a",
@@ -315,12 +338,29 @@
             "version": "KqlParameterItem/1.0",
             "name": "ComputerFilter",
             "type": 1,
-            "query": "let computerFilter = iff('*' in ({Computers}), \"{CustomComputerQuery}\", \"| where Computer in ({Computers})\");\r\nprint(computerFilter)",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
             "isHiddenWhenLocked": true,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "criteriaData": [
+              {
+                "condition": "if (Computers contains '*'), result = CustomComputerQuery",
+                "criteriaContext": {
+                  "leftOperand": "Computers",
+                  "operator": "contains",
+                  "rightValType": "static",
+                  "rightVal": "*",
+                  "resultValType": "param",
+                  "resultVal": "CustomComputerQuery"
+                }
+              },
+              {
+                "condition": "else result = '| where Computer in ({Computers})'",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "static",
+                  "resultVal": "| where Computer in ({Computers})"
+                }
+              }
+            ]
           },
           {
             "id": "9c56155c-9a7e-41db-ac56-40cabb7d7ddf",
@@ -349,11 +389,14 @@
             "name": "Test",
             "label": "Not Onboarded",
             "type": 1,
-            "query": "VMConnection\r\n| take 1\r\n| summarize count()",
+            "query": "InsightsMetrics\r\n| take 1\r\n| summarize count()",
             "crossComponentResources": [
               "{Workspaces}"
             ],
             "isHiddenWhenLocked": true,
+            "timeContext": {
+              "durationMs": 0
+            },
             "timeContextFromParameter": "TimeRange",
             "queryType": 0,
             "resourceType": "microsoft.operationalinsights/workspaces"
@@ -388,27 +431,27 @@
       "type": 9,
       "content": {
         "version": "KqlParameterItem/1.0",
-        "crossComponentResources": [
-          "{Workspaces}"
-        ],
         "parameters": [
           {
             "id": "aa2368fc-ad30-4608-b96a-72abf7b1e1af",
             "version": "KqlParameterItem/1.0",
             "name": "Counter1",
+            "label": "Counter",
             "type": 2,
             "isRequired": true,
-            "query": "InsightsMetrics\r\n| where TimeGenerated {TimeRange}\r\n| summarize by Name, Namespace, CounterText = Name\r\n| order by Namespace asc, CounterText asc\r\n| project Counter = pack('counter', Name, 'object', Namespace), CounterText, group = Namespace",
+            "query": "InsightsMetrics\r\n| summarize by Name, Namespace, CounterText = Name\r\n| order by Namespace asc, CounterText asc\r\n| project Counter = pack('counter', Name, 'object', Namespace), CounterText, group = Namespace",
             "crossComponentResources": [
               "{Workspaces}"
             ],
-            "value": "{\"counter\":\"UtilizationPercentage\",\"object\":\"Processor\"}",
             "typeSettings": {
               "additionalResourceOptions": []
             },
+            "timeContext": {
+              "durationMs": 0
+            },
+            "timeContextFromParameter": "TimeRange",
             "queryType": 0,
-            "resourceType": "microsoft.operationalinsights/workspaces",
-            "label": "Counter"
+            "resourceType": "microsoft.operationalinsights/workspaces"
           },
           {
             "id": "6a7306ea-247f-46ca-abca-501911f9e9d3",
@@ -427,13 +470,40 @@
             "version": "KqlParameterItem/1.0",
             "name": "TrendAggregatorOrder1",
             "type": 1,
-            "query": "print(iff('{TrendAggregator1:label}' == 'P5th'  or '{TrendAggregator1:label}' == 'P10th', 'asc', 'desc'))",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
             "isHiddenWhenLocked": true,
-            "queryType": 0,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "criteriaData": [
+              {
+                "condition": "if (TrendAggregator1 contains 'P5th'), result = 'asc'",
+                "criteriaContext": {
+                  "leftOperand": "TrendAggregator1",
+                  "operator": "contains",
+                  "rightValType": "static",
+                  "rightVal": "P5th",
+                  "resultValType": "static",
+                  "resultVal": "asc"
+                }
+              },
+              {
+                "condition": "if (TrendAggregator1 contains 'P10th'), result = 'asc'",
+                "criteriaContext": {
+                  "leftOperand": "TrendAggregator1",
+                  "operator": "contains",
+                  "rightValType": "static",
+                  "rightVal": "P10th",
+                  "resultValType": "static",
+                  "resultVal": "asc"
+                }
+              },
+              {
+                "condition": "else result = 'desc'",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "static",
+                  "resultVal": "desc"
+                }
+              }
+            ]
           },
           {
             "id": "d026cf36-d22e-4f92-a577-94220726ba3f",
@@ -441,14 +511,10 @@
             "name": "Visualization",
             "type": 2,
             "isRequired": true,
-            "query": "datatable (value:long, Display:string, isSelected:boolean)\r\n    [0, \"Line Chart\", true,\r\n     1, \"Grid\", false]",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
             "typeSettings": {
               "additionalResourceOptions": []
             },
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "jsonData": "[\r\n    {\r\n        \"value\": \"0\",\r\n        \"label\": \"Line Chart\",\r\n        \"selected\": true\r\n    },\r\n    {\r\n        \"value\": \"1\",\r\n        \"label\": \"Grid\",\r\n        \"selected\": false\r\n    }\r\n]"
           },
           {
             "id": "a9ac011f-176f-4c31-b82e-139aba93a426",
@@ -456,12 +522,29 @@
             "name": "Snippet1",
             "type": 1,
             "isRequired": true,
-            "query": "print(iff({Visualization} == 0, \"{LineChartQuerySnippet}\", \"{GridQuerySnippet}\") )",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
             "isHiddenWhenLocked": true,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "criteriaData": [
+              {
+                "condition": "if (Visualization == '0'), result = LineChartQuerySnippet",
+                "criteriaContext": {
+                  "leftOperand": "Visualization",
+                  "operator": "==",
+                  "rightValType": "static",
+                  "rightVal": "0",
+                  "resultValType": "param",
+                  "resultVal": "LineChartQuerySnippet"
+                }
+              },
+              {
+                "condition": "else result = GridQuerySnippet",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "param",
+                  "resultVal": "GridQuerySnippet"
+                }
+              }
+            ]
           },
           {
             "id": "26106dfe-4e33-4c7c-b4b6-2eff5cc76476",
@@ -508,16 +591,20 @@
             "id": "aa2368fc-ad30-4608-b96a-72abf7b1e1af",
             "version": "KqlParameterItem/1.0",
             "name": "Counter2",
+            "label": "Counter",
             "type": 2,
             "isRequired": true,
-            "query": "InsightsMetrics\r\n| where TimeGenerated {TimeRange}\r\n| summarize by Name, Namespace, CounterText = Name\r\n| order by Namespace asc, CounterText asc\r\n| project Counter = pack('counter', Name, 'object', Namespace), CounterText, group = Namespace",
+            "query": "InsightsMetrics\r\n| summarize by Name, Namespace, CounterText = Name\r\n| order by Namespace asc, CounterText asc\r\n| project Counter = pack('counter', Name, 'object', Namespace), CounterText, group = Namespace",
             "crossComponentResources": [
               "{Workspaces}"
             ],
-            "value": "{\"counter\":\"AvailableMB\",\"object\":\"Memory\"}",
             "typeSettings": {
               "additionalResourceOptions": []
             },
+            "timeContext": {
+              "durationMs": 0
+            },
+            "timeContextFromParameter": "TimeRange",
             "queryType": 0,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
@@ -525,56 +612,98 @@
             "id": "6a7306ea-247f-46ca-abca-501911f9e9d3",
             "version": "KqlParameterItem/1.0",
             "name": "TrendAggregator2",
+            "label": "Trend Aggregator",
             "type": 2,
             "isRequired": true,
             "typeSettings": {
               "additionalResourceOptions": []
             },
-            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(Val), 2)\", \"label\":\"Average\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(Val, 5), 2)\", \"label\":\"P5th\", \"selected\":false},\r\n    { \"value\":\"P10th = round(percentile(Val, 10), 2)\", \"label\":\"P10th\", \"selected\":false},\r\n    { \"value\":\"P50th = round(percentile(Val, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P80th = round(percentile(Val, 80), 2)\", \"label\":\"P80th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(Val, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(Val, 95), 2)\", \"label\":\"P95th\", \"selected\":true}    \r\n]",
-            "value": "P5th = round(percentile(Val, 5), 2)"
+            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(Val), 2)\", \"label\":\"Average\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(Val, 5), 2)\", \"label\":\"P5th\", \"selected\":false},\r\n    { \"value\":\"P10th = round(percentile(Val, 10), 2)\", \"label\":\"P10th\", \"selected\":false},\r\n    { \"value\":\"P50th = round(percentile(Val, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P80th = round(percentile(Val, 80), 2)\", \"label\":\"P80th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(Val, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(Val, 95), 2)\", \"label\":\"P95th\", \"selected\":true}    \r\n]"
           },
           {
             "id": "0327f26e-cdde-4b48-b512-6c35f06ad1d0",
             "version": "KqlParameterItem/1.0",
             "name": "TrendAggregatorOrder2",
             "type": 1,
-            "query": "print(iff('{TrendAggregator2:label}' == 'P5th'  or '{TrendAggregator2:label}' == 'P10th', 'asc', 'desc'))",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
             "isHiddenWhenLocked": true,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "criteriaData": [
+              {
+                "condition": "if (TrendAggregator2 contains 'P5th'), result = 'asc'",
+                "criteriaContext": {
+                  "leftOperand": "TrendAggregator2",
+                  "operator": "contains",
+                  "rightValType": "static",
+                  "rightVal": "P5th",
+                  "resultValType": "static",
+                  "resultVal": "asc"
+                }
+              },
+              {
+                "condition": "if (TrendAggregator2 contains 'P10th'), result = 'asc'",
+                "criteriaContext": {
+                  "leftOperand": "TrendAggregator2",
+                  "operator": "contains",
+                  "rightValType": "static",
+                  "rightVal": "P10th",
+                  "resultValType": "static",
+                  "resultVal": "asc"
+                }
+              },
+              {
+                "condition": "else result = 'desc'",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "static",
+                  "resultVal": "desc"
+                }
+              }
+            ]
           },
           {
-            "id": "bf55b759-7b6a-4ea6-8040-e3e6cc2ffe25",
+            "id": "d026cf36-d22e-4f92-a577-94220726ba3f",
             "version": "KqlParameterItem/1.0",
             "name": "Visualization2",
+            "label": "Visualization",
             "type": 2,
             "isRequired": true,
-            "query": "datatable (value:long, Display:string, isSelected:boolean)\r\n    [0, \"Line Chart\", true,\r\n     1, \"Grid\", false]",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
             "typeSettings": {
               "additionalResourceOptions": []
             },
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "jsonData": "[\r\n    {\r\n        \"value\": \"0\",\r\n        \"label\": \"Line Chart\",\r\n        \"selected\": true\r\n    },\r\n    {\r\n        \"value\": \"1\",\r\n        \"label\": \"Grid\",\r\n        \"selected\": false\r\n    }\r\n]"
           },
           {
-            "id": "de7bf116-f413-457b-8c71-fb95cc6adc87",
+            "id": "a9ac011f-176f-4c31-b82e-139aba93a426",
             "version": "KqlParameterItem/1.0",
             "name": "Snippet2",
             "type": 1,
             "isRequired": true,
-            "query": "print(iff({Visualization2} == 0, \"{LineChartQuerySnippet}\", \"{GridQuerySnippet}\") )",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
             "isHiddenWhenLocked": true,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "criteriaData": [
+              {
+                "condition": "if (Visualization2 == '0'), result = LineChartQuerySnippet",
+                "criteriaContext": {
+                  "leftOperand": "Visualization2",
+                  "operator": "==",
+                  "rightValType": "static",
+                  "rightVal": "0",
+                  "resultValType": "param",
+                  "resultVal": "LineChartQuerySnippet"
+                }
+              },
+              {
+                "condition": "else result = GridQuerySnippet",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "param",
+                  "resultVal": "GridQuerySnippet"
+                }
+              }
+            ]
           },
           {
-            "id": "2ce20c70-a462-4c7d-b5af-7f3b4cc27511",
+            "id": "26106dfe-4e33-4c7c-b4b6-2eff5cc76476",
             "version": "KqlParameterItem/1.0",
             "name": "Unit2",
             "type": 2,
@@ -621,18 +750,20 @@
             "id": "aa2368fc-ad30-4608-b96a-72abf7b1e1af",
             "version": "KqlParameterItem/1.0",
             "name": "Counter3",
+            "label": "Counter",
             "type": 2,
             "isRequired": true,
-            "query": "InsightsMetrics\r\n| where TimeGenerated {TimeRange}\r\n| summarize by Name, Namespace, CounterText = Name\r\n| order by Namespace asc, CounterText asc\r\n| project Counter = pack('counter', Name, 'object', Namespace), CounterText, group = Namespace",
+            "query": "InsightsMetrics\r\n| summarize by Name, Namespace, CounterText = Name\r\n| order by Namespace asc, CounterText asc\r\n| project Counter = pack('counter', Name, 'object', Namespace), CounterText, group = Namespace",
             "crossComponentResources": [
               "{Workspaces}"
             ],
-            "value": "{\"counter\":\"WriteBytesPerSecond\",\"object\":\"Network\"}",
             "typeSettings": {
-              "additionalResourceOptions": [
-                "value::1"
-              ]
+              "additionalResourceOptions": []
             },
+            "timeContext": {
+              "durationMs": 0
+            },
+            "timeContextFromParameter": "TimeRange",
             "queryType": 0,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
@@ -640,6 +771,7 @@
             "id": "6a7306ea-247f-46ca-abca-501911f9e9d3",
             "version": "KqlParameterItem/1.0",
             "name": "TrendAggregator3",
+            "label": "Trend Aggregator",
             "type": 2,
             "isRequired": true,
             "typeSettings": {
@@ -652,43 +784,85 @@
             "version": "KqlParameterItem/1.0",
             "name": "TrendAggregatorOrder3",
             "type": 1,
-            "query": "print(iff('{TrendAggregator3:label}' == 'P5th'  or '{TrendAggregator3:label}' == 'P10th', 'asc', 'desc'))",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
             "isHiddenWhenLocked": true,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "criteriaData": [
+              {
+                "condition": "if (TrendAggregator3 contains 'P5th'), result = 'asc'",
+                "criteriaContext": {
+                  "leftOperand": "TrendAggregator3",
+                  "operator": "contains",
+                  "rightValType": "static",
+                  "rightVal": "P5th",
+                  "resultValType": "static",
+                  "resultVal": "asc"
+                }
+              },
+              {
+                "condition": "if (TrendAggregator3 contains 'P10th'), result = 'asc'",
+                "criteriaContext": {
+                  "leftOperand": "TrendAggregator3",
+                  "operator": "contains",
+                  "rightValType": "static",
+                  "rightVal": "P10th",
+                  "resultValType": "static",
+                  "resultVal": "asc"
+                }
+              },
+              {
+                "condition": "else result = 'desc'",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "static",
+                  "resultVal": "desc"
+                }
+              }
+            ]
           },
           {
-            "id": "db1c9737-0d87-41ad-8f3c-f22c853be400",
+            "id": "d026cf36-d22e-4f92-a577-94220726ba3f",
             "version": "KqlParameterItem/1.0",
             "name": "Visualization3",
+            "label": "Visualization",
             "type": 2,
             "isRequired": true,
-            "query": "datatable (value:long, Display:string, isSelected:boolean)\r\n    [0, \"Line Chart\", true,\r\n     1, \"Grid\", false]",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
             "typeSettings": {
               "additionalResourceOptions": []
             },
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "jsonData": "[\r\n    {\r\n        \"value\": \"0\",\r\n        \"label\": \"Line Chart\",\r\n        \"selected\": true\r\n    },\r\n    {\r\n        \"value\": \"1\",\r\n        \"label\": \"Grid\",\r\n        \"selected\": false\r\n    }\r\n]"
           },
           {
-            "id": "82cef2b6-4ce0-4a64-bd64-017810211147",
+            "id": "a9ac011f-176f-4c31-b82e-139aba93a426",
             "version": "KqlParameterItem/1.0",
             "name": "Snippet3",
             "type": 1,
             "isRequired": true,
-            "query": "print(iff({Visualization3} == 0, \"{LineChartQuerySnippet}\", \"{GridQuerySnippet}\") )",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
             "isHiddenWhenLocked": true,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "criteriaData": [
+              {
+                "condition": "if (Visualization3 == '0'), result = LineChartQuerySnippet",
+                "criteriaContext": {
+                  "leftOperand": "Visualization3",
+                  "operator": "==",
+                  "rightValType": "static",
+                  "rightVal": "0",
+                  "resultValType": "param",
+                  "resultVal": "LineChartQuerySnippet"
+                }
+              },
+              {
+                "condition": "else result = GridQuerySnippet",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "param",
+                  "resultVal": "GridQuerySnippet"
+                }
+              }
+            ]
           },
           {
-            "id": "def72a65-f496-4619-8fcb-85c338641907",
+            "id": "26106dfe-4e33-4c7c-b4b6-2eff5cc76476",
             "version": "KqlParameterItem/1.0",
             "name": "Unit3",
             "type": 2,
@@ -732,16 +906,20 @@
             "id": "aa2368fc-ad30-4608-b96a-72abf7b1e1af",
             "version": "KqlParameterItem/1.0",
             "name": "Counter4",
+            "label": "Counter",
             "type": 2,
             "isRequired": true,
-            "query": "InsightsMetrics\r\n| where TimeGenerated {TimeRange}\r\n| summarize by Name, Namespace, CounterText = Name\r\n| order by Namespace asc, CounterText asc\r\n| project Counter = pack('counter', Name, 'object', Namespace), CounterText, group = Namespace",
+            "query": "InsightsMetrics\r\n| summarize by Name, Namespace, CounterText = Name\r\n| order by Namespace asc, CounterText asc\r\n| project Counter = pack('counter', Name, 'object', Namespace), CounterText, group = Namespace",
             "crossComponentResources": [
               "{Workspaces}"
             ],
-            "value": "{\"counter\":\"ReadBytesPerSecond\",\"object\":\"Network\"}",
             "typeSettings": {
               "additionalResourceOptions": []
             },
+            "timeContext": {
+              "durationMs": 0
+            },
+            "timeContextFromParameter": "TimeRange",
             "queryType": 0,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
@@ -749,6 +927,7 @@
             "id": "6a7306ea-247f-46ca-abca-501911f9e9d3",
             "version": "KqlParameterItem/1.0",
             "name": "TrendAggregator4",
+            "label": "Trend Aggregator",
             "type": 2,
             "isRequired": true,
             "typeSettings": {
@@ -761,43 +940,85 @@
             "version": "KqlParameterItem/1.0",
             "name": "TrendAggregatorOrder4",
             "type": 1,
-            "query": "print(iff('{TrendAggregator4:label}' == 'P5th'  or '{TrendAggregator4:label}' == 'P10th', 'asc', 'desc'))",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
             "isHiddenWhenLocked": true,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "criteriaData": [
+              {
+                "condition": "if (TrendAggregator4 contains 'P5th'), result = 'asc'",
+                "criteriaContext": {
+                  "leftOperand": "TrendAggregator4",
+                  "operator": "contains",
+                  "rightValType": "static",
+                  "rightVal": "P5th",
+                  "resultValType": "static",
+                  "resultVal": "asc"
+                }
+              },
+              {
+                "condition": "if (TrendAggregator4 contains 'P10th'), result = 'asc'",
+                "criteriaContext": {
+                  "leftOperand": "TrendAggregator4",
+                  "operator": "contains",
+                  "rightValType": "static",
+                  "rightVal": "P10th",
+                  "resultValType": "static",
+                  "resultVal": "asc"
+                }
+              },
+              {
+                "condition": "else result = 'desc'",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "static",
+                  "resultVal": "desc"
+                }
+              }
+            ]
           },
           {
-            "id": "16d42161-ad5d-4bd8-9b2a-8e834e3b8fed",
+            "id": "d026cf36-d22e-4f92-a577-94220726ba3f",
             "version": "KqlParameterItem/1.0",
             "name": "Visualization4",
+            "label": "Visualization",
             "type": 2,
             "isRequired": true,
-            "query": "datatable (value:long, Display:string, isSelected:boolean)\r\n    [0, \"Line Chart\", true,\r\n     1, \"Grid\", false]",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
             "typeSettings": {
               "additionalResourceOptions": []
             },
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "jsonData": "[\r\n    {\r\n        \"value\": \"0\",\r\n        \"label\": \"Line Chart\",\r\n        \"selected\": true\r\n    },\r\n    {\r\n        \"value\": \"1\",\r\n        \"label\": \"Grid\",\r\n        \"selected\": false\r\n    }\r\n]"
           },
           {
-            "id": "d768c009-20aa-4476-83cd-afacf4694818",
+            "id": "a9ac011f-176f-4c31-b82e-139aba93a426",
             "version": "KqlParameterItem/1.0",
             "name": "Snippet4",
             "type": 1,
             "isRequired": true,
-            "query": "print(iff({Visualization4} == 0, \"{LineChartQuerySnippet}\", \"{GridQuerySnippet}\") )",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
             "isHiddenWhenLocked": true,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "criteriaData": [
+              {
+                "condition": "if (Visualization4 == '0'), result = LineChartQuerySnippet",
+                "criteriaContext": {
+                  "leftOperand": "Visualization4",
+                  "operator": "==",
+                  "rightValType": "static",
+                  "rightVal": "0",
+                  "resultValType": "param",
+                  "resultVal": "LineChartQuerySnippet"
+                }
+              },
+              {
+                "condition": "else result = GridQuerySnippet",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "param",
+                  "resultVal": "GridQuerySnippet"
+                }
+              }
+            ]
           },
           {
-            "id": "eb3e4d65-ee3c-481c-af2e-8b41e4049bf8",
+            "id": "26106dfe-4e33-4c7c-b4b6-2eff5cc76476",
             "version": "KqlParameterItem/1.0",
             "name": "Unit4",
             "type": 2,
@@ -1069,18 +1290,20 @@
             "id": "aa2368fc-ad30-4608-b96a-72abf7b1e1af",
             "version": "KqlParameterItem/1.0",
             "name": "Counter5",
+            "label": "Counter",
             "type": 2,
             "isRequired": true,
-            "query": "InsightsMetrics\r\n| where TimeGenerated {TimeRange}\r\n| summarize by Name, Namespace, CounterText = Name\r\n| order by Namespace asc, CounterText asc\r\n| project Counter = pack('counter', Name, 'object', Namespace), CounterText, group = Namespace",
+            "query": "InsightsMetrics\r\n| summarize by Name, Namespace, CounterText = Name\r\n| order by Namespace asc, CounterText asc\r\n| project Counter = pack('counter', Name, 'object', Namespace), CounterText, group = Namespace",
             "crossComponentResources": [
               "{Workspaces}"
             ],
-            "value": "{\"counter\":\"FreeSpacePercentage\",\"object\":\"LogicalDisk\"}",
             "typeSettings": {
-              "additionalResourceOptions": [
-                "value::1"
-              ]
+              "additionalResourceOptions": []
             },
+            "timeContext": {
+              "durationMs": 0
+            },
+            "timeContextFromParameter": "TimeRange",
             "queryType": 0,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
@@ -1088,6 +1311,7 @@
             "id": "6a7306ea-247f-46ca-abca-501911f9e9d3",
             "version": "KqlParameterItem/1.0",
             "name": "TrendAggregator5",
+            "label": "Trend Aggregator",
             "type": 2,
             "isRequired": true,
             "typeSettings": {
@@ -1100,43 +1324,85 @@
             "version": "KqlParameterItem/1.0",
             "name": "TrendAggregatorOrder5",
             "type": 1,
-            "query": "print(iff('{TrendAggregator5:label}' == 'P5th'  or '{TrendAggregator5:label}' == 'P10th', 'asc', 'desc'))",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
             "isHiddenWhenLocked": true,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "criteriaData": [
+              {
+                "condition": "if (TrendAggregator5 contains 'P5th'), result = 'asc'",
+                "criteriaContext": {
+                  "leftOperand": "TrendAggregator5",
+                  "operator": "contains",
+                  "rightValType": "static",
+                  "rightVal": "P5th",
+                  "resultValType": "static",
+                  "resultVal": "asc"
+                }
+              },
+              {
+                "condition": "if (TrendAggregator5 contains 'P10th'), result = 'asc'",
+                "criteriaContext": {
+                  "leftOperand": "TrendAggregator5",
+                  "operator": "contains",
+                  "rightValType": "static",
+                  "rightVal": "P10th",
+                  "resultValType": "static",
+                  "resultVal": "asc"
+                }
+              },
+              {
+                "condition": "else result = 'desc'",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "static",
+                  "resultVal": "desc"
+                }
+              }
+            ]
           },
           {
-            "id": "b75e4ca5-7d71-4d29-b69e-9104934905ba",
+            "id": "d026cf36-d22e-4f92-a577-94220726ba3f",
             "version": "KqlParameterItem/1.0",
             "name": "Visualization5",
+            "label": "Visualization",
             "type": 2,
             "isRequired": true,
-            "query": "datatable (value:long, Display:string, isSelected:boolean)\r\n    [0, \"Line Chart\", true,\r\n     1, \"Grid\", false]",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
             "typeSettings": {
               "additionalResourceOptions": []
             },
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "jsonData": "[\r\n    {\r\n        \"value\": \"0\",\r\n        \"label\": \"Line Chart\",\r\n        \"selected\": true\r\n    },\r\n    {\r\n        \"value\": \"1\",\r\n        \"label\": \"Grid\",\r\n        \"selected\": false\r\n    }\r\n]"
           },
           {
-            "id": "7df7ee71-c054-4a88-b8b1-33ba6dd9d70d",
+            "id": "a9ac011f-176f-4c31-b82e-139aba93a426",
             "version": "KqlParameterItem/1.0",
             "name": "Snippet5",
             "type": 1,
             "isRequired": true,
-            "query": "print(iff({Visualization5} == 0, \"{LineChartQuerySnippet}\", \"{GridQuerySnippet}\") )",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
             "isHiddenWhenLocked": true,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "criteriaData": [
+              {
+                "condition": "if (Visualization5 == '0'), result = LineChartQuerySnippet",
+                "criteriaContext": {
+                  "leftOperand": "Visualization5",
+                  "operator": "==",
+                  "rightValType": "static",
+                  "rightVal": "0",
+                  "resultValType": "param",
+                  "resultVal": "LineChartQuerySnippet"
+                }
+              },
+              {
+                "condition": "else result = GridQuerySnippet",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "param",
+                  "resultVal": "GridQuerySnippet"
+                }
+              }
+            ]
           },
           {
-            "id": "bb81032c-59e4-417f-a5e1-fc6552c3190f",
+            "id": "26106dfe-4e33-4c7c-b4b6-2eff5cc76476",
             "version": "KqlParameterItem/1.0",
             "name": "Unit5",
             "type": 2,
@@ -1180,18 +1446,20 @@
             "id": "aa2368fc-ad30-4608-b96a-72abf7b1e1af",
             "version": "KqlParameterItem/1.0",
             "name": "Counter6",
+            "label": "Counter",
             "type": 2,
             "isRequired": true,
-            "query": "InsightsMetrics\r\n| where TimeGenerated {TimeRange}\r\n| summarize by Name, Namespace, CounterText = Name\r\n| order by Namespace asc, CounterText asc\r\n| project Counter = pack('counter', Name, 'object', Namespace), CounterText, group = Namespace",
+            "query": "InsightsMetrics\r\n| summarize by Name, Namespace, CounterText = Name\r\n| order by Namespace asc, CounterText asc\r\n| project Counter = pack('counter', Name, 'object', Namespace), CounterText, group = Namespace",
             "crossComponentResources": [
               "{Workspaces}"
             ],
-            "value": "{\"counter\":\"ReadsPerSecond\",\"object\":\"LogicalDisk\"}",
             "typeSettings": {
-              "additionalResourceOptions": [
-                "value::1"
-              ]
+              "additionalResourceOptions": []
             },
+            "timeContext": {
+              "durationMs": 0
+            },
+            "timeContextFromParameter": "TimeRange",
             "queryType": 0,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
@@ -1199,6 +1467,7 @@
             "id": "6a7306ea-247f-46ca-abca-501911f9e9d3",
             "version": "KqlParameterItem/1.0",
             "name": "TrendAggregator6",
+            "label": "Trend Aggregator",
             "type": 2,
             "isRequired": true,
             "typeSettings": {
@@ -1211,43 +1480,85 @@
             "version": "KqlParameterItem/1.0",
             "name": "TrendAggregatorOrder6",
             "type": 1,
-            "query": "print(iff('{TrendAggregator6:label}' == 'P5th'  or '{TrendAggregator6:label}' == 'P10th', 'asc', 'desc'))",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
             "isHiddenWhenLocked": true,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "criteriaData": [
+              {
+                "condition": "if (TrendAggregator6 contains 'P5th'), result = 'asc'",
+                "criteriaContext": {
+                  "leftOperand": "TrendAggregator6",
+                  "operator": "contains",
+                  "rightValType": "static",
+                  "rightVal": "P5th",
+                  "resultValType": "static",
+                  "resultVal": "asc"
+                }
+              },
+              {
+                "condition": "if (TrendAggregator6 contains 'P10th'), result = 'asc'",
+                "criteriaContext": {
+                  "leftOperand": "TrendAggregator6",
+                  "operator": "contains",
+                  "rightValType": "static",
+                  "rightVal": "P10th",
+                  "resultValType": "static",
+                  "resultVal": "asc"
+                }
+              },
+              {
+                "condition": "else result = 'desc'",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "static",
+                  "resultVal": "desc"
+                }
+              }
+            ]
           },
           {
-            "id": "5b1ee58a-5d4d-4be8-b38c-3a8eb37a2f3e",
+            "id": "d026cf36-d22e-4f92-a577-94220726ba3f",
             "version": "KqlParameterItem/1.0",
             "name": "Visualization6",
+            "label": "Visualization",
             "type": 2,
             "isRequired": true,
-            "query": "datatable (value:long, Display:string, isSelected:boolean)\r\n    [0, \"Line Chart\", true,\r\n     1, \"Grid\", false]",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
             "typeSettings": {
               "additionalResourceOptions": []
             },
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "jsonData": "[\r\n    {\r\n        \"value\": \"0\",\r\n        \"label\": \"Line Chart\",\r\n        \"selected\": true\r\n    },\r\n    {\r\n        \"value\": \"1\",\r\n        \"label\": \"Grid\",\r\n        \"selected\": false\r\n    }\r\n]"
           },
           {
-            "id": "d931d741-2f83-4ca0-bc2b-5c0c13fe8058",
+            "id": "a9ac011f-176f-4c31-b82e-139aba93a426",
             "version": "KqlParameterItem/1.0",
             "name": "Snippet6",
             "type": 1,
             "isRequired": true,
-            "query": "print(iff({Visualization6} == 0, \"{LineChartQuerySnippet}\", \"{GridQuerySnippet}\") )",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
             "isHiddenWhenLocked": true,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "criteriaData": [
+              {
+                "condition": "if (Visualization6 == '0'), result = LineChartQuerySnippet",
+                "criteriaContext": {
+                  "leftOperand": "Visualization6",
+                  "operator": "==",
+                  "rightValType": "static",
+                  "rightVal": "0",
+                  "resultValType": "param",
+                  "resultVal": "LineChartQuerySnippet"
+                }
+              },
+              {
+                "condition": "else result = GridQuerySnippet",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "param",
+                  "resultVal": "GridQuerySnippet"
+                }
+              }
+            ]
           },
           {
-            "id": "ab35d419-d8c1-45be-8885-e39a55c0648d",
+            "id": "26106dfe-4e33-4c7c-b4b6-2eff5cc76476",
             "version": "KqlParameterItem/1.0",
             "name": "Unit6",
             "type": 2,
@@ -1291,18 +1602,20 @@
             "id": "aa2368fc-ad30-4608-b96a-72abf7b1e1af",
             "version": "KqlParameterItem/1.0",
             "name": "Counter7",
+            "label": "Counter",
             "type": 2,
             "isRequired": true,
-            "query": "InsightsMetrics\r\n| where TimeGenerated {TimeRange}\r\n| summarize by Name, Namespace, CounterText = Name\r\n| order by Namespace asc, CounterText asc\r\n| project Counter = pack('counter', Name, 'object', Namespace), CounterText, group = Namespace",
+            "query": "InsightsMetrics\r\n| summarize by Name, Namespace, CounterText = Name\r\n| order by Namespace asc, CounterText asc\r\n| project Counter = pack('counter', Name, 'object', Namespace), CounterText, group = Namespace",
             "crossComponentResources": [
               "{Workspaces}"
             ],
-            "value": "{\"counter\":\"WritesPerSecond\",\"object\":\"LogicalDisk\"}",
             "typeSettings": {
-              "additionalResourceOptions": [
-                "value::1"
-              ]
+              "additionalResourceOptions": []
             },
+            "timeContext": {
+              "durationMs": 0
+            },
+            "timeContextFromParameter": "TimeRange",
             "queryType": 0,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
@@ -1310,6 +1623,7 @@
             "id": "6a7306ea-247f-46ca-abca-501911f9e9d3",
             "version": "KqlParameterItem/1.0",
             "name": "TrendAggregator7",
+            "label": "Trend Aggregator",
             "type": 2,
             "isRequired": true,
             "typeSettings": {
@@ -1322,43 +1636,85 @@
             "version": "KqlParameterItem/1.0",
             "name": "TrendAggregatorOrder7",
             "type": 1,
-            "query": "print(iff('{TrendAggregator7:label}' == 'P5th'  or '{TrendAggregator7:label}' == 'P10th', 'asc', 'desc'))",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
             "isHiddenWhenLocked": true,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "criteriaData": [
+              {
+                "condition": "if (TrendAggregator7 contains 'P5th'), result = 'asc'",
+                "criteriaContext": {
+                  "leftOperand": "TrendAggregator7",
+                  "operator": "contains",
+                  "rightValType": "static",
+                  "rightVal": "P5th",
+                  "resultValType": "static",
+                  "resultVal": "asc"
+                }
+              },
+              {
+                "condition": "if (TrendAggregator7 contains 'P10th'), result = 'asc'",
+                "criteriaContext": {
+                  "leftOperand": "TrendAggregator7",
+                  "operator": "contains",
+                  "rightValType": "static",
+                  "rightVal": "P10th",
+                  "resultValType": "static",
+                  "resultVal": "asc"
+                }
+              },
+              {
+                "condition": "else result = 'desc'",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "static",
+                  "resultVal": "desc"
+                }
+              }
+            ]
           },
           {
-            "id": "bc1291ba-dd26-4224-9b25-3a1e7b3eb024",
+            "id": "d026cf36-d22e-4f92-a577-94220726ba3f",
             "version": "KqlParameterItem/1.0",
             "name": "Visualization7",
+            "label": "Visualization",
             "type": 2,
             "isRequired": true,
-            "query": "datatable (value:long, Display:string, isSelected:boolean)\r\n    [0, \"Line Chart\", true,\r\n     1, \"Grid\", false]",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
             "typeSettings": {
               "additionalResourceOptions": []
             },
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "jsonData": "[\r\n    {\r\n        \"value\": \"0\",\r\n        \"label\": \"Line Chart\",\r\n        \"selected\": true\r\n    },\r\n    {\r\n        \"value\": \"1\",\r\n        \"label\": \"Grid\",\r\n        \"selected\": false\r\n    }\r\n]"
           },
           {
-            "id": "6cc1a388-27c6-4cfe-a787-ff00cb8f4fae",
+            "id": "a9ac011f-176f-4c31-b82e-139aba93a426",
             "version": "KqlParameterItem/1.0",
             "name": "Snippet7",
             "type": 1,
             "isRequired": true,
-            "query": "print(iff({Visualization7} == 0, \"{LineChartQuerySnippet}\", \"{GridQuerySnippet}\") )",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
             "isHiddenWhenLocked": true,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "criteriaData": [
+              {
+                "condition": "if (Visualization7 == '0'), result = LineChartQuerySnippet",
+                "criteriaContext": {
+                  "leftOperand": "Visualization7",
+                  "operator": "==",
+                  "rightValType": "static",
+                  "rightVal": "0",
+                  "resultValType": "param",
+                  "resultVal": "LineChartQuerySnippet"
+                }
+              },
+              {
+                "condition": "else result = GridQuerySnippet",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "param",
+                  "resultVal": "GridQuerySnippet"
+                }
+              }
+            ]
           },
           {
-            "id": "dce874fa-b71d-4a09-bcee-bd1b3f672f7f",
+            "id": "26106dfe-4e33-4c7c-b4b6-2eff5cc76476",
             "version": "KqlParameterItem/1.0",
             "name": "Unit7",
             "type": 2,
@@ -1402,18 +1758,20 @@
             "id": "aa2368fc-ad30-4608-b96a-72abf7b1e1af",
             "version": "KqlParameterItem/1.0",
             "name": "Counter8",
+            "label": "Counter",
             "type": 2,
             "isRequired": true,
-            "query": "InsightsMetrics\r\n| where TimeGenerated {TimeRange}\r\n| summarize by Name, Namespace, CounterText = Name\r\n| order by Namespace asc, CounterText asc\r\n| project Counter = pack('counter', Name, 'object', Namespace), CounterText, group = Namespace",
+            "query": "InsightsMetrics\r\n| summarize by Name, Namespace, CounterText = Name\r\n| order by Namespace asc, CounterText asc\r\n| project Counter = pack('counter', Name, 'object', Namespace), CounterText, group = Namespace",
             "crossComponentResources": [
               "{Workspaces}"
             ],
-            "value": "{\"counter\":\"TransfersPerSecond\",\"object\":\"LogicalDisk\"}",
             "typeSettings": {
-              "additionalResourceOptions": [
-                "value::1"
-              ]
+              "additionalResourceOptions": []
             },
+            "timeContext": {
+              "durationMs": 0
+            },
+            "timeContextFromParameter": "TimeRange",
             "queryType": 0,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
@@ -1421,6 +1779,7 @@
             "id": "6a7306ea-247f-46ca-abca-501911f9e9d3",
             "version": "KqlParameterItem/1.0",
             "name": "TrendAggregator8",
+            "label": "Trend Aggregator",
             "type": 2,
             "isRequired": true,
             "typeSettings": {
@@ -1433,43 +1792,85 @@
             "version": "KqlParameterItem/1.0",
             "name": "TrendAggregatorOrder8",
             "type": 1,
-            "query": "print(iff('{TrendAggregator8:label}' == 'P5th'  or '{TrendAggregator8:label}' == 'P10th', 'asc', 'desc'))",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
             "isHiddenWhenLocked": true,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "criteriaData": [
+              {
+                "condition": "if (TrendAggregator8 contains 'P5th'), result = 'asc'",
+                "criteriaContext": {
+                  "leftOperand": "TrendAggregator8",
+                  "operator": "contains",
+                  "rightValType": "static",
+                  "rightVal": "P5th",
+                  "resultValType": "static",
+                  "resultVal": "asc"
+                }
+              },
+              {
+                "condition": "if (TrendAggregator8 contains 'P10th'), result = 'asc'",
+                "criteriaContext": {
+                  "leftOperand": "TrendAggregator8",
+                  "operator": "contains",
+                  "rightValType": "static",
+                  "rightVal": "P10th",
+                  "resultValType": "static",
+                  "resultVal": "asc"
+                }
+              },
+              {
+                "condition": "else result = 'desc'",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "static",
+                  "resultVal": "desc"
+                }
+              }
+            ]
           },
           {
-            "id": "68468652-570f-4d77-af12-a59d463d5f02",
+            "id": "d026cf36-d22e-4f92-a577-94220726ba3f",
             "version": "KqlParameterItem/1.0",
             "name": "Visualization8",
+            "label": "Visualization",
             "type": 2,
             "isRequired": true,
-            "query": "datatable (value:long, Display:string, isSelected:boolean)\r\n    [0, \"Line Chart\", true,\r\n     1, \"Grid\", false]",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
             "typeSettings": {
               "additionalResourceOptions": []
             },
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "jsonData": "[\r\n    {\r\n        \"value\": \"0\",\r\n        \"label\": \"Line Chart\",\r\n        \"selected\": true\r\n    },\r\n    {\r\n        \"value\": \"1\",\r\n        \"label\": \"Grid\",\r\n        \"selected\": false\r\n    }\r\n]"
           },
           {
-            "id": "15738505-f7e6-446e-995d-280cf70dde93",
+            "id": "a9ac011f-176f-4c31-b82e-139aba93a426",
             "version": "KqlParameterItem/1.0",
             "name": "Snippet8",
             "type": 1,
             "isRequired": true,
-            "query": "print(iff({Visualization8} == 0, \"{LineChartQuerySnippet}\", \"{GridQuerySnippet}\") )",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
             "isHiddenWhenLocked": true,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "criteriaData": [
+              {
+                "condition": "if (Visualization8 == '0'), result = LineChartQuerySnippet",
+                "criteriaContext": {
+                  "leftOperand": "Visualization8",
+                  "operator": "==",
+                  "rightValType": "static",
+                  "rightVal": "0",
+                  "resultValType": "param",
+                  "resultVal": "LineChartQuerySnippet"
+                }
+              },
+              {
+                "condition": "else result = GridQuerySnippet",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "param",
+                  "resultVal": "GridQuerySnippet"
+                }
+              }
+            ]
           },
           {
-            "id": "c78d15dd-79cb-4cd2-8749-df9d97625b31",
+            "id": "26106dfe-4e33-4c7c-b4b6-2eff5cc76476",
             "version": "KqlParameterItem/1.0",
             "name": "Unit8",
             "type": 2,

--- a/Workbooks/Virtual Machines - Performance Analysis/Performance Counters/Performance Counters.workbook
+++ b/Workbooks/Virtual Machines - Performance Analysis/Performance Counters/Performance Counters.workbook
@@ -10,6 +10,17 @@
         ],
         "parameters": [
           {
+            "id": "2c4ef86b-c7cb-434e-9051-291940cb51bf",
+            "version": "KqlParameterItem/1.0",
+            "name": "Blank",
+            "type": 1,
+            "isHiddenWhenLocked": true,
+            "timeContext": {
+              "durationMs": 0
+            },
+            "timeContextFromParameter": "TimeRange"
+          },
+          {
             "id": "80a15801-7442-49f3-a82f-6e55849ec7fb",
             "version": "KqlParameterItem/1.0",
             "name": "DefaultWorkspace",
@@ -47,7 +58,7 @@
             "version": "KqlParameterItem/1.0",
             "name": "ContextSelection",
             "type": 1,
-            "query": "// {DefaultWorkspace}\r\nwhere strcat(\"'\", id, \"'\") =~ \"{DefaultWorkspace:value}\"\r\n| project value = tostring(pack('sub', subscriptionId, 'rg', resourceGroup, 'ws', id))",
+            "query": "where strcat(\"'\", id, \"'\") =~ \"{DefaultWorkspace:value}\"\r\n| project value = tostring(pack('sub', subscriptionId, 'rg', resourceGroup, 'ws', id))",
             "crossComponentResources": [
               "value::all"
             ],
@@ -92,7 +103,7 @@
             "multiSelect": true,
             "quote": "'",
             "delimiter": ",",
-            "query": "// {DefaultWorkspace} {ContextSelection} {DefaultSubscription}\r\nsummarize by subscriptionId\r\n| project strcat('/subscriptions/', subscriptionId), selected = iff({HybridMode} == true, iff(subscriptionId == todynamic('{ContextSelection}').sub, true, false), iff(strcat('/subscriptions/', subscriptionId) == '{DefaultSubscription}', true, false))",
+            "query": "summarize by subscriptionId\r\n| project strcat('/subscriptions/', subscriptionId), selected = iff({HybridMode} == true, iff(subscriptionId == todynamic('{ContextSelection}').sub, true, false), iff(strcat('/subscriptions/', subscriptionId) == '{DefaultSubscription}', true, false))",
             "crossComponentResources": [
               "value::all"
             ],
@@ -111,7 +122,7 @@
             "multiSelect": true,
             "quote": "'",
             "delimiter": ",",
-            "query": "// {DefaultWorkspace} {ContextSelection} {Subscriptions}\r\nwhere type =~ 'microsoft.operationalinsights/workspaces'\r\n| summarize by id, name\r\n| order by tolower(name) asc\r\n| extend Row = row_number()\r\n| project id, selected = iff({HybridMode} == 'true', iff(id == todynamic('{ContextSelection}').ws, true, false), Row == 1)",
+            "query": "where type =~ 'microsoft.operationalinsights/workspaces'\r\n| summarize by id, name\r\n| order by tolower(name) asc\r\n| extend Row = row_number()\r\n| project id, selected = iff({HybridMode} == 'true', iff(id == todynamic('{ContextSelection}').ws, true, false), Row == 1)",
             "crossComponentResources": [
               "{Subscriptions}"
             ],
@@ -255,12 +266,9 @@
             "version": "KqlParameterItem/1.0",
             "name": "LineChartQuerySnippet",
             "type": 1,
-            "query": "print(\"bin(TimeGenerated, {TimeGrain}), ResourceName | render linechart\")",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
+            "query": "{\"version\":\"1.0.0\",\"content\":\"\\\"bin(TimeGenerated, {TimeGrain}), ResourceName | render linechart\\\"\",\"transformers\":null}",
             "isHiddenWhenLocked": true,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "queryType": 8
           },
           {
             "id": "7055a395-0d53-4724-93ad-15e03d4e2ffa",
@@ -283,13 +291,28 @@
             "version": "KqlParameterItem/1.0",
             "name": "CustomComputerQuery",
             "type": 1,
-            "query": "let computerFilter = iff('{ComputerNameContains}' != '', \"| where Computer contains '{ComputerNameContains}'\", \"\");\r\nprint(computerFilter)",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
             "isHiddenWhenLocked": true,
-            "queryType": 0,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "criteriaData": [
+              {
+                "condition": "if (ComputerNameContains is not empty ), result = '| where Computer contains '{ComputerNameContains}''",
+                "criteriaContext": {
+                  "leftOperand": "ComputerNameContains",
+                  "operator": "isNotNull",
+                  "rightValType": "param",
+                  "resultValType": "static",
+                  "resultVal": "| where Computer contains '{ComputerNameContains}'"
+                }
+              },
+              {
+                "condition": "else result = Blank",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "param",
+                  "resultVal": "Blank"
+                }
+              }
+            ]
           },
           {
             "id": "3cd4c13e-bb7a-4b71-952e-ebf5779fba6a",
@@ -315,12 +338,29 @@
             "version": "KqlParameterItem/1.0",
             "name": "ComputerFilter",
             "type": 1,
-            "query": "let computerFilter = iff('*' in ({Computers}), \"{CustomComputerQuery}\", \"| where Computer in ({Computers})\");\r\nprint(computerFilter)",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
             "isHiddenWhenLocked": true,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "criteriaData": [
+              {
+                "condition": "if (Computers contains '*'), result = CustomComputerQuery",
+                "criteriaContext": {
+                  "leftOperand": "Computers",
+                  "operator": "contains",
+                  "rightValType": "static",
+                  "rightVal": "*",
+                  "resultValType": "param",
+                  "resultVal": "CustomComputerQuery"
+                }
+              },
+              {
+                "condition": "else result = '| where Computer in ({Computers})'",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "static",
+                  "resultVal": "| where Computer in ({Computers})"
+                }
+              }
+            ]
           },
           {
             "id": "9c56155c-9a7e-41db-ac56-40cabb7d7ddf",
@@ -349,11 +389,14 @@
             "name": "Test",
             "label": "Not Onboarded",
             "type": 1,
-            "query": "VMConnection\r\n| take 1\r\n| summarize count()",
+            "query": "InsightsMetrics\r\n| take 1\r\n| summarize count()",
             "crossComponentResources": [
               "{Workspaces}"
             ],
             "isHiddenWhenLocked": true,
+            "timeContext": {
+              "durationMs": 0
+            },
             "timeContextFromParameter": "TimeRange",
             "queryType": 0,
             "resourceType": "microsoft.operationalinsights/workspaces"
@@ -388,27 +431,27 @@
       "type": 9,
       "content": {
         "version": "KqlParameterItem/1.0",
-        "crossComponentResources": [
-          "{Workspaces}"
-        ],
         "parameters": [
           {
             "id": "aa2368fc-ad30-4608-b96a-72abf7b1e1af",
             "version": "KqlParameterItem/1.0",
             "name": "Counter1",
+            "label": "Counter",
             "type": 2,
             "isRequired": true,
-            "query": "InsightsMetrics\r\n| where TimeGenerated {TimeRange}\r\n| summarize by Name, Namespace, CounterText = Name\r\n| order by Namespace asc, CounterText asc\r\n| project Counter = pack('counter', Name, 'object', Namespace), CounterText, group = Namespace",
+            "query": "InsightsMetrics\r\n| summarize by Name, Namespace, CounterText = Name\r\n| order by Namespace asc, CounterText asc\r\n| project Counter = pack('counter', Name, 'object', Namespace), CounterText, group = Namespace",
             "crossComponentResources": [
               "{Workspaces}"
             ],
-            "value": "{\"counter\":\"UtilizationPercentage\",\"object\":\"Processor\"}",
             "typeSettings": {
               "additionalResourceOptions": []
             },
+            "timeContext": {
+              "durationMs": 0
+            },
+            "timeContextFromParameter": "TimeRange",
             "queryType": 0,
-            "resourceType": "microsoft.operationalinsights/workspaces",
-            "label": "Counter"
+            "resourceType": "microsoft.operationalinsights/workspaces"
           },
           {
             "id": "6a7306ea-247f-46ca-abca-501911f9e9d3",
@@ -427,13 +470,40 @@
             "version": "KqlParameterItem/1.0",
             "name": "TrendAggregatorOrder1",
             "type": 1,
-            "query": "print(iff('{TrendAggregator1:label}' == 'P5th'  or '{TrendAggregator1:label}' == 'P10th', 'asc', 'desc'))",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
             "isHiddenWhenLocked": true,
-            "queryType": 0,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "criteriaData": [
+              {
+                "condition": "if (TrendAggregator1 contains 'P5th'), result = 'asc'",
+                "criteriaContext": {
+                  "leftOperand": "TrendAggregator1",
+                  "operator": "contains",
+                  "rightValType": "static",
+                  "rightVal": "P5th",
+                  "resultValType": "static",
+                  "resultVal": "asc"
+                }
+              },
+              {
+                "condition": "if (TrendAggregator1 contains 'P10th'), result = 'asc'",
+                "criteriaContext": {
+                  "leftOperand": "TrendAggregator1",
+                  "operator": "contains",
+                  "rightValType": "static",
+                  "rightVal": "P10th",
+                  "resultValType": "static",
+                  "resultVal": "asc"
+                }
+              },
+              {
+                "condition": "else result = 'desc'",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "static",
+                  "resultVal": "desc"
+                }
+              }
+            ]
           },
           {
             "id": "d026cf36-d22e-4f92-a577-94220726ba3f",
@@ -441,14 +511,10 @@
             "name": "Visualization",
             "type": 2,
             "isRequired": true,
-            "query": "datatable (value:long, Display:string, isSelected:boolean)\r\n    [0, \"Line Chart\", true,\r\n     1, \"Grid\", false]",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
             "typeSettings": {
               "additionalResourceOptions": []
             },
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "jsonData": "[\r\n    {\r\n        \"value\": \"0\",\r\n        \"label\": \"Line Chart\",\r\n        \"selected\": true\r\n    },\r\n    {\r\n        \"value\": \"1\",\r\n        \"label\": \"Grid\",\r\n        \"selected\": false\r\n    }\r\n]"
           },
           {
             "id": "a9ac011f-176f-4c31-b82e-139aba93a426",
@@ -456,12 +522,29 @@
             "name": "Snippet1",
             "type": 1,
             "isRequired": true,
-            "query": "print(iff({Visualization} == 0, \"{LineChartQuerySnippet}\", \"{GridQuerySnippet}\") )",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
             "isHiddenWhenLocked": true,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "criteriaData": [
+              {
+                "condition": "if (Visualization == '0'), result = LineChartQuerySnippet",
+                "criteriaContext": {
+                  "leftOperand": "Visualization",
+                  "operator": "==",
+                  "rightValType": "static",
+                  "rightVal": "0",
+                  "resultValType": "param",
+                  "resultVal": "LineChartQuerySnippet"
+                }
+              },
+              {
+                "condition": "else result = GridQuerySnippet",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "param",
+                  "resultVal": "GridQuerySnippet"
+                }
+              }
+            ]
           },
           {
             "id": "26106dfe-4e33-4c7c-b4b6-2eff5cc76476",
@@ -508,16 +591,20 @@
             "id": "aa2368fc-ad30-4608-b96a-72abf7b1e1af",
             "version": "KqlParameterItem/1.0",
             "name": "Counter2",
+            "label": "Counter",
             "type": 2,
             "isRequired": true,
-            "query": "InsightsMetrics\r\n| where TimeGenerated {TimeRange}\r\n| summarize by Name, Namespace, CounterText = Name\r\n| order by Namespace asc, CounterText asc\r\n| project Counter = pack('counter', Name, 'object', Namespace), CounterText, group = Namespace",
+            "query": "InsightsMetrics\r\n| summarize by Name, Namespace, CounterText = Name\r\n| order by Namespace asc, CounterText asc\r\n| project Counter = pack('counter', Name, 'object', Namespace), CounterText, group = Namespace",
             "crossComponentResources": [
               "{Workspaces}"
             ],
-            "value": "{\"counter\":\"AvailableMB\",\"object\":\"Memory\"}",
             "typeSettings": {
               "additionalResourceOptions": []
             },
+            "timeContext": {
+              "durationMs": 0
+            },
+            "timeContextFromParameter": "TimeRange",
             "queryType": 0,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
@@ -525,56 +612,98 @@
             "id": "6a7306ea-247f-46ca-abca-501911f9e9d3",
             "version": "KqlParameterItem/1.0",
             "name": "TrendAggregator2",
+            "label": "Trend Aggregator",
             "type": 2,
             "isRequired": true,
             "typeSettings": {
               "additionalResourceOptions": []
             },
-            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(Val), 2)\", \"label\":\"Average\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(Val, 5), 2)\", \"label\":\"P5th\", \"selected\":false},\r\n    { \"value\":\"P10th = round(percentile(Val, 10), 2)\", \"label\":\"P10th\", \"selected\":false},\r\n    { \"value\":\"P50th = round(percentile(Val, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P80th = round(percentile(Val, 80), 2)\", \"label\":\"P80th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(Val, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(Val, 95), 2)\", \"label\":\"P95th\", \"selected\":true}    \r\n]",
-            "value": "P5th = round(percentile(Val, 5), 2)"
+            "jsonData": "[\r\n    { \"value\":\"Average = round(avg(Val), 2)\", \"label\":\"Average\", \"selected\":false},\r\n    { \"value\":\"P5th = round(percentile(Val, 5), 2)\", \"label\":\"P5th\", \"selected\":false},\r\n    { \"value\":\"P10th = round(percentile(Val, 10), 2)\", \"label\":\"P10th\", \"selected\":false},\r\n    { \"value\":\"P50th = round(percentile(Val, 50), 2)\", \"label\":\"P50th\", \"selected\":false},\r\n    { \"value\":\"P80th = round(percentile(Val, 80), 2)\", \"label\":\"P80th\", \"selected\":false},\r\n    { \"value\":\"P90th = round(percentile(Val, 90), 2)\", \"label\":\"P90th\", \"selected\":false},\r\n    { \"value\":\"P95th = round(percentile(Val, 95), 2)\", \"label\":\"P95th\", \"selected\":true}    \r\n]"
           },
           {
             "id": "0327f26e-cdde-4b48-b512-6c35f06ad1d0",
             "version": "KqlParameterItem/1.0",
             "name": "TrendAggregatorOrder2",
             "type": 1,
-            "query": "print(iff('{TrendAggregator2:label}' == 'P5th'  or '{TrendAggregator2:label}' == 'P10th', 'asc', 'desc'))",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
             "isHiddenWhenLocked": true,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "criteriaData": [
+              {
+                "condition": "if (TrendAggregator2 contains 'P5th'), result = 'asc'",
+                "criteriaContext": {
+                  "leftOperand": "TrendAggregator2",
+                  "operator": "contains",
+                  "rightValType": "static",
+                  "rightVal": "P5th",
+                  "resultValType": "static",
+                  "resultVal": "asc"
+                }
+              },
+              {
+                "condition": "if (TrendAggregator2 contains 'P10th'), result = 'asc'",
+                "criteriaContext": {
+                  "leftOperand": "TrendAggregator2",
+                  "operator": "contains",
+                  "rightValType": "static",
+                  "rightVal": "P10th",
+                  "resultValType": "static",
+                  "resultVal": "asc"
+                }
+              },
+              {
+                "condition": "else result = 'desc'",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "static",
+                  "resultVal": "desc"
+                }
+              }
+            ]
           },
           {
-            "id": "bf55b759-7b6a-4ea6-8040-e3e6cc2ffe25",
+            "id": "d026cf36-d22e-4f92-a577-94220726ba3f",
             "version": "KqlParameterItem/1.0",
             "name": "Visualization2",
+            "label": "Visualization",
             "type": 2,
             "isRequired": true,
-            "query": "datatable (value:long, Display:string, isSelected:boolean)\r\n    [0, \"Line Chart\", true,\r\n     1, \"Grid\", false]",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
             "typeSettings": {
               "additionalResourceOptions": []
             },
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "jsonData": "[\r\n    {\r\n        \"value\": \"0\",\r\n        \"label\": \"Line Chart\",\r\n        \"selected\": true\r\n    },\r\n    {\r\n        \"value\": \"1\",\r\n        \"label\": \"Grid\",\r\n        \"selected\": false\r\n    }\r\n]"
           },
           {
-            "id": "de7bf116-f413-457b-8c71-fb95cc6adc87",
+            "id": "a9ac011f-176f-4c31-b82e-139aba93a426",
             "version": "KqlParameterItem/1.0",
             "name": "Snippet2",
             "type": 1,
             "isRequired": true,
-            "query": "print(iff({Visualization2} == 0, \"{LineChartQuerySnippet}\", \"{GridQuerySnippet}\") )",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
             "isHiddenWhenLocked": true,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "criteriaData": [
+              {
+                "condition": "if (Visualization2 == '0'), result = LineChartQuerySnippet",
+                "criteriaContext": {
+                  "leftOperand": "Visualization2",
+                  "operator": "==",
+                  "rightValType": "static",
+                  "rightVal": "0",
+                  "resultValType": "param",
+                  "resultVal": "LineChartQuerySnippet"
+                }
+              },
+              {
+                "condition": "else result = GridQuerySnippet",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "param",
+                  "resultVal": "GridQuerySnippet"
+                }
+              }
+            ]
           },
           {
-            "id": "2ce20c70-a462-4c7d-b5af-7f3b4cc27511",
+            "id": "26106dfe-4e33-4c7c-b4b6-2eff5cc76476",
             "version": "KqlParameterItem/1.0",
             "name": "Unit2",
             "type": 2,
@@ -621,18 +750,20 @@
             "id": "aa2368fc-ad30-4608-b96a-72abf7b1e1af",
             "version": "KqlParameterItem/1.0",
             "name": "Counter3",
+            "label": "Counter",
             "type": 2,
             "isRequired": true,
-            "query": "InsightsMetrics\r\n| where TimeGenerated {TimeRange}\r\n| summarize by Name, Namespace, CounterText = Name\r\n| order by Namespace asc, CounterText asc\r\n| project Counter = pack('counter', Name, 'object', Namespace), CounterText, group = Namespace",
+            "query": "InsightsMetrics\r\n| summarize by Name, Namespace, CounterText = Name\r\n| order by Namespace asc, CounterText asc\r\n| project Counter = pack('counter', Name, 'object', Namespace), CounterText, group = Namespace",
             "crossComponentResources": [
               "{Workspaces}"
             ],
-            "value": "{\"counter\":\"WriteBytesPerSecond\",\"object\":\"Network\"}",
             "typeSettings": {
-              "additionalResourceOptions": [
-                "value::1"
-              ]
+              "additionalResourceOptions": []
             },
+            "timeContext": {
+              "durationMs": 0
+            },
+            "timeContextFromParameter": "TimeRange",
             "queryType": 0,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
@@ -640,6 +771,7 @@
             "id": "6a7306ea-247f-46ca-abca-501911f9e9d3",
             "version": "KqlParameterItem/1.0",
             "name": "TrendAggregator3",
+            "label": "Trend Aggregator",
             "type": 2,
             "isRequired": true,
             "typeSettings": {
@@ -652,43 +784,85 @@
             "version": "KqlParameterItem/1.0",
             "name": "TrendAggregatorOrder3",
             "type": 1,
-            "query": "print(iff('{TrendAggregator3:label}' == 'P5th'  or '{TrendAggregator3:label}' == 'P10th', 'asc', 'desc'))",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
             "isHiddenWhenLocked": true,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "criteriaData": [
+              {
+                "condition": "if (TrendAggregator3 contains 'P5th'), result = 'asc'",
+                "criteriaContext": {
+                  "leftOperand": "TrendAggregator3",
+                  "operator": "contains",
+                  "rightValType": "static",
+                  "rightVal": "P5th",
+                  "resultValType": "static",
+                  "resultVal": "asc"
+                }
+              },
+              {
+                "condition": "if (TrendAggregator3 contains 'P10th'), result = 'asc'",
+                "criteriaContext": {
+                  "leftOperand": "TrendAggregator3",
+                  "operator": "contains",
+                  "rightValType": "static",
+                  "rightVal": "P10th",
+                  "resultValType": "static",
+                  "resultVal": "asc"
+                }
+              },
+              {
+                "condition": "else result = 'desc'",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "static",
+                  "resultVal": "desc"
+                }
+              }
+            ]
           },
           {
-            "id": "db1c9737-0d87-41ad-8f3c-f22c853be400",
+            "id": "d026cf36-d22e-4f92-a577-94220726ba3f",
             "version": "KqlParameterItem/1.0",
             "name": "Visualization3",
+            "label": "Visualization",
             "type": 2,
             "isRequired": true,
-            "query": "datatable (value:long, Display:string, isSelected:boolean)\r\n    [0, \"Line Chart\", true,\r\n     1, \"Grid\", false]",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
             "typeSettings": {
               "additionalResourceOptions": []
             },
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "jsonData": "[\r\n    {\r\n        \"value\": \"0\",\r\n        \"label\": \"Line Chart\",\r\n        \"selected\": true\r\n    },\r\n    {\r\n        \"value\": \"1\",\r\n        \"label\": \"Grid\",\r\n        \"selected\": false\r\n    }\r\n]"
           },
           {
-            "id": "82cef2b6-4ce0-4a64-bd64-017810211147",
+            "id": "a9ac011f-176f-4c31-b82e-139aba93a426",
             "version": "KqlParameterItem/1.0",
             "name": "Snippet3",
             "type": 1,
             "isRequired": true,
-            "query": "print(iff({Visualization3} == 0, \"{LineChartQuerySnippet}\", \"{GridQuerySnippet}\") )",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
             "isHiddenWhenLocked": true,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "criteriaData": [
+              {
+                "condition": "if (Visualization3 == '0'), result = LineChartQuerySnippet",
+                "criteriaContext": {
+                  "leftOperand": "Visualization3",
+                  "operator": "==",
+                  "rightValType": "static",
+                  "rightVal": "0",
+                  "resultValType": "param",
+                  "resultVal": "LineChartQuerySnippet"
+                }
+              },
+              {
+                "condition": "else result = GridQuerySnippet",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "param",
+                  "resultVal": "GridQuerySnippet"
+                }
+              }
+            ]
           },
           {
-            "id": "def72a65-f496-4619-8fcb-85c338641907",
+            "id": "26106dfe-4e33-4c7c-b4b6-2eff5cc76476",
             "version": "KqlParameterItem/1.0",
             "name": "Unit3",
             "type": 2,
@@ -732,16 +906,20 @@
             "id": "aa2368fc-ad30-4608-b96a-72abf7b1e1af",
             "version": "KqlParameterItem/1.0",
             "name": "Counter4",
+            "label": "Counter",
             "type": 2,
             "isRequired": true,
-            "query": "InsightsMetrics\r\n| where TimeGenerated {TimeRange}\r\n| summarize by Name, Namespace, CounterText = Name\r\n| order by Namespace asc, CounterText asc\r\n| project Counter = pack('counter', Name, 'object', Namespace), CounterText, group = Namespace",
+            "query": "InsightsMetrics\r\n| summarize by Name, Namespace, CounterText = Name\r\n| order by Namespace asc, CounterText asc\r\n| project Counter = pack('counter', Name, 'object', Namespace), CounterText, group = Namespace",
             "crossComponentResources": [
               "{Workspaces}"
             ],
-            "value": "{\"counter\":\"ReadBytesPerSecond\",\"object\":\"Network\"}",
             "typeSettings": {
               "additionalResourceOptions": []
             },
+            "timeContext": {
+              "durationMs": 0
+            },
+            "timeContextFromParameter": "TimeRange",
             "queryType": 0,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
@@ -749,6 +927,7 @@
             "id": "6a7306ea-247f-46ca-abca-501911f9e9d3",
             "version": "KqlParameterItem/1.0",
             "name": "TrendAggregator4",
+            "label": "Trend Aggregator",
             "type": 2,
             "isRequired": true,
             "typeSettings": {
@@ -761,43 +940,85 @@
             "version": "KqlParameterItem/1.0",
             "name": "TrendAggregatorOrder4",
             "type": 1,
-            "query": "print(iff('{TrendAggregator4:label}' == 'P5th'  or '{TrendAggregator4:label}' == 'P10th', 'asc', 'desc'))",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
             "isHiddenWhenLocked": true,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "criteriaData": [
+              {
+                "condition": "if (TrendAggregator4 contains 'P5th'), result = 'asc'",
+                "criteriaContext": {
+                  "leftOperand": "TrendAggregator4",
+                  "operator": "contains",
+                  "rightValType": "static",
+                  "rightVal": "P5th",
+                  "resultValType": "static",
+                  "resultVal": "asc"
+                }
+              },
+              {
+                "condition": "if (TrendAggregator4 contains 'P10th'), result = 'asc'",
+                "criteriaContext": {
+                  "leftOperand": "TrendAggregator4",
+                  "operator": "contains",
+                  "rightValType": "static",
+                  "rightVal": "P10th",
+                  "resultValType": "static",
+                  "resultVal": "asc"
+                }
+              },
+              {
+                "condition": "else result = 'desc'",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "static",
+                  "resultVal": "desc"
+                }
+              }
+            ]
           },
           {
-            "id": "16d42161-ad5d-4bd8-9b2a-8e834e3b8fed",
+            "id": "d026cf36-d22e-4f92-a577-94220726ba3f",
             "version": "KqlParameterItem/1.0",
             "name": "Visualization4",
+            "label": "Visualization",
             "type": 2,
             "isRequired": true,
-            "query": "datatable (value:long, Display:string, isSelected:boolean)\r\n    [0, \"Line Chart\", true,\r\n     1, \"Grid\", false]",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
             "typeSettings": {
               "additionalResourceOptions": []
             },
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "jsonData": "[\r\n    {\r\n        \"value\": \"0\",\r\n        \"label\": \"Line Chart\",\r\n        \"selected\": true\r\n    },\r\n    {\r\n        \"value\": \"1\",\r\n        \"label\": \"Grid\",\r\n        \"selected\": false\r\n    }\r\n]"
           },
           {
-            "id": "d768c009-20aa-4476-83cd-afacf4694818",
+            "id": "a9ac011f-176f-4c31-b82e-139aba93a426",
             "version": "KqlParameterItem/1.0",
             "name": "Snippet4",
             "type": 1,
             "isRequired": true,
-            "query": "print(iff({Visualization4} == 0, \"{LineChartQuerySnippet}\", \"{GridQuerySnippet}\") )",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
             "isHiddenWhenLocked": true,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "criteriaData": [
+              {
+                "condition": "if (Visualization4 == '0'), result = LineChartQuerySnippet",
+                "criteriaContext": {
+                  "leftOperand": "Visualization4",
+                  "operator": "==",
+                  "rightValType": "static",
+                  "rightVal": "0",
+                  "resultValType": "param",
+                  "resultVal": "LineChartQuerySnippet"
+                }
+              },
+              {
+                "condition": "else result = GridQuerySnippet",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "param",
+                  "resultVal": "GridQuerySnippet"
+                }
+              }
+            ]
           },
           {
-            "id": "eb3e4d65-ee3c-481c-af2e-8b41e4049bf8",
+            "id": "26106dfe-4e33-4c7c-b4b6-2eff5cc76476",
             "version": "KqlParameterItem/1.0",
             "name": "Unit4",
             "type": 2,
@@ -1069,18 +1290,20 @@
             "id": "aa2368fc-ad30-4608-b96a-72abf7b1e1af",
             "version": "KqlParameterItem/1.0",
             "name": "Counter5",
+            "label": "Counter",
             "type": 2,
             "isRequired": true,
-            "query": "InsightsMetrics\r\n| where TimeGenerated {TimeRange}\r\n| summarize by Name, Namespace, CounterText = Name\r\n| order by Namespace asc, CounterText asc\r\n| project Counter = pack('counter', Name, 'object', Namespace), CounterText, group = Namespace",
+            "query": "InsightsMetrics\r\n| summarize by Name, Namespace, CounterText = Name\r\n| order by Namespace asc, CounterText asc\r\n| project Counter = pack('counter', Name, 'object', Namespace), CounterText, group = Namespace",
             "crossComponentResources": [
               "{Workspaces}"
             ],
-            "value": "{\"counter\":\"FreeSpacePercentage\",\"object\":\"LogicalDisk\"}",
             "typeSettings": {
-              "additionalResourceOptions": [
-                "value::1"
-              ]
+              "additionalResourceOptions": []
             },
+            "timeContext": {
+              "durationMs": 0
+            },
+            "timeContextFromParameter": "TimeRange",
             "queryType": 0,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
@@ -1088,6 +1311,7 @@
             "id": "6a7306ea-247f-46ca-abca-501911f9e9d3",
             "version": "KqlParameterItem/1.0",
             "name": "TrendAggregator5",
+            "label": "Trend Aggregator",
             "type": 2,
             "isRequired": true,
             "typeSettings": {
@@ -1100,43 +1324,85 @@
             "version": "KqlParameterItem/1.0",
             "name": "TrendAggregatorOrder5",
             "type": 1,
-            "query": "print(iff('{TrendAggregator5:label}' == 'P5th'  or '{TrendAggregator5:label}' == 'P10th', 'asc', 'desc'))",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
             "isHiddenWhenLocked": true,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "criteriaData": [
+              {
+                "condition": "if (TrendAggregator5 contains 'P5th'), result = 'asc'",
+                "criteriaContext": {
+                  "leftOperand": "TrendAggregator5",
+                  "operator": "contains",
+                  "rightValType": "static",
+                  "rightVal": "P5th",
+                  "resultValType": "static",
+                  "resultVal": "asc"
+                }
+              },
+              {
+                "condition": "if (TrendAggregator5 contains 'P10th'), result = 'asc'",
+                "criteriaContext": {
+                  "leftOperand": "TrendAggregator5",
+                  "operator": "contains",
+                  "rightValType": "static",
+                  "rightVal": "P10th",
+                  "resultValType": "static",
+                  "resultVal": "asc"
+                }
+              },
+              {
+                "condition": "else result = 'desc'",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "static",
+                  "resultVal": "desc"
+                }
+              }
+            ]
           },
           {
-            "id": "b75e4ca5-7d71-4d29-b69e-9104934905ba",
+            "id": "d026cf36-d22e-4f92-a577-94220726ba3f",
             "version": "KqlParameterItem/1.0",
             "name": "Visualization5",
+            "label": "Visualization",
             "type": 2,
             "isRequired": true,
-            "query": "datatable (value:long, Display:string, isSelected:boolean)\r\n    [0, \"Line Chart\", true,\r\n     1, \"Grid\", false]",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
             "typeSettings": {
               "additionalResourceOptions": []
             },
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "jsonData": "[\r\n    {\r\n        \"value\": \"0\",\r\n        \"label\": \"Line Chart\",\r\n        \"selected\": true\r\n    },\r\n    {\r\n        \"value\": \"1\",\r\n        \"label\": \"Grid\",\r\n        \"selected\": false\r\n    }\r\n]"
           },
           {
-            "id": "7df7ee71-c054-4a88-b8b1-33ba6dd9d70d",
+            "id": "a9ac011f-176f-4c31-b82e-139aba93a426",
             "version": "KqlParameterItem/1.0",
             "name": "Snippet5",
             "type": 1,
             "isRequired": true,
-            "query": "print(iff({Visualization5} == 0, \"{LineChartQuerySnippet}\", \"{GridQuerySnippet}\") )",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
             "isHiddenWhenLocked": true,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "criteriaData": [
+              {
+                "condition": "if (Visualization5 == '0'), result = LineChartQuerySnippet",
+                "criteriaContext": {
+                  "leftOperand": "Visualization5",
+                  "operator": "==",
+                  "rightValType": "static",
+                  "rightVal": "0",
+                  "resultValType": "param",
+                  "resultVal": "LineChartQuerySnippet"
+                }
+              },
+              {
+                "condition": "else result = GridQuerySnippet",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "param",
+                  "resultVal": "GridQuerySnippet"
+                }
+              }
+            ]
           },
           {
-            "id": "bb81032c-59e4-417f-a5e1-fc6552c3190f",
+            "id": "26106dfe-4e33-4c7c-b4b6-2eff5cc76476",
             "version": "KqlParameterItem/1.0",
             "name": "Unit5",
             "type": 2,
@@ -1180,18 +1446,20 @@
             "id": "aa2368fc-ad30-4608-b96a-72abf7b1e1af",
             "version": "KqlParameterItem/1.0",
             "name": "Counter6",
+            "label": "Counter",
             "type": 2,
             "isRequired": true,
-            "query": "InsightsMetrics\r\n| where TimeGenerated {TimeRange}\r\n| summarize by Name, Namespace, CounterText = Name\r\n| order by Namespace asc, CounterText asc\r\n| project Counter = pack('counter', Name, 'object', Namespace), CounterText, group = Namespace",
+            "query": "InsightsMetrics\r\n| summarize by Name, Namespace, CounterText = Name\r\n| order by Namespace asc, CounterText asc\r\n| project Counter = pack('counter', Name, 'object', Namespace), CounterText, group = Namespace",
             "crossComponentResources": [
               "{Workspaces}"
             ],
-            "value": "{\"counter\":\"ReadsPerSecond\",\"object\":\"LogicalDisk\"}",
             "typeSettings": {
-              "additionalResourceOptions": [
-                "value::1"
-              ]
+              "additionalResourceOptions": []
             },
+            "timeContext": {
+              "durationMs": 0
+            },
+            "timeContextFromParameter": "TimeRange",
             "queryType": 0,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
@@ -1199,6 +1467,7 @@
             "id": "6a7306ea-247f-46ca-abca-501911f9e9d3",
             "version": "KqlParameterItem/1.0",
             "name": "TrendAggregator6",
+            "label": "Trend Aggregator",
             "type": 2,
             "isRequired": true,
             "typeSettings": {
@@ -1211,43 +1480,85 @@
             "version": "KqlParameterItem/1.0",
             "name": "TrendAggregatorOrder6",
             "type": 1,
-            "query": "print(iff('{TrendAggregator6:label}' == 'P5th'  or '{TrendAggregator6:label}' == 'P10th', 'asc', 'desc'))",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
             "isHiddenWhenLocked": true,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "criteriaData": [
+              {
+                "condition": "if (TrendAggregator6 contains 'P5th'), result = 'asc'",
+                "criteriaContext": {
+                  "leftOperand": "TrendAggregator6",
+                  "operator": "contains",
+                  "rightValType": "static",
+                  "rightVal": "P5th",
+                  "resultValType": "static",
+                  "resultVal": "asc"
+                }
+              },
+              {
+                "condition": "if (TrendAggregator6 contains 'P10th'), result = 'asc'",
+                "criteriaContext": {
+                  "leftOperand": "TrendAggregator6",
+                  "operator": "contains",
+                  "rightValType": "static",
+                  "rightVal": "P10th",
+                  "resultValType": "static",
+                  "resultVal": "asc"
+                }
+              },
+              {
+                "condition": "else result = 'desc'",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "static",
+                  "resultVal": "desc"
+                }
+              }
+            ]
           },
           {
-            "id": "5b1ee58a-5d4d-4be8-b38c-3a8eb37a2f3e",
+            "id": "d026cf36-d22e-4f92-a577-94220726ba3f",
             "version": "KqlParameterItem/1.0",
             "name": "Visualization6",
+            "label": "Visualization",
             "type": 2,
             "isRequired": true,
-            "query": "datatable (value:long, Display:string, isSelected:boolean)\r\n    [0, \"Line Chart\", true,\r\n     1, \"Grid\", false]",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
             "typeSettings": {
               "additionalResourceOptions": []
             },
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "jsonData": "[\r\n    {\r\n        \"value\": \"0\",\r\n        \"label\": \"Line Chart\",\r\n        \"selected\": true\r\n    },\r\n    {\r\n        \"value\": \"1\",\r\n        \"label\": \"Grid\",\r\n        \"selected\": false\r\n    }\r\n]"
           },
           {
-            "id": "d931d741-2f83-4ca0-bc2b-5c0c13fe8058",
+            "id": "a9ac011f-176f-4c31-b82e-139aba93a426",
             "version": "KqlParameterItem/1.0",
             "name": "Snippet6",
             "type": 1,
             "isRequired": true,
-            "query": "print(iff({Visualization6} == 0, \"{LineChartQuerySnippet}\", \"{GridQuerySnippet}\") )",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
             "isHiddenWhenLocked": true,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "criteriaData": [
+              {
+                "condition": "if (Visualization6 == '0'), result = LineChartQuerySnippet",
+                "criteriaContext": {
+                  "leftOperand": "Visualization6",
+                  "operator": "==",
+                  "rightValType": "static",
+                  "rightVal": "0",
+                  "resultValType": "param",
+                  "resultVal": "LineChartQuerySnippet"
+                }
+              },
+              {
+                "condition": "else result = GridQuerySnippet",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "param",
+                  "resultVal": "GridQuerySnippet"
+                }
+              }
+            ]
           },
           {
-            "id": "ab35d419-d8c1-45be-8885-e39a55c0648d",
+            "id": "26106dfe-4e33-4c7c-b4b6-2eff5cc76476",
             "version": "KqlParameterItem/1.0",
             "name": "Unit6",
             "type": 2,
@@ -1291,18 +1602,20 @@
             "id": "aa2368fc-ad30-4608-b96a-72abf7b1e1af",
             "version": "KqlParameterItem/1.0",
             "name": "Counter7",
+            "label": "Counter",
             "type": 2,
             "isRequired": true,
-            "query": "InsightsMetrics\r\n| where TimeGenerated {TimeRange}\r\n| summarize by Name, Namespace, CounterText = Name\r\n| order by Namespace asc, CounterText asc\r\n| project Counter = pack('counter', Name, 'object', Namespace), CounterText, group = Namespace",
+            "query": "InsightsMetrics\r\n| summarize by Name, Namespace, CounterText = Name\r\n| order by Namespace asc, CounterText asc\r\n| project Counter = pack('counter', Name, 'object', Namespace), CounterText, group = Namespace",
             "crossComponentResources": [
               "{Workspaces}"
             ],
-            "value": "{\"counter\":\"WritesPerSecond\",\"object\":\"LogicalDisk\"}",
             "typeSettings": {
-              "additionalResourceOptions": [
-                "value::1"
-              ]
+              "additionalResourceOptions": []
             },
+            "timeContext": {
+              "durationMs": 0
+            },
+            "timeContextFromParameter": "TimeRange",
             "queryType": 0,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
@@ -1310,6 +1623,7 @@
             "id": "6a7306ea-247f-46ca-abca-501911f9e9d3",
             "version": "KqlParameterItem/1.0",
             "name": "TrendAggregator7",
+            "label": "Trend Aggregator",
             "type": 2,
             "isRequired": true,
             "typeSettings": {
@@ -1322,43 +1636,85 @@
             "version": "KqlParameterItem/1.0",
             "name": "TrendAggregatorOrder7",
             "type": 1,
-            "query": "print(iff('{TrendAggregator7:label}' == 'P5th'  or '{TrendAggregator7:label}' == 'P10th', 'asc', 'desc'))",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
             "isHiddenWhenLocked": true,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "criteriaData": [
+              {
+                "condition": "if (TrendAggregator7 contains 'P5th'), result = 'asc'",
+                "criteriaContext": {
+                  "leftOperand": "TrendAggregator7",
+                  "operator": "contains",
+                  "rightValType": "static",
+                  "rightVal": "P5th",
+                  "resultValType": "static",
+                  "resultVal": "asc"
+                }
+              },
+              {
+                "condition": "if (TrendAggregator7 contains 'P10th'), result = 'asc'",
+                "criteriaContext": {
+                  "leftOperand": "TrendAggregator7",
+                  "operator": "contains",
+                  "rightValType": "static",
+                  "rightVal": "P10th",
+                  "resultValType": "static",
+                  "resultVal": "asc"
+                }
+              },
+              {
+                "condition": "else result = 'desc'",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "static",
+                  "resultVal": "desc"
+                }
+              }
+            ]
           },
           {
-            "id": "bc1291ba-dd26-4224-9b25-3a1e7b3eb024",
+            "id": "d026cf36-d22e-4f92-a577-94220726ba3f",
             "version": "KqlParameterItem/1.0",
             "name": "Visualization7",
+            "label": "Visualization",
             "type": 2,
             "isRequired": true,
-            "query": "datatable (value:long, Display:string, isSelected:boolean)\r\n    [0, \"Line Chart\", true,\r\n     1, \"Grid\", false]",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
             "typeSettings": {
               "additionalResourceOptions": []
             },
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "jsonData": "[\r\n    {\r\n        \"value\": \"0\",\r\n        \"label\": \"Line Chart\",\r\n        \"selected\": true\r\n    },\r\n    {\r\n        \"value\": \"1\",\r\n        \"label\": \"Grid\",\r\n        \"selected\": false\r\n    }\r\n]"
           },
           {
-            "id": "6cc1a388-27c6-4cfe-a787-ff00cb8f4fae",
+            "id": "a9ac011f-176f-4c31-b82e-139aba93a426",
             "version": "KqlParameterItem/1.0",
             "name": "Snippet7",
             "type": 1,
             "isRequired": true,
-            "query": "print(iff({Visualization7} == 0, \"{LineChartQuerySnippet}\", \"{GridQuerySnippet}\") )",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
             "isHiddenWhenLocked": true,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "criteriaData": [
+              {
+                "condition": "if (Visualization7 == '0'), result = LineChartQuerySnippet",
+                "criteriaContext": {
+                  "leftOperand": "Visualization7",
+                  "operator": "==",
+                  "rightValType": "static",
+                  "rightVal": "0",
+                  "resultValType": "param",
+                  "resultVal": "LineChartQuerySnippet"
+                }
+              },
+              {
+                "condition": "else result = GridQuerySnippet",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "param",
+                  "resultVal": "GridQuerySnippet"
+                }
+              }
+            ]
           },
           {
-            "id": "dce874fa-b71d-4a09-bcee-bd1b3f672f7f",
+            "id": "26106dfe-4e33-4c7c-b4b6-2eff5cc76476",
             "version": "KqlParameterItem/1.0",
             "name": "Unit7",
             "type": 2,
@@ -1402,18 +1758,20 @@
             "id": "aa2368fc-ad30-4608-b96a-72abf7b1e1af",
             "version": "KqlParameterItem/1.0",
             "name": "Counter8",
+            "label": "Counter",
             "type": 2,
             "isRequired": true,
-            "query": "InsightsMetrics\r\n| where TimeGenerated {TimeRange}\r\n| summarize by Name, Namespace, CounterText = Name\r\n| order by Namespace asc, CounterText asc\r\n| project Counter = pack('counter', Name, 'object', Namespace), CounterText, group = Namespace",
+            "query": "InsightsMetrics\r\n| summarize by Name, Namespace, CounterText = Name\r\n| order by Namespace asc, CounterText asc\r\n| project Counter = pack('counter', Name, 'object', Namespace), CounterText, group = Namespace",
             "crossComponentResources": [
               "{Workspaces}"
             ],
-            "value": "{\"counter\":\"TransfersPerSecond\",\"object\":\"LogicalDisk\"}",
             "typeSettings": {
-              "additionalResourceOptions": [
-                "value::1"
-              ]
+              "additionalResourceOptions": []
             },
+            "timeContext": {
+              "durationMs": 0
+            },
+            "timeContextFromParameter": "TimeRange",
             "queryType": 0,
             "resourceType": "microsoft.operationalinsights/workspaces"
           },
@@ -1421,6 +1779,7 @@
             "id": "6a7306ea-247f-46ca-abca-501911f9e9d3",
             "version": "KqlParameterItem/1.0",
             "name": "TrendAggregator8",
+            "label": "Trend Aggregator",
             "type": 2,
             "isRequired": true,
             "typeSettings": {
@@ -1433,43 +1792,85 @@
             "version": "KqlParameterItem/1.0",
             "name": "TrendAggregatorOrder8",
             "type": 1,
-            "query": "print(iff('{TrendAggregator8:label}' == 'P5th'  or '{TrendAggregator8:label}' == 'P10th', 'asc', 'desc'))",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
             "isHiddenWhenLocked": true,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "criteriaData": [
+              {
+                "condition": "if (TrendAggregator8 contains 'P5th'), result = 'asc'",
+                "criteriaContext": {
+                  "leftOperand": "TrendAggregator8",
+                  "operator": "contains",
+                  "rightValType": "static",
+                  "rightVal": "P5th",
+                  "resultValType": "static",
+                  "resultVal": "asc"
+                }
+              },
+              {
+                "condition": "if (TrendAggregator8 contains 'P10th'), result = 'asc'",
+                "criteriaContext": {
+                  "leftOperand": "TrendAggregator8",
+                  "operator": "contains",
+                  "rightValType": "static",
+                  "rightVal": "P10th",
+                  "resultValType": "static",
+                  "resultVal": "asc"
+                }
+              },
+              {
+                "condition": "else result = 'desc'",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "static",
+                  "resultVal": "desc"
+                }
+              }
+            ]
           },
           {
-            "id": "68468652-570f-4d77-af12-a59d463d5f02",
+            "id": "d026cf36-d22e-4f92-a577-94220726ba3f",
             "version": "KqlParameterItem/1.0",
             "name": "Visualization8",
+            "label": "Visualization",
             "type": 2,
             "isRequired": true,
-            "query": "datatable (value:long, Display:string, isSelected:boolean)\r\n    [0, \"Line Chart\", true,\r\n     1, \"Grid\", false]",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
             "typeSettings": {
               "additionalResourceOptions": []
             },
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "jsonData": "[\r\n    {\r\n        \"value\": \"0\",\r\n        \"label\": \"Line Chart\",\r\n        \"selected\": true\r\n    },\r\n    {\r\n        \"value\": \"1\",\r\n        \"label\": \"Grid\",\r\n        \"selected\": false\r\n    }\r\n]"
           },
           {
-            "id": "15738505-f7e6-446e-995d-280cf70dde93",
+            "id": "a9ac011f-176f-4c31-b82e-139aba93a426",
             "version": "KqlParameterItem/1.0",
             "name": "Snippet8",
             "type": 1,
             "isRequired": true,
-            "query": "print(iff({Visualization8} == 0, \"{LineChartQuerySnippet}\", \"{GridQuerySnippet}\") )",
-            "crossComponentResources": [
-              "{Workspaces}"
-            ],
             "isHiddenWhenLocked": true,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "criteriaData": [
+              {
+                "condition": "if (Visualization8 == '0'), result = LineChartQuerySnippet",
+                "criteriaContext": {
+                  "leftOperand": "Visualization8",
+                  "operator": "==",
+                  "rightValType": "static",
+                  "rightVal": "0",
+                  "resultValType": "param",
+                  "resultVal": "LineChartQuerySnippet"
+                }
+              },
+              {
+                "condition": "else result = GridQuerySnippet",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "param",
+                  "resultVal": "GridQuerySnippet"
+                }
+              }
+            ]
           },
           {
-            "id": "c78d15dd-79cb-4cd2-8749-df9d97625b31",
+            "id": "26106dfe-4e33-4c7c-b4b6-2eff5cc76476",
             "version": "KqlParameterItem/1.0",
             "name": "Unit8",
             "type": 2,


### PR DESCRIPTION
Update the templates and ensure `queryType` is specified. Also optimized
the Performance Counter workbook to utilize non-LA based parameters to
reduce amount of LA queries.

Signed-off-by: andrewki-msft <43890980+andrewki-msft@users.noreply.github.com>

Test
-

InsightsMetrics
![image](https://user-images.githubusercontent.com/43890980/76924805-bd623580-6894-11ea-90b7-3c32071a64ec.png)

Perf
![image](https://user-images.githubusercontent.com/43890980/76925187-d15a6700-6895-11ea-952f-d65226d98bb3.png)
