### PR TITLE
Localization v2 - Reduce output path under 260 char

### DIFF
--- a/scripts/extractStrings.js
+++ b/scripts/extractStrings.js
@@ -103,7 +103,8 @@ function generateOutputPath(dir, folder) {
     outputPath = dir.replace(WorkbookTemplateFolder, folder);
   }
   if (!fs.existsSync(outputPath)) {
-    fs.mkdirSync(outputPath, { recursive: true });
+    const directoryPath = outputPath.substr(0, outputPath.lastIndexOf("\\"));
+    fs.mkdirSync(directoryPath, { recursive: true });
   }
   return outputPath;
 }

--- a/scripts/extractStrings.js
+++ b/scripts/extractStrings.js
@@ -568,7 +568,7 @@ for (var d in directories) {
     }
   };
 
-  if (Object.keys(extracted).length > 0) {
+  if (Object.keys(extracted).length > 0 && !templatePath.endsWith("\\")) {
     // Add LocProject entry
     const locProjectEntry = generateLocProjectEntry(templatePath, resjonOutputPath, rootDirectory);
     locProjectOutput.push(locProjectEntry);

--- a/scripts/extractStrings.js
+++ b/scripts/extractStrings.js
@@ -278,8 +278,8 @@ function generateLocProjectEntry(templatePath, resjsonOutputPath, rootDirectory)
 function getLocOutputPath(templatePath, extensionType, root) {
   const newTemplatePath = templatePath.replace(root, root.concat(LangOutputSpecifier))
   const templateSplit = newTemplatePath.split("\\");
-  const fileName = templateSplit[templateSplit.length -1];
-  return newTemplatePath.replace(fileName, fileName.concat(extensionType));
+  templateSplit[templateSplit.length -1] = templateSplit[templateSplit.length -1].concat(extensionType);
+  return templateSplit.join("\\");
 }
 
 function replaceFileExtension(fileName, extensionType) {

--- a/scripts/extractStrings.js
+++ b/scripts/extractStrings.js
@@ -33,8 +33,8 @@ const CategoryResourcesFile = "categoryResources.json";
 const SettingsFile = "settings.json";
 
 const Encoding = 'utf8';
-const ResJsonStringFileExtension = 'resjson';
-const LCLStringFileExtension = "resjson.lcl";
+const ResJsonStringFileExtension = '.resjson';
+const LCLStringFileExtension = ".resjson.lcl";
 
 const WorkbookTemplateFolder = "\\Workbooks\\";
 const CohortsTemplateFolder = "\\Cohorts\\";
@@ -43,7 +43,7 @@ const RESJSONOutputFolder = "\\output\\loc\\";
 const TemplateOutputFolder = "\\output\\templates\\"
 
 const LocProjectFileName = "LocProject.json";
-const LangOutputSpecifier = "\\{Lang}\\";
+const LangOutputSpecifier = "{Lang}\\";
 
 const Languages = [
   "cs", "de", "es", "fr", "hu", "it", "ja", "ko", "nl", "pl", "pl-BR", "pt-PT", "ru", "sv", "tr", "zh-Hans", "zh-Hant"
@@ -263,17 +263,20 @@ function findColumnNameReferences(text) {
 }
 
 /** Generate LocProject entry for localization tool */
-function generateLocProjectEntry(fileName, templatePath, resjsonOutputPath) {
-  const resjsonFileName = replaceFileExtension(fileName, ResJsonStringFileExtension);
-  const lclFileName = replaceFileExtension(fileName, LCLStringFileExtension);
-
+function generateLocProjectEntry(templatePath, resjsonOutputPath) {
   // For explanations on what each field does, see doc here: https://aka.ms/cdpxloc
   return {
-    "SourceFile": resjsonOutputPath.concat("\\", resjsonFileName),
-    "LclFile": templatePath.concat(LangOutputSpecifier, lclFileName),
+    "SourceFile": resjsonOutputPath.concat(ResJsonStringFileExtension),
+    "LclFile": getLocOutputPath(templatePath, LCLStringFileExtension),
     "CopyOption": "LangIDOnPath",
-    "OutputPath": templatePath.concat(LangOutputSpecifier, resjsonFileName)
+    "OutputPath": getLocOutputPath(templatePath, ResJsonStringFileExtension)
   };
+}
+
+function getLocOutputPath(templatePath, extensionType) {
+  const templateSplit = templatePath.split("\\");
+  const fileName = templateSplit[templateSplit.length -1];
+  return templatePath.replace(fileName,LangOutputSpecifier.concat(fileName, extensionType));
 }
 
 function replaceFileExtension(fileName, extensionType) {
@@ -283,13 +286,12 @@ function replaceFileExtension(fileName, extensionType) {
 }
 
 /** Write string file as RESJSON */
-function writeToFileRESJSON(data, fileName, outputPath) {
-  const resjsonFileName = replaceFileExtension(fileName, ResJsonStringFileExtension);
-  const fullpath = outputPath.concat("\\", resjsonFileName);
+function writeToFileRESJSON(data, outputPath) {
+  const fullpath = outputPath.concat(ResJsonStringFileExtension);
 
   const content = JSON.stringify(data, null, "\t");
   if (content.localeCompare("{}") === 0) {
-    console.log(">>>>> No strings found for: ", fileName);
+    console.log(">>>>> No strings found for: ", fullpath);
     return;
   }
 
@@ -532,7 +534,6 @@ for (var d in directories) {
   // This is where we will output the resjson artifact
   const resjonOutputPath = generateOutputPath(templatePath, RESJSONOutputFolder);
   var extracted = {};
-  var resJsonFileName; // Name of the file as entry for localization, since we are combining settings and template file
 
   for (var i in files) {
     const fileName = files[i];
@@ -552,12 +553,10 @@ for (var d in directories) {
       if (extensionType.localeCompare(CategoryResourcesFile) === 0) {
         // Special case for category resource strings
         getCategoryResourceStrings(jsonParsedData, extracted);
-        resJsonFileName = fileName;
       } else if (extensionType.localeCompare(SettingsFile) === 0) {
         getSettingStrings(jsonParsedData, extracted);
       } else {
         getLocalizeableStrings(jsonParsedData, '', extracted);
-        resJsonFileName = fileName;
       }
     } catch (error) {
       console.error("ERROR: Cannot extract JSON: ", filePath, "ERROR: ", error);
@@ -567,11 +566,11 @@ for (var d in directories) {
 
   if (Object.keys(extracted).length > 0) {
     // Add LocProject entry
-    const locProjectEntry = generateLocProjectEntry(resJsonFileName, templatePath, resjonOutputPath);
+    const locProjectEntry = generateLocProjectEntry(templatePath, resjonOutputPath);
     locProjectOutput.push(locProjectEntry);
 
     // Write extracted strings to file
-    writeToFileRESJSON(extracted, resJsonFileName, resjonOutputPath);
+    writeToFileRESJSON(extracted, resjonOutputPath);
 
     // TODO: un-comment this when localized strings are ready
     // // Generate localized templates
@@ -591,8 +590,6 @@ for (var d in directories) {
     //       writeTranslatedWorkbookToFile(jsonParsedData, translatedDir, generatedTemplatePath, Languages[l]);
     //     }
     //   }
-  } else {
-    console.log(">>>>> No localizeable strings found for template: ", resJsonFileName);
   }
 }
 


### PR DESCRIPTION
Windows has a max of 260 chars. Output path can be reduced by not including redundant template name as it is not necessary to include in the file path (folder used as unique identifier).