### PR TITLE
SAP Monitor: Fix provider picker in MsSqlServer template

### DIFF
--- a/Workbooks/SapMonitor/MsSqlServer/MsSqlServer.workbook
+++ b/Workbooks/SapMonitor/MsSqlServer/MsSqlServer.workbook
@@ -71,8 +71,8 @@
             "name": "Provider",
             "type": 2,
             "isRequired": true,
-            "query": "MSSQL_SystemProps_CL\r\n| project PROVIDER_INSTANCE_s \r\n| distinct PROVIDER_INSTANCE_s\r\n",
-            "value": "MOM-Node-1",
+            "query": "MSSQL_SystemProps_CL\r\n| where TimeGenerated > ago(30d)\r\n| project PROVIDER_INSTANCE_s \r\n| distinct PROVIDER_INSTANCE_s\r\n",
+            "value": null,
             "typeSettings": {
               "additionalResourceOptions": []
             },


### PR DESCRIPTION
- In the workbook template for the MsSqlServer provider type, the dropdown (picker) for the provider instance defaults to using the last 24 hours. In cases where there is no "fresh" data, this would result in the workbook template becoming unusable, because the user cannot select a provider anymore.
- This PR extends the picker query by a 30-day filter to ensure users can at least select from previous providers.

## PR Checklist

* [x] Explain your changes, so people looking at the PR know *what* and *why*, the code changes are the *how*.
* [ ] *if updating templates, it is helpful to post a screenshot of what the changes look like.*
* [x] *if updating templates, ensure that your parameters and steps have meaningful names.*
* [ ] *if adding new templates, or changing items in a gallery, it's helpful to post a screenshot of what the gallery looks like now*
