### PR TITLE
Add resource type explicitly to queries

### DIFF
--- a/Workbooks/SapMonitor/MsSqlServer/MsSqlServer.workbook
+++ b/Workbooks/SapMonitor/MsSqlServer/MsSqlServer.workbook
@@ -71,8 +71,8 @@
             "name": "Provider",
             "type": 2,
             "isRequired": true,
-            "query": "MSSQL_SystemProps_CL\r\n| where TimeGenerated {Days}\r\n| project PROVIDER_INSTANCE_s \r\n| distinct PROVIDER_INSTANCE_s\r\n",
-            "value": null,
+            "query": "MSSQL_SystemProps_CL\r\n| project PROVIDER_INSTANCE_s \r\n| distinct PROVIDER_INSTANCE_s\r\n",
+            "value": "MOM-Node-1",
             "typeSettings": {
               "additionalResourceOptions": []
             },
@@ -158,18 +158,34 @@
             "isHiddenWhenLocked": true,
             "queryType": 0,
             "resourceType": "microsoft.operationalinsights/workspaces"
+          },
+          {
+            "id": "842310b3-c00a-43bb-b55a-b77335526979",
+            "version": "KqlParameterItem/1.0",
+            "name": "BlockingTableExists",
+            "type": 1,
+            "isRequired": true,
+            "query": "MSSQL_BlockingProcesses_CL \r\n| limit 1\r\n\r\n\r\n\r\n\r\n\r\n",
+            "isHiddenWhenLocked": true,
+            "timeContext": {
+              "durationMs": 3600000
+            },
+            "queryType": 0,
+            "resourceType": "microsoft.insights/components"
           }
         ],
         "style": "above",
         "queryType": 0
       },
