### PR TITLE
Explore metrics fix

### DIFF
--- a/Workbooks/Workloads-AMA/Azure SQL Managed Instance/Azure SQL Managed Instance.workbook
+++ b/Workbooks/Workloads-AMA/Azure SQL Managed Instance/Azure SQL Managed Instance.workbook
@@ -1020,7 +1020,7 @@
               "queryType": 0,
               "resourceType": "microsoft.operationalinsights/workspaces"
             },
-            "name": "Metric Selectors",
+            "name": "Metric selectors",
             "styleSettings": {
               "margin": "15px 0 10px 0"
             }

--- a/Workbooks/Workloads-AMA/Azure SQL Managed Instance/Azure SQL Managed Instance.workbook
+++ b/Workbooks/Workloads-AMA/Azure SQL Managed Instance/Azure SQL Managed Instance.workbook
@@ -261,7 +261,7 @@
               "showAnalytics": true,
               "title": "SQL Wait Category stats",
               "timeContext": {
-                "durationMs": 0
+                "durationMs": 14400000
               },
               "timeContextFromParameter": "TimeRange",
               "exportFieldName": "series",
@@ -314,7 +314,7 @@
               "showAnalytics": true,
               "title": "SQL Wait Type Stats",
               "timeContext": {
-                "durationMs": 0
+                "durationMs": 14400000
               },
               "timeContextFromParameter": "TimeRange",
               "showExportToExcel": true,
@@ -973,8 +973,7 @@
                   "name": "SplitBy",
                   "label": "Split by",
                   "type": 2,
-                  "isRequired": true,
-                  "query": "InsightsMetrics\r\n| extend Tags = todynamic(Tags)\r\n| where Computer =~ '{Computer}'\r\n{Metric}\r\n| take 10\r\n| project Keys = bag_keys(Tags)\r\n| mvexpand Keys\r\n| summarize by label = tostring(Keys)\r\n| project value = strcat('by Split = tostring(Tags[\"', label, '\"])'), label = replace('vm.azm.ms/', '', label), selected = false\r\n| union (datatable(value:string, label:string, selected: boolean)[\r\n    \"by Computer\", \"Computer\", true\r\n])",
+                  "query": "InsightsMetrics\r\n| extend Tags = todynamic(Tags)\r\n| where Computer =~ '{Computer}'\r\n{Metric}\r\n| take 10\r\n| project Keys = bag_keys(Tags)\r\n| mvexpand Keys\r\n| summarize by label = tostring(Keys)\r\n| project value = strcat('by Split = tostring(Tags[\"', label, '\"])'), label = replace('vm.azm.ms/', '', label), selected = true\r\n",
                   "crossComponentResources": [
                     "{Workspace}"
                   ],
@@ -988,6 +987,36 @@
                   "timeContextFromParameter": "TimeRange",
                   "queryType": 0,
                   "resourceType": "microsoft.operationalinsights/workspaces"
+                },
+                {
+                  "id": "1358fefc-333a-477b-973d-9926da5c852e",
+                  "version": "KqlParameterItem/1.0",
+                  "name": "SplitByValue",
+                  "type": 1,
+                  "isRequired": true,
+                  "isHiddenWhenLocked": true,
+                  "criteriaData": [
+                    {
+                      "criteriaContext": {
+                        "leftOperand": "SplitBy",
+                        "operator": "isNotNull",
+                        "resultValType": "param",
+                        "resultVal": "SplitBy"
+                      }
+                    },
+                    {
+                      "criteriaContext": {
+                        "operator": "Default",
+                        "rightValType": "param",
+                        "resultValType": "static",
+                        "resultVal": "by Computer"
+                      }
+                    }
+                  ],
+                  "timeContext": {
+                    "durationMs": 14400000
+                  },
+                  "timeContextFromParameter": "TimeRange"
                 }
               ],
               "style": "above",
@@ -1003,7 +1032,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "InsightsMetrics\n| extend Tags = todynamic(Tags)\n| where Computer =~ '{Computer}'\n| where Tags.sql_instance == '{SqlInstance}' or Tags.sql_instance == ''\n{Metric}\n| make-series Trend = {Aggregation} default = 0 on TimeGenerated from {TimeRange:start} to {TimeRange:end} step {TimeRange:grain} {SplitBy}\n",
+              "query": "InsightsMetrics\n| extend Tags = todynamic(Tags)\n| where Computer =~ '{Computer}'\n| where Tags.sql_instance == '{SqlInstance}' or Tags.sql_instance == ''\n{Metric}\n| make-series Trend = {Aggregation} default = 0 on TimeGenerated from {TimeRange:start} to {TimeRange:end} step {TimeRange:grain} {SplitByValue}\n",
               "size": 0,
               "aggregation": 3,
               "showAnalytics": true,

