### PR TITLE
fix duplicate metric for shards

### DIFF
--- a/Workbooks/Resource Insights/RedisCache/ResourceInsights.workbook
+++ b/Workbooks/Resource Insights/RedisCache/ResourceInsights.workbook
@@ -321,7 +321,7 @@
                 },
                 {
                   "namespace": "microsoft.cache/redis",
-                  "metric": "microsoft.cache/redis--usedmemory2",
+                  "metric": "microsoft.cache/redis--usedmemory1",
                   "aggregation": 1
                 },
                 {


### PR DESCRIPTION
the same usedmemory2 metric was used twice, instead of usedmemory1

![image](https://user-images.githubusercontent.com/10158007/89587235-13108d80-d7f6-11ea-80a1-7cde2c230d55.png)
