### PR TITLE
remove mseng references from package-lock to fix travis-ci build?

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,8 +6,8 @@
   "dependencies": {
     "assertion-error": {
       "version": "1.1.0",
-      "resolved": "https://mseng.pkgs.visualstudio.com/_packaging/ApplicationInsights-Team/npm/registry/assertion-error/-/assertion-error-1.1.0.tgz",
-      "integrity": "sha1-5gtrDo8wG9l+U3UhW9pAbIURjAs=",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true
     },
     "balanced-match": {
@@ -34,8 +34,8 @@
     },
     "chai": {
       "version": "4.2.0",
-      "resolved": "https://mseng.pkgs.visualstudio.com/_packaging/ApplicationInsights-Team/npm/registry/chai/-/chai-4.2.0.tgz",
-      "integrity": "sha1-dgqnLPION5XoSxKHfODoNzeqKeU=",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
+      "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
       "dev": true,
       "requires": {
         "assertion-error": "^1.1.0",
@@ -48,7 +48,7 @@
     },
     "check-error": {
       "version": "1.0.2",
-      "resolved": "https://mseng.pkgs.visualstudio.com/_packaging/ApplicationInsights-Team/npm/registry/check-error/-/check-error-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
       "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
       "dev": true
     },
@@ -75,8 +75,8 @@
     },
     "deep-eql": {
       "version": "3.0.1",
-      "resolved": "https://mseng.pkgs.visualstudio.com/_packaging/ApplicationInsights-Team/npm/registry/deep-eql/-/deep-eql-3.0.1.tgz",
-      "integrity": "sha1-38lARACtHI/gI+faHfHBR8S0RN8=",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
       "dev": true,
       "requires": {
         "type-detect": "^4.0.0"
@@ -102,7 +102,7 @@
     },
     "get-func-name": {
       "version": "2.0.0",
-      "resolved": "https://mseng.pkgs.visualstudio.com/_packaging/ApplicationInsights-Team/npm/registry/get-func-name/-/get-func-name-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
       "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
       "dev": true
     },
@@ -220,9 +220,9 @@
       "dev": true
     },
     "node-trx": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/node-trx/-/node-trx-0.9.1.tgz",
-      "integrity": "sha512-Lh143LcNvOpdTWqw2E5owPBP0bdzBiFrLBEOHbvZNwT5TB1cklapW7XzO8U3QXrEHzC62Eq6ubQP1MIkFl1Bbg==",
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/node-trx/-/node-trx-0.9.2.tgz",
+      "integrity": "sha512-BcLqws24v4cuv/3PknmY1VvS59MW6w+ma+rY52/KCoED0yhZ+fjlFZKNPpUCgiVoZ2jQIUqhRzKVjYesCUk74g==",
       "requires": {
         "uuid": "^3.3.2",
         "xmlbuilder": "^13.0.2"
@@ -245,7 +245,7 @@
     },
     "pathval": {
       "version": "1.1.0",
-      "resolved": "https://mseng.pkgs.visualstudio.com/_packaging/ApplicationInsights-Team/npm/registry/pathval/-/pathval-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
       "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
       "dev": true
     },
@@ -260,8 +260,8 @@
     },
     "type-detect": {
       "version": "4.0.8",
-      "resolved": "https://mseng.pkgs.visualstudio.com/_packaging/ApplicationInsights-Team/npm/registry/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha1-dkb7XxiHHPu3dJ5pvTmmOI63RQw=",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "dev": true
     },
     "uuid": {


### PR DESCRIPTION
I'm not sure why the travis-ci build has started failing, it shouldn't require any keys/auth as all the packages the travis build needs are public.

`package-lock.json` lists some mseng packages references though, so maybe that is the issue?