### PR TITLE
Add ADX At Scale workbook to new location

### DIFF
--- a/Workbooks/ADXCluster/AtScale/Insights.workbook
+++ b/Workbooks/ADXCluster/AtScale/Insights.workbook
@@ -1,0 +1,1404 @@
+{
+  "version": "Notebook/1.0",
+  "items": [
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "crossComponentResources": [
+          "{Subscription}"
+        ],
+        "parameters": [
+          {
+            "id": "1f74ed9a-e3ed-498d-bd5b-f68f3836a117",
+            "version": "KqlParameterItem/1.0",
+            "name": "Subscription",
+            "label": "Subscriptions",
+            "type": 6,
+            "description": "All subscriptions with ADX Cluster",
+            "isRequired": true,
+            "multiSelect": true,
+            "quote": "'",
+            "delimiter": ",",
+            "query": "Resources\r\n| where type =~ 'Microsoft.Kusto/clusters'\r\n| summarize Count = count() by subscriptionId\r\n| order by Count desc\r\n| extend Rank = row_number()\r\n| project value = subscriptionId, label = subscriptionId, selected = Rank == 1",
+            "crossComponentResources": [
+              "value::selected"
+            ],
+            "typeSettings": {
+              "additionalResourceOptions": [],
+              "showDefault": false
+            },
+            "queryType": 1,
+            "resourceType": "microsoft.resourcegraph/resources"
+          },
+          {
+            "id": "f60ea0a0-3703-44ca-a59b-df0246423f41",
+            "version": "KqlParameterItem/1.0",
+            "name": "Resources",
+            "label": "Azure Data Explorer Cluster",
+            "type": 5,
+            "isRequired": true,
+            "multiSelect": true,
+            "quote": "'",
+            "delimiter": ",",
+            "query": "Resources\r\n| where type =~  'Microsoft.Kusto/clusters'\r\n| order by name asc\r\n| extend Rank = row_number()\r\n| project value = id, label = name, selected = Rank <= 5",
+            "crossComponentResources": [
+              "{Subscription}"
+            ],
+            "typeSettings": {
+              "additionalResourceOptions": [
+                "value::all"
+              ],
+              "showDefault": false
+            },
+            "queryType": 1,
+            "resourceType": "microsoft.resourcegraph/resources"
+          },
+          {
+            "id": "182d6324-854c-4cc0-802a-de4f3bee9f76",
+            "version": "KqlParameterItem/1.0",
+            "name": "TimeRange",
+            "label": "Time range",
+            "type": 4,
+            "isRequired": true,
+            "value": {
+              "durationMs": 604800000
+            },
+            "typeSettings": {
+              "selectableValues": [
+                {
+                  "durationMs": 300000
+                },
+                {
+                  "durationMs": 900000
+                },
+                {
+                  "durationMs": 1800000
+                },
+                {
+                  "durationMs": 3600000
+                },
+                {
+                  "durationMs": 14400000
+                },
+                {
+                  "durationMs": 43200000
+                },
+                {
+                  "durationMs": 86400000
+                },
+                {
+                  "durationMs": 172800000
+                },
+                {
+                  "durationMs": 259200000
+                },
+                {
+                  "durationMs": 604800000
+                }
+              ],
+              "allowCustom": true
+            }
+          },
+          {
+            "id": "5ab45df9-371b-4dba-8ee3-6ec9fbb33ff9",
+            "version": "KqlParameterItem/1.0",
+            "name": "Message",
+            "type": 1,
+            "query": "where type =~ 'Microsoft.Kusto/clusters'\r\n| summarize Selected = countif(id in ({Resources:value})), Total = count()\r\n| extend Selected = iff(Selected > 200, 200, Selected)\r\n| project Message = strcat('# ', Selected, ' / ', Total)",
+            "crossComponentResources": [
+              "{Subscription}"
+            ],
+            "isHiddenWhenLocked": true,
+            "queryType": 1,
+            "resourceType": "microsoft.resourcegraph/resources"
+          },
+          {
+            "id": "46dfcfa4-d5d4-47c2-9dfd-ca0fcb935dc7",
+            "version": "KqlParameterItem/1.0",
+            "name": "ResourceName",
+            "type": 1,
+            "description": "Used for 'No Subscriptions' workbook template",
+            "isRequired": true,
+            "value": "ADX Cluster",
+            "isHiddenWhenLocked": true,
+            "criteriaData": [
+              {
+                "condition": "else result = 'ADX Cluster'",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "static",
+                  "resultVal": "ADX Cluster"
+                }
+              }
+            ]
+          },
+          {
+            "id": "1c84117c-7449-4484-b693-00f41a578bd6",
+            "version": "KqlParameterItem/1.0",
+            "name": "ResourceImageUrl",
+            "type": 1,
+            "description": "Used for 'No Subscriptions' workbook template",
+            "isHiddenWhenLocked": true,
+            "timeContext": {
+              "durationMs": 0
+            },
+            "timeContextFromParameter": "TimeRange"
+          }
+        ],
+        "style": "above",
+        "queryType": 1,
+        "resourceType": "microsoft.resourcegraph/resources"
+      },
+      "name": "ADX Cluster parameters",
+      "styleSettings": {
+        "margin": "15px 0 0 0"
+      }
+    },
+    {
+      "type": 12,
+      "content": {
+        "version": "NotebookGroup/1.0",
+        "groupType": "template",
+        "loadFromTemplateId": "community-Workbooks/Common/noSubscriptions",
+        "items": []
+      },
+      "conditionalVisibility": {
+        "parameterName": "Subscription",
+        "comparison": "isEqualTo",
+        "value": ""
+      },
+      "name": "No Subscriptions group"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "{Message}\r\n_Azure Data Explorer Cluster_\r\n<br />\r\n<br />"
+      },
+      "name": "resource summary",
+      "styleSettings": {
+        "margin": "15px 0 10px 10px"
+      }
+    },
+    {
+      "type": 11,
+      "content": {
+        "version": "LinkItem/1.0",
+        "style": "tabs",
+        "links": [
+          {
+            "cellValue": "selectedTab",
+            "linkTarget": "parameter",
+            "linkLabel": "Overview",
+            "subTarget": "Overview",
+            "style": "link"
+          },
+          {
+            "cellValue": "selectedTab",
+            "linkTarget": "parameter",
+            "linkLabel": "Query Performance",
+            "subTarget": "QueryPerf",
+            "style": "link"
+          },
+          {
+            "cellValue": "selectedTab",
+            "linkTarget": "parameter",
+            "linkLabel": "Ingestion Performance",
+            "subTarget": "Ingestion",
+            "style": "link"
+          },
+          {
+            "cellValue": "selectedTab",
+            "linkTarget": "parameter",
+            "linkLabel": "Streaming Ingest Performance",
+            "subTarget": "Stream",
+            "style": "link"
+          },
+          {
+            "cellValue": "selectedTab",
+            "linkTarget": "parameter",
+            "linkLabel": "Export Performance",
+            "subTarget": "Export",
+            "style": "link"
+          }
+        ]
+      },
+      "name": "At Scale sections",
+      "styleSettings": {
+        "margin": "-15px 0px -15px 0px"
+      }
+    },
+    {
+      "type": 12,
+      "content": {
+        "version": "NotebookGroup/1.0",
+        "groupType": "editable",
+        "items": [
+          {
+            "type": 10,
+            "content": {
+              "chartId": "workbook19356bdc-cfd5-47c7-8e70-05bbd3f39558",
+              "version": "MetricsItem/2.0",
+              "size": 2,
+              "chartType": 0,
+              "metricScope": 0,
+              "resourceIds": [
+                "{Resources}"
+              ],
+              "timeContext": {
+                "durationMs": 0
+              },
+              "timeContextFromParameter": "TimeRange",
+              "resourceType": "microsoft.kusto/clusters",
+              "resourceParameter": "Resources",
+              "metrics": [
+                {
+                  "namespace": "microsoft.kusto/clusters",
+                  "metric": "microsoft.kusto/clusters-Cluster health-KeepAlive",
+                  "aggregation": 4
+                },
+                {
+                  "namespace": "microsoft.kusto/clusters",
+                  "metric": "microsoft.kusto/clusters-Cluster health-CPU",
+                  "aggregation": 4
+                },
+                {
+                  "namespace": "microsoft.kusto/clusters",
+                  "metric": "microsoft.kusto/clusters-Cluster health-IngestionUtilization",
+                  "aggregation": 4
+                },
+                {
+                  "namespace": "microsoft.kusto/clusters",
+                  "metric": "microsoft.kusto/clusters-Cluster health-CacheUtilization",
+                  "aggregation": 4
+                },
+                {
+                  "namespace": "microsoft.kusto/clusters",
+                  "metric": "microsoft.kusto/clusters-Cluster health-TotalNumberOfThrottledCommands",
+                  "aggregation": 4
+                },
+                {
+                  "namespace": "microsoft.kusto/clusters",
+                  "metric": "microsoft.kusto/clusters-Cluster health-InstanceCount",
+                  "aggregation": 4
+                }
+              ],
+              "gridSettings": {
+                "formatters": [
+                  {
+                    "columnMatch": "$gen_group",
+                    "formatter": 13,
+                    "formatOptions": {
+                      "linkTarget": "Resource",
+                      "subTarget": "insights",
+                      "showIcon": true
+                    }
+                  },
+                  {
+                    "columnMatch": "Subscription",
+                    "formatter": 5
+                  },
+                  {
+                    "columnMatch": "Name",
+                    "formatter": 5
+                  },
+                  {
+                    "columnMatch": "microsoft.kusto/clusters-Cluster health-KeepAlive",
+                    "formatter": 18,
+                    "formatOptions": {
+                      "thresholdsOptions": "icons",
+                      "thresholdsGrid": [
+                        {
+                          "operator": "is Empty",
+                          "representation": "Blank",
+                          "text": "{0}{1}"
+                        },
+                        {
+                          "operator": "<",
+                          "thresholdValue": "0.995",
+                          "representation": "2",
+                          "text": "{0}{1}"
+                        },
+                        {
+                          "operator": "Default",
+                          "thresholdValue": null,
+                          "representation": "success",
+                          "text": "{0}{1}"
+                        }
+                      ]
+                    },
+                    "numberFormat": {
+                      "unit": 0,
+                      "options": {
+                        "style": "decimal",
+                        "useGrouping": false
+                      }
+                    },
+                    "tooltipFormat": {
+                      "tooltip": "An average Keep Alive below 0.33 for a long period, may indicate an health issue. Above 0.33 is considered OK (Pay attention to your time range. This rule is important over a long time range)"
+                    }
+                  },
+                  {
+                    "columnMatch": "microsoft.kusto/clusters-Cluster health-KeepAlive Timeline",
+                    "formatter": 5
+                  },
+                  {
+                    "columnMatch": "microsoft.kusto/clusters-Cluster health-CPU",
+                    "formatter": 18,
+                    "formatOptions": {
+                      "thresholdsOptions": "colors",
+                      "thresholdsGrid": [
+                        {
+                          "operator": ">=",
+                          "thresholdValue": "80",
+                          "representation": "orange",
+                          "text": "{0}{1}"
+                        },
+                        {
+                          "operator": "Default",
+                          "thresholdValue": null,
+                          "text": "{0}{1}"
+                        }
+                      ]
+                    },
+                    "numberFormat": {
+                      "unit": 1,
+                      "options": {
+                        "style": "decimal",
+                        "useGrouping": false
+                      },
+                      "emptyValCustomText": "-"
+                    }
+                  },
+                  {
+                    "columnMatch": "microsoft.kusto/clusters-Cluster health-CPU Timeline",
+                    "formatter": 9,
+                    "formatOptions": {
+                      "palette": "blue"
+                    }
+                  },
+                  {
+                    "columnMatch": "microsoft.kusto/clusters-Cluster health-IngestionUtilization",
+                    "formatter": 18,
+                    "formatOptions": {
+                      "thresholdsOptions": "colors",
+                      "thresholdsGrid": [
+                        {
+                          "operator": ">=",
+                          "thresholdValue": "80",
+                          "representation": "orange",
+                          "text": "{0}{1}"
+                        },
+                        {
+                          "operator": "Default",
+                          "thresholdValue": null,
+                          "text": "{0}{1}"
+                        }
+                      ]
+                    },
+                    "numberFormat": {
+                      "unit": 1,
+                      "options": {
+                        "style": "decimal"
+                      },
+                      "emptyValCustomText": "-"
+                    }
+                  },
+                  {
+                    "columnMatch": "microsoft.kusto/clusters-Cluster health-IngestionUtilization Timeline",
+                    "formatter": 9,
+                    "formatOptions": {
+                      "palette": "blue"
+                    }
+                  },
+                  {
+                    "columnMatch": "microsoft.kusto/clusters-Cluster health-CacheUtilization",
+                    "formatter": 18,
+                    "formatOptions": {
+                      "thresholdsOptions": "colors",
+                      "thresholdsGrid": [
+                        {
+                          "operator": ">=",
+                          "thresholdValue": "80",
+                          "representation": "orange",
+                          "text": "{0}{1}"
+                        },
+                        {
+                          "operator": "Default",
+                          "thresholdValue": null,
+                          "text": "{0}{1}"
+                        }
+                      ]
+                    },
+                    "numberFormat": {
+                      "unit": 1,
+                      "options": {
+                        "style": "decimal"
+                      },
+                      "emptyValCustomText": "-"
+                    }
+                  },
+                  {
+                    "columnMatch": "microsoft.kusto/clusters-Cluster health-CacheUtilization Timeline",
+                    "formatter": 9
+                  },
+                  {
+                    "columnMatch": "microsoft.kusto/clusters-Cluster health-TotalNumberOfThrottledCommands",
+                    "formatter": 1,
+                    "numberFormat": {
+                      "unit": 17,
+                      "options": {
+                        "style": "decimal",
+                        "maximumFractionDigits": 2
+                      },
+                      "emptyValCustomText": "-"
+                    }
+                  },
+                  {
+                    "columnMatch": "microsoft.kusto/clusters-Cluster health-TotalNumberOfThrottledCommands Timeline",
+                    "formatter": 5
+                  },
+                  {
+                    "columnMatch": "microsoft.kusto/clusters-Cluster health-InstanceCount",
+                    "formatter": 4,
+                    "formatOptions": {
+                      "palette": "blue"
+                    },
+                    "numberFormat": {
+                      "unit": 17,
+                      "options": {
+                        "style": "decimal"
+                      },
+                      "emptyValCustomText": "-"
+                    }
+                  },
+                  {
+                    "columnMatch": "microsoft.kusto/clusters-Cluster health-InstanceCount Timeline",
+                    "formatter": 5
+                  }
+                ],
+                "rowLimit": 10000,
+                "filter": true,
+                "hierarchySettings": {
+                  "treeType": 1,
+                  "groupBy": [
+                    "Subscription"
+                  ],
+                  "expandTopLevel": true,
+                  "finalBy": "Name"
+                },
+                "labelSettings": [
+                  {
+                    "columnId": "Subscription",
+                    "label": "Subscription"
+                  },
+                  {
+                    "columnId": "Name",
+                    "label": "Name"
+                  },
+                  {
+                    "columnId": "microsoft.kusto/clusters-Cluster health-KeepAlive",
+                    "label": "Keep alive (Average)"
+                  },
+                  {
+                    "columnId": "microsoft.kusto/clusters-Cluster health-KeepAlive Timeline",
+                    "label": "Keep alive Timeline"
+                  },
+                  {
+                    "columnId": "microsoft.kusto/clusters-Cluster health-CPU",
+                    "label": "CPU (Average)"
+                  },
+                  {
+                    "columnId": "microsoft.kusto/clusters-Cluster health-CPU Timeline",
+                    "label": "CPU Timeline"
+                  },
+                  {
+                    "columnId": "microsoft.kusto/clusters-Cluster health-IngestionUtilization",
+                    "label": "Ingestion utilization (Average)"
+                  },
+                  {
+                    "columnId": "microsoft.kusto/clusters-Cluster health-IngestionUtilization Timeline",
+                    "label": "Ingestion utilization Timeline"
+                  },
+                  {
+                    "columnId": "microsoft.kusto/clusters-Cluster health-CacheUtilization",
+                    "label": "Cache utilization (Average)"
+                  },
+                  {
+                    "columnId": "microsoft.kusto/clusters-Cluster health-CacheUtilization Timeline",
+                    "label": "Cache utilization Timeline"
+                  },
+                  {
+                    "columnId": "microsoft.kusto/clusters-Cluster health-TotalNumberOfThrottledCommands",
+                    "label": "Total number of throttled commands (Average)"
+                  },
+                  {
+                    "columnId": "microsoft.kusto/clusters-Cluster health-TotalNumberOfThrottledCommands Timeline",
+                    "label": "Total number of throttled commands (Average) Timeline"
+                  },
+                  {
+                    "columnId": "microsoft.kusto/clusters-Cluster health-InstanceCount",
+                    "label": "Instance Count (Average)"
+                  },
+                  {
+                    "columnId": "microsoft.kusto/clusters-Cluster health-InstanceCount Timeline",
+                    "label": "Instance Count (Average) Timeline"
+                  }
+                ]
+              },
+              "sortBy": [],
+              "showExportToExcel": true
+            },
+            "conditionalVisibility": {
+              "parameterName": "selectedTab",
+              "comparison": "isEqualTo",
+              "value": "Overview"
+            },
+            "showPin": true,
+            "name": "Overview"
+          },
+          {
+            "type": 10,
+            "content": {
+              "chartId": "workbook19356bdc-cfd5-47c7-8e70-05bbd3f39558",
+              "version": "MetricsItem/2.0",
+              "size": 2,
+              "chartType": 0,
+              "metricScope": 0,
+              "resourceIds": [
+                "{Resources}"
+              ],
+              "timeContext": {
+                "durationMs": 0
+              },
+              "timeContextFromParameter": "TimeRange",
+              "resourceType": "microsoft.kusto/clusters",
+              "resourceParameter": "Resources",
+              "metrics": [
+                {
+                  "namespace": "microsoft.kusto/clusters",
+                  "metric": "microsoft.kusto/clusters-Export health and performance-ContinuousExportNumOfRecordsExported",
+                  "aggregation": 1,
+                  "columnName": "Continuous Exported Records"
+                },
+                {
+                  "namespace": "microsoft.kusto/clusters",
+                  "metric": "microsoft.kusto/clusters-Export health and performance-ContinuousExportMaxLatenessMinutes",
+                  "aggregation": 3,
+                  "columnName": "Continuous Export Lateness (Max)"
+                },
+                {
+                  "namespace": "microsoft.kusto/clusters",
+                  "metric": "microsoft.kusto/clusters-Export health and performance-ContinuousExportPendingCount",
+                  "aggregation": 3,
+                  "columnName": "Continuous Export Pending Count (Max)"
+                },
+                {
+                  "namespace": "microsoft.kusto/clusters",
+                  "metric": "microsoft.kusto/clusters-Export health and performance-ContinuousExportResult",
+                  "aggregation": 7
+                },
+                {
+                  "namespace": "microsoft.kusto/clusters",
+                  "metric": "microsoft.kusto/clusters-Export health and performance-ExportUtilization",
+                  "aggregation": 3
+                }
+              ],
+              "gridSettings": {
+                "formatters": [
+                  {
+                    "columnMatch": "$gen_group",
+                    "formatter": 13,
+                    "formatOptions": {
+                      "linkTarget": "Resource",
+                      "subTarget": "insights",
+                      "showIcon": true
+                    }
+                  },
+                  {
+                    "columnMatch": "Subscription",
+                    "formatter": 5
+                  },
+                  {
+                    "columnMatch": "Name",
+                    "formatter": 5
+                  },
+                  {
+                    "columnMatch": "Continuous Exported Records",
+                    "formatter": 1,
+                    "numberFormat": {
+                      "unit": 17,
+                      "options": {
+                        "style": "decimal",
+                        "useGrouping": false,
+                        "maximumFractionDigits": 2
+                      },
+                      "emptyValCustomText": "-"
+                    }
+                  },
+                  {
+                    "columnMatch": "Continuous Exported Records Timeline",
+                    "formatter": 5
+                  },
+                  {
+                    "columnMatch": "Continuous Export Lateness (Max)",
+                    "formatter": 1,
+                    "numberFormat": {
+                      "unit": 17,
+                      "options": {
+                        "style": "decimal",
+                        "maximumFractionDigits": 2
+                      },
+                      "emptyValCustomText": "-"
+                    }
+                  },
+                  {
+                    "columnMatch": "Continuous Export Lateness (Max) Timeline",
+                    "formatter": 5
+                  },
+                  {
+                    "columnMatch": "Continuous Export Pending Count (Max)",
+                    "formatter": 1,
+                    "numberFormat": {
+                      "unit": 17,
+                      "options": {
+                        "style": "decimal",
+                        "maximumFractionDigits": 2
+                      },
+                      "emptyValCustomText": "-"
+                    }
+                  },
+                  {
+                    "columnMatch": "Continuous Export Pending Count (Max) Timeline",
+                    "formatter": 5
+                  },
+                  {
+                    "columnMatch": "microsoft.kusto/clusters-Export health and performance-ContinuousExportResult",
+                    "formatter": 1,
+                    "numberFormat": {
+                      "unit": 17,
+                      "options": {
+                        "style": "decimal",
+                        "maximumFractionDigits": 2
+                      },
+                      "emptyValCustomText": "-"
+                    }
+                  },
+                  {
+                    "columnMatch": "microsoft.kusto/clusters-Export health and performance-ContinuousExportResult Timeline",
+                    "formatter": 5
+                  },
+                  {
+                    "columnMatch": "microsoft.kusto/clusters-Export health and performance-ExportUtilization",
+                    "formatter": 1,
+                    "numberFormat": {
+                      "unit": 1,
+                      "options": {
+                        "style": "decimal",
+                        "maximumFractionDigits": 2
+                      },
+                      "emptyValCustomText": "-"
+                    }
+                  },
+                  {
+                    "columnMatch": "microsoft.kusto/clusters-Export health and performance-ExportUtilization Timeline",
+                    "formatter": 5
+                  },
+                  {
+                    "columnMatch": "microsoft.kusto/clusters-Export health and performance-ContinuousExportNumOfRecordsExported Timeline",
+                    "formatter": 5
+                  },
+                  {
+                    "columnMatch": "microsoft.kusto/clusters-Export health and performance-ContinuousExportNumOfRecordsExported",
+                    "formatter": 1,
+                    "numberFormat": {
+                      "unit": 17,
+                      "options": {
+                        "style": "decimal",
+                        "maximumFractionDigits": 2
+                      },
+                      "emptyValCustomText": "-"
+                    }
+                  },
+                  {
+                    "columnMatch": "microsoft.kusto/clusters-Export health and performance-ContinuousExportMaxLatenessMinutes Timeline",
+                    "formatter": 5
+                  },
+                  {
+                    "columnMatch": "microsoft.kusto/clusters-Export health and performance-ContinuousExportMaxLatenessMinutes",
+                    "formatter": 1,
+                    "numberFormat": {
+                      "unit": 17,
+                      "options": {
+                        "style": "decimal",
+                        "maximumFractionDigits": 2
+                      },
+                      "emptyValCustomText": "-"
+                    }
+                  },
+                  {
+                    "columnMatch": "microsoft.kusto/clusters-Export health and performance-ContinuousExportPendingCount Timeline",
+                    "formatter": 5
+                  },
+                  {
+                    "columnMatch": "microsoft.kusto/clusters-Export health and performance-ContinuousExportPendingCount",
+                    "formatter": 1,
+                    "numberFormat": {
+                      "unit": 17,
+                      "options": {
+                        "style": "decimal",
+                        "maximumFractionDigits": 2
+                      },
+                      "emptyValCustomText": "-"
+                    }
+                  }
+                ],
+                "rowLimit": 10000,
+                "filter": true,
+                "hierarchySettings": {
+                  "treeType": 1,
+                  "groupBy": [
+                    "Subscription"
+                  ],
+                  "expandTopLevel": true,
+                  "finalBy": "Name"
+                },
+                "labelSettings": [
+                  {
+                    "columnId": "Subscription",
+                    "label": "Subscription"
+                  },
+                  {
+                    "columnId": "Name",
+                    "label": "Name"
+                  },
+                  {
+                    "columnId": "microsoft.kusto/clusters-Export health and performance-ContinuousExportNumOfRecordsExported",
+                    "label": "Continuous Exported Records"
+                  },
+                  {
+                    "columnId": "microsoft.kusto/clusters-Export health and performance-ContinuousExportMaxLatenessMinutes",
+                    "label": "Continuous Export Lateness (Max)"
+                  },
+                  {
+                    "columnId": "microsoft.kusto/clusters-Export health and performance-ContinuousExportPendingCount",
+                    "label": "Continuous Export Pending Count (Max)"
+                  },
+                  {
+                    "columnId": "microsoft.kusto/clusters-Export health and performance-ContinuousExportResult",
+                    "label": "Continuous Export Result (Count)"
+                  },
+                  {
+                    "columnId": "microsoft.kusto/clusters-Export health and performance-ContinuousExportResult Timeline",
+                    "label": "Continuous Export Result (Count) Timeline"
+                  },
+                  {
+                    "columnId": "microsoft.kusto/clusters-Export health and performance-ExportUtilization",
+                    "label": "Export Utilization (Max)"
+                  },
+                  {
+                    "columnId": "microsoft.kusto/clusters-Export health and performance-ExportUtilization Timeline",
+                    "label": "Export Utilization Timeline"
+                  }
+                ]
+              },
+              "sortBy": [],
+              "showExportToExcel": true
+            },
+            "conditionalVisibility": {
+              "parameterName": "selectedTab",
+              "comparison": "isEqualTo",
+              "value": "Export"
+            },
+            "showPin": true,
+            "name": "Export Performance"
+          },
+          {
+            "type": 10,
+            "content": {
+              "chartId": "workbook19356bdc-cfd5-47c7-8e70-05bbd3f39558",
+              "version": "MetricsItem/2.0",
+              "size": 2,
+              "chartType": 0,
+              "metricScope": 0,
+              "resourceIds": [
+                "{Resources}"
+              ],
+              "timeContext": {
+                "durationMs": 0
+              },
+              "timeContextFromParameter": "TimeRange",
+              "resourceType": "microsoft.kusto/clusters",
+              "resourceParameter": "Resources",
+              "metrics": [
+                {
+                  "namespace": "microsoft.kusto/clusters",
+                  "metric": "microsoft.kusto/clusters-Ingestion health and performance-EventsProcessedForEventHubs",
+                  "aggregation": 1
+                },
+                {
+                  "namespace": "microsoft.kusto/clusters",
+                  "metric": "microsoft.kusto/clusters-Ingestion health and performance-IngestionLatencyInSeconds",
+                  "aggregation": 4
+                },
+                {
+                  "namespace": "microsoft.kusto/clusters",
+                  "metric": "microsoft.kusto/clusters-Ingestion health and performance-IngestionResult",
+                  "aggregation": 7
+                },
+                {
+                  "namespace": "microsoft.kusto/clusters",
+                  "metric": "microsoft.kusto/clusters-Ingestion health and performance-IngestionVolumeInMB",
+                  "aggregation": 1
+                }
+              ],
+              "gridSettings": {
+                "formatters": [
+                  {
+                    "columnMatch": "$gen_group",
+                    "formatter": 13,
+                    "formatOptions": {
+                      "linkTarget": "Resource",
+                      "subTarget": "insights",
+                      "showIcon": true
+                    }
+                  },
+                  {
+                    "columnMatch": "Subscription",
+                    "formatter": 5
+                  },
+                  {
+                    "columnMatch": "Name",
+                    "formatter": 5
+                  },
+                  {
+                    "columnMatch": "microsoft.kusto/clusters-Ingestion health and performance-EventsProcessedForEventHubs",
+                    "formatter": 1,
+                    "numberFormat": {
+                      "unit": 17,
+                      "options": {
+                        "style": "decimal",
+                        "useGrouping": false,
+                        "maximumFractionDigits": 2
+                      },
+                      "emptyValCustomText": "-"
+                    }
+                  },
+                  {
+                    "columnMatch": "microsoft.kusto/clusters-Ingestion health and performance-EventsProcessedForEventHubs Timeline",
+                    "formatter": 9,
+                    "formatOptions": {
+                      "palette": "blue"
+                    }
+                  },
+                  {
+                    "columnMatch": "microsoft.kusto/clusters-Ingestion health and performance-IngestionLatencyInSeconds",
+                    "formatter": 1,
+                    "numberFormat": {
+                      "unit": 24,
+                      "options": {
+                        "style": "decimal",
+                        "maximumFractionDigits": 2
+                      },
+                      "emptyValCustomText": "-"
+                    }
+                  },
+                  {
+                    "columnMatch": "microsoft.kusto/clusters-Ingestion health and performance-IngestionLatencyInSeconds Timeline",
+                    "formatter": 5
+                  },
+                  {
+                    "columnMatch": "microsoft.kusto/clusters-Ingestion health and performance-IngestionResult",
+                    "formatter": 4,
+                    "formatOptions": {
+                      "palette": "blue"
+                    },
+                    "numberFormat": {
+                      "unit": 17,
+                      "options": {
+                        "style": "decimal",
+                        "maximumFractionDigits": 2
+                      },
+                      "emptyValCustomText": "-"
+                    }
+                  },
+                  {
+                    "columnMatch": "microsoft.kusto/clusters-Ingestion health and performance-IngestionResult Timeline",
+                    "formatter": 5
+                  },
+                  {
+                    "columnMatch": "microsoft.kusto/clusters-Ingestion health and performance-IngestionVolumeInMB",
+                    "formatter": 1,
+                    "numberFormat": {
+                      "unit": 38,
+                      "options": {
+                        "style": "decimal",
+                        "maximumFractionDigits": 2,
+                        "maximumSignificantDigits": 1
+                      },
+                      "emptyValCustomText": "-"
+                    }
+                  },
+                  {
+                    "columnMatch": "microsoft.kusto/clusters-Ingestion health and performance-IngestionVolumeInMB Timeline",
+                    "formatter": 9
+                  }
+                ],
+                "rowLimit": 10000,
+                "filter": true,
+                "hierarchySettings": {
+                  "treeType": 1,
+                  "groupBy": [
+                    "Subscription"
+                  ],
+                  "expandTopLevel": true,
+                  "finalBy": "Name"
+                },
+                "sortBy": [
+                  {
+                    "itemKey": "$gen_link_$gen_group_0",
+                    "sortOrder": 1
+                  }
+                ],
+                "labelSettings": [
+                  {
+                    "columnId": "Subscription",
+                    "label": "Subscription"
+                  },
+                  {
+                    "columnId": "Name",
+                    "label": "Name"
+                  },
+                  {
+                    "columnId": "microsoft.kusto/clusters-Ingestion health and performance-EventsProcessedForEventHubs",
+                    "label": "Events processed (for Event/IoT Hubs) (Sum)"
+                  },
+                  {
+                    "columnId": "microsoft.kusto/clusters-Ingestion health and performance-EventsProcessedForEventHubs Timeline",
+                    "label": "Events processed (for Event/IoT Hubs) (Sum) Timeline"
+                  },
+                  {
+                    "columnId": "microsoft.kusto/clusters-Ingestion health and performance-IngestionLatencyInSeconds",
+                    "label": "Ingestion latency (in seconds) (Average)"
+                  },
+                  {
+                    "columnId": "microsoft.kusto/clusters-Ingestion health and performance-IngestionLatencyInSeconds Timeline",
+                    "label": "Ingestion latency (in seconds) Timeline"
+                  },
+                  {
+                    "columnId": "microsoft.kusto/clusters-Ingestion health and performance-IngestionResult",
+                    "label": "Ingestion result (Count)"
+                  },
+                  {
+                    "columnId": "microsoft.kusto/clusters-Ingestion health and performance-IngestionResult Timeline",
+                    "label": "Ingestion result Timeline"
+                  },
+                  {
+                    "columnId": "microsoft.kusto/clusters-Ingestion health and performance-IngestionVolumeInMB",
+                    "label": "Ingestion volume (in MB) (Sum)"
+                  },
+                  {
+                    "columnId": "microsoft.kusto/clusters-Ingestion health and performance-IngestionVolumeInMB Timeline",
+                    "label": "Ingestion volume (in MB) Timeline"
+                  }
+                ]
+              },
+              "sortBy": [
+                {
+                  "itemKey": "$gen_link_$gen_group_0",
+                  "sortOrder": 1
+                }
+              ],
+              "showExportToExcel": true
+            },
+            "conditionalVisibility": {
+              "parameterName": "selectedTab",
+              "comparison": "isEqualTo",
+              "value": "Ingestion"
+            },
+            "showPin": true,
+            "name": "Ingestion Performance"
+          },
+          {
+            "type": 10,
+            "content": {
+              "chartId": "workbook19356bdc-cfd5-47c7-8e70-05bbd3f39558",
+              "version": "MetricsItem/2.0",
+              "size": 2,
+              "chartType": 0,
+              "metricScope": 0,
+              "resourceIds": [
+                "{Resources}"
+              ],
+              "timeContext": {
+                "durationMs": 0
+              },
+              "timeContextFromParameter": "TimeRange",
+              "resourceType": "microsoft.kusto/clusters",
+              "resourceParameter": "Resources",
+              "metrics": [
+                {
+                  "namespace": "microsoft.kusto/clusters",
+                  "metric": "microsoft.kusto/clusters-Query performance-QueryDuration",
+                  "aggregation": 4
+                },
+                {
+                  "namespace": "microsoft.kusto/clusters",
+                  "metric": "microsoft.kusto/clusters-Query performance-TotalNumberOfConcurrentQueries",
+                  "aggregation": 1
+                },
+                {
+                  "namespace": "microsoft.kusto/clusters",
+                  "metric": "microsoft.kusto/clusters-Query performance-TotalNumberOfThrottledQueries",
+                  "aggregation": 1
+                }
+              ],
+              "gridSettings": {
+                "formatters": [
+                  {
+                    "columnMatch": "$gen_group",
+                    "formatter": 13,
+                    "formatOptions": {
+                      "linkTarget": "Resource",
+                      "subTarget": "insights",
+                      "showIcon": true
+                    }
+                  },
+                  {
+                    "columnMatch": "Subscription",
+                    "formatter": 5
+                  },
+                  {
+                    "columnMatch": "Name",
+                    "formatter": 5
+                  },
+                  {
+                    "columnMatch": "microsoft.kusto/clusters-Query performance-QueryDuration",
+                    "formatter": 1,
+                    "numberFormat": {
+                      "unit": 23,
+                      "options": {
+                        "style": "decimal",
+                        "useGrouping": false,
+                        "maximumFractionDigits": 2
+                      },
+                      "emptyValCustomText": "-"
+                    }
+                  },
+                  {
+                    "columnMatch": "microsoft.kusto/clusters-Query performance-QueryDuration Timeline",
+                    "formatter": 5
+                  },
+                  {
+                    "columnMatch": "microsoft.kusto/clusters-Query performance-TotalNumberOfConcurrentQueries",
+                    "formatter": 1,
+                    "numberFormat": {
+                      "unit": 17,
+                      "options": {
+                        "style": "decimal",
+                        "maximumFractionDigits": 2
+                      },
+                      "emptyValCustomText": "-"
+                    }
+                  },
+                  {
+                    "columnMatch": "microsoft.kusto/clusters-Query performance-TotalNumberOfConcurrentQueries Timeline",
+                    "formatter": 5
+                  },
+                  {
+                    "columnMatch": "microsoft.kusto/clusters-Query performance-TotalNumberOfThrottledQueries",
+                    "formatter": 1,
+                    "numberFormat": {
+                      "unit": 17,
+                      "options": {
+                        "style": "decimal",
+                        "maximumFractionDigits": 2
+                      },
+                      "emptyValCustomText": "-"
+                    }
+                  },
+                  {
+                    "columnMatch": "microsoft.kusto/clusters-Query performance-TotalNumberOfThrottledQueries Timeline",
+                    "formatter": 5
+                  }
+                ],
+                "rowLimit": 10000,
+                "filter": true,
+                "hierarchySettings": {
+                  "treeType": 1,
+                  "groupBy": [
+                    "Subscription"
+                  ],
+                  "expandTopLevel": true,
+                  "finalBy": "Name"
+                },
+                "labelSettings": [
+                  {
+                    "columnId": "Subscription",
+                    "label": "Subscription"
+                  },
+                  {
+                    "columnId": "Name",
+                    "label": "Name"
+                  },
+                  {
+                    "columnId": "microsoft.kusto/clusters-Query performance-QueryDuration",
+                    "label": "Query duration (Average)"
+                  },
+                  {
+                    "columnId": "microsoft.kusto/clusters-Query performance-QueryDuration Timeline",
+                    "label": "Query duration Timeline"
+                  },
+                  {
+                    "columnId": "microsoft.kusto/clusters-Query performance-TotalNumberOfConcurrentQueries",
+                    "label": "Total number of concurrent queries (Sum)"
+                  },
+                  {
+                    "columnId": "microsoft.kusto/clusters-Query performance-TotalNumberOfConcurrentQueries Timeline",
+                    "label": "Total number of concurrent queries Timeline"
+                  },
+                  {
+                    "columnId": "microsoft.kusto/clusters-Query performance-TotalNumberOfThrottledQueries",
+                    "label": "Total number of throttled queries (Sum)"
+                  },
+                  {
+                    "columnId": "microsoft.kusto/clusters-Query performance-TotalNumberOfThrottledQueries Timeline",
+                    "label": "Total number of throttled queries Timeline"
+                  }
+                ]
+              },
+              "sortBy": [],
+              "showExportToExcel": true
+            },
+            "conditionalVisibility": {
+              "parameterName": "selectedTab",
+              "comparison": "isEqualTo",
+              "value": "QueryPerf"
+            },
+            "showPin": true,
+            "name": "Query Performance"
+          },
+          {
+            "type": 10,
+            "content": {
+              "chartId": "workbook19356bdc-cfd5-47c7-8e70-05bbd3f39558",
+              "version": "MetricsItem/2.0",
+              "size": 2,
+              "chartType": 0,
+              "metricScope": 0,
+              "resourceIds": [
+                "{Resources}"
+              ],
+              "timeContext": {
+                "durationMs": 0
+              },
+              "timeContextFromParameter": "TimeRange",
+              "resourceType": "microsoft.kusto/clusters",
+              "resourceParameter": "Resources",
+              "metrics": [
+                {
+                  "namespace": "microsoft.kusto/clusters",
+                  "metric": "microsoft.kusto/clusters-Streaming Ingest-StreamingIngestDataRate",
+                  "aggregation": 4,
+                  "columnName": "Data Rate"
+                },
+                {
+                  "namespace": "microsoft.kusto/clusters",
+                  "metric": "microsoft.kusto/clusters-Streaming Ingest-StreamingIngestDuration",
+                  "aggregation": 4,
+                  "columnName": "Duration"
+                },
+                {
+                  "namespace": "microsoft.kusto/clusters",
+                  "metric": "microsoft.kusto/clusters-Streaming Ingest-SteamingIngestRequestRate",
+                  "aggregation": 7,
+                  "columnName": "Request Rate"
+                },
+                {
+                  "namespace": "microsoft.kusto/clusters",
+                  "metric": "microsoft.kusto/clusters-Streaming Ingest-StreamingIngestResults",
+                  "aggregation": 4,
+                  "columnName": "Result"
+                }
+              ],
+              "gridSettings": {
+                "formatters": [
+                  {
+                    "columnMatch": "$gen_group",
+                    "formatter": 13,
+                    "formatOptions": {
+                      "linkTarget": "Resource",
+                      "subTarget": "insights",
+                      "showIcon": true
+                    }
+                  },
+                  {
+                    "columnMatch": "Subscription",
+                    "formatter": 5
+                  },
+                  {
+                    "columnMatch": "Name",
+                    "formatter": 5
+                  },
+                  {
+                    "columnMatch": "Data Rate",
+                    "formatter": 1,
+                    "numberFormat": {
+                      "unit": 31,
+                      "options": {
+                        "style": "decimal",
+                        "maximumFractionDigits": 2
+                      },
+                      "emptyValCustomText": "-"
+                    }
+                  },
+                  {
+                    "columnMatch": "Data Rate Timeline",
+                    "formatter": 5
+                  },
+                  {
+                    "columnMatch": "Duration",
+                    "formatter": 1,
+                    "numberFormat": {
+                      "unit": 23,
+                      "options": {
+                        "style": "decimal",
+                        "maximumFractionDigits": 2
+                      },
+                      "emptyValCustomText": "-"
+                    }
+                  },
+                  {
+                    "columnMatch": "Duration Timeline",
+                    "formatter": 5
+                  },
+                  {
+                    "columnMatch": "Request Rate",
+                    "formatter": 1,
+                    "numberFormat": {
+                      "unit": 17,
+                      "options": {
+                        "style": "decimal",
+                        "maximumFractionDigits": 2
+                      },
+                      "emptyValCustomText": "-"
+                    }
+                  },
+                  {
+                    "columnMatch": "Request Rate Timeline",
+                    "formatter": 5
+                  },
+                  {
+                    "columnMatch": "Result",
+                    "formatter": 1,
+                    "numberFormat": {
+                      "unit": 17,
+                      "options": {
+                        "style": "decimal",
+                        "maximumFractionDigits": 2
+                      },
+                      "emptyValCustomText": "-"
+                    }
+                  },
+                  {
+                    "columnMatch": "Result Timeline",
+                    "formatter": 5
+                  },
+                  {
+                    "columnMatch": "microsoft.kusto/clusters-Streaming Ingest-StreamingIngestDataRate",
+                    "formatter": 1,
+                    "numberFormat": {
+                      "unit": 31,
+                      "options": {
+                        "style": "decimal",
+                        "maximumFractionDigits": 2
+                      },
+                      "emptyValCustomText": "-"
+                    }
+                  },
+                  {
+                    "columnMatch": "microsoft.kusto/clusters-Streaming Ingest-SteamingIngestRequestRate",
+                    "formatter": 1,
+                    "numberFormat": {
+                      "unit": 0,
+                      "options": null
+                    }
+                  },
+                  {
+                    "columnMatch": "microsoft.kusto/clusters-Streaming Ingest-StreamingIngestDuration",
+                    "formatter": 1,
+                    "numberFormat": {
+                      "unit": 0,
+                      "options": null
+                    }
+                  },
+                  {
+                    "columnMatch": "microsoft.kusto/clusters-Streaming Ingest-StreamingIngestResults",
+                    "formatter": 1,
+                    "numberFormat": {
+                      "unit": 0,
+                      "options": null
+                    }
+                  }
+                ],
+                "rowLimit": 10000,
+                "filter": true,
+                "hierarchySettings": {
+                  "treeType": 1,
+                  "groupBy": [
+                    "Subscription"
+                  ],
+                  "expandTopLevel": true,
+                  "finalBy": "Name"
+                },
+                "labelSettings": [
+                  {
+                    "columnId": "Subscription",
+                    "label": "Subscription"
+                  },
+                  {
+                    "columnId": "Name",
+                    "label": "Name"
+                  },
+                  {
+                    "columnId": "microsoft.kusto/clusters-Streaming Ingest-StreamingIngestDataRate",
+                    "label": "Data Rate"
+                  },
+                  {
+                    "columnId": "microsoft.kusto/clusters-Streaming Ingest-StreamingIngestDuration",
+                    "label": "Duration"
+                  },
+                  {
+                    "columnId": "microsoft.kusto/clusters-Streaming Ingest-SteamingIngestRequestRate",
+                    "label": "Request Rate"
+                  },
+                  {
+                    "columnId": "microsoft.kusto/clusters-Streaming Ingest-StreamingIngestResults",
+                    "label": "Result"
+                  }
+                ]
+              },
+              "sortBy": [],
+              "showExportToExcel": true
+            },
+            "conditionalVisibility": {
+              "parameterName": "selectedTab",
+              "comparison": "isEqualTo",
+              "value": "Stream"
+            },
+            "showPin": true,
+            "name": "Streaming Ingest"
+          }
+        ]
+      },
+      "conditionalVisibility": {
+        "parameterName": "Subscription",
+        "comparison": "isNotEqualTo",
+        "value": ""
+      },
+      "name": "ADX Summary"
+    }
+  ],
+  "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
+}

--- a/Workbooks/ADXCluster/AtScale/settings.json
+++ b/Workbooks/ADXCluster/AtScale/settings.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/settings.json",
+    "name":"Azure Data Explorer Overview",
+    "isPreview": true,
+    "author": "Microsoft",
+    "galleries": [{ "type": "workbook", "resourceType": "Azure Monitor", "categoryKey": "azureMonitorInsights", "order": 100 }, { "type": "adxcluster-insights", "resourceType": "Azure Monitor", "order": 100 }]
+}

--- a/Workbooks/ADXCluster/categoryResources.json
+++ b/Workbooks/ADXCluster/categoryResources.json
@@ -1,0 +1,4 @@
+{
+    "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/settings.json",
+    "en-us": {"name":"Azure Data Explorer Cluster Insights", "description": "Provides insights for your Azure Data Explorer Cluster", "order": 100}
+}


### PR DESCRIPTION
Copying the ADX At Scale workbook from Workbooks/Insights/ADXCluster to its new home here. The files in the original location
will be deleted once required changes in Azure Monitor Extension have been made. 
![image](https://user-images.githubusercontent.com/65260104/85619301-ef630080-b616-11ea-9289-c0e16a4a8a85.png)
