### PR TITLE
add codeowners settings for loc files anywhere in the repo

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -47,3 +47,8 @@
 /Workbooks/Virtual*Machine*/** @andrewki-msft @nasundar @rakshith210 @microsoft/applicationinsights-devtools
 
 /Workbooks/UsageMetrics/** @MSKaiLian @OsvaldoRosado @akkumari-ms @microsoft/ApplicationInsights-PortalExperiences @microsoft/applicationinsights-devtools
+
+
+# leave this at the bottom!
+# EVERYTHING ending with resjson* is for loc, and is owned by the workbooks team and the loc team
+*.resjson* @microsoft/applicationinsights-devtools csigs

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -51,4 +51,4 @@
 
 # leave this at the bottom!
 # EVERYTHING ending with resjson* is for loc, and is owned by the workbooks team and the loc team
-*.resjson* @microsoft/applicationinsights-devtools csigs
+*.resjson* @microsoft/applicationinsights-devtools csigs @microsoft/csigs


### PR DESCRIPTION
Adds a line to the `CODEOWNERS` file that makes the workbooks team and the loc team the owners of all the loc `*.resjson*` files in the repo.  the loc process will start checking loc'd content into this repo instead of the 17 repos they have copied right now