### PR TITLE
Localization: Remove strings path

### DIFF
--- a/scripts/extractStrings.js
+++ b/scripts/extractStrings.js
@@ -37,7 +37,6 @@ const CohortsTemplateFolder = "\\Cohorts\\";
 const RESJSONOutputFolder = "\\output\\loc\\";
 
 const LocProjectFileName = "LocProject.json";
-const StringOutputPath = "\\strings";
 const LangOutputSpecifier = "\\{Lang}\\";
 
 /**
@@ -256,9 +255,9 @@ for (var i in files) {
     // For explanations on what each field does, see doc here: https://aka.ms/cdpxloc
     locItems.push({
       "SourceFile": RESJSONOutputPath.concat("\\", resjsonFileName),
-      "LclFile": templatePath.concat(StringOutputPath, LangOutputSpecifier, lclFileName),
+      "LclFile": templatePath.concat(LangOutputSpecifier, lclFileName),
       "CopyOption": "LangIDOnPath",
-      "OutputPath": templatePath.concat(StringOutputPath, LangOutputSpecifier, resjsonFileName)
+      "OutputPath": templatePath.concat(LangOutputSpecifier, resjsonFileName)
     });
 
     // Write extracted strings to file


### PR DESCRIPTION
Originally wanted loc files to be under a string subfolder, but that would require manually adding a strings folder under every single workbook folder and requiring this folder being created going forward. Loc tool does not handle auto-creation of specified paths other than the {Lang} folder. So just removing the strings subfolder since it's not really needed.

