### PR TITLE
use constant for telegraf user id

### DIFF
--- a/Workbooks/Workloads-AMA/Add monitoring virtual machine/Add monitoring virtual machine.workbook
+++ b/Workbooks/Workloads-AMA/Add monitoring virtual machine/Add monitoring virtual machine.workbook
@@ -164,7 +164,7 @@
             "label": "Connection strings",
             "type": 1,
             "isRequired": true,
-            "value": "{\n    \"version\": 1,\n    \"secrets\": {\n        \"telegrafPassword\": {\n            \"keyvault\": \"https://mykeyvault.vault.azure.net/\",\n            \"name\": \"sqlPassword\"\n        }\n    },\n    \"parameters\": {\n        \"telegrafUsername\": \"telegraf\",\n        \"sqlAzureConnections\": [\n            \"Server=mysqlserver.database.windows.net;Port=1433;Database=mydatabase;User Id=$telegrafUsername;Password=$telegrafPassword;\"\n        ],\n        \"sqlVmConnections\": [\n        ],\n        \"sqlManagedInstanceConnections\": [\n        ]\n    }\n}",
+            "value": "{\n    \"version\": 1,\n    \"secrets\": {\n        \"telegrafPassword\": {\n            \"keyvault\": \"https://mykeyvault.vault.azure.net/\",\n            \"name\": \"sqlPassword\"\n        }\n    },\n    \"parameters\": {\n        \"sqlAzureConnections\": [\n            \"Server=mysqlserver.database.windows.net;Port=1433;Database=mydatabase;User Id=telegraf;Password=$telegrafPassword;\"\n        ],\n        \"sqlVmConnections\": [\n        ],\n        \"sqlManagedInstanceConnections\": [\n        ]\n    }\n}",
             "typeSettings": {
               "multiLineText": true,
               "editorLanguage": "json",


### PR DESCRIPTION
- use constant for telegraf userid
![image](https://user-images.githubusercontent.com/7664931/101818860-5303bc00-3ad9-11eb-871f-84168fe8f396.png)

## PR Checklist

* [ ] Explain your changes, so people looking at the PR know *what* and *why*, the code changes are the *how*.

### If adding or updating templates:
* [ ] post a screenshot of templates and/or gallery changes
* [ ] ensure all steps have meaningful names
* [ ] ensure all parameters and grid columns have display names set so they can be localized
* [ ] ensure that parameters id values are unique __or they will fail PR validation__ (parameter ids are used for localization)
* [ ] ensure that steps names are unique __or they will fail PR validation__ (step names are used for localization)
* [ ] grep `/subscription/` and ensure that your parameters don't have any hardcoded resourceIds __or they will fail PR validation__
* [ ] remove `fallbackResourceIds` and `fromTemplateId` fields from your template workbook __or they will fail PR validation__