### PR TITLE
make sure storage insights single resource is in a "gallery" so it can get looked up for metadata in that gallery

### DIFF
--- a/Workbooks/Individual Storage/Overview/settings.json
+++ b/Workbooks/Individual Storage/Overview/settings.json
@@ -2,5 +2,5 @@
     "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/settings.json",
     "name":"Storage Account Overview",
     "author": "Microsoft",
-    "galleries": [{ "type": "workbook", "resourceType": "microsoft.storage/storageaccounts", "order": 100 }]
+    "galleries": [{ "type": "workbook", "resourceType": "microsoft.storage/storageaccounts", "order": 100 }, { "type": "storage-insights", "resourceType": "microsoft.storage/storageaccounts", "order": 100 }]
 }


### PR DESCRIPTION
the at resource storage insights template isn't in the "storage-insights" gallery (nothing is), so that call to get templates for that gallery fails all the time.

and since it isn't in the gallery, when things like pins try to look it up to get its info, it doesn't get found since it isn't in a gallery.  so the pinned item shows up as "unknown":
![image](https://user-images.githubusercontent.com/10158007/83173945-7c757100-a0ce-11ea-98ea-90f205963285.png)
