### PR TITLE
Revert "force all json files to be UTF-8 no BOM"

### DIFF
--- a/scripts/ProcessTemplates.ps1
+++ b/scripts/ProcessTemplates.ps1
@@ -487,19 +487,7 @@ Function CreatePackageContent() {
             $allCategories | ConvertTo-Json -depth 2 -Compress | Out-File -Encoding "UTF8" -FilePath $categoryFileName -Force
         }
 
-        # FORCE ALL the files in this folder to be UTF-8 with no byte order mark
-        $utf8 = New-Object System.Text.UTF8Encoding $false
-
-        Write-Host "... FORCING UTF-8 NOBOM: $reporttype "
-        foreach ($f in ls -name $reportTypePath\*.json)
-        {
-            $path = "$reportTypePath\$f"
-            $content = Get-Content $path -Raw
-            Write-Host "... $path"
-            Set-Content -Value $utf8.GetBytes($content) -Encoding Byte -Path $path
-        }
-
-        Write-Host "DONE building gallery: $reporttype "
+        Write-Host "... DONE building gallery: $reporttype "
     }
 }
 


### PR DESCRIPTION
Undoing just the part where we force all the files to be utf8 no bom.  it is messing up emojis in files that already are fine.  leaving the part that generates all of our generated files in the build as UTF8 (ps was generating UCS-2?)