### PR TITLE
Revert "make PR validation fail if you have a settings.json file but no workbook (catch spelling/etc errors of filenames)"

### DIFF
--- a/test/jsonValidationTest.js
+++ b/test/jsonValidationTest.js
@@ -81,8 +81,6 @@ describe('Validating Workbooks...', () => {
                 .forEach(file => {
                     let settings = validateJsonStringAndGetObject(file)
                     validateSettingsForWorkbook(settings, file);
-                    // verify there is a workbook file in this directory too
-                    validateWorkbookExistForSettings(file);
                 });
 
             done();
@@ -123,16 +121,6 @@ function validateJsonExistForWorkbook(rootPath, results, file) {
         });
         if (result.length === 0) {
             assert.fail("categoryResources.json or settings.json doesn't exist in folder '" + folder + "'")
-        }
-    });
-}
-
-function validateWorkbookExistForSettings(file) {
-    let folder = path.dirname(file);
-    fs.readdir(folder, (err, list) => {
-        let workbooks = list.filter(s => s.endsWith(".workbook"));
-        if (workbooks.length == 0 ) {
-            assert.fail("settings.json file exists with no corresponding .workbook in folder '" + folder + "'")
         }
     });
 }


### PR DESCRIPTION
Reverts microsoft/Application-Insights-Workbooks#1041
somehow some commit here (a merge?) added a submodule for the localization folder which shouldn't exist.
