### PR TITLE
Moved old SAP HANA template to the front

### DIFF
--- a/Workbooks/SapMonitor/SapHana.old/settings.json
+++ b/Workbooks/SapMonitor/SapHana.old/settings.json
@@ -3,5 +3,5 @@
     "name": "SAP HANA (deprecated)",
     "description": "For old single-instance SAP Monitors only",
     "author": "Microsoft",
-    "galleries": [{ "type": "workbook", "resourceType": "Microsoft.HanaOnAzure/sapMonitors", "order": 400 }]
+    "galleries": [{ "type": "workbook", "resourceType": "Microsoft.HanaOnAzure/sapMonitors", "order": 50 }]
 }


### PR DESCRIPTION
Until we officially roll out the new SAP Monitor version, we would like to keep the old SAP HANA workbook template in the very front of the gallery. This way, we ensure it gets invoked automatically when a user clicks on the "Insights (Preview)" TOC node inside a SAP Monitor resource.

## PR Checklist

* [x] Explain your changes, so people looking at the PR know *what* and *why*, the code changes are the *how*.
* [ ] *if updating templates, it is helpful to post a screenshot of what the changes look like.*
* [ ] *if updating templates, ensure that your parameters and steps have meaningful names.*
* [ ] *if adding new templates, or changing items in a gallery, it's helpful to post a screenshot of what the gallery looks like now*
