### PR TITLE
Add PV Workload Workbook

### DIFF
--- a/Workbooks/AKS/Workload Details Persistent Volumes Tab/Workload Details Persistent Volumes Tab.workbook
+++ b/Workbooks/AKS/Workload Details Persistent Volumes Tab/Workload Details Persistent Volumes Tab.workbook
@@ -1,0 +1,811 @@
+{
+  "version": "Notebook/1.0",
+  "items": [
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "crossComponentResources": [
+          "{resource}"
+        ],
+        "parameters": [
+          {
+            "id": "a6e04bfc-f278-4937-9acb-b569434e0538",
+            "version": "KqlParameterItem/1.0",
+            "name": "timeRange",
+            "label": "Time Range",
+            "type": 4,
+            "description": "Filter data by time range",
+            "isRequired": true,
+            "value": {
+              "durationMs": 14400000
+            },
+            "typeSettings": {
+              "selectableValues": [
+                {
+                  "durationMs": 300000
+                },
+                {
+                  "durationMs": 900000
+                },
+                {
+                  "durationMs": 1800000
+                },
+                {
+                  "durationMs": 3600000
+                },
+                {
+                  "durationMs": 14400000
+                },
+                {
+                  "durationMs": 43200000
+                },
+                {
+                  "durationMs": 86400000
+                },
+                {
+                  "durationMs": 172800000
+                },
+                {
+                  "durationMs": 259200000
+                },
+                {
+                  "durationMs": 604800000
+                },
+                {
+                  "durationMs": 1209600000
+                },
+                {
+                  "durationMs": 2419200000
+                },
+                {
+                  "durationMs": 2592000000
+                },
+                {
+                  "durationMs": 5184000000
+                },
+                {
+                  "durationMs": 7776000000
+                }
+              ],
+              "allowCustom": true
+            }
+          },
+          {
+            "id": "bd93c710-a6f3-41c9-a275-403c0c52aca9",
+            "version": "KqlParameterItem/1.0",
+            "name": "resource",
+            "type": 5,
+            "isRequired": true,
+            "isHiddenWhenLocked": true,
+            "typeSettings": {
+              "resourceTypeFilter": {
+                "microsoft.containerservice/managedclusters": true,
+                "microsoft.kubernetes/connectedclusters": true,
+                "microsoft.operationalinsights/workspaces": true
+              },
+              "additionalResourceOptions": [
+                "value::1"
+              ],
+              "showDefault": false
+            },
+            "timeContextFromParameter": "timeRange",
+            "defaultValue": "value::1"
+          },
+          {
+            "id": "a80ce772-e249-48fe-8ffa-eca9589179c9",
+            "version": "KqlParameterItem/1.0",
+            "name": "resourceType",
+            "type": 7,
+            "isRequired": true,
+            "query": "{\"version\":\"1.0.0\",\"content\":\"\\\"{resource:resourcetype}\\\"\",\"transformers\":null}",
+            "isHiddenWhenLocked": true,
+            "typeSettings": {
+              "additionalResourceOptions": [
+                "value::1"
+              ],
+              "showDefault": false
+            },
+            "defaultValue": "value::1",
+            "queryType": 8
+          },
+          {
+            "id": "be6e0f63-55e3-40b5-a088-7f1c0832345a",
+            "version": "KqlParameterItem/1.0",
+            "name": "clusterId",
+            "type": 1,
+            "description": "Filter workspace by cluster id",
+            "isHiddenWhenLocked": true,
+            "timeContext": {
+              "durationMs": 14400000
+            },
+            "timeContextFromParameter": "timeRange"
+          },
+          {
+            "id": "8b3caaa6-1c88-4fe0-b8d9-25d87d07d01a",
+            "version": "KqlParameterItem/1.0",
+            "name": "clusterIdWhereClause",
+            "type": 1,
+            "description": "Add to queries to filter by cluster id",
+            "value": "| where ClusterId =~ ''",
+            "isHiddenWhenLocked": true,
+            "criteriaData": [
+              {
+                "criteriaContext": {
+                  "leftOperand": "resourceType",
+                  "operator": "contains",
+                  "rightValType": "static",
+                  "rightVal": "microsoft.operationalinsights/workspaces",
+                  "resultValType": "static",
+                  "resultVal": "| where ClusterId =~ '{clusterId}'"
+                }
+              },
+              {
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "static",
+                  "resultVal": "| where \"a\" == \"a\""
+                }
+              }
+            ],
+            "timeContext": {
+              "durationMs": 14400000
+            },
+            "timeContextFromParameter": "timeRange"
+          },
+          {
+            "id": "d6a33bd8-6382-45cc-958e-1d4b1e6c8ec6",
+            "version": "KqlParameterItem/1.0",
+            "name": "workloadType",
+            "label": "Workload Type",
+            "type": 2,
+            "multiSelect": true,
+            "quote": "'",
+            "delimiter": ",",
+            "query": "KubePodInventory\r\n{clusterIdWhereClause}\r\n| distinct ControllerKind\r\n| where isempty(ControllerKind) == false\r\n| order by ControllerKind asc",
+            "crossComponentResources": [
+              "{resource}"
+            ],
+            "typeSettings": {
+              "additionalResourceOptions": [
+                "value::all"
+              ],
+              "selectAllValue": "",
+              "showDefault": false
+            },
+            "timeContext": {
+              "durationMs": 14400000
+            },
+            "timeContextFromParameter": "timeRange",
+            "defaultValue": "value::all",
+            "queryType": 0,
+            "resourceType": "{resourceType}"
+          },
+          {
+            "id": "aa7889a8-e832-4eb1-96e5-310eda133322",
+            "version": "KqlParameterItem/1.0",
+            "name": "workloadKindWhereClause",
+            "type": 1,
+            "value": "| where \"a\" == \"a\"",
+            "isHiddenWhenLocked": true,
+            "criteriaData": [
+              {
+                "condition": "if (workloadType is not empty ), result = '| where ControllerKind in ({workloadType})'",
+                "criteriaContext": {
+                  "leftOperand": "workloadType",
+                  "operator": "isNotNull",
+                  "rightValType": "static",
+                  "rightVal": "unset",
+                  "resultValType": "static",
+                  "resultVal": "| where ControllerKind in ({workloadType})"
+                }
+              },
+              {
+                "condition": "else result = '| where \"a\" == \"a\"'",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "static",
+                  "resultVal": "| where \"a\" == \"a\""
+                }
+              }
+            ],
+            "timeContext": {
+              "durationMs": 0
+            },
+            "timeContextFromParameter": "timeRange"
+          },
+          {
+            "id": "bf304c30-c03a-45fe-8441-2a6e62d72a98",
+            "version": "KqlParameterItem/1.0",
+            "name": "namespace",
+            "label": "Namespace",
+            "type": 2,
+            "description": "Filter the workbook by namespace",
+            "multiSelect": true,
+            "quote": "'",
+            "delimiter": ",",
+            "query": "KubePodInventory\r\n{clusterIdWhereClause}\r\n{workloadKindWhereClause}\r\n| distinct Namespace\r\n| where isnotempty(Namespace)\r\n| order by Namespace asc",
+            "crossComponentResources": [
+              "{resource}"
+            ],
+            "value": [
+              "value::all"
+            ],
+            "typeSettings": {
+              "additionalResourceOptions": [
+                "value::1",
+                "value::all"
+              ],
+              "selectAllValue": "",
+              "showDefault": false
+            },
+            "timeContext": {
+              "durationMs": 14400000
+            },
+            "timeContextFromParameter": "timeRange",
+            "defaultValue": "value::1",
+            "queryType": 0,
+            "resourceType": "{resourceType}"
+          },
+          {
+            "id": "0f1adca0-2764-4a54-b204-ee876530c8fc",
+            "version": "KqlParameterItem/1.0",
+            "name": "namespaceWhereClause",
+            "type": 1,
+            "value": "| where \"a\" == \"a\"",
+            "isHiddenWhenLocked": true,
+            "criteriaData": [
+              {
+                "condition": "if (namespace is not empty ), result = '| where Namespace in ({namespace})'",
+                "criteriaContext": {
+                  "leftOperand": "namespace",
+                  "operator": "isNotNull",
+                  "rightValType": "static",
+                  "rightVal": "unset",
+                  "resultValType": "static",
+                  "resultVal": "| where Namespace in ({namespace})"
+                }
+              },
+              {
+                "condition": "else result = '| where \"a\" == \"a\"'",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "static",
+                  "resultVal": "| where \"a\" == \"a\""
+                }
+              }
+            ],
+            "timeContext": {
+              "durationMs": 0
+            },
+            "timeContextFromParameter": "timeRange"
+          },
+          {
+            "id": "a9be89ac-822f-4156-828d-615b11830c11",
+            "version": "KqlParameterItem/1.0",
+            "name": "workloadName",
+            "label": "Workload Name",
+            "type": 2,
+            "description": "Filter the data for a particular workload",
+            "isRequired": true,
+            "query": "KubePodInventory\r\n{clusterIdWhereClause}\r\n{namespaceWhereClause}\r\n{workloadKindWhereClause}\r\n| distinct ControllerName\r\n| where isnotempty(ControllerName)\r\n| order by ControllerName asc",
+            "crossComponentResources": [
+              "{resource}"
+            ],
+            "typeSettings": {
+              "additionalResourceOptions": [
+                "value::1"
+              ],
+              "showDefault": false
+            },
+            "timeContext": {
+              "durationMs": 14400000
+            },
+            "timeContextFromParameter": "timeRange",
+            "defaultValue": "value::1",
+            "queryType": 0,
+            "resourceType": "{resourceType}"
+          },
+          {
+            "id": "7a78b755-3218-40fe-91f6-49c57f1543f6",
+            "version": "KqlParameterItem/1.0",
+            "name": "podStatus",
+            "label": "Pod Status",
+            "type": 2,
+            "description": "Filter by Pod status like Pending/Running/Failed etc.",
+            "multiSelect": true,
+            "quote": "'",
+            "delimiter": ",",
+            "query": "KubePodInventory\r\n{clusterIdWhereClause}\r\n| where ControllerName == '{workloadName}'\r\n| distinct PodStatus\r\n| where isnotempty(PodStatus)\r\n| order by PodStatus asc",
+            "crossComponentResources": [
+              "{resource}"
+            ],
+            "typeSettings": {
+              "additionalResourceOptions": [
+                "value::all"
+              ],
+              "selectAllValue": "",
+              "showDefault": false
+            },
+            "timeContext": {
+              "durationMs": 14400000
+            },
+            "timeContextFromParameter": "timeRange",
+            "defaultValue": "value::all",
+            "queryType": 0,
+            "resourceType": "{resourceType}"
+          },
+          {
+            "id": "20c74eae-034e-4f40-aeab-bf68f6ae9319",
+            "version": "KqlParameterItem/1.0",
+            "name": "podStatusWhereClause",
+            "type": 1,
+            "value": "| where \"a\" == \"a\"",
+            "isHiddenWhenLocked": true,
+            "criteriaData": [
+              {
+                "criteriaContext": {
+                  "leftOperand": "podStatus",
+                  "operator": "isNotNull",
+                  "rightValType": "static",
+                  "rightVal": "unset",
+                  "resultValType": "static",
+                  "resultVal": "| where PodStatus in ({podStatus})"
+                }
+              },
+              {
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "static",
+                  "resultVal": "| where \"a\" == \"a\""
+                }
+              }
+            ],
+            "timeContext": {
+              "durationMs": 2592000000
+            },
+            "timeContextFromParameter": "timeRange"
+          },
+          {
+            "id": "cca220dc-e576-464e-8674-4fe7cc5e263c",
+            "version": "KqlParameterItem/1.0",
+            "name": "podName",
+            "label": "Pod Name",
+            "type": 2,
+            "description": "Filter by pod name ",
+            "multiSelect": true,
+            "quote": "'",
+            "delimiter": ",",
+            "query": "KubePodInventory\r\n{clusterIdWhereClause}\r\n| where ControllerName == '{workloadName:value}'\r\n{podStatusWhereClause}\r\n| summarize arg_max(TimeGenerated, PodStatus) by Name\r\n| project Name\r\n| where isempty(Name) == false\r\n| order by Name asc",
+            "crossComponentResources": [
+              "{resource}"
+            ],
+            "typeSettings": {
+              "additionalResourceOptions": [
+                "value::all"
+              ],
+              "selectAllValue": "",
+              "showDefault": false
+            },
+            "timeContext": {
+              "durationMs": 14400000
+            },
+            "timeContextFromParameter": "timeRange",
+            "defaultValue": "value::all",
+            "queryType": 0,
+            "resourceType": "{resourceType}"
+          },
+          {
+            "id": "79f77775-9320-4a0c-a46f-328c6e80ca9c",
+            "version": "KqlParameterItem/1.0",
+            "name": "podNameWhereClause",
+            "type": 1,
+            "value": "| where \"a\" == \"a\"",
+            "isHiddenWhenLocked": true,
+            "criteriaData": [
+              {
+                "condition": "if (podName is not empty ), result = '| where PodName in ({podName})'",
+                "criteriaContext": {
+                  "leftOperand": "podName",
+                  "operator": "isNotNull",
+                  "rightValType": "static",
+                  "rightVal": "unset",
+                  "resultValType": "static",
+                  "resultVal": "| where PodName in ({podName})"
+                }
+              },
+              {
+                "condition": "else result = '| where \"a\" == \"a\"'",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "static",
+                  "resultVal": "| where \"a\" == \"a\""
+                }
+              }
+            ],
+            "timeContext": {
+              "durationMs": 0
+            },
+            "timeContextFromParameter": "timeRange"
+          },
+          {
+            "id": "51498a43-6309-4324-896d-3f61f27588ae",
+            "version": "KqlParameterItem/1.0",
+            "name": "workloadNamespaceText",
+            "type": 1,
+            "description": "For displaying name space of the selected workload",
+            "query": "KubePodInventory\r\n{clusterIdWhereClause}\r\n| where ControllerName == '{workloadName}'\r\n| take 1 \r\n| project Namespace",
+            "crossComponentResources": [
+              "{resource}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContext": {
+              "durationMs": 0
+            },
+            "timeContextFromParameter": "timeRange",
+            "queryType": 0,
+            "resourceType": "{resourceType}"
+          },
+          {
+            "id": "fd834531-2085-4bc0-9a93-1c919997df72",
+            "version": "KqlParameterItem/1.0",
+            "name": "workloadTypeText",
+            "type": 1,
+            "description": "For displaying workload type of the selected workload",
+            "query": "KubePodInventory\r\n{clusterIdWhereClause}\r\n| where ControllerName == '{workloadName}'\r\n| take 1 \r\n| project ControllerKind",
+            "crossComponentResources": [
+              "{resource}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContext": {
+              "durationMs": 0
+            },
+            "timeContextFromParameter": "timeRange",
+            "queryType": 0,
+            "resourceType": "{resourceType}"
+          }
+        ],
+        "style": "above",
+        "queryType": 0,
+        "resourceType": "{resourceType}"
+      },
+      "name": "PVMainParameters"
+    },
+    {
+      "type": 12,
+      "content": {
+        "version": "NotebookGroup/1.0",
+        "groupType": "editable",
+        "items": [
+          {
+            "type": 9,
+            "content": {
+              "version": "KqlParameterItem/1.0",
+              "crossComponentResources": [
+                "{resource}"
+              ],
+              "parameters": [
+                {
+                  "id": "58df4821-a81a-410b-8da3-188bfb94c0fa",
+                  "version": "KqlParameterItem/1.0",
+                  "name": "pvHighUsageThreshold",
+                  "label": "PV High Usage Threshold",
+                  "type": 1,
+                  "description": "Set the percentage threshold to define high usage status.",
+                  "isRequired": true,
+                  "value": "80",
+                  "isHiddenWhenLocked": true,
+                  "timeContext": {
+                    "durationMs": 86400000
+                  }
+                },
+                {
+                  "id": "f45e0d19-03da-43ac-ad86-50b2303c53b3",
+                  "version": "KqlParameterItem/1.0",
+                  "name": "selectedPVC",
+                  "label": "Selected PVC",
+                  "type": 1,
+                  "description": "Selected PVC to show detailed graph",
+                  "query": "let endDateTime = {timeRange:end};\r\nlet startDateTime = {timeRange:start};\r\nlet trendBinSize = {timeRange:grain};\r\nlet controllerName= '{workloadName:value}';\r\nKubePodInventory\r\n| where TimeGenerated < endDateTime\r\n| where TimeGenerated >= startDateTime\r\n{clusterIdWhereClause}\r\n| where ControllerName in (controllerName)\r\n| extend PodName = Name\r\n{podStatusWhereClause}\r\n{podNameWhereClause}\r\n| distinct PodUid\r\n| join hint.strategy=shuffle (\r\n    InsightsMetrics\r\n    | where TimeGenerated < endDateTime + trendBinSize\r\n    | where TimeGenerated >= startDateTime - trendBinSize\r\n    | where Namespace == 'container.azm.ms/pv'\r\n    | where Name == 'pvUsedBytes'\r\n    | extend Tags = todynamic(Tags)\r\n    | extend Capacity = tolong(Tags.pvCapacityBytes), Namespace = tostring(Tags.pvcNamespace)\r\n    | extend UsagePercent = (Val / Capacity) * 100\r\n    | extend PVCName = tostring(Tags.pvcName), PodUid = tostring(Tags.podUid)\r\n    | project PodUid, UsagePercent, TimeGenerated, PVCName = strcat(Namespace, '/', PVCName)\r\n) on PodUid\r\n| summarize arg_max(TimeGenerated, *) by PVCName\r\n| top 1 by UsagePercent\r\n| project PVCName",
+                  "crossComponentResources": [
+                    "{resource}"
+                  ],
+                  "isHiddenWhenLocked": true,
+                  "queryType": 0,
+                  "resourceType": "{resourceType}"
+                }
+              ],
+              "style": "above",
+              "queryType": 0,
+              "resourceType": "{resourceType}"
+            },
+            "conditionalVisibility": {
+              "parameterName": "1",
+              "comparison": "isEqualTo",
+              "value": "2"
+            },
+            "name": "PersistentVolumeParameters"
+          },
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "let endDateTime = {timeRange:end};\r\nlet startDateTime = {timeRange:start};\r\nlet trendBinSize = {timeRange:grain};\r\nlet controllerName= '{workloadName:value}';\r\nlet threshold = {pvHighUsageThreshold:value};\r\nlet data = KubePodInventory\r\n| where TimeGenerated < endDateTime\r\n| where TimeGenerated >= startDateTime\r\n{clusterIdWhereClause}\r\n| where ControllerName in (controllerName)\r\n| extend PodName = Name\r\n{podStatusWhereClause}\r\n{podNameWhereClause}\r\n| distinct PodUid\r\n| join hint.strategy=shuffle (\r\n    InsightsMetrics\r\n    | where TimeGenerated < endDateTime + trendBinSize\r\n    | where TimeGenerated >= startDateTime - trendBinSize\r\n    | where Namespace == 'container.azm.ms/pv'\r\n    | where Name == 'pvUsedBytes'\r\n    | extend Tags = todynamic(Tags)\r\n    | extend Capacity = tolong(Tags.pvCapacityBytes), PVCName = tostring(Tags.pvcName), PodUid = tostring(Tags.podUid)\r\n    | extend UsagePercent = (Val / Capacity) * 100\r\n    | project PodUid, UsagePercent, TimeGenerated, PVCName\r\n) on PodUid\r\n| summarize arg_max(TimeGenerated, *) by PVCName\r\n| extend State = iff(UsagePercent >= threshold, 'High Usage', 'Regular Usage')\r\n| project PVCName, UsagePercent, State;\r\n\r\ndata\r\n| summarize Count = count(), PVCs = makeset(PVCName) by State\r\n| union (\r\n    data\r\n    | summarize Count = count(), PVCs = dynamic([\"*\"])\r\n    | extend State = 'All PVs'\r\n)\r\n| join kind = fullouter (datatable (State: string) ['All PVs', 'High Usage', 'Regular Usage']) on State\r\n| extend Count = iff(State == '', 0, Count), PVCs = iff(State == '', dynamic([]), PVCs), State = iff(State == '', State1, State)\r\n| where State != 'Regular Usage'\r\n| extend State = iff(State == 'High Usage', strcat('Greater than ', tostring(threshold), '% Usage'), State), noPVs = iff(Count == 0, 'true', 'false')\r\n| order by Count desc",
+              "size": 3,
+              "showAnalytics": true,
+              "timeContext": {
+                "durationMs": 14400000
+              },
+              "timeContextFromParameter": "timeRange",
+              "exportedParameters": [
+                {
+                  "fieldName": "noPVs",
+                  "parameterName": "noPVs",
+                  "parameterType": 1,
+                  "defaultValue": "false"
+                },
+                {
+                  "fieldName": "State",
+                  "parameterName": "onlyHighUsage",
+                  "parameterType": 1,
+                  "defaultValue": "All PVs"
+                }
+              ],
+              "queryType": 0,
+              "resourceType": "{resourceType}",
+              "crossComponentResources": [
+                "{resource}"
+              ],
+              "visualization": "tiles",
+              "tileSettings": {
+                "titleContent": {
+                  "columnMatch": "State",
+                  "formatter": 1
+                },
+                "leftContent": {
+                  "columnMatch": "State",
+                  "formatter": 18,
+                  "formatOptions": {
+                    "thresholdsOptions": "icons",
+                    "thresholdsGrid": [
+                      {
+                        "operator": "contains",
+                        "thresholdValue": "Greater than",
+                        "representation": "4",
+                        "text": ""
+                      },
+                      {
+                        "operator": "Default",
+                        "thresholdValue": null,
+                        "representation": "Blank",
+                        "text": ""
+                      }
+                    ],
+                    "compositeBarSettings": {
+                      "labelText": "",
+                      "columnSettings": []
+                    }
+                  }
+                },
+                "rightContent": {
+                  "columnMatch": "Count",
+                  "formatter": 12,
+                  "formatOptions": {
+                    "palette": "none"
+                  }
+                },
+                "showBorder": true,
+                "size": "auto"
+              }
+            },
+            "showPin": true,
+            "name": "PVCountOverview"
+          },
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "let endDateTime = {timeRange:end};\r\nlet startDateTime = {timeRange:start};\r\nlet trendBinSize = {timeRange:grain};\r\nlet controllerName= '{workloadName:value}';\r\nlet highUsageThreshold = toreal({pvHighUsageThreshold});\r\nlet threshold = iff('{onlyHighUsage}' contains \"Greater than\", highUsageThreshold, -1.0);\r\nKubePodInventory\r\n| where TimeGenerated < endDateTime\r\n| where TimeGenerated >= startDateTime\r\n{clusterIdWhereClause}\r\n| where ControllerName in (controllerName)\r\n| extend PodName = Name\r\n{podStatusWhereClause}\r\n{podNameWhereClause}\r\n| distinct PodUid\r\n| join hint.strategy=shuffle (\r\n    InsightsMetrics\r\n    | where TimeGenerated < endDateTime + trendBinSize\r\n    | where TimeGenerated >= startDateTime - trendBinSize\r\n    | where Namespace == 'container.azm.ms/pv'\r\n    | where Name == 'pvUsedBytes'\r\n    | extend Tags = todynamic(Tags)\r\n    | extend Capacity = tolong(Tags.pvCapacityBytes), PVCName = tostring(Tags.pvcName), PodUid = tostring(Tags.podUid), PodName = tostring(Tags.podName), VolumeName = tostring(Tags.volumeName), Namespace = tostring(Tags.pvcNamespace)\r\n    | extend UsagePercent = (Val / Capacity) * 100\r\n    | project PodUid, UsagePercent, TimeGenerated, PVCName = strcat(Namespace, '/', PVCName), Capacity, PodName, Computer, VolumeName\r\n) on PodUid\r\n| order by TimeGenerated asc\r\n| make-series Trend = max(UsagePercent) default = 0 on TimeGenerated step trendBinSize by PVCName, Capacity, Computer, PodName, VolumeName\r\n| extend CurrentUsage = toreal(Trend[-1])\r\n| where CurrentUsage > threshold\r\n| extend Used = format_bytes(CurrentUsage * toreal(Capacity) / 100, 2), Capacity = format_bytes(Capacity, 2)\r\n| extend UsedAndCapacity = strcat(Used, ' / ', Capacity)\r\n| project PVCName, CurrentUsage, Trend, UsedAndCapacity, VolumeName, PodName, Computer\r\n| order by CurrentUsage desc",
+              "size": 3,
+              "showAnalytics": true,
+              "title": "💡 Select a row to see the usage for the PV charted below",
+              "noDataMessage": "There are no persistent volumes for the selected criteria",
+              "timeContext": {
+                "durationMs": 14400000
+              },
+              "timeContextFromParameter": "timeRange",
+              "exportFieldName": "PVCName",
+              "exportParameterName": "selectedPVC",
+              "queryType": 0,
+              "resourceType": "{resourceType}",
+              "crossComponentResources": [
+                "{resource}"
+              ],
+              "visualization": "table",
+              "gridSettings": {
+                "formatters": [
+                  {
+                    "columnMatch": "CurrentUsage",
+                    "formatter": 18,
+                    "formatOptions": {
+                      "thresholdsOptions": "icons",
+                      "thresholdsGrid": [
+                        {
+                          "operator": ">=",
+                          "thresholdValue": "80",
+                          "representation": "failed",
+                          "text": "{0}%"
+                        },
+                        {
+                          "operator": ">=",
+                          "thresholdValue": "60",
+                          "representation": "2",
+                          "text": "{0}%"
+                        },
+                        {
+                          "operator": "Default",
+                          "thresholdValue": null,
+                          "representation": "success",
+                          "text": "{0}%"
+                        }
+                      ]
+                    },
+                    "numberFormat": {
+                      "unit": 1,
+                      "options": {
+                        "style": "decimal",
+                        "useGrouping": false,
+                        "maximumFractionDigits": 2
+                      }
+                    }
+                  },
+                  {
+                    "columnMatch": "Trend",
+                    "formatter": 9,
+                    "formatOptions": {
+                      "min": 0,
+                      "max": 100,
+                      "palette": "greenRed",
+                      "aggregation": "Max",
+                      "compositeBarSettings": {
+                        "labelText": "",
+                        "columnSettings": []
+                      }
+                    },
+                    "numberFormat": {
+                      "unit": 1,
+                      "options": {
+                        "style": "decimal",
+                        "useGrouping": false
+                      }
+                    }
+                  },
+                  {
+                    "columnMatch": "UsedAndCapacity",
+                    "formatter": 0,
+                    "numberFormat": {
+                      "unit": 2,
+                      "options": {
+                        "style": "decimal",
+                        "useGrouping": false,
+                        "maximumFractionDigits": 2
+                      }
+                    }
+                  }
+                ],
+                "labelSettings": [
+                  {
+                    "columnId": "PVCName",
+                    "label": "PVC Name"
+                  },
+                  {
+                    "columnId": "CurrentUsage",
+                    "label": "Usage"
+                  },
+                  {
+                    "columnId": "Trend",
+                    "label": "Usage Trend"
+                  },
+                  {
+                    "columnId": "UsedAndCapacity",
+                    "label": "Used / Capacity"
+                  },
+                  {
+                    "columnId": "VolumeName",
+                    "label": "Volume Name"
+                  },
+                  {
+                    "columnId": "PodName",
+                    "label": "Pod Name"
+                  },
+                  {
+                    "columnId": "Computer",
+                    "label": "Node Name"
+                  }
+                ]
+              }
+            },
+            "showPin": true,
+            "name": "PVGrid",
+            "styleSettings": {
+              "showBorder": true
+            }
+          },
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "let endDateTime = {timeRange:end};\r\nlet startDateTime = {timeRange:start};\r\nlet trendBinSize = {timeRange:grain};\r\nlet controllerName= '{workloadName:value}';\r\nlet selectedPVC = '{selectedPVC:value}';\r\nKubePodInventory\r\n| where TimeGenerated < endDateTime\r\n| where TimeGenerated >= startDateTime\r\n{clusterIdWhereClause}\r\n| where ControllerName in (controllerName)\r\n| extend PodName = Name\r\n{podStatusWhereClause}\r\n{podNameWhereClause}\r\n| distinct PodUid\r\n| join hint.strategy=shuffle (\r\n    InsightsMetrics\r\n    | where TimeGenerated < endDateTime + trendBinSize\r\n    | where TimeGenerated >= startDateTime - trendBinSize\r\n    | where Namespace == 'container.azm.ms/pv'\r\n    | where Name == 'pvUsedBytes'\r\n    | extend Tags = todynamic(Tags)\r\n    | extend PVCName = strcat(Namespace = tostring(Tags.pvcNamespace), '/', tostring(Tags.pvcName))\r\n    | where PVCName == selectedPVC\r\n    | extend Capacity = Tags.pvCapacityBytes, PodUid = tostring(Tags.podUid)\r\n    | extend UsagePercent = (Val / Capacity) * 100\r\n    | project TimeGenerated, UsagePercent, PVCName, PodUid\r\n) on PodUid\r\n| project PVCName, TimeGenerated, UsagePercent\r\n| summarize UsagePercentage=max(UsagePercent) by bin(TimeGenerated, trendBinSize), PVCName",
+              "size": 0,
+              "aggregation": 5,
+              "showAnalytics": true,
+              "title": "{selectedPVC} usage",
+              "noDataMessage": "Select a PV to view details",
+              "queryType": 0,
+              "resourceType": "{resourceType}",
+              "crossComponentResources": [
+                "{resource}"
+              ],
+              "visualization": "linechart",
+              "sortBy": [],
+              "graphSettings": {
+                "type": 0,
+                "unit": 1,
+                "topContent": {
+                  "columnMatch": "TenantId",
+                  "formatter": 1
+                },
+                "centerContent": {
+                  "columnMatch": "Val",
+                  "formatter": 1,
+                  "numberFormat": {
+                    "unit": 17,
+                    "options": {
+                      "maximumSignificantDigits": 3,
+                      "maximumFractionDigits": 2
+                    }
+                  }
+                }
+              },
+              "chartSettings": {
+                "ySettings": {
+                  "numberFormatSettings": {
+                    "unit": 1,
+                    "options": {
+                      "style": "decimal",
+                      "useGrouping": true,
+                      "maximumFractionDigits": 2
+                    }
+                  }
+                }
+              }
+            },
+            "conditionalVisibilities": [
+              {
+                "parameterName": "noPVs",
+                "comparison": "isNotEqualTo",
+                "value": "true"
+              },
+              {
+                "parameterName": "selectedPVC",
+                "comparison": "isNotEqualTo"
+              }
+            ],
+            "showPin": true,
+            "name": "PVDetailedChart",
+            "styleSettings": {
+              "showBorder": true
+            }
+          }
+        ]
+      },
+      "name": "PV"
+    }
+  ],
+  "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
+}

--- a/Workbooks/AKS/Workload Details Persistent Volumes Tab/settings.json
+++ b/Workbooks/AKS/Workload Details Persistent Volumes Tab/settings.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/settings.json",
+  "name":"Workload Details Persistent Volumes Tab",
+  "author": "Microsoft",
+  "isPreview": true,
+  "galleries": [
+      { "type": "container-insights", "resourceType": "Microsoft.ContainerService/managedClusters", "order": 1203 },
+      { "type": "container-insights", "resourceType": "Microsoft.Kubernetes/connectedClusters", "order": 1203 },
+      { "type": "container-insights", "resourceType": "Microsoft.operationalinsights/workspaces", "order": 1203 }
+  ]
+}


### PR DESCRIPTION
Allow users to visualize the new PV usage data sent to InsightsMetrics, so that they can easily discover PVs with high usage and troubleshoot problems with usage and capacity for each workload. Users can filter by all PVs or only those with high usage and also select a specific one to see a detailed usage chart over the time frame.

![image](https://user-images.githubusercontent.com/21349004/97050526-5eebec80-1532-11eb-9e3c-5b6e4814ef9a.png)
