### PR TITLE
Add a metrics based default single vm overview template

### DIFF
--- a/Workbooks/Virtual Machines/Virtual Machine overview/Virtual Machine overview.workbook
+++ b/Workbooks/Virtual Machines/Virtual Machine overview/Virtual Machine overview.workbook
@@ -1,0 +1,230 @@
+{
+  "version": "Notebook/1.0",
+  "items": [
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "parameters": [
+          {
+            "id": "2241c21b-5a59-4a42-b3a9-b503de023938",
+            "version": "KqlParameterItem/1.0",
+            "name": "TimeRange",
+            "label": "Time Range",
+            "type": 4,
+            "isRequired": true,
+            "value": {
+              "durationMs": 3600000
+            },
+            "typeSettings": {
+              "selectableValues": [
+                {
+                  "durationMs": 300000
+                },
+                {
+                  "durationMs": 900000
+                },
+                {
+                  "durationMs": 1800000
+                },
+                {
+                  "durationMs": 3600000
+                },
+                {
+                  "durationMs": 14400000
+                },
+                {
+                  "durationMs": 43200000
+                },
+                {
+                  "durationMs": 86400000
+                },
+                {
+                  "durationMs": 172800000
+                },
+                {
+                  "durationMs": 259200000
+                },
+                {
+                  "durationMs": 604800000
+                },
+                {
+                  "durationMs": 1209600000
+                },
+                {
+                  "durationMs": 2592000000
+                }
+              ]
+            }
+          },
+          {
+            "id": "41637606-f74f-4e7b-8380-8ff980f79138",
+            "version": "KqlParameterItem/1.0",
+            "name": "SelectedVM",
+            "type": 5,
+            "value": "value::1",
+            "isHiddenWhenLocked": true,
+            "typeSettings": {
+              "resourceTypeFilter": {
+                "microsoft.compute/virtualmachines": true
+              },
+              "additionalResourceOptions": [
+                "value::1"
+              ]
+            }
+          }
+        ],
+        "style": "above",
+        "queryType": 0,
+        "resourceType": "microsoft.compute/virtualmachines"
+      },
+      "name": "parameters - 1"
+    },
+    {
+      "type": 11,
+      "content": {
+        "version": "LinkItem/1.0",
+        "style": "tabs",
+        "links": [
+          {
+            "id": "5da7e3c6-4362-4799-b6b5-bf58ba0c5e96",
+            "cellValue": "tab",
+            "linkTarget": "parameter",
+            "linkLabel": "Host Metrics",
+            "subTarget": "metrics",
+            "style": "link"
+          },
+          {
+            "id": "a57f5379-1555-4dd2-b68b-5284bd0fbd68",
+            "cellValue": "tab",
+            "linkTarget": "parameter",
+            "linkLabel": "Alerts",
+            "subTarget": "alerts",
+            "style": "link"
+          }
+        ]
+      },
+      "name": "tabs"
+    },
+    {
+      "type": 12,
+      "content": {
+        "version": "NotebookGroup/1.0",
+        "groupType": "template",
+        "loadFromTemplateId": "Workbooks/Virtual Machines/Virtual machine details",
+        "items": []
+      },
+      "conditionalVisibility": {
+        "parameterName": "tab",
+        "comparison": "isEqualTo",
+        "value": "metrics"
+      },
+      "name": "metrics group"
+    },
+    {
+      "type": 12,
+      "content": {
+        "version": "NotebookGroup/1.0",
+        "groupType": "editable",
+        "items": [
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "AlertsManagementResources | where type =~ 'microsoft.alertsmanagement/alerts'\r\n| where properties.essentials.startDateTime {TimeRange}  \r\n| extend Severity=tostring(properties.essentials.severity)\r\n| extend State=tostring(properties.essentials.alertState)\r\n| where properties.essentials.targetResource =~ \"{SelectedVM}\"\r\n| project AlertId=id, StartTime=todatetime(tostring(properties.essentials.startDateTime)), Severity, State=tostring(properties.essentials.alertState), Name=name, \r\n  TargetResource = tostring(properties.essentials.targetResource), \r\n  MonitorService = tostring(properties.essentials.monitorService),\r\n  SignalType=tostring(properties.essentials.signalType), Description=tostring(properties.essentials.description)\r\n| order by StartTime desc\r\n",
+              "size": 0,
+              "title": "Alerts during {TimeRange:label} for {SelectedVM:name}",
+              "noDataMessage": "No alerts found.",
+              "queryType": 1,
+              "resourceType": "microsoft.resourcegraph/resources",
+              "crossComponentResources": [
+                "{SelectedVM}"
+              ],
+              "gridSettings": {
+                "formatters": [
+                  {
+                    "columnMatch": "AlertId",
+                    "formatter": 5,
+                    "formatOptions": {
+                      "linkTarget": "Resource"
+                    }
+                  },
+                  {
+                    "columnMatch": "StartTime",
+                    "formatter": 6
+                  },
+                  {
+                    "columnMatch": "Severity",
+                    "formatter": 11
+                  },
+                  {
+                    "columnMatch": "State",
+                    "formatter": 1
+                  },
+                  {
+                    "columnMatch": "Name",
+                    "formatter": 1,
+                    "formatOptions": {
+                      "linkTarget": "OpenBlade",
+                      "linkIsContextBlade": true,
+                      "bladeOpenContext": {
+                        "bladeName": "AlertDetailsTemplateBlade",
+                        "extensionName": "Microsoft_Azure_Monitoring",
+                        "bladeParameters": [
+                          {
+                            "name": "alertId",
+                            "source": "column",
+                            "value": "AlertId"
+                          },
+                          {
+                            "name": "alertName",
+                            "source": "column",
+                            "value": "Name"
+                          },
+                          {
+                            "name": "invokedFrom",
+                            "source": "static",
+                            "value": "Workbooks"
+                          }
+                        ]
+                      }
+                    },
+                    "tooltipFormat": {
+                      "tooltip": "View alert details"
+                    }
+                  },
+                  {
+                    "columnMatch": "TargetResource",
+                    "formatter": 5,
+                    "formatOptions": {
+                      "linkTarget": "Resource",
+                      "subTarget": "alerts"
+                    }
+                  },
+                  {
+                    "columnMatch": "essentials",
+                    "formatter": 5,
+                    "formatOptions": {
+                      "linkTarget": "CellDetails",
+                      "linkIsContextBlade": true
+                    }
+                  }
+                ],
+                "rowLimit": 1000,
+                "filter": true
+              }
+            },
+            "name": "alerts query"
+          }
+        ]
+      },
+      "conditionalVisibility": {
+        "parameterName": "tab",
+        "comparison": "isEqualTo",
+        "value": "alerts"
+      },
+      "name": "alerts group"
+    }
+  ],
+  "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
+}

--- a/Workbooks/Virtual Machines/Virtual Machine overview/settings.json
+++ b/Workbooks/Virtual Machines/Virtual Machine overview/settings.json
@@ -1,0 +1,6 @@
+{
+    "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/settings.json",
+    "name":"Overview",
+    "author": "Microsoft",
+    "galleries": [{ "type": "workbook", "resourceType": "microsoft.compute/virtualmachines", "order": 100 }]
+}


### PR DESCRIPTION
## PR Checklist

Adds a simple template that wraps the existing vm details context blade template, and has an alerts tab to have a default metrics based template on VMs.

### screenshots:

the gallery with my new item in it:
![image](https://user-images.githubusercontent.com/10158007/100678213-88621a00-3321-11eb-8d39-6a860ea7f8a5.png)

The default look of the workbook:
![image](https://user-images.githubusercontent.com/10158007/100678258-9c0d8080-3321-11eb-9894-9748c3734a49.png)


alerts tab:
![image](https://user-images.githubusercontent.com/10158007/100678284-ab8cc980-3321-11eb-9898-0c1e90ed40e5.png)
