### PR TITLE
update codeowners for azuremonitorforsapsolutions

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -42,7 +42,7 @@
 /Workbooks/Network*Insights/VirtualWANWorkbooks/** @skishen525 @sayghosh @deveshjagwani @gnani-varkala @microsoft/applicationinsights-devtools
 /Workbooks/Network*Insights/NetworkInsights-AppGatewayMetrics/** @abshamsft @sayghosh @deveshjagwani @gnani-varkala @microsoft/applicationinsights-devtools
  
-/Workbooks/SapMonitor/** @tniek @persiaAziz @PakDLiu @rukawata @microsoft/applicationinsights-devtools
+/Workbooks/SapMonitor/** @microsoft/azuremonitorforsapsolutions @microsoft/applicationinsights-devtools
 
 /Workbooks/Virtual*Machine*/** @andrewki-msft @nasundar @rakshith210 @microsoft/applicationinsights-devtools
 


### PR DESCRIPTION
Changed CODEOWNERS to point to the azuremonitorforsapsolutions team instead of individuals on the team