### PR TITLE
Contributing.md clarifications

### DIFF
--- a/Documentation/Contributing.md
+++ b/Documentation/Contributing.md
@@ -219,7 +219,7 @@ If you are only changing the contents of an existing template, not adding new te
 
 1. Make your changes to your branch
 2. Push the branch to github
-3. Add `?feature.workbookGalleryBranch=[name of branch]` to the portal url.
+3. Add `?feature.workbookGalleryBranch=[name of branch]` to the portal url. So you URL looks something like [https://portal.azure.com/?feature.workbookGalleryBranch=master](https://portal.azure.com/?feature.workbookGalleryBranch=master)
 
    If it works correctly, you'll see a banner in the gallery:
    ![Gallery Redirect Banner](Images/GalleryBranchRedirect.png)
@@ -295,5 +295,5 @@ Here is an example:
 }
 ```
 
-Once you have add marked your template as `isPreview`, you can see this workbook by adding `feature.includePreviewTemplates` in your Azure Portal Url. So you URL looks something like [https://portal.azure.com/?feature.includePreviewTemplates=true](https://portal.azure.com/?feature.includePreviewTemplates=true)
+Once you have add marked your template as `isPreview`, you can see this workbook by adding `feature.includePreviewTemplates` in your Azure Portal Url. So you URL looks something like [https://portal.azure.com/?feature.includePreviewTemplates=true](https://portal.azure.com/?feature.includePreviewTemplates=true). (Include & between feature flags if also deploying your own gallery or redirecting to a github branch)
 

--- a/Documentation/Contributing.md
+++ b/Documentation/Contributing.md
@@ -219,7 +219,7 @@ If you are only changing the contents of an existing template, not adding new te
 
 1. Make your changes to your branch
 2. Push the branch to github
-3. Add `?feature.workbookGalleryBranch=[name of branch]` to the portal url. So you URL looks something like [https://portal.azure.com/?feature.workbookGalleryBranch=master](https://portal.azure.com/?feature.workbookGalleryBranch=master)
+3. Add `?feature.workbookGalleryBranch=[name of branch]` to the portal url, so your URL looks something like [https://portal.azure.com/?feature.workbookGalleryBranch=master](https://portal.azure.com/?feature.workbookGalleryBranch=master)
 
    If it works correctly, you'll see a banner in the gallery:
    ![Gallery Redirect Banner](Images/GalleryBranchRedirect.png)
@@ -295,5 +295,5 @@ Here is an example:
 }
 ```
 
-Once you have add marked your template as `isPreview`, you can see this workbook by adding `feature.includePreviewTemplates` in your Azure Portal Url. So you URL looks something like [https://portal.azure.com/?feature.includePreviewTemplates=true](https://portal.azure.com/?feature.includePreviewTemplates=true). (Include & between feature flags if also deploying your own gallery or redirecting to a github branch)
+Once you have add marked your template as `isPreview`, you can see this workbook by adding `feature.includePreviewTemplates` in your Azure Portal Url. So your URL looks something like [https://portal.azure.com/?feature.includePreviewTemplates=true](https://portal.azure.com/?feature.includePreviewTemplates=true). (Include & between feature flags if also deploying your own gallery or redirecting to a github branch)
 

--- a/Documentation/Contributing.md
+++ b/Documentation/Contributing.md
@@ -295,5 +295,5 @@ Here is an example:
 }
 ```
 
-Once you have add marked your template as `isPreview`, you can see this workbook by adding `feature.includePreviewTemplates` in your Azure Portal Url. So your URL looks something like [https://portal.azure.com/?feature.includePreviewTemplates=true](https://portal.azure.com/?feature.includePreviewTemplates=true). (Include & between feature flags if also deploying your own gallery or redirecting to a github branch)
+Once you have add marked your template as `isPreview`, you can see this workbook by adding `feature.includePreviewTemplates` in your Azure Portal Url. So your URL looks something like [https://portal.azure.com/?feature.includePreviewTemplates=true](https://portal.azure.com/?feature.includePreviewTemplates=true).
 


### PR DESCRIPTION
This PR clarifies an item in Contributing.md that tripped me up and fixes a typo.

### The clarification:

> Add `?feature.workbookGalleryBranch=[name of branch]` to the portal url.

was changed to
 
> Add `?feature.workbookGalleryBranch=[name of branch]` to the portal url. So you URL looks something like [https://portal.azure.com/?feature.workbookGalleryBranch=master](https://portal.azure.com/?feature.workbookGalleryBranch=master)

so it can't be confused for [https://portal.azure.com/?feature.workbookGalleryBranch=[master]](https://portal.azure.com/?feature.workbookGalleryBranch=[master]) (which does not work)

### The typo:

> Once you have add marked your template as `isPreview`, you can see this workbook by adding `feature.includePreviewTemplates` in your Azure Portal Url. So you URL looks something like [https://portal.azure.com/?feature.includePreviewTemplates=true](https://portal.azure.com/?feature.includePreviewTemplates=true)

was changed to

>Once you have add marked your template as `isPreview`, you can see this workbook by adding `feature.includePreviewTemplates` in your Azure Portal Url. So your URL looks something like [https://portal.azure.com/?feature.includePreviewTemplates=true](https://portal.azure.com/?feature.includePreviewTemplates=true).

"So you URL" was changed to "So your URL"


## PR Checklist

* [x] Explain your changes, so people looking at the PR know *what* and *why*, the code changes are the *how*.


### If adding or updating templates:
~* [ ] post a screenshot of templates and/or gallery changes~
~* [ ] ensure all steps have meaningful names~
~* [ ] ensure all parameters and grid columns have display names set so they can be localized~
~* [ ] ensure that parameters id values are unique __or they will fail PR validation__ (parameter ids are used for localization)~
~* [ ] ensure that steps names are unique __or they will fail PR validation__ (step names are used for localization)~
~* [ ] grep `/subscription/` and ensure that your parameters don't have any hardcoded resourceIds __or they will fail PR ~validation__~
~* [ ] remove `fallbackResourceIds` and `fromTemplateId` fields from your template workbook __or they will fail PR validation__~