### PR TITLE
add link to alerts details in alerts template

### DIFF
--- a/Workbooks/Azure Resources/Alerts/Alerts.workbook
+++ b/Workbooks/Azure Resources/Alerts/Alerts.workbook
@@ -240,17 +240,7 @@
                 "formatters": [
                   {
                     "columnMatch": "Severity",
-                    "formatter": 11,
-                    "formatOptions": {
-                      "showIcon": true
-                    }
-                  },
-                  {
-                    "columnMatch": "State",
-                    "formatter": 1,
-                    "formatOptions": {
-                      "showIcon": true
-                    }
+                    "formatter": 11
                   },
                   {
                     "columnMatch": "Count",
@@ -258,7 +248,6 @@
                     "formatOptions": {
                       "min": 0,
                       "palette": "blue",
-                      "showIcon": true,
                       "aggregation": "Sum"
                     },
                     "numberFormat": {
@@ -268,6 +257,10 @@
                         "maximumFractionDigits": 2
                       }
                     }
+                  },
+                  {
+                    "columnMatch": "State",
+                    "formatter": 1
                   }
                 ]
               }
@@ -318,7 +311,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "AlertsManagementResources | where type =~ 'microsoft.alertsmanagement/alerts'\r\n| where properties.essentials.startDateTime {timeRange}  \r\n| extend Severity=tostring(properties.essentials.severity)\r\n| where Severity in ({Severity})\r\n| extend State=tostring(properties.essentials.alertState)\r\n| where \"*\" in ({State}) or State in ({State})\r\n| where \"*\" in ({ResourceTypes}) or properties.essentials.targetResourceType in~ ({ResourceTypes})\r\n| where \"*\" in ({ResourceGroups}) or properties.essentials.targetResourceGroup in~ ({ResourceGroups})\r\n| where \"*\" in ({Resources}) or properties.essentials.targetResource in~ ({Resources})\r\n| project AlertId=id, StartTime=todatetime(tostring(properties.essentials.startDateTime)), Severity, State=tostring(properties.essentials.alertState), name, \r\n  TargetResource = tostring(properties.essentials.targetResource), \r\n  MonitorService = tostring(properties.essentials.monitorService),\r\n  SignalType=tostring(properties.essentials.signalType), Description=tostring(properties.essentials.description)\r\n| order by StartTime desc\r\n",
+              "query": "AlertsManagementResources | where type =~ 'microsoft.alertsmanagement/alerts'\r\n| where properties.essentials.startDateTime {timeRange}  \r\n| extend Severity=tostring(properties.essentials.severity)\r\n| where Severity in ({Severity})\r\n| extend State=tostring(properties.essentials.alertState)\r\n| where \"*\" in ({State}) or State in ({State})\r\n| where \"*\" in ({ResourceTypes}) or properties.essentials.targetResourceType in~ ({ResourceTypes})\r\n| where \"*\" in ({ResourceGroups}) or properties.essentials.targetResourceGroup in~ ({ResourceGroups})\r\n| where \"*\" in ({Resources}) or properties.essentials.targetResource in~ ({Resources})\r\n| project AlertId=id, StartTime=todatetime(tostring(properties.essentials.startDateTime)), Severity, State=tostring(properties.essentials.alertState), Name=name, \r\n  TargetResource = tostring(properties.essentials.targetResource), \r\n  MonitorService = tostring(properties.essentials.monitorService),\r\n  SignalType=tostring(properties.essentials.signalType), Description=tostring(properties.essentials.description)\r\n| order by StartTime desc\r\n",
               "size": 0,
               "title": "{$rowCount} {Severity} Alerts",
               "noDataMessage": "No alerts found",
