### PR TITLE
[HOTFIX] SAP Monitor: Add check if PROVIDER_INSTANCE_s column exists

### DIFF
--- a/Workbooks/SapMonitor/SapHanaInfrastructure/SapHanaInfrastructure.workbook
+++ b/Workbooks/SapMonitor/SapHanaInfrastructure/SapHanaInfrastructure.workbook
@@ -9,6 +9,45 @@
         "crossComponentResources": [],
         "parameters": [
           {
+            "id": "386c5637-375e-437c-acdb-542be563ed5a",
+            "version": "KqlParameterItem/1.0",
+            "name": "testDataExist",
+            "type": 1,
+            "query": "SapHana_LoadHistory_CL\r\n| project HOST_s\r\n| take 1",
+            "isHiddenWhenLocked": true,
+            "timeContext": {
+              "durationMs": 43200000
+            },
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          },
+          {
+            "id": "5bca0011-344c-42a3-b69d-af95eb75fea2",
+            "version": "KqlParameterItem/1.0",
+            "name": "testProviderExists",
+            "type": 1,
+            "query": "SapHana_LoadHistory_CL \r\n| extend providerExists = case( columnifexists(\"PROVIDER_INSTANCE_s\", false)==false, false, true)\r\n| limit 1\r\n| where providerExists\r\n| project providerExists",
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          }
+        ],
+        "style": "pills",
+        "queryType": 0,
+        "resourceType": "microsoft.operationalinsights/workspaces"
+      },
+      "conditionalVisibility": {
+        "parameterName": "dummy",
+        "comparison": "isEqualTo",
+        "value": "0"
+      },
+      "name": "testExist_Parameters"
+    },
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "parameters": [
+          {
             "id": "696da4a1-0e13-40a2-9463-202f0ea90375",
             "version": "KqlParameterItem/1.0",
             "name": "Provider",
@@ -17,9 +56,10 @@
             "description": "Please select the instance of the monitoring provider",
             "isRequired": true,
             "multiSelect": true,
-            "quote": "\"",
+            "quote": "'",
             "delimiter": ",",
-            "query": "SapHana_LoadHistory_CL\r\n| summarize arg_max(TimeGenerated, * ) by PROVIDER_INSTANCE_s\r\n| project Provider=PROVIDER_INSTANCE_s",
+            "query": "SapHana_LoadHistory_CL\n| extend p = columnifexists(\"PROVIDER_INSTANCE_s\", \"*\")\n| distinct p",
+            "crossComponentResources": [],
             "value": [
               "value::all"
             ],
@@ -34,35 +74,15 @@
           }
         ],
         "style": "above",
+        "doNotRunWhenHidden": true,
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces"
+      },
+      "conditionalVisibility": {
+        "parameterName": "testProviderExists",
+        "comparison": "isNotEqualTo"
       },
       "name": "Provider_Parameters"