--- a/Workbooks/Workloads-AMA/Azure SQL Managed Instance/Azure SQL Managed Instance.workbook
+++ b/Workbooks/Workloads-AMA/Azure SQL Managed Instance/Azure SQL Managed Instance.workbook
@@ -926,9 +926,6 @@
             "type": 9,
             "content": {
               "version": "KqlParameterItem/1.0",
-              "crossComponentResources": [
-                "{Workspace}"
-              ],
               "parameters": [
                 {
                   "id": "d96a773c-653b-468b-bba0-33925dabe752",
@@ -936,7 +933,7 @@
                   "name": "Metric",
                   "type": 2,
                   "isRequired": true,
-                  "query": "InsightsMetrics\n| where Computer =~ '{Computer}'\n| where Namespace !in ('sqlserver_performance')\n| summarize by Namespace, Name\n| project value = strcat('| where Namespace == \"', Namespace, '\" and Name == \"', Name, '\"'), label = Name, group = Namespace\n| union (InsightsMetrics\n    | where Computer =~ '{Computer}'\n    | where Namespace == 'sqlserver_performance'\n    | summarize by Namespace, Name, Counter = tostring(todynamic(Tags).counter)\n    | project value = strcat('| where Namespace == \"', Namespace, '\" and Tags.counter == \"', Counter, '\"'), label = Counter, group = \"Sql performance counters\")\n| order by group asc, label asc\n| extend Row = row_number()\n| project value, label, selected = Row == 1, group",
+                  "query": "InsightsMetrics\n| extend Tags = todynamic(Tags)\n| extend SqlInstance = tostring(Tags.sql_instance)\n| where Computer =~ '{Computer}'\n| where Namespace !in ('sqlserver_performance')\n| where SqlInstance == '{SqlInstance}'\n| summarize by Namespace, Name\n| project value = strcat('| where Namespace == \"', Namespace, '\" and Name == \"', Name, '\"'), label = Name, group = Namespace\n| order by group asc, label asc\n| extend Row = row_number()\n| project value, label, selected = Row == 1, group",
                   "crossComponentResources": [
                     "{Workspace}"
                   ],
@@ -1009,7 +1006,7 @@
                         "operator": "Default",
                         "rightValType": "param",
                         "resultValType": "static",
-                        "resultVal": "by Computer"
+                        "resultVal": "//"
                       }
                     }
                   ],
@@ -1023,7 +1020,7 @@
               "queryType": 0,
               "resourceType": "microsoft.operationalinsights/workspaces"
             },
-            "name": "parameters - 1",
+            "name": "Metric Selectors",
             "styleSettings": {
               "margin": "15px 0 10px 0"
             }

--- a/Workbooks/Workloads-AMA/Azure SQL Managed Instances/Azure SQL Managed Instances.workbook
+++ b/Workbooks/Workloads-AMA/Azure SQL Managed Instances/Azure SQL Managed Instances.workbook
@@ -1494,7 +1494,7 @@
               "queryType": 0,
               "resourceType": "microsoft.operationalinsights/workspaces"
             },
-            "name": "Metrics Selectors",
+            "name": "Metric selectors",
             "styleSettings": {
               "margin": "15px 0 10px 0"
             }

--- a/Workbooks/Workloads-AMA/Azure SQL Managed Instances/Azure SQL Managed Instances.workbook
+++ b/Workbooks/Workloads-AMA/Azure SQL Managed Instances/Azure SQL Managed Instances.workbook
@@ -1406,7 +1406,7 @@
                   "name": "Metric",
                   "type": 2,
                   "isRequired": true,
-                  "query": "InsightsMetrics\n| where (Computer in ({OnboardedComputers}) or '*' in ({OnboardedComputers}))  \n| where Namespace !in ('sqlserver_performance')\n| summarize by Namespace, Name\n| project value = strcat('| where Namespace == \"', Namespace, '\" and Name == \"', Name, '\"'), label = Name, group = Namespace\n| union (InsightsMetrics\n    | where (Computer in ({OnboardedComputers}) or '*' in ({OnboardedComputers}))  \n    | where Namespace == 'sqlserver_performance'\n    | summarize by Namespace, Name, Counter = tostring(todynamic(Tags).counter)\n    | project value = strcat('| where Namespace == \"', Namespace, '\" and Tags.counter == \"', Counter, '\"'), label = Counter, group = \"Sql performance counters\")\n| order by group asc, label asc\n| extend Row = row_number()\n| project value, label, selected = Row == 1, group",
+                  "query": "InsightsMetrics\n| extend Tags = todynamic(Tags)\n| extend SqlInstance = tostring(Tags.sql_instance)\n| where (Computer in ({OnboardedComputers}) or '*' in ({OnboardedComputers}))  \n| where Namespace !in ('sqlserver_performance')\n| where SqlInstance in ({SqlServers})\n| summarize by Namespace, Name\n| project value = strcat('| where Namespace == \"', Namespace, '\" and Name == \"', Name, '\"'), label = Name, group = Namespace\n| order by group asc, label asc\n| extend Row = row_number()\n| project value, label, selected = Row == 1, group",
                   "crossComponentResources": [
                     "{Workspaces}"
                   ],
@@ -1415,7 +1415,7 @@
                     "showDefault": false
                   },
                   "timeContext": {
-                    "durationMs": 86400000
+                    "durationMs": 0
                   },
                   "timeContextFromParameter": "TimeRange",
                   "queryType": 0,
