### PR TITLE
fix tsg error filter, selecting vm automatically

### DIFF
--- a/Workbooks/Workloads-AMA/Custom Telegraf/Enable monitoring/Enable monitoring.workbook
+++ b/Workbooks/Workloads-AMA/Custom Telegraf/Enable monitoring/Enable monitoring.workbook
@@ -456,6 +456,11 @@
                             "name": "CommonErrors",
                             "source": "parameter",
                             "value": "CommonErrors"
+                          },
+                          {
+                            "name": "VirtualMachine",
+                            "source": "column",
+                            "value": "Virtual machine"
                           }
                         ]
                       }

--- a/Workbooks/Workloads-AMA/Enable monitoring/Enable monitoring.workbook
+++ b/Workbooks/Workloads-AMA/Enable monitoring/Enable monitoring.workbook
@@ -457,6 +457,11 @@
                             "name": "CommonErrors",
                             "source": "parameter",
                             "value": "CommonErrors"
+                          },
+                          {
+                            "name": "VirtualMachine",
+                            "source": "column",
+                            "value": "Virtual machine"
                           }
                         ]
                       }

--- a/Workbooks/Workloads-AMA/Troubleshoot SQL logs/Troubleshoot SQL logs.workbook
+++ b/Workbooks/Workloads-AMA/Troubleshoot SQL logs/Troubleshoot SQL logs.workbook
@@ -7,6 +7,19 @@
         "version": "KqlParameterItem/1.0",
         "parameters": [
           {
+            "id": "6bfa7e76-409a-4310-a083-c1d03f338493",
+            "version": "KqlParameterItem/1.0",
+            "name": "VirtualMachine",
+            "type": 5,
+            "isRequired": true,
+            "value": null,
+            "isHiddenWhenLocked": true,
+            "typeSettings": {
+              "additionalResourceOptions": [],
+              "showDefault": false
+            }
+          },
+          {
             "id": "b27b8a61-5aac-4066-a8a4-1fea34c1481b",
             "version": "KqlParameterItem/1.0",
             "name": "MonitoringProfile",
@@ -55,7 +68,7 @@
             "label": "Monitoring Virtual Machine",
             "type": 5,
             "isRequired": true,
-            "query": "Resources\r\n| take 1\r\n| project associations = dynamic([{Associations}])\r\n| mvexpand associations limit 400\r\n| project id = tolower(extract(@'(?i)/subscriptions/.+/resourcegroups/.+/providers/microsoft.compute/virtualmachines/(.+)/providers/microsoft.insights/datacollectionruleassociations/.+', 1, tostring(associations)))\r\n| project value = id, label = id, selected = true\r\n\r\n",
+            "query": "Resources\r\n| take 1\r\n| project associations = dynamic([{Associations}])\r\n| mvexpand associations limit 400\r\n| project id = tolower(extract(@'(?i)/subscriptions/.+/resourcegroups/.+/providers/microsoft.compute/virtualmachines/(.+)/providers/microsoft.insights/datacollectionruleassociations/.+', 1, tostring(associations)))\r\n| project value = id, label = id, selected = id == '{VirtualMachine:name}'\r\n\r\n",
             "typeSettings": {
               "additionalResourceOptions": [],
               "showDefault": false
@@ -188,7 +201,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "Operation\n| where _ResourceId contains '{OnboardedComputers}'\n| where Detail !contains \"mssql: Incorrect syntax near ','.\"\n| where OperationStatus == \"Error\" or \"{LogsFilter}\" == \"All Logs\"\n| extend jk=1\n| join kind=leftouter (\n    datatable (CommonErrors:dynamic)[dynamic({CommonErrors})]\n    | mv-expand CommonErrors\n    | extend jk=1) on jk\n| extend ContainsCommonError = Detail contains CommonErrors.key\n| summarize by OperationStatus, Time = TimeGenerated, Message = Detail, Action = iff(ContainsCommonError, tostring(CommonErrors.action), \"\"), Description = iff(ContainsCommonError, tostring(CommonErrors.description), \"\")\n| order by Time, Message, Action desc\n| extend isValidRow = iff(Message == prev(Message) and Time == prev(Time), iff(Action != prev(Action) and isnotempty(Action), true, false), true)\n| where isValidRow\n| take 500",
+              "query": "Operation\n| where _ResourceId contains '{OnboardedComputers}'\n| where Detail !contains \"mssql: Incorrect syntax near ','.\"\n| where OperationStatus == \"Error\" or OperationStatus == \"Warning\" or \"{LogsFilter}\" == \"All Logs\"\n| extend jk=1\n| join kind=leftouter (\n    datatable (CommonErrors:dynamic)[dynamic({CommonErrors})]\n    | mv-expand CommonErrors\n    | extend jk=1) on jk\n| extend ContainsCommonError = Detail contains CommonErrors.key\n| summarize by OperationStatus, Time = TimeGenerated, Message = Detail, Action = iff(ContainsCommonError, tostring(CommonErrors.action), \"\"), Description = iff(ContainsCommonError, tostring(CommonErrors.description), \"\")\n| order by Time, Message, Action desc\n| extend isValidRow = iff(Message == prev(Message) and Time == prev(Time), iff(Action != prev(Action) and isnotempty(Action), true, false), true)\n| where isValidRow\n| take 500",
               "size": 2,
               "showAnalytics": true,
               "timeContext": {
@@ -215,6 +228,12 @@
                           "operator": "==",
                           "thresholdValue": "Error",
                           "representation": "3",
+                          "text": "{0}{1}"
+                        },
+                        {
+                          "operator": "==",
+                          "thresholdValue": "Warning",
+                          "representation": "2",
                           "text": "{0}{1}"
                         },
                         {


### PR DESCRIPTION
- error filter now shows warning+Error
- updated logs to include warning icon
- fix bug where if a monitoring profile has multiple VMS, select the correct vm that was used to open logs

## PR Checklist

* [ ] Explain your changes, so people looking at the PR know *what* and *why*, the code changes are the *how*.

### If adding or updating templates:
* [ ] post a screenshot of templates and/or gallery changes
* [ ] ensure all steps have meaningful names
* [ ] ensure all parameters and grid columns have display names set so they can be localized
* [ ] ensure that parameters id values are unique __or they will fail PR validation__ (parameter ids are used for localization)
* [ ] ensure that steps names are unique __or they will fail PR validation__ (step names are used for localization)
* [ ] grep `/subscription/` and ensure that your parameters don't have any hardcoded resourceIds __or they will fail PR validation__
* [ ] remove `fallbackResourceIds` and `fromTemplateId` fields from your template workbook __or they will fail PR validation__