### PR TITLE
fix label for file sizes

### DIFF
--- a/Workbooks/Workloads-AMA/Azure SQL databases/Azure SQL databases.workbook
+++ b/Workbooks/Workloads-AMA/Azure SQL databases/Azure SQL databases.workbook
@@ -16,7 +16,6 @@
             "label": "Monitoring profile",
             "type": 5,
             "isRequired": true,
-            "value": "/subscriptions/8980832b-9589-4ac2-b322-a6ae6a97f02b/resourceGroups/aruna-dcr-rg/providers/Microsoft.Insights/dataCollectionRules/aruna-sql-profile-8",
             "isHiddenWhenLocked": true,
             "typeSettings": {
               "additionalResourceOptions": [],

--- a/Workbooks/Workloads-AMA/Database Drilldown/File Sizes/File Sizes.workbook
+++ b/Workbooks/Workloads-AMA/Database Drilldown/File Sizes/File Sizes.workbook
@@ -349,6 +349,14 @@
                   }
                 },
                 "showBorder": false
+              },
+              "chartSettings": {
+                "seriesLabelSettings": [
+                  {
+                    "seriesName": "Log File(s) Used Size (KB)",
+                    "label": "Data File(s) Used Size"
+                  }
+                ]
               }
             },
             "conditionalVisibility": {

--- a/Workbooks/Workloads-AMA/Database Drilldown/File Sizes/File Sizes.workbook
+++ b/Workbooks/Workloads-AMA/Database Drilldown/File Sizes/File Sizes.workbook
@@ -354,7 +354,7 @@
                 "seriesLabelSettings": [
                   {
                     "seriesName": "Log File(s) Used Size (KB)",
-                    "label": "Data File(s) Used Size"
+                    "label": "Data File(s) Used Size (KB)"
                   }
                 ]
               }


### PR DESCRIPTION
- File sizes chart label now says "Data File(s) Used Size (KB)"

## PR Checklist

* [ ] Explain your changes, so people looking at the PR know *what* and *why*, the code changes are the *how*.

### If adding or updating templates:
* [ ] post a screenshot of templates and/or gallery changes
* [ ] ensure all steps have meaningful names
* [ ] ensure all parameters and grid columns have display names set so they can be localized
* [ ] ensure that parameters id values are unique __or they will fail PR validation__ (parameter ids are used for localization)
* [ ] ensure that steps names are unique __or they will fail PR validation__ (step names are used for localization)
* [ ] grep `/subscription/` and ensure that your parameters don't have any hardcoded resourceIds __or they will fail PR validation__
* [ ] remove `fallbackResourceIds` and `fromTemplateId` fields from your template workbook __or they will fail PR validation__