### PR TITLE
Fix bin 2nd argument error

### DIFF
--- a/Workbooks/UsageMetrics/Usage - Events/Usage - Events.workbook
+++ b/Workbooks/UsageMetrics/Usage - Events/Usage - Events.workbook
@@ -435,7 +435,7 @@
             "type": 1,
             "description": "Get bar Chart mode",
             "isRequired": true,
-            "query": "let splitByValue = '{UsageSplitBy:escape}';\r\nprint iff(splitByValue == '<unset>' and '{isTimeRange}' == 'true', 'TimeBar', iff(splitByValue == '<unset>' and '{isTimeRange}' == 'false', 'ByValueBar', 'SplitBar'))",
+            "query": "let splitByValue = '{UsageSplitBy:escape}';\r\nprint iff(splitByValue == '<unset>' and '{isTimeRange}' == 'true', 'TimeBar', iff('{isTimeRange}' == 'false', 'ByValueBar', 'SplitBar'))",
             "isHiddenWhenLocked": true,
             "queryType": 0,
             "resourceType": "microsoft.insights/components"

--- a/Workbooks/UsageMetrics/Usage - Sessions/Usage - Sessions.workbook
+++ b/Workbooks/UsageMetrics/Usage - Sessions/Usage - Sessions.workbook
@@ -435,7 +435,7 @@
             "type": 1,
             "description": "Get bar Chart mode",
             "isRequired": true,
-            "query": "let splitByValue = '{UsageSplitBy:escape}';\r\nprint iff(splitByValue == '<unset>' and '{isTimeRange}' == 'true', 'TimeBar', iff(splitByValue == '<unset>' and '{isTimeRange}' == 'false', 'ByValueBar', 'SplitBar'))",
+            "query": "let splitByValue = '{UsageSplitBy:escape}';\r\nprint iff(splitByValue == '<unset>' and '{isTimeRange}' == 'true', 'TimeBar', iff('{isTimeRange}' == 'false', 'ByValueBar', 'SplitBar'))",
             "isHiddenWhenLocked": true,
             "queryType": 0,
             "resourceType": "microsoft.insights/components"

--- a/Workbooks/UsageMetrics/Usage - Users/Usage - Users.workbook
+++ b/Workbooks/UsageMetrics/Usage - Users/Usage - Users.workbook
@@ -450,7 +450,7 @@
             "type": 1,
             "description": "Get bar Chart mode",
             "isRequired": true,
-            "query": "let splitByValue = '{UsageSplitBy:escape}';\r\nprint iff(splitByValue == '<unset>' and '{isTimeRange}' == 'true', 'TimeBar', iff(splitByValue == '<unset>' and '{isTimeRange}' == 'false', 'ByValueBar', 'SplitBar'))",
+            "query": "let splitByValue = '{UsageSplitBy:escape}';\r\nprint iff(splitByValue == '<unset>' and '{isTimeRange}' == 'true', 'TimeBar', iff('{isTimeRange}' == 'false', 'ByValueBar', 'SplitBar'))",
             "isHiddenWhenLocked": true,
             "queryType": 0,
             "resourceType": "microsoft.insights/components"


### PR DESCRIPTION
## PR Checklist

* Fix error "bin(): argument #2 must be a positive constant timespan (1 tick or higher)" in barChartMode query