### PR TITLE
apparently a single invalid user can invalidate the entire codeowners file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -54,4 +54,4 @@
 
 # leave this at the bottom!
 # EVERYTHING ending with resjson* is for loc, and is owned by the workbooks team and the loc team
-*.resjson* @microsoft/applicationinsights-devtools csigs @microsoft/csigs
+*.resjson* @microsoft/applicationinsights-devtools @microsoft/csigs


### PR DESCRIPTION
I noticed recently that suggested/reqiured reviewers aren't getting set by codeowners.

I opened a support ticket with github and was told:

> If any line in your CODEOWNERS file contains invalid syntax, the file will not be detected and will not be used to request reviews. 
> Invalid syntax includes inline comments and user or team names that do not exist on GitHub.

invalid syntax includes users that do not exist!
(it might also apply to teams that are marked "secret" instead of public, i still need to verify that part)

support told me this one, `csigs`, is not by itself a valid user, so the whole file is technically incorrect.