@@ -1443,8 +1443,7 @@
                   "name": "SplitBy",
                   "label": "Split by",
                   "type": 2,
-                  "isRequired": true,
-                  "query": "InsightsMetrics\r\n| extend Tags = todynamic(Tags)\r\n| where (Computer in ({OnboardedComputers}) or '*' in ({OnboardedComputers}))\r\n{Metric}\r\n| take 10\r\n| project Keys = bag_keys(Tags)\r\n| mvexpand Keys\r\n| summarize by label = tostring(Keys)\r\n| extend value = case(label in ('counter', 'database_name', 'instance', 'object'), strcat('by Split = strcat(Tags[\"sql_instance\"], \"/\", Tags[\"', label, '\"])'), strcat('by Split = tostring(Tags[\"', label, '\"])'))\r\n| project value, label = replace('vm.azm.ms/', '', label), selected = false\r\n| union (datatable(value:string, label:string, selected: boolean)[\r\n    \"by Computer\", \"Computer\", true\r\n])",
+                  "query": "InsightsMetrics\r\n| extend Tags = todynamic(Tags)\r\n| where (Computer in ({OnboardedComputers}) or '*' in ({OnboardedComputers}))\r\n{Metric}\r\n| take 10\r\n| project Keys = bag_keys(Tags)\r\n| mvexpand Keys\r\n| summarize by label = tostring(Keys)\r\n| extend value = case(label in ('counter', 'database_name', 'instance', 'object'), strcat('by Split = strcat(Tags[\"sql_instance\"], \"/\", Tags[\"', label, '\"])'), strcat('by Split = tostring(Tags[\"', label, '\"])'))\r\n| project value, label = replace('vm.azm.ms/', '', label), selected = true",
                   "crossComponentResources": [
                     "{Workspaces}"
                   ],
@@ -1453,18 +1452,49 @@
                     "showDefault": false
                   },
                   "timeContext": {
-                    "durationMs": 86400000
+                    "durationMs": 0
                   },
                   "timeContextFromParameter": "TimeRange",
                   "queryType": 0,
                   "resourceType": "microsoft.operationalinsights/workspaces"
+                },
+                {
+                  "id": "2e618e97-18c4-4885-b551-4b2ecdc140a5",
+                  "version": "KqlParameterItem/1.0",
+                  "name": "SplitByValue",
+                  "type": 1,
+                  "isRequired": true,
+                  "isHiddenWhenLocked": true,
+                  "criteriaData": [
+                    {
+                      "criteriaContext": {
+                        "leftOperand": "SplitBy",
+                        "operator": "isNotNull",
+                        "rightValType": "param",
+                        "resultValType": "param",
+                        "resultVal": "SplitBy"
+                      }
+                    },
+                    {
+                      "criteriaContext": {
+                        "operator": "Default",
+                        "rightValType": "param",
+                        "resultValType": "static",
+                        "resultVal": "//"
+                      }
+                    }
+                  ],
+                  "timeContext": {
+                    "durationMs": 14400000
+                  },
+                  "timeContextFromParameter": "TimeRange"
                 }
               ],
               "style": "above",
               "queryType": 0,
               "resourceType": "microsoft.operationalinsights/workspaces"
             },
-            "name": "parameters - 1",
+            "name": "Metrics Selectors",
             "styleSettings": {
               "margin": "15px 0 10px 0"
             }

--- a/Workbooks/Workloads-AMA/Azure SQL database/Azure SQL database.workbook
+++ b/Workbooks/Workloads-AMA/Azure SQL database/Azure SQL database.workbook
@@ -1108,7 +1108,7 @@
                         "operator": "Default",
                         "rightValType": "param",
                         "resultValType": "static",
-                        "resultVal": "by Computer"
+                        "resultVal": "//"
                       }
                     }
                   ],

--- a/Workbooks/Workloads-AMA/Azure SQL database/Azure SQL database.workbook
+++ b/Workbooks/Workloads-AMA/Azure SQL database/Azure SQL database.workbook
@@ -1035,7 +1035,7 @@
                   "name": "Metric",
                   "type": 2,
                   "isRequired": true,
-                  "query": "InsightsMetrics\n| where Computer =~ '{Computer}'\n| where Namespace !in ('sqlserver_performance')\n| summarize by Namespace, Name\n| project value = strcat('| where Namespace == \"', Namespace, '\" and Name == \"', Name, '\"'), label = Name, group = Namespace\n| union (InsightsMetrics\n    | where Computer =~ '{Computer}'\n    | where Namespace == 'sqlserver_performance'\n    | summarize by Namespace, Name, Counter = tostring(todynamic(Tags).counter)\n    | project value = strcat('| where Namespace == \"', Namespace, '\" and Tags.counter == \"', Counter, '\"'), label = Counter, group = \"Sql performance counters\")\n| order by group asc, label asc\n| extend Row = row_number()\n| project value, label, selected = Row == 1, group",
+                  "query": "InsightsMetrics\n| extend Tags = todynamic(Tags)\n| extend SqlInstance = tostring(Tags.sql_instance), Database = tostring(Tags.database_name)\n| where Computer =~ '{Computer}'\n| where Namespace !in ('sqlserver_performance') and SqlInstance == '{SqlInstance}' and Database == '{SqlDatabase}'\n| summarize by Namespace, Name\n| project value = strcat('| where Namespace == \"', Namespace, '\" and Name == \"', Name, '\"'), label = Name, group = Namespace\n| order by group asc, label asc\n| extend Row = row_number()\n| project value, label, group, selected = Row == 1",
                   "crossComponentResources": [
                     "{Workspace}"
                   ],