@@ -333,36 +326,51 @@
                     "columnMatch": "AlertId",
                     "formatter": 5,
                     "formatOptions": {
-                      "linkTarget": "Resource",
-                      "showIcon": true
+                      "linkTarget": "Resource"
                     }
                   },
                   {
                     "columnMatch": "StartTime",
-                    "formatter": 6,
-                    "formatOptions": {
-                      "showIcon": true
-                    }
+                    "formatter": 6
                   },
                   {
                     "columnMatch": "Severity",
-                    "formatter": 11,
-                    "formatOptions": {
-                      "showIcon": true
-                    }
+                    "formatter": 11
                   },
                   {
                     "columnMatch": "State",
-                    "formatter": 1,
-                    "formatOptions": {
-                      "showIcon": true
-                    }
+                    "formatter": 1
                   },
                   {
-                    "columnMatch": "name",
+                    "columnMatch": "Name",
                     "formatter": 1,
                     "formatOptions": {
-                      "showIcon": true
+                      "linkTarget": "OpenBlade",
+                      "linkIsContextBlade": true,
+                      "bladeOpenContext": {
+                        "bladeName": "AlertDetailsTemplateBlade",
+                        "extensionName": "Microsoft_Azure_Monitoring",
+                        "bladeParameters": [
+                          {
+                            "name": "alertId",
+                            "source": "column",
+                            "value": "AlertId"
+                          },
+                          {
+                            "name": "alertName",
+                            "source": "column",
+                            "value": "Name"
+                          },
+                          {
+                            "name": "invokedFrom",
+                            "source": "static",
+                            "value": "Workbooks"
+                          }
+                        ]
+                      }
+                    },
+                    "tooltipFormat": {
+                      "tooltip": "View alert details"
                     }
                   },
                   {
@@ -375,33 +383,11 @@
                     }
                   },
                   {
-                    "columnMatch": "MonitorService",
-                    "formatter": 0,
-                    "formatOptions": {
-                      "showIcon": true
-                    }
-                  },
-                  {
-                    "columnMatch": "SignalType",
-                    "formatter": 0,
-                    "formatOptions": {
-                      "showIcon": true
-                    }
-                  },
-                  {
-                    "columnMatch": "Description",
-                    "formatter": 0,
-                    "formatOptions": {
-                      "showIcon": true
-                    }
-                  },
-                  {
                     "columnMatch": "essentials",
                     "formatter": 5,
                     "formatOptions": {
                       "linkTarget": "CellDetails",
-                      "linkIsContextBlade": true,
-                      "showIcon": true
+                      "linkIsContextBlade": true
                     }
                   }
                 ],
@@ -451,22 +437,6 @@
               ],
               "visualization": "map",
               "gridSettings": {
-                "formatters": [
-                  {
-                    "columnMatch": "properties_essentials_targetResource",
-                    "formatter": 0,
-                    "formatOptions": {
-                      "showIcon": true
-                    }
-                  },
-                  {
-                    "columnMatch": "count_",
-                    "formatter": 0,
-                    "formatOptions": {
-                      "showIcon": true
-                    }
-                  }
-                ],
                 "rowLimit": 1000
               },
               "mapSettings": {
@@ -538,7 +508,6 @@
               "title": "Resources with {Severity} Alerts in the Selected Regions",
               "noDataMessage": "No alerts found",
               "queryType": 8,
-              "resourceType": "microsoft.operationalinsights/workspaces",
               "gridSettings": {
                 "formatters": [
                   {
@@ -551,17 +520,11 @@
                   },
                   {
                     "columnMatch": "regionName",
-                    "formatter": 5,
-                    "formatOptions": {
-                      "showIcon": true
-                    }
+                    "formatter": 5
                   },
                   {
                     "columnMatch": "Resource",
-                    "formatter": 5,
-                    "formatOptions": {
-                      "showIcon": true
-                    }
+                    "formatter": 5
                   },
                   {
                     "columnMatch": "Alerts",
@@ -569,7 +532,6 @@
                     "formatOptions": {
                       "min": 0,
                       "palette": "blue",
-                      "showIcon": true,
                       "aggregation": "Sum"
                     },
                     "numberFormat": {
@@ -585,7 +547,6 @@
                     "columnMatch": "New",
                     "formatter": 0,
                     "formatOptions": {
-                      "showIcon": true,
                       "aggregation": "Sum"
                     }
                   },
@@ -593,7 +554,6 @@
                     "columnMatch": "Acknowledged",
                     "formatter": 0,
                     "formatOptions": {
-                      "showIcon": true,
                       "aggregation": "Sum"
                     }
                   },
@@ -601,7 +561,6 @@
                     "columnMatch": "Closed",
                     "formatter": 0,
                     "formatOptions": {
-                      "showIcon": true,
                       "aggregation": "Sum"
                     }
                   }


### PR DESCRIPTION
## PR Checklist

now that links to any view are enabled, add the ability to open up alert details from the alerts template.

the alert name column now opens the alert details:

![image](https://user-images.githubusercontent.com/10158007/80657324-2a422100-8a38-11ea-810d-c24cc6b6e063.png)
