### PR TITLE
Load existing wli config per vm

### DIFF
--- a/Workbooks/Workloads-AMA/Add monitoring virtual machine/Add monitoring virtual machine.workbook
+++ b/Workbooks/Workloads-AMA/Add monitoring virtual machine/Add monitoring virtual machine.workbook
@@ -156,6 +156,56 @@
       "type": 9,
       "content": {
         "version": "KqlParameterItem/1.0",
+        "crossComponentResources": [
+          "value::all"
+        ],
+        "parameters": [
+          {
+            "id": "ceb4f028-a3cb-4e49-b5f7-d018a660502d",
+            "version": "KqlParameterItem/1.0",
+            "name": "savedConfig",
+            "type": 1,
+            "isRequired": true,
+            "query": "Resources\r\n| where id startswith '{VmId}' and name =~ 'Workload.WLILinuxExtension' and type =~ 'microsoft.compute/virtualmachines/extensions'\r\n| project tostring(properties.settings.workloadConfig)",
+            "crossComponentResources": [
+              "value::all"
+            ],
+            "isHiddenWhenLocked": true,
+            "typeSettings": {
+              "multiLineText": true,
+              "editorLanguage": "json",
+              "multiLineHeight": 15,
+              "preFormatJsonData": true
+            },
+            "timeContext": {
+              "durationMs": 86400000
+            },
+            "queryType": 1,
+            "resourceType": "microsoft.resourcegraph/resources"
+          }
+        ],
+        "style": "above",
+        "queryType": 1,
+        "resourceType": "microsoft.resourcegraph/resources"
+      },
+      "name": "savedConfig"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "Please configure using the template below.",
+        "style": "info"
+      },
+      "conditionalVisibility": {
+        "parameterName": "savedConfig",
+        "comparison": "isEqualTo"
+      },
+      "name": "Saved config not found message"
+    },
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
         "parameters": [
           {
             "id": "ef5f9e5a-8298-4993-aa2d-bd20d69c8f3f",
@@ -179,8 +229,62 @@
         "queryType": 0,
         "resourceType": "microsoft.insights/datacollectionrules"
       },
+      "conditionalVisibility": {
+        "parameterName": "savedConfig",
+        "comparison": "isEqualTo"
+      },
       "customWidth": "90",
-      "name": "parameters - 4"
+      "name": "Connection strings"
+    },
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "parameters": [
+          {
+            "id": "4d03e768-7350-40c3-b44e-0eff614645ae",
+            "version": "KqlParameterItem/1.0",
+            "name": "Config",
+            "label": "Current monitoring configuration",
+            "type": 1,
+            "typeSettings": {
+              "multiLineText": true,
+              "editorLanguage": "json",
+              "multiLineHeight": 15
+            },
+            "criteriaData": [
+              {
+                "criteriaContext": {
+                  "leftOperand": "savedConfig",
+                  "operator": "isNotNull",
+                  "rightValType": "param",
+                  "resultValType": "param",
+                  "resultVal": "savedConfig"
+                }
+              },
+              {
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "param",
+                  "resultVal": "PerVmConfig"
+                }
+              }
+            ],
+            "timeContext": {
+              "durationMs": 86400000
+            }
+          }
+        ],
+        "style": "formVertical",
+        "queryType": 0,
+        "resourceType": "microsoft.compute/virtualmachines"
+      },
+      "conditionalVisibility": {
+        "parameterName": "savedConfig",
+        "comparison": "isNotEqualTo"
+      },
+      "name": "Final Config"
     },
     {
       "type": 1,
@@ -349,7 +453,7 @@
                 {
                   "name": "workloadconfig",
                   "source": "parameter",
-                  "value": "PerVmConfig",
+                  "value": "Config",
                   "kind": "objectValue"
                 },
                 {

--- a/Workbooks/Workloads-AMA/Custom Telegraf/Add monitoring virtual machine/Add monitoring virtual machine.workbook
+++ b/Workbooks/Workloads-AMA/Custom Telegraf/Add monitoring virtual machine/Add monitoring virtual machine.workbook
@@ -156,6 +156,56 @@
       "type": 9,
       "content": {
         "version": "KqlParameterItem/1.0",
+        "crossComponentResources": [
+          "value::all"
+        ],
+        "parameters": [
+          {
+            "id": "ceb4f028-a3cb-4e49-b5f7-d018a660502d",
+            "version": "KqlParameterItem/1.0",
+            "name": "savedConfig",
+            "type": 1,
+            "isRequired": true,
+            "query": "Resources\r\n| where id startswith '{VmId}' and name =~ 'Workload.WLILinuxExtension' and type =~ 'microsoft.compute/virtualmachines/extensions'\r\n| project tostring(properties.settings.workloadConfig)",
+            "crossComponentResources": [
+              "value::all"
+            ],
+            "isHiddenWhenLocked": true,
+            "typeSettings": {
+              "multiLineText": true,
+              "editorLanguage": "json",
+              "multiLineHeight": 15,
+              "preFormatJsonData": true
+            },
+            "timeContext": {
+              "durationMs": 86400000
+            },
+            "queryType": 1,
+            "resourceType": "microsoft.resourcegraph/resources"
+          }
+        ],
+        "style": "above",
+        "queryType": 1,
+        "resourceType": "microsoft.resourcegraph/resources"
+      },
+      "name": "savedConfig"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "Please configure using the template below.",
+        "style": "info"
+      },
+      "conditionalVisibility": {
+        "parameterName": "savedConfig",
+        "comparison": "isEqualTo"
+      },
+      "name": "Saved config not found message"
+    },
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
         "parameters": [
           {
             "id": "ef5f9e5a-8298-4993-aa2d-bd20d69c8f3f",
@@ -179,8 +229,62 @@
         "queryType": 0,
         "resourceType": "microsoft.insights/datacollectionrules"
       },
+      "conditionalVisibility": {
+        "parameterName": "savedConfig",
+        "comparison": "isEqualTo"
+      },
       "customWidth": "90",
-      "name": "parameters - 4"
+      "name": "Connection strings"
+    },
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "parameters": [
+          {
+            "id": "4d03e768-7350-40c3-b44e-0eff614645ae",
+            "version": "KqlParameterItem/1.0",
+            "name": "Config",
+            "label": "Current monitoring configuration",
+            "type": 1,
+            "typeSettings": {
+              "multiLineText": true,
+              "editorLanguage": "json",
+              "multiLineHeight": 15
+            },
+            "criteriaData": [
+              {
+                "criteriaContext": {
+                  "leftOperand": "savedConfig",
+                  "operator": "isNotNull",
+                  "rightValType": "param",
+                  "resultValType": "param",
+                  "resultVal": "savedConfig"
+                }
+              },
+              {
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "param",
+                  "resultVal": "PerVmConfig"
+                }
+              }
+            ],
+            "timeContext": {
+              "durationMs": 86400000
+            }
+          }
+        ],
+        "style": "formVertical",
+        "queryType": 0,
+        "resourceType": "microsoft.compute/virtualmachines"
+      },
+      "conditionalVisibility": {
+        "parameterName": "savedConfig",
+        "comparison": "isNotEqualTo"
+      },
+      "name": "Final Config"
     },
     {
       "type": 1,
@@ -304,7 +408,7 @@
                 {
                   "name": "workloadconfig",
                   "source": "parameter",
-                  "value": "PerVmConfig",
+                  "value": "Config",
                   "kind": "objectValue"
                 },
                 {


### PR DESCRIPTION
- Adding a VM to a profile now loads the existing WLI config if it exists

## PR Checklist

* [ ] Explain your changes, so people looking at the PR know *what* and *why*, the code changes are the *how*.

### If adding or updating templates:
* [ ] post a screenshot of templates and/or gallery changes
* [ ] ensure all steps have meaningful names
* [ ] ensure all parameters and grid columns have display names set so they can be localized
* [ ] ensure that parameters id values are unique __or they will fail PR validation__ (parameter ids are used for localization)
* [ ] ensure that steps names are unique __or they will fail PR validation__ (step names are used for localization)
* [ ] grep `/subscription/` and ensure that your parameters don't have any hardcoded resourceIds __or they will fail PR validation__
* [ ] remove `fallbackResourceIds` and `fromTemplateId` fields from your template workbook __or they will fail PR validation__