### PR TITLE
Workload Workbook PV Tab: Add back in column labels

### DIFF
--- a/Workbooks/AKS/Workload Details Persistent Volumes Tab/Workload Details Persistent Volumes Tab.workbook
+++ b/Workbooks/AKS/Workload Details Persistent Volumes Tab/Workload Details Persistent Volumes Tab.workbook
@@ -683,6 +683,30 @@
             {
               "columnId": "Computer",
               "label": "Node Name"
+            },
+            {
+              "columnId": "PVCName",
+              "label": "PVC Name"
+            },
+            {
+              "columnId": "CurrentUsage",
+              "label": "Usage"
+            },
+            {
+              "columnId": "Trend",
+              "label": "Usage Trend"
+            },
+            {
+              "columnId": "UsedAndCapacity",
+              "label": "Used / Capacity"
+            },
+            {
+              "columnId": "VolumeName",
+              "label": "Volume Name"
+            },
+            {
+              "columnId": "PodName",
+              "label": "Pod Name"
             }
           ]
         }


### PR DESCRIPTION
Column labels for the PV usage grid were accidentally deleted at some point. Adding back in.

## PR Checklist

* [x] Explain your changes, so people looking at the PR know *what* and *why*, the code changes are the *how*.

### If adding or updating templates:
* [ ] post a screenshot of templates and/or gallery changes
* [x] ensure all steps have meaningful names
* [x] ensure all parameters and grid columns have display names set so they can be localized
* [x] ensure that parameters id values are unique __or they will fail PR validation__ (parameter ids are used for localization)
* [x] ensure that steps names are unique __or they will fail PR validation__ (step names are used for localization)
* [x] grep `/subscription/` and ensure that your parameters don't have any hardcoded resourceIds __or they will fail PR validation__
* [x] remove `fallbackResourceIds` and `fromTemplateId` fields from your template workbook __or they will fail PR validation__