@@ -1122,7 +1122,7 @@
               "queryType": 0,
               "resourceType": "microsoft.operationalinsights/workspaces"
             },
-            "name": "parameters - 1",
+            "name": "Metric Selectors",
             "styleSettings": {
               "margin": "15px 0 10px 0"
             }

--- a/Workbooks/Workloads-AMA/Azure SQL database/Azure SQL database.workbook
+++ b/Workbooks/Workloads-AMA/Azure SQL database/Azure SQL database.workbook
@@ -1122,7 +1122,7 @@
               "queryType": 0,
               "resourceType": "microsoft.operationalinsights/workspaces"
             },
-            "name": "Metric Selectors",
+            "name": "Metric selectors",
             "styleSettings": {
               "margin": "15px 0 10px 0"
             }

--- a/Workbooks/Workloads-AMA/Azure SQL database/Azure SQL database.workbook
+++ b/Workbooks/Workloads-AMA/Azure SQL database/Azure SQL database.workbook
@@ -1072,8 +1072,7 @@
                   "name": "SplitBy",
                   "label": "Split by",
                   "type": 2,
-                  "isRequired": true,
-                  "query": "InsightsMetrics\r\n| extend Tags = todynamic(Tags)\r\n| where Computer =~ '{Computer}'\r\n{Metric}\r\n| take 10\r\n| project Keys = bag_keys(Tags)\r\n| mvexpand Keys\r\n| summarize by label = tostring(Keys)\r\n| project value = strcat('by Split = tostring(Tags[\"', label, '\"])'), label = replace('vm.azm.ms/', '', label), selected = false\r\n| union (datatable(value:string, label:string, selected: boolean)[\r\n    \"by Computer\", \"Computer\", true\r\n])",
+                  "query": "InsightsMetrics\r\n| extend Tags = todynamic(Tags)\r\n| where Computer =~ '{Computer}'\r\n{Metric}\r\n| take 10\r\n| project Keys = bag_keys(Tags)\r\n| mvexpand Keys\r\n| summarize by label = tostring(Keys)\r\n| project value = strcat('by Split = tostring(Tags[\"', label, '\"])'), label = replace('vm.azm.ms/', '', label), selected = true\r\n",
                   "crossComponentResources": [
                     "{Workspace}"
                   ],
@@ -1087,6 +1086,36 @@
                   "timeContextFromParameter": "TimeRange",
                   "queryType": 0,
                   "resourceType": "microsoft.operationalinsights/workspaces"
+                },
+                {
+                  "id": "1358fefc-333a-477b-973d-9926da5c852e",
+                  "version": "KqlParameterItem/1.0",
+                  "name": "SplitByValue",
+                  "type": 1,
+                  "isRequired": true,
+                  "isHiddenWhenLocked": true,
+                  "criteriaData": [
+                    {
+                      "criteriaContext": {
+                        "leftOperand": "SplitBy",
+                        "operator": "isNotNull",
+                        "resultValType": "param",
+                        "resultVal": "SplitBy"
+                      }
+                    },
+                    {
+                      "criteriaContext": {
+                        "operator": "Default",
+                        "rightValType": "param",
+                        "resultValType": "static",
+                        "resultVal": "by Computer"
+                      }
+                    }
+                  ],
+                  "timeContext": {
+                    "durationMs": 14400000
+                  },
+                  "timeContextFromParameter": "TimeRange"
                 }
               ],
               "style": "above",

--- a/Workbooks/Workloads-AMA/Azure SQL databases/Azure SQL databases.workbook
+++ b/Workbooks/Workloads-AMA/Azure SQL databases/Azure SQL databases.workbook
@@ -16,7 +16,6 @@
             "label": "Monitoring profile",
             "type": 5,
             "isRequired": true,
