### PR TITLE
remove cosmos sub picker

### DIFF
--- a/Workbooks/CosmosDb/Resource Insights/Resource Insights.workbook
+++ b/Workbooks/CosmosDb/Resource Insights/Resource Insights.workbook
@@ -7,49 +7,19 @@
         "version": "KqlParameterItem/1.0",
         "parameters": [
           {
-            "id": "1a5523c4-8b8f-405b-915b-29f2bb09ad6b",
-            "version": "KqlParameterItem/1.0",
-            "name": "Subscription",
-            "label": "Subscriptions",
-            "type": 6,
-            "description": "All subscriptions with CosmosDB accounts",
-            "isRequired": true,
-            "query": "where type =~ 'Microsoft.DocumentDB/databaseAccounts'\r\n\t| summarize Count = count() by subscriptionId\r\n\t| order by Count desc\r\n\t| extend Rank = row_number()\r\n\t| project value = subscriptionId, label = subscriptionId, selected = Rank == 1",
-            "crossComponentResources": [
-              "value::selected"
-            ],
-            "value": "",
-            "typeSettings": {
-              "additionalResourceOptions": [],
-              "showDefault": false
-            },
-            "timeContext": {
-              "durationMs": 86400000
-            },
-            "queryType": 1,
-            "resourceType": "microsoft.resourcegraph/resources"
-          },
-          {
             "id": "aa83f370-5c47-4eb5-b44a-fedcad97f71b",
             "version": "KqlParameterItem/1.0",
             "name": "Resources",
             "label": "Azure Cosmos DB",
             "type": 5,
             "isRequired": true,
-            "query": "where type =~ 'Microsoft.DocumentDB/databaseAccounts'\r\n\t| order by name asc\r\n\t| extend Rank = row_number()\r\n\t| project value = id, label = id, selected = Rank <= 5",
-            "crossComponentResources": [
-              "{Subscription}"
-            ],
-            "value": "",
+            "value": "value::1",
+            "isHiddenWhenLocked": true,
             "typeSettings": {
-              "additionalResourceOptions": [],
-              "showDefault": false
-            },
-            "timeContext": {
-              "durationMs": 86400000
-            },
-            "queryType": 1,
-            "resourceType": "microsoft.resourcegraph/resources"
+              "additionalResourceOptions": [
+                "value::1"
+              ]
+            }
           },
           {
             "id": "f5e823d5-9ac2-4aa2-9553-46f0529f9f2f",


### PR DESCRIPTION
- Remove cosmos sub picker

- Can test via oychan-cosmos scale and clicking on one of the cosmos db's in overview tab
![image](https://user-images.githubusercontent.com/7664931/102393819-ba17e980-3f8d-11eb-974c-51d2a5219815.png)


## PR Checklist

* [x] Explain your changes, so people looking at the PR know *what* and *why*, the code changes are the *how*.

### If adding or updating templates:
* [x] post a screenshot of templates and/or gallery changes
* [x] ensure all steps have meaningful names
* [x] ensure all parameters and grid columns have display names set so they can be localized
* [x] ensure that parameters id values are unique __or they will fail PR validation__ (parameter ids are used for localization)
* [x] ensure that steps names are unique __or they will fail PR validation__ (step names are used for localization)
* [x] grep `/subscription/` and ensure that your parameters don't have any hardcoded resourceIds __or they will fail PR validation__
* [x] remove `fallbackResourceIds` and `fromTemplateId` fields from your template workbook __or they will fail PR validation__