### PR TITLE
fix issue where similar vm names would pull more than one config

### DIFF
--- a/Workbooks/Workloads-AMA/Add monitoring virtual machine/Add monitoring virtual machine.workbook
+++ b/Workbooks/Workloads-AMA/Add monitoring virtual machine/Add monitoring virtual machine.workbook
@@ -166,7 +166,7 @@
             "name": "savedConfig",
             "type": 1,
             "isRequired": true,
-            "query": "Resources\r\n| where id startswith '{VmId}' and name =~ 'Workload.WLILinuxExtension' and type =~ 'microsoft.compute/virtualmachines/extensions'\r\n| project tostring(properties.settings.workloadConfig)",
+            "query": "Resources\r\n| where id =~ strcat('{VmId}','/extensions/Workload.WLILinuxExtension') and name =~ 'Workload.WLILinuxExtension' and type =~ 'microsoft.compute/virtualmachines/extensions'\r\n| project tostring(properties.settings.workloadConfig)",
             "crossComponentResources": [
               "value::all"
             ],

--- a/Workbooks/Workloads-AMA/Custom Telegraf/Add monitoring virtual machine/Add monitoring virtual machine.workbook
+++ b/Workbooks/Workloads-AMA/Custom Telegraf/Add monitoring virtual machine/Add monitoring virtual machine.workbook
@@ -195,7 +195,7 @@
             "name": "savedConfig",
             "type": 1,
             "isRequired": true,
-            "query": "Resources\r\n| where id startswith '{VmId}' and name =~ 'Workload.WLILinuxExtension' and type =~ 'microsoft.compute/virtualmachines/extensions'\r\n| project tostring(properties.settings.workloadConfig)",
+            "query": "Resources\r\n| where id =~ strcat('{VmId}','/extensions/Workload.WLILinuxExtension') and name =~ 'Workload.WLILinuxExtension' and type =~ 'microsoft.compute/virtualmachines/extensions'\r\n| project tostring(properties.settings.workloadConfig)",
             "crossComponentResources": [
               "value::all"
             ],

--- a/Workbooks/Workloads-AMA/Update monitoring vm config/Update monitoring vm config.workbook
+++ b/Workbooks/Workloads-AMA/Update monitoring vm config/Update monitoring vm config.workbook
@@ -93,7 +93,7 @@
       "content": {
         "version": "KqlParameterItem/1.0",
         "crossComponentResources": [
-          "value::all"
+          "{VirtualMachine}"
         ],
         "parameters": [
           {
@@ -102,9 +102,9 @@
             "name": "savedConfig",
             "type": 1,
             "isRequired": true,
-            "query": "Resources\r\n| where id startswith '{VirtualMachine}' and name =~ 'Workload.WLILinuxExtension' and type =~ 'microsoft.compute/virtualmachines/extensions'\r\n| project tostring(properties.settings.workloadConfig)",
+            "query": "Resources\r\n| where id =~ strcat('{VirtualMachine}','/extensions/Workload.WLILinuxExtension') and name =~ 'Workload.WLILinuxExtension' and type =~ 'microsoft.compute/virtualmachines/extensions'\r\n| project tostring(properties.settings.workloadConfig)",
             "crossComponentResources": [
-              "value::all"
+              "{VirtualMachine}"
             ],
             "isHiddenWhenLocked": true,
             "typeSettings": {


### PR DESCRIPTION
- if vms start with the same name, it could pull more than one vm config. This fixes it

## PR Checklist

* [ ] Explain your changes, so people looking at the PR know *what* and *why*, the code changes are the *how*.

### If adding or updating templates:
* [ ] post a screenshot of templates and/or gallery changes
* [ ] ensure all steps have meaningful names
* [ ] ensure all parameters and grid columns have display names set so they can be localized
* [ ] ensure that parameters id values are unique __or they will fail PR validation__ (parameter ids are used for localization)
* [ ] ensure that steps names are unique __or they will fail PR validation__ (step names are used for localization)
* [ ] grep `/subscription/` and ensure that your parameters don't have any hardcoded resourceIds __or they will fail PR validation__
* [ ] remove `fallbackResourceIds` and `fromTemplateId` fields from your template workbook __or they will fail PR validation__