-            "value": "/subscriptions/8980832b-9589-4ac2-b322-a6ae6a97f02b/resourceGroups/aruna-dcr-rg/providers/Microsoft.Insights/dataCollectionRules/aruna-sql-profile-8",
             "isHiddenWhenLocked": true,
             "typeSettings": {
               "additionalResourceOptions": [],
@@ -1253,7 +1252,7 @@
                   "name": "Metric",
                   "type": 2,
                   "isRequired": true,
-                  "query": "InsightsMetrics\n| where (Computer in ({OnboardedComputers}) or '*' in ({OnboardedComputers}))  \n| where Namespace !in ('sqlserver_performance')\n| summarize by Namespace, Name\n| project value = strcat('| where Namespace == \"', Namespace, '\" and Name == \"', Name, '\"'), label = Name, group = Namespace\n| union (InsightsMetrics\n    | where (Computer in ({OnboardedComputers}) or '*' in ({OnboardedComputers}))  \n    | where Namespace == 'sqlserver_performance'\n    | summarize by Namespace, Name, Counter = tostring(todynamic(Tags).counter)\n    | project value = strcat('| where Namespace == \"', Namespace, '\" and Tags.counter == \"', Counter, '\"'), label = Counter, group = \"Sql performance counters\")\n| order by group asc, label asc\n| extend Row = row_number()\n| project value, label, selected = Row == 1, group",
+                  "query": "InsightsMetrics\n| extend Tags = todynamic(Tags)\n| extend SqlInstance = tostring(Tags.sql_instance)\n| where (Computer in ({OnboardedComputers}) or '*' in ({OnboardedComputers}))  \n| where Namespace !in ('sqlserver_performance')\n| where SqlInstance in ({SqlServers})\n| summarize by Namespace, Name\n| project value = strcat('| where Namespace == \"', Namespace, '\" and Name == \"', Name, '\"'), label = Name, group = Namespace\n| order by group asc, label asc\n| extend Row = row_number()\n| project value, label, selected = Row == 1, group",
                   "crossComponentResources": [
                     "{Workspaces}"
                   ],
@@ -1262,7 +1261,7 @@
                     "showDefault": false
                   },
                   "timeContext": {
-                    "durationMs": 86400000
+                    "durationMs": 0
                   },
                   "timeContextFromParameter": "TimeRange",
                   "queryType": 0,
@@ -1290,8 +1289,7 @@
                   "name": "SplitBy",
                   "label": "Split by",
                   "type": 2,
-                  "isRequired": true,
-                  "query": "InsightsMetrics\r\n| extend Tags = todynamic(Tags)\r\n| where (Computer in ({OnboardedComputers}) or '*' in ({OnboardedComputers}))\r\n{Metric}\r\n| take 10\r\n| project Keys = bag_keys(Tags)\r\n| mvexpand Keys\r\n| summarize by label = tostring(Keys)\r\n| extend value = case(label in ('counter', 'database_name', 'instance', 'object'), strcat('by Split = strcat(Tags[\"sql_instance\"], \"/\", Tags[\"', label, '\"])'), strcat('by Split = tostring(Tags[\"', label, '\"])'))\r\n| project value, label = replace('vm.azm.ms/', '', label), selected = false\r\n| union (datatable(value:string, label:string, selected: boolean)[\r\n    \"by Computer\", \"Computer\", true\r\n])",
+                  "query": "InsightsMetrics\r\n| extend Tags = todynamic(Tags)\r\n| where (Computer in ({OnboardedComputers}) or '*' in ({OnboardedComputers}))\r\n{Metric}\r\n| take 10\r\n| project Keys = bag_keys(Tags)\r\n| mvexpand Keys\r\n| summarize by label = tostring(Keys)\r\n| extend value = case(label in ('counter', 'database_name', 'instance', 'object'), strcat('by Split = strcat(Tags[\"sql_instance\"], \"/\", Tags[\"', label, '\"])'), strcat('by Split = tostring(Tags[\"', label, '\"])'))\r\n| project value, label = replace('vm.azm.ms/', '', label), selected = true",
                   "crossComponentResources": [
                     "{Workspaces}"
                   ],
@@ -1300,18 +1298,49 @@
                     "showDefault": false
                   },
                   "timeContext": {
-                    "durationMs": 86400000
+                    "durationMs": 0
                   },
                   "timeContextFromParameter": "TimeRange",
                   "queryType": 0,
                   "resourceType": "microsoft.operationalinsights/workspaces"
+                },
+                {
+                  "id": "2e618e97-18c4-4885-b551-4b2ecdc140a5",
+                  "version": "KqlParameterItem/1.0",
+                  "name": "SplitByValue",
+                  "type": 1,
+                  "isRequired": true,
+                  "isHiddenWhenLocked": true,
+                  "criteriaData": [
+                    {
+                      "criteriaContext": {
+                        "leftOperand": "SplitBy",
+                        "operator": "isNotNull",
+                        "rightValType": "param",
+                        "resultValType": "param",
+                        "resultVal": "SplitBy"
+                      }
+                    },
+                    {
+                      "criteriaContext": {
+                        "operator": "Default",
+                        "rightValType": "param",
+                        "resultValType": "static",
+                        "resultVal": "//"
+                      }
+                    }
+                  ],
+                  "timeContext": {
+                    "durationMs": 14400000
+                  },
+                  "timeContextFromParameter": "TimeRange"
                 }
               ],
               "style": "above",
               "queryType": 0,
               "resourceType": "microsoft.operationalinsights/workspaces"
             },
-            "name": "parameters - 1",
+            "name": "Metrics selectors",
             "styleSettings": {
               "margin": "15px 0 10px 0"
             }
