### PR TITLE
Storage Insights: Change Capacity metrics units from SI Bytes to Bytes

### DIFF
--- a/Workbooks/Individual Storage/Capacity/Capacity.workbook
+++ b/Workbooks/Individual Storage/Capacity/Capacity.workbook
@@ -201,7 +201,7 @@
               "showIcon": true
             },
             "numberFormat": {
-              "unit": 36,
+              "unit": 2,
               "options": {
                 "style": "decimal",
                 "maximumFractionDigits": 2

--- a/Workbooks/Storage/Overview/Overview.workbook
+++ b/Workbooks/Storage/Overview/Overview.workbook
@@ -628,7 +628,7 @@
                       }
                     },
                     "numberFormat": {
-                      "unit": 36,
+                      "unit": 2,
                       "options": {
                         "style": "decimal",
                         "maximumFractionDigits": 1


### PR DESCRIPTION
Metrics chart show metrics in Bytes but tiles/graph is showing number format units in Bytes (SI). Since we can't change the metric chart number format, change the tiles/graph number format to Bytes instead