+      "customWidth": "50",
       "name": "Parameter "
     },
     {
       "type": 1,
       "content": {
-        "json": "## Microsoft SQL Server for SAP on Azure\r\n---\r\n<b style=\"color:DodgerBlue;\">OS Hostname:</b> {Hostname} on {WindowsRelease} ({WindowsSKU}) - {WindowsLanguage} </br>\r\n<b style=\"color:DodgerBlue;\">SQL Instance:</b> {SQLInstance} - {SQLEdition} Version {SQLVersion}  </br>\r\n<b style=\"color:DodgerBlue;\">SAP Instance:</b> {SAPSID}\r\n"
+        "json": "## Azure Monitor for SAP Solutions on MS SQL Server\r\n---\r\n<b style=\"color:DodgerBlue;\">OS Hostname:</b> {Hostname} on {WindowsRelease} ({WindowsSKU}) - {WindowsLanguage} </br>\r\n<b style=\"color:DodgerBlue;\">SQL Instance:</b> {SQLInstance} - {SQLEdition} Version {SQLVersion}  </br>\r\n<b style=\"color:DodgerBlue;\">SAP Instance:</b> {SAPSID}\r\n"
       },
+      "customWidth": "50",
       "name": "Headline"
     },
     {
@@ -226,10 +242,11 @@
         "aggregation": 3,
         "title": "Batch Request/sec ({Days:label})",
         "timeContext": {
-          "durationMs": 900000
+          "durationMs": 172800000
         },
         "timeContextFromParameter": "Days",
         "queryType": 0,
+        "resourceType": "microsoft.operationalinsights/workspaces",
         "visualization": "areachart",
         "chartSettings": {
           "xSettings": {},
@@ -257,10 +274,11 @@
         "title": "Compilations and Re-Compilations/sec ({Days:label})",
         "noDataMessage": "Sorry, no data.",
         "timeContext": {
-          "durationMs": 900000
+          "durationMs": 172800000
         },
         "timeContextFromParameter": "Days",
         "queryType": 0,
+        "resourceType": "microsoft.operationalinsights/workspaces",
         "visualization": "areachart",
         "chartSettings": {
           "seriesLabelSettings": [
@@ -298,10 +316,11 @@
         "title": "CPU Usage",
         "noDataMessage": "No Data.",
         "timeContext": {
-          "durationMs": 900000
+          "durationMs": 172800000
         },
         "timeContextFromParameter": "Days",
         "queryType": 0,
+        "resourceType": "microsoft.operationalinsights/workspaces",
         "visualization": "linechart",
         "chartSettings": {
           "seriesLabelSettings": [
@@ -346,6 +365,7 @@
         "title": "DB IO Latency ({Days:label})",
         "noDataMessage": "Sorry, no data.",
         "queryType": 0,
+        "resourceType": "microsoft.operationalinsights/workspaces",
         "visualization": "linechart",
         "tileSettings": {
           "showBorder": false
@@ -412,10 +432,11 @@
         "title": "Buffer Cache Hit Ratio ({Days:label})",
         "noDataMessage": "No data.",
         "timeContext": {
-          "durationMs": 900000
+          "durationMs": 172800000
         },
         "timeContextFromParameter": "Days",
         "queryType": 0,
+        "resourceType": "microsoft.operationalinsights/workspaces",
         "visualization": "barchart",
         "tileSettings": {
           "showBorder": false,
@@ -488,10 +509,11 @@
         "title": "Page File Expectency ({Days:label})",
         "noDataMessage": "No data.",
         "timeContext": {
-          "durationMs": 900000
+          "durationMs": 172800000
         },
         "timeContextFromParameter": "Days",
         "queryType": 0,
+        "resourceType": "microsoft.operationalinsights/workspaces",
         "visualization": "linechart"
       },
       "conditionalVisibility": {
@@ -514,6 +536,7 @@
         "title": "Memory Overview ({Days:label})",
         "noDataMessage": "Sorry, no data.",
         "queryType": 0,
+        "resourceType": "microsoft.operationalinsights/workspaces",
         "visualization": "piechart",
         "gridSettings": {
           "formatters": [
@@ -596,10 +619,11 @@
         "title": "Actual Top 10 Waits Statistics (Percent)",
         "noDataMessage": "Sorry, no data.",
         "timeContext": {
-          "durationMs": 900000
+          "durationMs": 172800000
         },
         "timeContextFromParameter": "Days",
         "queryType": 0,
+        "resourceType": "microsoft.operationalinsights/workspaces",
         "visualization": "tiles",
         "gridSettings": {
           "formatters": [
@@ -717,10 +741,11 @@
         "title": "Top 10 SQL Statements ({Days:label})",
         "noDataMessage": "Sorry, no data.",
         "timeContext": {
-          "durationMs": 900000
+          "durationMs": 172800000
         },
         "timeContextFromParameter": "Days",
         "queryType": 0,
+        "resourceType": "microsoft.operationalinsights/workspaces",
         "gridSettings": {
           "formatters": [
             {
@@ -1016,6 +1041,7 @@
         "title": "Top 12 largest Tables",
         "noDataMessage": "Sorry, no data.",
         "queryType": 0,
+        "resourceType": "microsoft.operationalinsights/workspaces",
         "visualization": "table",
         "gridSettings": {
           "formatters": [
@@ -1118,6 +1144,7 @@
         "noDataMessage": "No warnings or errors for the given timeframe.",
         "noDataMessageStyle": 3,
         "queryType": 0,
+        "resourceType": "microsoft.operationalinsights/workspaces",
         "gridSettings": {
           "formatters": [
             {
@@ -1194,15 +1221,17 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let hasNonEmptyTable = (T:string) {toscalar( union isfuzzy=true ( table(T) | count as Count ), (print Count=0) | summarize sum(Count) ) > 0};\r\nlet TableName = 'MSSQL_BlockingProcesses_CL';\r\n\r\niif(hasNonEmptyTable(TableName), \r\n\r\nMSSQL_BlockingProcesses_CL\r\n| where TimeGenerated {Days}\r\n| where PROVIDER_INSTANCE_s == \"{Provider}\"\r\n| extend status_s = replace(@\"(\\s+)$\", @\"\", status_s) \r\n| extend waitresource_s = replace(@\"(\\s+)$\", @\"\", waitresource_s) \r\n| extend hostname_s = replace(@\"(\\s+)$\", @\"\", hostname_s) \r\n| project TimeGenerated, spid_d, blocked_d, type_s, status_s, cmd_s, lastwaittype_s, waitresource_s, waittime_d, cpu_d, ecid_d, dbid_d, physical_io_d, memusage_d, kpid_d, hostname_s, program_name_s, sql_handle_s\r\n| take 200\r\n\r\n, \"Table not preset\")\r\n\r\n",
+        "query": "MSSQL_BlockingProcesses_CL\r\n| where TimeGenerated {Days}\r\n| where PROVIDER_INSTANCE_s == \"{Provider}\"\r\n| extend status_s = replace(@\"(\\s+)$\", @\"\", status_s) \r\n| extend waitresource_s = replace(@\"(\\s+)$\", @\"\", waitresource_s) \r\n| extend hostname_s = replace(@\"(\\s+)$\", @\"\", hostname_s) \r\n| project TimeGenerated, spid_d, blocked_d, type_s, status_s, cmd_s, lastwaittype_s, waitresource_s, waittime_d, cpu_d, ecid_d, dbid_d, physical_io_d, memusage_d, kpid_d, hostname_s, program_name_s, sql_handle_s\r\n| take 200\r\n\r\n\r\n\r\n",
         "size": 0,
         "title": "Blocking Processes ({Days:label})",
         "noDataMessage": "No data.",
         "timeContext": {
-          "durationMs": 900000
+          "durationMs": 172800000
         },
         "timeContextFromParameter": "Days",
         "queryType": 0,
+        "resourceType": "microsoft.operationalinsights/workspaces",
+        "visualization": "table",
         "gridSettings": {
           "formatters": [
             {
@@ -1252,11 +1281,18 @@
           }
         }
       },
-      "conditionalVisibility": {
-        "parameterName": "selectedTab",
-        "comparison": "isEqualTo",
-        "value": "4"
-      },
+      "conditionalVisibilities": [
+        {
+          "parameterName": "selectedTab",
+          "comparison": "isEqualTo",
+          "value": "4"
+        },
+        {
+          "parameterName": "BlockingTableExists",
+          "comparison": "isNotEqualTo",
+          "value": ""
+        }
+      ],
       "name": "Blocking",
       "styleSettings": {
         "showBorder": true
@@ -1273,7 +1309,8 @@
         "timeContext": {
           "durationMs": 86400000
         },
-        "queryType": 0
+        "queryType": 0,
+        "resourceType": "microsoft.operationalinsights/workspaces"
       },
       "conditionalVisibility": {
         "parameterName": "selectedTab",
@@ -1289,6 +1326,97 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
+        "query": "let LastOne = MSSQL_AOWaitstats_CL\r\n| where TimeGenerated {Days} and PROVIDER_INSTANCE_s == \"{Provider}\"\r\n| summarize TimeGenerated = max(TimeGenerated)\r\n| project TimeGenerated;\r\n\r\nMSSQL_AOWaitstats_CL\r\n| join kind=inner (LastOne) on TimeGenerated\r\n| where PROVIDER_INSTANCE_s == \"{Provider}\"\r\n| project WaitType_s, Percentage_d, WaitCount_d, Wait_S_d, AvgWait_S_d,Resource_S_d, AvgRes_S_d, Signal_S_d, AvgSig_S_d, TimeGenerated\r\n| order by Percentage_d desc",
+        "size": 3,
+        "title": "AlwaysOn Waitstats",
+        "noDataMessage": "No data.",
+        "timeContext": {
+          "durationMs": 86400000
+        },
+        "queryType": 0,
+        "resourceType": "microsoft.operationalinsights/workspaces",
+        "visualization": "table",
+        "gridSettings": {
+          "formatters": [
+            {
+              "columnMatch": "Percentage_d",
+              "formatter": 4,
+              "formatOptions": {
+                "max": 100,
+                "palette": "orange"
+              },
+              "numberFormat": {
+                "unit": 1,
+                "options": {
+                  "style": "decimal",
+                  "useGrouping": false,
+                  "minimumFractionDigits": 2,
+                  "maximumFractionDigits": 2
+                }
+              }
+            },
+            {
+              "columnMatch": "TimeGenerated",
+              "formatter": 5
+            }
+          ],
+          "labelSettings": [
+            {
+              "columnId": "WaitType_s",
+              "label": "Waitytype"
+            },
+            {
+              "columnId": "Percentage_d",
+              "label": "Percent"
+            },
+            {
+              "columnId": "WaitCount_d",
+              "label": "Waits (#)"
+            },
+            {
+              "columnId": "Wait_S_d",
+              "label": "Waits (sec)"
+            },
+            {
+              "columnId": "AvgWait_S_d",
+              "label": "Waits (avg. sec)"
+            },
+            {
+              "columnId": "Resource_S_d",
+              "label": "Resource Wait (sec)"
+            },
+            {
+              "columnId": "AvgRes_S_d",
+              "label": "Resource Wait (avg. sec)"
+            },
+            {
+              "columnId": "Signal_S_d",
+              "label": "Signal Waits (sec)"
+            },
+            {
+              "columnId": "AvgSig_S_d",
+              "label": "Signalwait (avg. sec)"
+            },
+            {
+              "columnId": "TimeGenerated"
+            }
+          ]
+        }
+      },
+      "conditionalVisibility": {
+        "parameterName": "selectedTab",
+        "comparison": "isEqualTo",
+        "value": "5"
+      },
+      "name": "AOWaitStats",
+      "styleSettings": {
+        "showBorder": true
+      }
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
         "query": "let LastOne = MSSQL_AOFailovers_CL\r\n| where TimeGenerated {Days} and PROVIDER_INSTANCE_s == \"{Provider}\"\r\n| summarize TimeGenerated = max(TimeGenerated)\r\n| project TimeGenerated;\r\n\r\nMSSQL_AOFailovers_CL\r\n| join kind=inner (LastOne) on TimeGenerated\r\n| where PROVIDER_INSTANCE_s == '{Provider}'\r\n| project server_name_s, timestamp_t, Message\r\n\r\n",
         "size": 3,
         "title": "AlwaysOn Failovers",
@@ -1296,7 +1424,8 @@
         "timeContext": {
           "durationMs": 86400000
         },
-        "queryType": 0
+        "queryType": 0,
+        "resourceType": "microsoft.operationalinsights/workspaces"
       },
       "conditionalVisibility": {
         "parameterName": "selectedTab",
@@ -1307,20 +1436,6 @@
       "styleSettings": {
         "showBorder": true
       }
-    },
-    {
-      "type": 3,
-      "content": {
-        "version": "KqlItem/1.0",
-        "query": "let LastOne = MSSQL_AOWaitstats_CL\r\n| where TimeGenerated {Days} and PROVIDER_INSTANCE_s == \"{Provider}\"\r\n| summarize TimeGenerated = max(TimeGenerated)\r\n| project TimeGenerated;\r\n\r\nMSSQL_AOWaitstats_CL\r\n| join kind=inner (LastOne) on TimeGenerated\r\n| where PROVIDER_INSTANCE_s == '{Provider}'\r\n| project waittype_s,requests_d,waittime_d,wtperreq_d, TimeGenerated",
-        "size": 0,
-        "timeContext": {
-          "durationMs": 86400000
-        },
-        "queryType": 0,
-        "visualization": "table"
-      },
-      "name": "Abfrage - 17"
     }
   ],
   "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"

--- a/Workbooks/SapMonitor/PrometheusHaCluster/PrometheusHaCluster.workbook
+++ b/Workbooks/SapMonitor/PrometheusHaCluster/PrometheusHaCluster.workbook
@@ -105,6 +105,7 @@
                 }
               ],
               "queryType": 0,
+              "resourceType": "microsoft.operationalinsights/workspaces",
               "visualization": "graph",
               "graphSettings": {
                 "type": 2,
@@ -172,6 +173,7 @@
               "noDataMessage": "No monitoring data has been received.",
               "noDataMessageStyle": 4,
               "queryType": 0,
+              "resourceType": "microsoft.operationalinsights/workspaces",
               "gridSettings": {
                 "formatters": [
                   {
@@ -316,6 +318,7 @@
               "noDataMessage": "No monitoring data has been received.",
               "noDataMessageStyle": 4,
               "queryType": 0,
+              "resourceType": "microsoft.operationalinsights/workspaces",
               "gridSettings": {
                 "formatters": [
                   {
@@ -565,5 +568,6 @@
       "name": "endpointStatusView"
     }
   ],
+  "fromTemplateId": "community-Workbooks/SapMonitor/PrometheusHaCluster",
   "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
 }

--- a/Workbooks/SapMonitor/PrometheusHaCluster/PrometheusHaCluster.workbook
+++ b/Workbooks/SapMonitor/PrometheusHaCluster/PrometheusHaCluster.workbook
@@ -568,6 +568,5 @@
       "name": "endpointStatusView"
     }
   ],
-  "fromTemplateId": "community-Workbooks/SapMonitor/PrometheusHaCluster",
   "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
 }

--- a/Workbooks/SapMonitor/SapHana.old/settings.json
+++ b/Workbooks/SapMonitor/SapHana.old/settings.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/settings.json",
     "name": "SAP HANA (deprecated)",
-    "description": "For old single-instance SAP Monitors only",
+    "description": "For single-instance SAP Monitors only",
     "author": "Microsoft",
     "galleries": [{ "type": "workbook", "resourceType": "Microsoft.HanaOnAzure/sapMonitors", "order": 50 }]
 }

--- a/Workbooks/SapMonitor/SapHana/SapHana.workbook
+++ b/Workbooks/SapMonitor/SapHana/SapHana.workbook
@@ -1070,6 +1070,5 @@
       "name": "group_utilization"
     }
   ],
-  "fromTemplateId": "community-Workbooks/SapMonitor/SapHana",
   "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
 }

--- a/Workbooks/SapMonitor/SapHana/SapHana.workbook
+++ b/Workbooks/SapMonitor/SapHana/SapHana.workbook
@@ -40,6 +40,7 @@
         "exportParameterName": "param_sid",
         "exportDefaultValue": "*",
         "queryType": 0,
+        "resourceType": "microsoft.operationalinsights/workspaces",
         "visualization": "tiles",
         "tileSettings": {
           "titleContent": {
@@ -1069,5 +1070,6 @@
       "name": "group_utilization"
     }
   ],
+  "fromTemplateId": "community-Workbooks/SapMonitor/SapHana",
   "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
 }


### PR DESCRIPTION
- For our newly added workbook templates, resource type was missing and not properly passed; this causes the loading of the workbook template to fail with error message "No resources set."
- This fix addresses the issue by manually adding the following line to the pertinent queries:
`            "resourceType": "microsoft.operationalinsights/workspaces"`
- The fix has been applied on the latest version of the workbook templates.

## PR Checklist

* [x] Explain your changes, so people looking at the PR know *what* and *why*, the code changes are the *how*.
* [ ] *if updating templates, it is helpful to post a screenshot of what the changes look like.*
* [ ] *if updating templates, ensure that your parameters and steps have meaningful names.*
* [ ] *if adding new templates, or changing items in a gallery, it's helpful to post a screenshot of what the gallery looks like now*