@@ -1320,7 +1349,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "InsightsMetrics\n| extend Tags = todynamic(Tags)\n| where (Computer in ({OnboardedComputers}) or '*' in ({OnboardedComputers})) \n| where Tags.sql_instance in ({SqlServers}) or '*' in ({SqlServers})\n{Metric}\n| make-series Trend = {Aggregation} default = 0 on TimeGenerated from {TimeRange:start} to {TimeRange:end} step {TimeRange:grain} {SplitBy}\n",
+              "query": "InsightsMetrics\n| extend Tags = todynamic(Tags)\n| where (Computer in ({OnboardedComputers}) or '*' in ({OnboardedComputers})) \n| where Tags.sql_instance in ({SqlServers}) or '*' in ({SqlServers})\n{Metric}\n| make-series Trend = {Aggregation} default = 0 on TimeGenerated from {TimeRange:start} to {TimeRange:end} step {TimeRange:grain} {SplitByValue}\n",
               "size": 0,
               "aggregation": 3,
               "showAnalytics": true,

--- a/Workbooks/Workloads-AMA/Azure SQL databases/Azure SQL databases.workbook
+++ b/Workbooks/Workloads-AMA/Azure SQL databases/Azure SQL databases.workbook
@@ -1340,7 +1340,7 @@
               "queryType": 0,
               "resourceType": "microsoft.operationalinsights/workspaces"
             },
-            "name": "Metrics selectors",
+            "name": "Metric selectors",
             "styleSettings": {
               "margin": "15px 0 10px 0"
             }

--- a/Workbooks/Workloads-AMA/SQL Server/SQL Server.workbook
+++ b/Workbooks/Workloads-AMA/SQL Server/SQL Server.workbook
@@ -2705,9 +2705,6 @@
             "type": 9,
             "content": {
               "version": "KqlParameterItem/1.0",
-              "crossComponentResources": [
-                "{Workspace}"
-              ],
               "parameters": [
                 {
                   "id": "d96a773c-653b-468b-bba0-33925dabe752",
@@ -2715,7 +2712,7 @@
                   "name": "Metric",
                   "type": 2,
                   "isRequired": true,
-                  "query": "InsightsMetrics\n| where Computer =~ '{Computer}'\n| where Namespace !in ('sqlserver_performance')\n| summarize by Namespace, Name\n| project value = strcat('| where Namespace == \"', Namespace, '\" and Name == \"', Name, '\"'), label = Name, group = Namespace\n| union (InsightsMetrics\n    | where Computer =~ '{Computer}'\n    | where Namespace == 'sqlserver_performance'\n    | summarize by Namespace, Name, Counter = tostring(todynamic(Tags).counter)\n    | project value = strcat('| where Namespace == \"', Namespace, '\" and Tags.counter == \"', Counter, '\"'), label = Counter, group = \"Sql performance counters\")\n| order by group asc, label asc\n| extend Row = row_number()\n| project value, label, selected = Row == 1, group",
+                  "query": "InsightsMetrics\n| extend Tags = todynamic(Tags)\n| extend SqlInstance = tostring(Tags.sql_instance)\n| where Computer =~ '{Computer}'\n| where Namespace !in ('sqlserver_performance')\n| where SqlInstance == '{SqlInstance}'\n| summarize by Namespace, Name\n| project value = strcat('| where Namespace == \"', Namespace, '\" and Name == \"', Name, '\"'), label = Name, group = Namespace\n| union (InsightsMetrics\n    | extend Tags = todynamic(Tags)\n    | extend SqlInstance = tostring(Tags.sql_instance)\n    | where Computer =~ '{Computer}'\n    | where Namespace in ('sqlserver_performance')\n    | where SqlInstance == '{SqlInstance}'\n    | summarize by Namespace, Name, Counter = tostring(todynamic(Tags).counter)\n    | project value = strcat('| where Namespace == \"', Namespace, '\" and Tags.counter == \"', Counter, '\"'), label = Counter, group = \"Sql performance counters\")\n| order by group asc, label asc\n| extend Row = row_number()\n| project value, label, selected = Row == 1, group",
                   "crossComponentResources": [
                     "{Workspace}"
                   ],
@@ -2788,7 +2785,7 @@
                         "operator": "Default",
                         "rightValType": "param",
                         "resultValType": "static",
-                        "resultVal": "by Computer"
+                        "resultVal": "//"
                       }
                     }
                   ],

--- a/Workbooks/Workloads-AMA/SQL Server/SQL Server.workbook
+++ b/Workbooks/Workloads-AMA/SQL Server/SQL Server.workbook
@@ -2752,8 +2752,7 @@
                   "name": "SplitBy",
                   "label": "Split by",
                   "type": 2,
-                  "isRequired": true,
-                  "query": "InsightsMetrics\r\n| extend Tags = todynamic(Tags)\r\n| where Computer =~ '{Computer}'\r\n{Metric}\r\n| take 10\r\n| project Keys = bag_keys(Tags)\r\n| mvexpand Keys\r\n| summarize by label = tostring(Keys)\r\n| project value = strcat('by Split = tostring(Tags[\"', label, '\"])'), label = replace('vm.azm.ms/', '', label), selected = false\r\n| union (datatable(value:string, label:string, selected: boolean)[\r\n    \"by Computer\", \"Computer\", true\r\n])",
+                  "query": "InsightsMetrics\r\n| extend Tags = todynamic(Tags)\r\n| where Computer =~ '{Computer}'\r\n{Metric}\r\n| take 10\r\n| project Keys = bag_keys(Tags)\r\n| mvexpand Keys\r\n| summarize by label = tostring(Keys)\r\n| project value = strcat('by Split = tostring(Tags[\"', label, '\"])'), label = replace('vm.azm.ms/', '', label), selected = true\r\n",
                   "crossComponentResources": [
                     "{Workspace}"
                   ],