-    },
-    {
-      "type": 9,
-      "content": {
-        "version": "KqlParameterItem/1.0",
-        "parameters": [
-          {
-            "id": "386c5637-375e-437c-acdb-542be563ed5a",
-            "version": "KqlParameterItem/1.0",
-            "name": "testDataExist",
-            "type": 1,
-            "query": "SapHana_LoadHistory_CL\r\n| project HOST_s\r\n| take 1",
-            "isHiddenWhenLocked": true,
-            "timeContext": {
-              "durationMs": 43200000
-            },
-            "queryType": 0,
-            "resourceType": "microsoft.operationalinsights/workspaces"
-          }
-        ],
-        "style": "pills",
-        "queryType": 0,
-        "resourceType": "microsoft.operationalinsights/workspaces"
-      },
-      "name": "testDataExist_Parameters"
     },
     {
       "type": 11,
@@ -117,10 +137,7 @@
             "multiSelect": true,
             "quote": "\"",
             "delimiter": ",",
-            "query": "SapHana_LoadHistory_CL\r\n| where PROVIDER_INSTANCE_s in  ({Provider}) or '*' in ({Provider})\r\n| summarize arg_max(TimeGenerated, * ) by HOST_s\r\n| project Host=HOST_s ",
-            "value": [
-              "value::all"
-            ],
+            "query": "SapHana_LoadHistory_CL\r\n| extend p = columnifexists(\"PROVIDER_INSTANCE_s\", \"*\")\r\n| where p == \"*\" or p in ({Provider}) or \"*\" in ({Provider})\r\n| distinct HOST_s",
             "typeSettings": {
               "additionalResourceOptions": [
                 "value::all"
@@ -128,7 +145,10 @@
               "selectAllValue": "*"
             },
             "queryType": 0,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "resourceType": "microsoft.operationalinsights/workspaces",
+            "value": [
+              "value::all"
+            ]
           },
           {
             "id": "8a72f4ec-ce64-49b7-88dc-d9b27de74f7a",
@@ -208,7 +228,7 @@
         ],
         "style": "pills",
         "queryType": 0,
-        "resourceType": "microsoft.insights/components"
+        "resourceType": "microsoft.operationalinsights/workspaces"
       },
       "conditionalVisibilities": [
         {
@@ -244,7 +264,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let nodata = datatable(HOST:string, ACTIVE:string,HOST_STATUS_s:string,INDEXSERVERROLE:string,NAMESERVERROLE:string)\r\n[\r\n\"N\\\\A\", \"YES\",\"OK\",\"MASTER\",\"MASTER\"\r\n];\r\nSapHana_HostConfig_CL\r\n| where TimeGenerated > ago(30d)\r\n| where PROVIDER_INSTANCE_s in  ({Provider}) or '*' in ({Provider})\r\n| summarize arg_max(TimeGenerated, *) by HOST_s \r\n| project HOST=HOST_s , ACTIVE=HOST_ACTIVE_s , HOST_STATUS_s , INDEXSERVERROLE=INDEXSERVER_ACTUAL_ROLE_s , NAMESERVERROLE=NAMESERVER_ACTUAL_ROLE_s\r\n| union   isfuzzy=true nodata  | where HOST <> \"N\\\\A\" ",
+        "query": "let nodata = datatable(HOST:string, ACTIVE:string,HOST_STATUS_s:string,INDEXSERVERROLE:string,NAMESERVERROLE:string)\r\n[\r\n\"N\\\\A\", \"YES\",\"OK\",\"MASTER\",\"MASTER\"\r\n];\r\nSapHana_HostConfig_CL\r\n| where TimeGenerated > ago(30d)\r\n| extend p = columnifexists(\"PROVIDER_INSTANCE_s\", \"*\")\r\n| where p == \"*\" or p in ({Provider}) or \"*\" in ({Provider})\r\n| summarize arg_max(TimeGenerated, *) by HOST_s \r\n| project HOST=HOST_s , ACTIVE=HOST_ACTIVE_s , HOST_STATUS_s , INDEXSERVERROLE=INDEXSERVER_ACTUAL_ROLE_s , NAMESERVERROLE=NAMESERVER_ACTUAL_ROLE_s\r\n| union   isfuzzy=true nodata  | where HOST <> \"N\\\\A\" ",
         "size": 4,
         "title": "HANA Host Status",
         "queryType": 0,
@@ -471,7 +491,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let nodata = datatable(HOST:string, ACTIVE:string,HOST_STATUS_s:string,INDEXSERVERROLE:string,NAMESERVERROLE:string)\r\n[\r\n\"N\\\\A\", \"YES\",\"OK\",\"MASTER\",\"MASTER\"\r\n];\r\nSapHana_HostConfig_CL\r\n| where PROVIDER_INSTANCE_s in  ({Provider}) or '*' in ({Provider})\r\n| where TimeGenerated > ago(30d)\r\n| summarize arg_max(TimeGenerated, *) by HOST_s \r\n| project HOST=HOST_s , ACTIVE=HOST_ACTIVE_s , HOST_STATUS_s , INDEXSERVERROLE=INDEXSERVER_ACTUAL_ROLE_s , NAMESERVERROLE=NAMESERVER_ACTUAL_ROLE_s\r\n| union   isfuzzy=true nodata  | where HOST <> \"N\\\\A\" ",
+        "query": "let nodata = datatable(HOST:string, ACTIVE:string,HOST_STATUS_s:string,INDEXSERVERROLE:string,NAMESERVERROLE:string)\r\n[\r\n\"N\\\\A\", \"YES\",\"OK\",\"MASTER\",\"MASTER\"\r\n];\r\nSapHana_HostConfig_CL\r\n| extend p = columnifexists(\"PROVIDER_INSTANCE_s\", \"*\")\r\n| where p == \"*\" or p in ({Provider}) or \"*\" in ({Provider})\r\n| where TimeGenerated > ago(30d)\r\n| summarize arg_max(TimeGenerated, *) by HOST_s \r\n| project HOST=HOST_s , ACTIVE=HOST_ACTIVE_s , HOST_STATUS_s , INDEXSERVERROLE=INDEXSERVER_ACTUAL_ROLE_s , NAMESERVERROLE=NAMESERVER_ACTUAL_ROLE_s\r\n| union   isfuzzy=true nodata  | where HOST <> \"N\\\\A\" ",
         "size": 4,
         "title": "HANA IndexServer Role",
         "queryType": 0,
@@ -547,7 +567,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let nodata = datatable(HOST:string, ACTIVE:string,HOST_STATUS_s:string,INDEXSERVERROLE:string,NAMESERVERROLE:string)\r\n[\r\n\"N\\\\A\", \"YES\",\"OK\",\"MASTER\",\"MASTER\"\r\n];\r\nSapHana_HostConfig_CL\r\n| where PROVIDER_INSTANCE_s in  ({Provider}) or '*' in ({Provider})\r\n| where TimeGenerated > ago(30d)\r\n| summarize arg_max(TimeGenerated, *) by HOST_s \r\n| project HOST=HOST_s , ACTIVE=HOST_ACTIVE_s , HOST_STATUS_s , INDEXSERVERROLE=INDEXSERVER_ACTUAL_ROLE_s , NAMESERVERROLE=NAMESERVER_ACTUAL_ROLE_s\r\n| union   isfuzzy=true nodata  | where HOST <> \"N\\\\A\" \r\n",
+        "query": "let nodata = datatable(HOST:string, ACTIVE:string,HOST_STATUS_s:string,INDEXSERVERROLE:string,NAMESERVERROLE:string)\r\n[\r\n\"N\\\\A\", \"YES\",\"OK\",\"MASTER\",\"MASTER\"\r\n];\r\nSapHana_HostConfig_CL\r\n| extend p = columnifexists(\"PROVIDER_INSTANCE_s\", \"*\")\r\n| where p == \"*\" or p in ({Provider}) or \"*\" in ({Provider})\r\n| where TimeGenerated > ago(30d)\r\n| summarize arg_max(TimeGenerated, *) by HOST_s \r\n| project HOST=HOST_s , ACTIVE=HOST_ACTIVE_s , HOST_STATUS_s , INDEXSERVERROLE=INDEXSERVER_ACTUAL_ROLE_s , NAMESERVERROLE=NAMESERVER_ACTUAL_ROLE_s\r\n| union   isfuzzy=true nodata  | where HOST <> \"N\\\\A\" \r\n",
         "size": 4,
         "title": "HANA NameServer Role",
         "queryType": 0,
@@ -623,7 +643,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let nodata = datatable([\"HANA Host\"]:string, [\"CPU used (%)\"]:real,[\"Memory used (%)\"]:real,[\"Disk used (GB)\"]:real,[\"Network in (MB/s)\"]:real,[\"Network out (MB/s)\"]:real)\r\n[\r\n\"N\\\\A\", 0,0,0,0,0\r\n];\r\nSapHana_LoadHistory_CL\r\n| where PROVIDER_INSTANCE_s in  ({Provider}) or '*' in ({Provider})\r\n| where HOST_s in  ({Host}) or '*' in ({Host})\r\n| summarize arg_max(TimeGenerated, *) by HOST_s\r\n| project [\"HANA Host\"]=HOST_s , [\"CPU used (%)\"]=CPU_d ,  [\"Memory used (%)\"]=round((MEMORY_USED_d/MEMORY_SIZE_d)*100,2),[\"Disk used (GB)\"]=DISK_USED_d  , [\"Network in (MB/s)\"]=NETWORK_IN_d , [\"Network out (MB/s)\"]=NETWORK_OUT_d \r\n| union   isfuzzy=true nodata  | where [\"HANA Host\"] <> \"N\\\\A\" ",
+        "query": "let nodata = datatable([\"HANA Host\"]:string, [\"CPU used (%)\"]:real,[\"Memory used (%)\"]:real,[\"Disk used (GB)\"]:real,[\"Network in (MB/s)\"]:real,[\"Network out (MB/s)\"]:real)\r\n[\r\n\"N\\\\A\", 0,0,0,0,0\r\n];\r\nSapHana_LoadHistory_CL\r\n| extend p = columnifexists(\"PROVIDER_INSTANCE_s\", \"*\")\r\n| where p == \"*\" or p in ({Provider}) or \"*\" in ({Provider})\r\n| where HOST_s in  ({Host}) or '*' in ({Host})\r\n| summarize arg_max(TimeGenerated, *) by HOST_s\r\n| project [\"HANA Host\"]=HOST_s , [\"CPU used (%)\"]=CPU_d ,  [\"Memory used (%)\"]=round((MEMORY_USED_d/MEMORY_SIZE_d)*100,2),[\"Disk used (GB)\"]=DISK_USED_d  , [\"Network in (MB/s)\"]=NETWORK_IN_d , [\"Network out (MB/s)\"]=NETWORK_OUT_d \r\n| union   isfuzzy=true nodata  | where [\"HANA Host\"] <> \"N\\\\A\" ",
         "size": 4,
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
@@ -707,7 +727,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let nodata = datatable(HOST_s:string,avg_CPU_d:real)\r\n[\r\n\"N\\\\A\",0,\r\n];\r\nSapHana_LoadHistory_CL\r\n| where TimeGenerated  {TimeRange}\r\n| where PROVIDER_INSTANCE_s in  ({Provider}) or '*' in ({Provider})\r\n| where HOST_s in  ({Host}) or '*' in ({Host})\r\n| summarize avg(CPU_d) by HOST_s , bin(TimeGenerated, {Granularity})\r\n| union   isfuzzy=true nodata |where HOST_s <> \"N\\\\A\"",
+        "query": "let nodata = datatable(HOST_s:string,avg_CPU_d:real)\r\n[\r\n\"N\\\\A\",0,\r\n];\r\nSapHana_LoadHistory_CL\r\n| where TimeGenerated  {TimeRange}\r\n| extend p = columnifexists(\"PROVIDER_INSTANCE_s\", \"*\")\r\n| where p == \"*\" or p in ({Provider}) or \"*\" in ({Provider})\r\n| where HOST_s in  ({Host}) or '*' in ({Host})\r\n| summarize avg(CPU_d) by HOST_s , bin(TimeGenerated, {Granularity})\r\n| union   isfuzzy=true nodata |where HOST_s <> \"N\\\\A\"",
         "size": 0,
         "aggregation": 3,
         "title": "CPU used (%)",
@@ -756,7 +776,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let nodata = datatable(HOST_s:string, TimeGenerated:dynamic,avgCPU:dynamic,CPU_Forecast:dynamic)\r\n[\r\n\"N\\\\A\", \"[\\\"2019-09-01T00:00:00Z\\\",\\\"2019-09-02T00:00:00Z\\\"]\",\"[0,0,0,0]\",\"[0,0,0,0]\"\r\n];\r\nlet startDate = startofday(ago(7d)); // go back in time nn days\r\nlet endDate = now(); // what is the date now\r\nlet projectTo = now()+7d; // project forward nn days\r\nlet projectForward = 7; // must be same as projectTo value\r\nSapHana_LoadHistory_CL\r\n| where PROVIDER_INSTANCE_s in  ({Provider}) or '*' in ({Provider})\r\n| where HOST_s in  ({Host}) or '*' in ({Host})\r\n|where TimeGenerated {TimeRange} //> ago(7d)\r\n| make-series avgCPU=avg(CPU_d) default=0 on TimeGenerated in range({TimeRange:start},projectTo, {TimeRange:grain}) by HOST_s\r\n| extend CPU_Forecast = series_decompose_forecast(avgCPU, projectForward*24)\r\n| union   isfuzzy=true nodata |where HOST_s <> \"N\\\\A\"",
+        "query": "let nodata = datatable(HOST_s:string, TimeGenerated:dynamic,avgCPU:dynamic,CPU_Forecast:dynamic)\r\n[\r\n\"N\\\\A\", \"[\\\"2019-09-01T00:00:00Z\\\",\\\"2019-09-02T00:00:00Z\\\"]\",\"[0,0,0,0]\",\"[0,0,0,0]\"\r\n];\r\nlet startDate = startofday(ago(7d)); // go back in time nn days\r\nlet endDate = now(); // what is the date now\r\nlet projectTo = now()+7d; // project forward nn days\r\nlet projectForward = 7; // must be same as projectTo value\r\nSapHana_LoadHistory_CL\r\n| extend p = columnifexists(\"PROVIDER_INSTANCE_s\", \"*\")\r\n| where p == \"*\" or p in ({Provider}) or \"*\" in ({Provider})\r\n| where HOST_s in  ({Host}) or '*' in ({Host})\r\n|where TimeGenerated {TimeRange} //> ago(7d)\r\n| make-series avgCPU=avg(CPU_d) default=0 on TimeGenerated in range({TimeRange:start},projectTo, {TimeRange:grain}) by HOST_s\r\n| extend CPU_Forecast = series_decompose_forecast(avgCPU, projectForward*24)\r\n| union   isfuzzy=true nodata |where HOST_s <> \"N\\\\A\"",
         "size": 0,
         "aggregation": 3,
         "title": "CPU (%) - Actual vs. Forecast",
@@ -806,7 +826,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let nodata = datatable(HOST_s:string,avgMEM:real)\r\n[\r\n\"N\\\\A\",0,\r\n];\r\nSapHana_LoadHistory_CL\r\n| where TimeGenerated  {TimeRange}\r\n| where PROVIDER_INSTANCE_s in  ({Provider}) or '*' in ({Provider})\r\n| where HOST_s in  ({Host}) or '*' in ({Host})\r\n| summarize avgMEM=avg(MEMORY_USED_d/MEMORY_SIZE_d)*100 by HOST_s, bin(TimeGenerated, {Granularity})\r\n| union   isfuzzy=true nodata |where HOST_s <> \"N\\\\A\"",
+        "query": "let nodata = datatable(HOST_s:string,avgMEM:real)\r\n[\r\n\"N\\\\A\",0,\r\n];\r\nSapHana_LoadHistory_CL\r\n| where TimeGenerated  {TimeRange}\r\n| extend p = columnifexists(\"PROVIDER_INSTANCE_s\", \"*\")\r\n| where p == \"*\" or p in ({Provider}) or \"*\" in ({Provider})\r\n| where HOST_s in  ({Host}) or '*' in ({Host})\r\n| summarize avgMEM=avg(MEMORY_USED_d/MEMORY_SIZE_d)*100 by HOST_s, bin(TimeGenerated, {Granularity})\r\n| union   isfuzzy=true nodata |where HOST_s <> \"N\\\\A\"",
         "size": 0,
         "title": "Memory used (%)",
         "color": "orange",
@@ -851,7 +871,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let nodata = datatable(HOST_s:string, TimeGenerated:dynamic,avgMEM:dynamic,MEM_Forecast:dynamic)\r\n[\r\n\"N\\\\A\", \"[\\\"2019-09-01T00:00:00Z\\\",\\\"2019-09-02T00:00:00Z\\\"]\",\"[0,0,0,0]\",\"[0,0,0,0]\"\r\n];\r\nlet startDate = startofday(ago(7d)); // go back in time nn days\r\nlet endDate = now(); // what is the date now\r\nlet projectTo = now()+7d; // project forward nn days\r\nlet projectForward = 7; // must be same as projectTo value\r\nSapHana_LoadHistory_CL\r\n| where PROVIDER_INSTANCE_s in  ({Provider}) or '*' in ({Provider})\r\n| where HOST_s in  ({Host}) or '*' in ({Host})\r\n|where TimeGenerated {TimeRange}\r\n| make-series avgMEM=avg(MEMORY_USED_d/MEMORY_SIZE_d)*100 default=0 on TimeGenerated in range({TimeRange:start},projectTo, {TimeRange:grain}) by HOST_s\r\n| extend MEM_Forecast = series_decompose_forecast(avgMEM, projectForward*24)\r\n| union   isfuzzy=true nodata |where HOST_s <> \"N\\\\A\"",
+        "query": "let nodata = datatable(HOST_s:string, TimeGenerated:dynamic,avgMEM:dynamic,MEM_Forecast:dynamic)\r\n[\r\n\"N\\\\A\", \"[\\\"2019-09-01T00:00:00Z\\\",\\\"2019-09-02T00:00:00Z\\\"]\",\"[0,0,0,0]\",\"[0,0,0,0]\"\r\n];\r\nlet startDate = startofday(ago(7d)); // go back in time nn days\r\nlet endDate = now(); // what is the date now\r\nlet projectTo = now()+7d; // project forward nn days\r\nlet projectForward = 7; // must be same as projectTo value\r\nSapHana_LoadHistory_CL\r\n| extend p = columnifexists(\"PROVIDER_INSTANCE_s\", \"*\")\r\n| where p == \"*\" or p in ({Provider}) or \"*\" in ({Provider})\r\n| where HOST_s in  ({Host}) or '*' in ({Host})\r\n|where TimeGenerated {TimeRange}\r\n| make-series avgMEM=avg(MEMORY_USED_d/MEMORY_SIZE_d)*100 default=0 on TimeGenerated in range({TimeRange:start},projectTo, {TimeRange:grain}) by HOST_s\r\n| extend MEM_Forecast = series_decompose_forecast(avgMEM, projectForward*24)\r\n| union   isfuzzy=true nodata |where HOST_s <> \"N\\\\A\"",
         "size": 0,
         "title": "Memory (%) - Actual vs. Forecast",
         "color": "orange",
@@ -892,7 +912,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let nodata = datatable(HOST_s:string, [\"Allocation limit\"]:real, [\"Resident memory\"]:real, [\"Memory size\"]:real, [\"Total resident memory\"]:real, [\"Memory used\"]:real)\r\n[\r\n\"N\\\\A\",0,0,0,0,0\r\n];SapHana_LoadHistory_CL\r\n| where TimeGenerated  {TimeRange}\r\n| where PROVIDER_INSTANCE_s in  ({Provider}) or '*' in ({Provider})\r\n| where HOST_s in  ({Host}) or '*' in ({Host})\r\n| summarize [\"Allocation limit\"]=avg(MEMORY_ALLOCATION_LIMIT_d/1024)  , [\"Resident memory\"]=avg(MEMORY_RESIDENT_d/1024)  , [\"Memory size\"]=avg(MEMORY_SIZE_d/1024)  , [\"Total resident memory\"]=avg(MEMORY_TOTAL_RESIDENT_d/1024)  , [\"Memory used\"]=avg(MEMORY_USED_d/1024) by HOST_s, bin(TimeGenerated, {Granularity})\r\n| union   isfuzzy=true nodata |where HOST_s <> \"N\\\\A\"",
+        "query": "let nodata = datatable(HOST_s:string, [\"Allocation limit\"]:real, [\"Resident memory\"]:real, [\"Memory size\"]:real, [\"Total resident memory\"]:real, [\"Memory used\"]:real)\r\n[\r\n\"N\\\\A\",0,0,0,0,0\r\n];SapHana_LoadHistory_CL\r\n| where TimeGenerated  {TimeRange}\r\n| extend p = columnifexists(\"PROVIDER_INSTANCE_s\", \"*\")\r\n| where p == \"*\" or p in ({Provider}) or \"*\" in ({Provider})\r\n| where HOST_s in  ({Host}) or '*' in ({Host})\r\n| summarize [\"Allocation limit\"]=avg(MEMORY_ALLOCATION_LIMIT_d/1024)  , [\"Resident memory\"]=avg(MEMORY_RESIDENT_d/1024)  , [\"Memory size\"]=avg(MEMORY_SIZE_d/1024)  , [\"Total resident memory\"]=avg(MEMORY_TOTAL_RESIDENT_d/1024)  , [\"Memory used\"]=avg(MEMORY_USED_d/1024) by HOST_s, bin(TimeGenerated, {Granularity})\r\n| union   isfuzzy=true nodata |where HOST_s <> \"N\\\\A\"",
         "size": 0,
         "aggregation": 3,
         "title": "Memory used (GB)",
@@ -945,7 +965,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let nodata = datatable(HOST_s:string, [\"Network in\"]:real, [\"Network out\"]:real)\r\n[\r\n\"N\\\\A\",0,0\r\n];\r\nSapHana_LoadHistory_CL\r\n| where TimeGenerated  {TimeRange}\r\n| where PROVIDER_INSTANCE_s in  ({Provider}) or '*' in ({Provider})\r\n| where HOST_s in  ({Host}) or '*' in ({Host})\r\n|where NETWORK_IN_d >= 0 and NETWORK_OUT_d >= 0\r\n| summarize [\"Network in\"]=avg(NETWORK_IN_d), [\"Network out\"]=avg(NETWORK_OUT_d) by HOST_s, bin(TimeGenerated, {Granularity}) \r\n| union   isfuzzy=true nodata |where HOST_s <> \"N\\\\A\"",
+        "query": "let nodata = datatable(HOST_s:string, [\"Network in\"]:real, [\"Network out\"]:real)\r\n[\r\n\"N\\\\A\",0,0\r\n];\r\nSapHana_LoadHistory_CL\r\n| where TimeGenerated  {TimeRange}\r\n| extend p = columnifexists(\"PROVIDER_INSTANCE_s\", \"*\")\r\n| where p == \"*\" or p in ({Provider}) or \"*\" in ({Provider})\r\n| where HOST_s in  ({Host}) or '*' in ({Host})\r\n|where NETWORK_IN_d >= 0 and NETWORK_OUT_d >= 0\r\n| summarize [\"Network in\"]=avg(NETWORK_IN_d), [\"Network out\"]=avg(NETWORK_OUT_d) by HOST_s, bin(TimeGenerated, {Granularity}) \r\n| union   isfuzzy=true nodata |where HOST_s <> \"N\\\\A\"",
         "size": 0,
         "aggregation": 3,
         "title": "Network In/Out (MB/s)",
@@ -976,7 +996,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let nodata = datatable(HOST_s:string, avgDisk:real)\r\n[\r\n\"N\\\\A\",0\r\n];\r\nSapHana_LoadHistory_CL| where TimeGenerated  {TimeRange}\r\n| where PROVIDER_INSTANCE_s in  ({Provider}) or '*' in ({Provider})\r\n| where HOST_s in  ({Host}) or '*' in ({Host})\r\n| summarize avgDisk=avg(DISK_USED_d) by HOST_s , bin(TimeGenerated, {Granularity})\r\n| union   isfuzzy=true nodata |where HOST_s <> \"N\\\\A\"",
+        "query": "let nodata = datatable(HOST_s:string, avgDisk:real)\r\n[\r\n\"N\\\\A\",0\r\n];\r\nSapHana_LoadHistory_CL| where TimeGenerated  {TimeRange}\r\n| extend p = columnifexists(\"PROVIDER_INSTANCE_s\", \"*\")\r\n| where p == \"*\" or p in ({Provider}) or \"*\" in ({Provider})\r\n| where HOST_s in  ({Host}) or '*' in ({Host})\r\n| summarize avgDisk=avg(DISK_USED_d) by HOST_s , bin(TimeGenerated, {Granularity})\r\n| union   isfuzzy=true nodata |where HOST_s <> \"N\\\\A\"",
         "size": 0,
         "title": "Disk used (GB)",
         "color": "turquoise",
@@ -1017,7 +1037,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let nodata = datatable(HOST_s:string, TimeGenerated:dynamic,avgDiskUsed:dynamic,DiskUsed_Forecast:dynamic)\r\n[\r\n\"N\\\\A\", \"[\\\"2019-09-01T00:00:00Z\\\",\\\"2019-09-02T00:00:00Z\\\"]\",\"[0,0,0,0]\",\"[0,0,0,0]\"\r\n];\r\nlet startDate = startofday(ago(7d)); // go back in time nn days\r\nlet endDate = now(); // what is the date now\r\nlet projectTo = now()+7d; // project forward nn days\r\nlet projectForward = 7; // must be same as projectTo value\r\nSapHana_LoadHistory_CL\r\n| where PROVIDER_INSTANCE_s in  ({Provider}) or '*' in ({Provider})\r\n| where HOST_s in  ({Host}) or '*' in ({Host})\r\n|where TimeGenerated {TimeRange}//> ago(7d)\r\n| make-series avgDiskUsed=avg(DISK_USED_d) default=0 on TimeGenerated in range({TimeRange:start},projectTo, {TimeRange:grain}) by HOST_s\r\n| extend DiskUsed_Forecast = series_decompose_forecast(avgDiskUsed, projectForward*24)\r\n| union   isfuzzy=true nodata |where HOST_s <> \"N\\\\A\"",
+        "query": "let nodata = datatable(HOST_s:string, TimeGenerated:dynamic,avgDiskUsed:dynamic,DiskUsed_Forecast:dynamic)\r\n[\r\n\"N\\\\A\", \"[\\\"2019-09-01T00:00:00Z\\\",\\\"2019-09-02T00:00:00Z\\\"]\",\"[0,0,0,0]\",\"[0,0,0,0]\"\r\n];\r\nlet startDate = startofday(ago(7d)); // go back in time nn days\r\nlet endDate = now(); // what is the date now\r\nlet projectTo = now()+7d; // project forward nn days\r\nlet projectForward = 7; // must be same as projectTo value\r\nSapHana_LoadHistory_CL\r\n| extend p = columnifexists(\"PROVIDER_INSTANCE_s\", \"*\")\r\n| where p == \"*\" or p in ({Provider}) or \"*\" in ({Provider})\r\n| where HOST_s in  ({Host}) or '*' in ({Host})\r\n|where TimeGenerated {TimeRange}//> ago(7d)\r\n| make-series avgDiskUsed=avg(DISK_USED_d) default=0 on TimeGenerated in range({TimeRange:start},projectTo, {TimeRange:grain}) by HOST_s\r\n| extend DiskUsed_Forecast = series_decompose_forecast(avgDiskUsed, projectForward*24)\r\n| union   isfuzzy=true nodata |where HOST_s <> \"N\\\\A\"",
         "size": 0,
         "title": "Disk (GB) - Actual vs. Forecast",
         "color": "turquoise",
@@ -1144,7 +1164,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let nodata = datatable(HOST_s:string, TimeGenerated:dynamic,avgCPU:dynamic,anomalies:dynamic)\r\n[\r\n\"N\\\\A\", \"[\\\"2019-09-01T00:00:00Z\\\",\\\"2019-09-02T00:00:00Z\\\"]\",\"[0,0,0,0]\",\"[0,0,0,0]\"\r\n];\r\nlet bucketsize=case(datetime_diff('day',{AnomalyDetectionRange:end},{AnomalyDetectionRange:start}) > 29 , 4h,datetime_diff('day',{AnomalyDetectionRange:end},{AnomalyDetectionRange:start}) > 6 , 1h ,30m);\r\nlet seasonalitybins=case(datetime_diff('day',{AnomalyDetectionRange:end},{AnomalyDetectionRange:start}) > 29 , 42,datetime_diff('day',{AnomalyDetectionRange:end},{AnomalyDetectionRange:start}) > 6 , 24 ,48);// for daily seasonality pattern\r\nSapHana_LoadHistory_CL\r\n| where PROVIDER_INSTANCE_s in  ({Provider}) or '*' in ({Provider})\r\n| where TimeGenerated {AnomalyDetectionRange}\r\n| make-series [\"Actual CPU (%)\"]=avg(CPU_d) default=0 on TimeGenerated in range({AnomalyDetectionRange:start},now(), bucketsize) by HOST_s\r\n| extend (flag, [\"Anomaly score\"], [\"Calculated baseline\"]) = series_decompose_anomalies([\"Actual CPU (%)\"],1.5,seasonalitybins)\r\n| project-away flag\r\n| union isfuzzy=true nodata | where HOST_s <> \"N\\\\A\"",
+        "query": "let nodata = datatable(HOST_s:string, TimeGenerated:dynamic,avgCPU:dynamic,anomalies:dynamic)\r\n[\r\n\"N\\\\A\", \"[\\\"2019-09-01T00:00:00Z\\\",\\\"2019-09-02T00:00:00Z\\\"]\",\"[0,0,0,0]\",\"[0,0,0,0]\"\r\n];\r\nlet bucketsize=case(datetime_diff('day',{AnomalyDetectionRange:end},{AnomalyDetectionRange:start}) > 29 , 4h,datetime_diff('day',{AnomalyDetectionRange:end},{AnomalyDetectionRange:start}) > 6 , 1h ,30m);\r\nlet seasonalitybins=case(datetime_diff('day',{AnomalyDetectionRange:end},{AnomalyDetectionRange:start}) > 29 , 42,datetime_diff('day',{AnomalyDetectionRange:end},{AnomalyDetectionRange:start}) > 6 , 24 ,48);// for daily seasonality pattern\r\nSapHana_LoadHistory_CL\r\n| extend p = columnifexists(\"PROVIDER_INSTANCE_s\", \"*\")\r\n| where p == \"*\" or p in ({Provider}) or \"*\" in ({Provider})\r\n| where TimeGenerated {AnomalyDetectionRange}\r\n| make-series [\"Actual CPU (%)\"]=avg(CPU_d) default=0 on TimeGenerated in range({AnomalyDetectionRange:start},now(), bucketsize) by HOST_s\r\n| extend (flag, [\"Anomaly score\"], [\"Calculated baseline\"]) = series_decompose_anomalies([\"Actual CPU (%)\"],1.5,seasonalitybins)\r\n| project-away flag\r\n| union isfuzzy=true nodata | where HOST_s <> \"N\\\\A\"",
         "size": 0,
         "aggregation": 3,
         "title": "CPU Anomalies",
@@ -1180,7 +1200,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let nodata = datatable(HOST_s:string, TimeGenerated:dynamic,avgMEM:dynamic,anomalies:dynamic)\r\n[\r\n\"N\\\\A\", \"[\\\"2019-09-01T00:00:00Z\\\",\\\"2019-09-02T00:00:00Z\\\"]\",\"[0,0,0,0]\",\"[0,0,0,0]\"\r\n];\r\nlet bucketsize=case(datetime_diff('day',{AnomalyDetectionRange:end},{AnomalyDetectionRange:start}) > 29 , 4h,datetime_diff('day',{AnomalyDetectionRange:end},{AnomalyDetectionRange:start}) > 6 , 1h ,30m);\r\nlet seasonalitybins=case(datetime_diff('day',{AnomalyDetectionRange:end},{AnomalyDetectionRange:start}) > 29 , 42,datetime_diff('day',{AnomalyDetectionRange:end},{AnomalyDetectionRange:start}) > 6 , 24 ,48);// for daily seasonality pattern\r\nSapHana_LoadHistory_CL\r\n| where PROVIDER_INSTANCE_s in  ({Provider}) or '*' in ({Provider})\r\n| where TimeGenerated {AnomalyDetectionRange}\r\n| make-series [\"Actual memory (GB)\"]=avg(MEMORY_USED_d/MEMORY_SIZE_d)*100 default=0 on TimeGenerated in range({AnomalyDetectionRange:start},now(), bucketsize) by HOST_s\r\n| extend (flag, [\"Anomaly score\"], [\"Calculated baseline\"]) = series_decompose_anomalies([\"Actual memory (GB)\"],1.5,seasonalitybins)\r\n| project-away  flag\r\n| union   isfuzzy=true nodata | where HOST_s <> \"N\\\\A\"",
+        "query": "let nodata = datatable(HOST_s:string, TimeGenerated:dynamic,avgMEM:dynamic,anomalies:dynamic)\r\n[\r\n\"N\\\\A\", \"[\\\"2019-09-01T00:00:00Z\\\",\\\"2019-09-02T00:00:00Z\\\"]\",\"[0,0,0,0]\",\"[0,0,0,0]\"\r\n];\r\nlet bucketsize=case(datetime_diff('day',{AnomalyDetectionRange:end},{AnomalyDetectionRange:start}) > 29 , 4h,datetime_diff('day',{AnomalyDetectionRange:end},{AnomalyDetectionRange:start}) > 6 , 1h ,30m);\r\nlet seasonalitybins=case(datetime_diff('day',{AnomalyDetectionRange:end},{AnomalyDetectionRange:start}) > 29 , 42,datetime_diff('day',{AnomalyDetectionRange:end},{AnomalyDetectionRange:start}) > 6 , 24 ,48);// for daily seasonality pattern\r\nSapHana_LoadHistory_CL\r\n| extend p = columnifexists(\"PROVIDER_INSTANCE_s\", \"*\")\r\n| where p == \"*\" or p in ({Provider}) or \"*\" in ({Provider})\r\n| where TimeGenerated {AnomalyDetectionRange}\r\n| make-series [\"Actual memory (GB)\"]=avg(MEMORY_USED_d/MEMORY_SIZE_d)*100 default=0 on TimeGenerated in range({AnomalyDetectionRange:start},now(), bucketsize) by HOST_s\r\n| extend (flag, [\"Anomaly score\"], [\"Calculated baseline\"]) = series_decompose_anomalies([\"Actual memory (GB)\"],1.5,seasonalitybins)\r\n| project-away  flag\r\n| union   isfuzzy=true nodata | where HOST_s <> \"N\\\\A\"",
         "size": 0,
         "aggregation": 3,
         "title": "Memory Anomalies",


### PR DESCRIPTION
- PR #685 added a filter on the new provider instance concept, which has been introduced with content version 0.4.0.
- As there are still a few legacy customers who haven't updated their SAP Monitor resource, the schema of their custom logs does not have the underlying column PROVIDER_INSTANCE_s yet. Therefore, the queries in their workbooks fail and show no data.
![image](https://user-images.githubusercontent.com/19369891/77370841-fda33700-6d1e-11ea-8ee2-5466c4fe78cc.png)

- This hotfix adds backwards compatibility and resolves the issue by checking if the new column actually exists. Only then, the provider dropdown is actually shown to the user.

## PR Checklist

* [x] Explain your changes, so people looking at the PR know *what* and *why*, the code changes are the *how*.
* [x] *if updating templates, it is helpful to post a screenshot of what the changes look like.*
* [x] *if updating templates, ensure that your parameters and steps have meaningful names.*
* [ ] *if adding new templates, or changing items in a gallery, it's helpful to post a screenshot of what the gallery looks like now*
