### PR TITLE
Update the validation badge to use the github action instead of travis

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# Azure Monitor Workbook Templates [![Build Status](https://travis-ci.org/microsoft/Application-Insights-Workbooks.svg?branch=master)](https://travis-ci.org/microsoft/Application-Insights-Workbooks)
+# Azure Monitor Workbook Templates [![Build Status](https://github.com/microsoft/Application-Insights-Workbooks/workflows/Template%20Validation/badge.svg)](https://travis-ci.org/microsoft/Application-Insights-Workbooks)
+
+
 
 ## Contributing
 


### PR DESCRIPTION
updated the badge here to show the status of the template validation build against master:
`https://github.com/microsoft/Application-Insights-Workbooks/workflows/Template%20Validation/badge.svg`

![badge](https://github.com/microsoft/Application-Insights-Workbooks/workflows/Template%20Validation/badge.svg)