@@ -2767,6 +2766,36 @@
                   "timeContextFromParameter": "TimeRange",
                   "queryType": 0,
                   "resourceType": "microsoft.operationalinsights/workspaces"
+                },
+                {
+                  "id": "1358fefc-333a-477b-973d-9926da5c852e",
+                  "version": "KqlParameterItem/1.0",
+                  "name": "SplitByValue",
+                  "type": 1,
+                  "isRequired": true,
+                  "isHiddenWhenLocked": true,
+                  "criteriaData": [
+                    {
+                      "criteriaContext": {
+                        "leftOperand": "SplitBy",
+                        "operator": "isNotNull",
+                        "resultValType": "param",
+                        "resultVal": "SplitBy"
+                      }
+                    },
+                    {
+                      "criteriaContext": {
+                        "operator": "Default",
+                        "rightValType": "param",
+                        "resultValType": "static",
+                        "resultVal": "by Computer"
+                      }
+                    }
+                  ],
+                  "timeContext": {
+                    "durationMs": 14400000
+                  },
+                  "timeContextFromParameter": "TimeRange"
                 }
               ],
               "style": "above",

--- a/Workbooks/Workloads-AMA/SQL Servers/SQL Servers.workbook
+++ b/Workbooks/Workloads-AMA/SQL Servers/SQL Servers.workbook
@@ -2839,10 +2839,10 @@
                   ],
                   "finalBy": "Database"
                 },
-                "sortBy": [              
-                  {	
-                    "itemKey": "$gen_heatmap_DataReadBytes|DataWriteBytes_3",	
-                    "sortOrder": 2	
+                "sortBy": [
+                  {
+                    "itemKey": "$gen_heatmap_DataReadBytes|DataWriteBytes_3",
+                    "sortOrder": 2
                   }
                 ],
                 "labelSettings": [
@@ -2886,10 +2886,10 @@
                   }
                 ]
               },
