### PR TITLE
Define defaults for filters

### DIFF
--- a/Workbooks/Azure Active Directory TroubleShooting/Provisioning/ProvisioningAnalysis.workbook
+++ b/Workbooks/Azure Active Directory TroubleShooting/Provisioning/ProvisioningAnalysis.workbook
@@ -84,13 +84,18 @@
             "delimiter": ",",
             "query": "AADProvisioningLogs\r\n| distinct JobId",
             "typeSettings": {
-              "additionalResourceOptions": [],
+              "additionalResourceOptions": [
+                "value::all"
+              ],
               "showDefault": false
             },
+            "timeContext": {
+              "durationMs": 86400000
+            },
             "timeContextFromParameter": "TimeRange",
+            "defaultValue": "value::all",
             "queryType": 0,
-            "resourceType": "microsoft.operationalinsights/workspaces",
-            "value": []
+            "resourceType": "microsoft.operationalinsights/workspaces"
           },
           {
             "id": "91a07371-89bf-42f5-9a7a-14eec6ac081c",
@@ -127,13 +132,18 @@
             "delimiter": ",",
             "query": "AADProvisioningLogs\r\n| extend servicePrincipal = parse_json(ServicePrincipal)\r\n| distinct tostring(servicePrincipal.Name)",
             "typeSettings": {
-              "additionalResourceOptions": [],
+              "additionalResourceOptions": [
+                "value::all"
+              ],
               "showDefault": false
             },
+            "timeContext": {
+              "durationMs": 86400000
+            },
             "timeContextFromParameter": "TimeRange",
+            "defaultValue": "value::all",
             "queryType": 0,
-            "resourceType": "microsoft.operationalinsights/workspaces",
-            "value": []
+            "resourceType": "microsoft.operationalinsights/workspaces"
           }
         ],
         "style": "pills",
@@ -150,7 +160,7 @@
         "size": 4,
         "showAnalytics": true,
         "timeContext": {
-          "durationMs": 259200000
+          "durationMs": 86400000
         },
         "timeContextFromParameter": "TimeRange",
         "showExportToExcel": true,
@@ -185,7 +195,7 @@
         "size": 0,
         "title": "Provisioning events per hour",
         "timeContext": {
-          "durationMs": 259200000
+          "durationMs": 86400000
         },
         "timeContextFromParameter": "TimeRange",
         "queryType": 0,
@@ -223,7 +233,7 @@
         "size": 2,
         "title": "Provisioning success rate",
         "timeContext": {
-          "durationMs": 259200000
+          "durationMs": 86400000
         },
         "timeContextFromParameter": "TimeRange",
         "queryType": 0,
@@ -260,7 +270,7 @@
         "size": 1,
         "title": "Top Provisioning Errors",
         "timeContext": {
-          "durationMs": 259200000
+          "durationMs": 86400000
         },
         "timeContextFromParameter": "TimeRange",
         "queryType": 0,
@@ -296,7 +306,7 @@
         "size": 1,
         "title": "Provisioning activity by app",
         "timeContext": {
-          "durationMs": 259200000
+          "durationMs": 86400000
         },
         "timeContextFromParameter": "TimeRange",
         "queryType": 0,
@@ -332,7 +342,7 @@
         "size": 0,
         "title": "Provisioning events per cycle",
         "timeContext": {
-          "durationMs": 259200000
+          "durationMs": 86400000
         },
         "timeContextFromParameter": "TimeRange",
         "queryType": 0,
@@ -514,7 +524,7 @@
         "size": 0,
         "showAnalytics": true,
         "timeContext": {
-          "durationMs": 0
+          "durationMs": 259200000
         },
         "timeContextFromParameter": "TimeRange",
         "showExportToExcel": true,
@@ -553,7 +563,7 @@
         "size": 0,
         "showAnalytics": true,
         "timeContext": {
-          "durationMs": 0
+          "durationMs": 259200000
         },
         "timeContextFromParameter": "TimeRange",
         "showExportToExcel": true,
@@ -586,5 +596,6 @@
       "name": "query - 10"
     }
   ],
+  "fromTemplateId": "community-Workbooks/Azure Active Directory TroubleShooting/Provisioning",
   "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
 }

--- a/Workbooks/Azure Active Directory TroubleShooting/Provisioning/ProvisioningAnalysis.workbook
+++ b/Workbooks/Azure Active Directory TroubleShooting/Provisioning/ProvisioningAnalysis.workbook
@@ -596,6 +596,5 @@
       "name": "query - 10"
     }
   ],
-  "fromTemplateId": "community-Workbooks/Azure Active Directory TroubleShooting/Provisioning",
   "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
 }


### PR DESCRIPTION
JobID and App filters will be defaulted to "All" to prevent from seeing error messages when viewing the workbook.

## PR Checklist

* [ ] Explain your changes, so people looking at the PR know *what* and *why*, the code changes are the *how*.

### If adding or updating templates:
* [ ] post a screenshot of templates and/or gallery changes
* [ ] ensure all steps have meaningful names
* [ ] ensure all parameters and grid columns have display names set so they can be localized
* [ ] ensure that parameters id values are unique __or they will fail PR validation__ (parameter ids are used for localization)
* [ ] ensure that steps names are unique __or they will fail PR validation__ (step names are used for localization)
* [ ] grep `/subscription/` and ensure that your parameters don't have any hardcoded resourceIds __or they will fail PR validation__
* [ ] remove `fallbackResourceIds` and `fromTemplateId` fields from your template workbook __or they will fail PR validation__