-              "sortBy": [              
-                {	
-                  "itemKey": "$gen_heatmap_DataReadBytes|DataWriteBytes_3",	
-                  "sortOrder": 2	
+              "sortBy": [
+                {
+                  "itemKey": "$gen_heatmap_DataReadBytes|DataWriteBytes_3",
+                  "sortOrder": 2
                 }
               ],
               "tileSettings": {
@@ -2960,7 +2960,7 @@
                   "name": "Metric",
                   "type": 2,
                   "isRequired": true,
-                  "query": "InsightsMetrics\n| where (Computer in ({OnboardedComputers}) or '*' in ({OnboardedComputers}))  \n| where Namespace !in ('sqlserver_performance')\n| summarize by Namespace, Name\n| project value = strcat('| where Namespace == \"', Namespace, '\" and Name == \"', Name, '\"'), label = Name, group = Namespace\n| union (InsightsMetrics\n    | where (Computer in ({OnboardedComputers}) or '*' in ({OnboardedComputers}))  \n    | where Namespace == 'sqlserver_performance'\n    | summarize by Namespace, Name, Counter = tostring(todynamic(Tags).counter)\n    | project value = strcat('| where Namespace == \"', Namespace, '\" and Tags.counter == \"', Counter, '\"'), label = Counter, group = \"Sql performance counters\")\n| order by group asc, label asc\n| extend Row = row_number()\n| project value, label, selected = Row == 1, group",
+                  "query": "InsightsMetrics\n| extend Tags = todynamic(Tags)\n| extend SqlServer = tostring(Tags.sql_instance)\n| where (Computer in ({OnboardedComputers}) or '*' in ({OnboardedComputers}))  \n| where Namespace !in ('sqlserver_performance')\n| where SqlServer in ({SqlServers})\n| summarize by Namespace, Name\n| project value = strcat('| where Namespace == \"', Namespace, '\" and Name == \"', Name, '\"'), label = Name, group = Namespace\n| union (InsightsMetrics\n    | extend Tags = todynamic(Tags)\n    | extend SqlServer = tostring(Tags.sql_instance)\n    | where (Computer in ({OnboardedComputers}) or '*' in ({OnboardedComputers}))  \n    | where Namespace =~ 'sqlserver_performance'\n    | where SqlServer in ({SqlServers})\n    | summarize by Namespace, Name, Counter = tostring(todynamic(Tags).counter)\n    | project value = strcat('| where Namespace == \"', Namespace, '\" and Tags.counter == \"', Counter, '\"'), label = Counter, group = \"Sql performance counters\")\n| order by group asc, label asc\n| extend Row = row_number()\n| project value, label, selected = Row == 1, group",
                   "crossComponentResources": [
                     "{Workspaces}"
                   ],
@@ -2997,8 +2997,7 @@
                   "name": "SplitBy",
                   "label": "Split by",
                   "type": 2,
-                  "isRequired": true,
-                  "query": "InsightsMetrics\r\n| extend Tags = todynamic(Tags)\r\n| where (Computer in ({OnboardedComputers}) or '*' in ({OnboardedComputers}))\r\n{Metric}\r\n| take 10\r\n| project Keys = bag_keys(Tags)\r\n| mvexpand Keys\r\n| summarize by label = tostring(Keys)\r\n| extend value = case(label in ('counter', 'database_name', 'instance', 'object'), strcat('by Split = strcat(Tags[\"sql_instance\"], \"/\", Tags[\"', label, '\"])'), strcat('by Split = tostring(Tags[\"', label, '\"])'))\r\n| project value, label = replace('vm.azm.ms/', '', label), selected = false\r\n| union (datatable(value:string, label:string, selected: boolean)[\r\n    \"by Computer\", \"Computer\", true\r\n])",
+                  "query": "InsightsMetrics\r\n| extend Tags = todynamic(Tags)\r\n| where (Computer in ({OnboardedComputers}) or '*' in ({OnboardedComputers}))\r\n{Metric}\r\n| take 10\r\n| project Keys = bag_keys(Tags)\r\n| mvexpand Keys\r\n| summarize by label = tostring(Keys)\r\n| extend value = case(label in ('counter', 'database_name', 'instance', 'object'), strcat('by Split = strcat(Tags[\"sql_instance\"], \"/\", Tags[\"', label, '\"])'), strcat('by Split = tostring(Tags[\"', label, '\"])'))\r\n| project value, label = replace('vm.azm.ms/', '', label), selected = true",
                   "crossComponentResources": [
                     "{Workspaces}"
                   ],
@@ -3012,13 +3011,41 @@
                   "timeContextFromParameter": "TimeRange",
                   "queryType": 0,
                   "resourceType": "microsoft.operationalinsights/workspaces"
+                },
+                {
+                  "id": "f6dbed75-a152-4906-a04c-2b9989624538",
+                  "version": "KqlParameterItem/1.0",
+                  "name": "SplitByValue",
+                  "type": 1,
+                  "isRequired": true,
+                  "isHiddenWhenLocked": true,
+                  "criteriaData": [
+                    {
+                      "criteriaContext": {
+                        "leftOperand": "SplitBy",
+                        "operator": "isNotNull",
+                        "rightValType": "param",
+                        "resultValType": "param",
+                        "resultVal": "SplitBy"
+                      }
+                    },
+                    {
+                      "criteriaContext": {
+                        "operator": "Default",
+                        "rightValType": "param",
+                        "resultValType": "static",
+                        "resultVal": "//"
+                      }
+                    }
+                  ],
+                  "timeContextFromParameter": "TimeRange"
                 }
               ],
               "style": "above",
               "queryType": 0,
               "resourceType": "microsoft.operationalinsights/workspaces"
             },
-            "name": "parameters - 1",
+            "name": "Metric selectors",
             "styleSettings": {
               "margin": "15px 0 10px 0"
             }
@@ -3027,7 +3054,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "InsightsMetrics\n| extend Tags = todynamic(Tags)\n| where (Computer in ({OnboardedComputers}) or '*' in ({OnboardedComputers})) \n| where Tags.sql_instance in ({SqlServers}) or '*' in ({SqlServers})\n{Metric}\n| make-series Trend = {Aggregation} default = 0 on TimeGenerated from {TimeRange:start} to {TimeRange:end} step {TimeRange:grain} {SplitBy}\n",
+              "query": "InsightsMetrics\n| extend Tags = todynamic(Tags)\n| where (Computer in ({OnboardedComputers}) or '*' in ({OnboardedComputers})) \n| where Tags.sql_instance in ({SqlServers}) or '*' in ({SqlServers})\n{Metric}\n| make-series Trend = {Aggregation} default = 0 on TimeGenerated from {TimeRange:start} to {TimeRange:end} step {TimeRange:grain} {SplitByValue}\n",
               "size": 0,
               "aggregation": 3,
               "showAnalytics": true,


### PR DESCRIPTION
- Remove 'Computer' as a split by options
- remove namespace 'sqlserver_performance' metrics from Azure SQL Dbs and Azure SQL MI
- only show the metrics applicable

## PR Checklist

* [x] Explain your changes, so people looking at the PR know *what* and *why*, the code changes are the *how*.

### If adding or updating templates:
* [x] post a screenshot of templates and/or gallery changes
* [x] ensure all steps have meaningful names
* [x] ensure all parameters and grid columns have display names set so they can be localized
* [x] ensure that parameters id values are unique __or they will fail PR validation__ (parameter ids are used for localization)
* [x] ensure that steps names are unique __or they will fail PR validation__ (step names are used for localization)
* [x] grep `/subscription/` and ensure that your parameters don't have any hardcoded resourceIds __or they will fail PR validation__
* [x] remove `fallbackResourceIds` and `fromTemplateId` fields from your template workbook __or they will fail PR validation__