### PR TITLE
SapMonitor - SapNetWeaver Workbook Update

### DIFF
--- a/Workbooks/SapMonitor/SapNetWeaver/SapNetWeaver.workbook
+++ b/Workbooks/SapMonitor/SapNetWeaver/SapNetWeaver.workbook
@@ -6,7 +6,7 @@
       "content": {
         "json": "## Azure Monitor for SAP Solutions on SAP NetWeaver\n---"
       },
-      "name": "text - 2"
+      "name": "Workbook Title"
     },
     {
       "type": 11,
@@ -31,6 +31,14 @@
             "style": "link"
           },
           {
+            "id": "caa49a61-476e-4311-ad90-8d7bff8c5d88",
+            "cellValue": "selectedMenu",
+            "linkTarget": "parameter",
+            "linkLabel": "Utilization",
+            "subTarget": "Utilization",
+            "style": "link"
+          },
+          {
             "id": "e844d4f7-2017-4360-824f-4ac26e8a941d",
             "cellValue": "selectedMenu",
             "linkTarget": "parameter",
@@ -48,7 +56,7 @@
           }
         ]
       },
-      "name": "MainNavigationLinks"
+      "name": "Main Navigation Links"
     },
     {
       "type": 12,
@@ -63,14 +71,18 @@
               "version": "KqlItem/1.0",
               "query": "let extractColumn = dynamic(['UTC Timestamp', 'Server Timestamp']);\r\nSapNetweaver_GetSystemInstanceList_CL\r\n| summarize ['UTC Timestamp'] = max(timestamp_t), ['Server Timestamp'] = max(serverTimestamp_t)\r\n| project properties = pack_all()\r\n| mv-apply name = extractColumn to typeof(string) on \r\n(\r\n    project name, value=properties[name]\r\n)\r\n| project-away properties",
               "size": 3,
-              "title": "Current Status Updated at",
+              "title": "Current Status Updated At",
               "queryType": 0,
               "resourceType": "microsoft.operationalinsights/workspaces",
               "visualization": "tiles",
               "tileSettings": {
                 "titleContent": {
                   "columnMatch": "value",
-                  "formatter": 6
+                  "formatter": 6,
+                  "dateFormat": {
+                    "showUtcTime": true,
+                    "formatName": "fullDateTimePattern"
+                  }
                 },
                 "subtitleContent": {
                   "columnMatch": "name",
@@ -109,6 +121,85 @@
             "name": "OverviewNavigationLinks"
           },
           {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "{\"version\":\"1.0.0\",\"content\":\"[\\r\\n\\t{ \\\"Status\\\": \\\"Available\\\", \\\"Color\\\": 0 },\\r\\n\\t{ \\\"Status\\\": \\\"Not Functional\\\", \\\"Color\\\": 1 },\\r\\n\\t{ \\\"Status\\\": \\\"Error\\\", \\\"Color\\\": 2 },\\r\\n\\t{ \\\"Status\\\": \\\"Offline\\\", \\\"Color\\\": 3 },\\r\\n\\t{ \\\"Status\\\": \\\"Status Updated 5 Minutes Earlier\\\", \\\"Color\\\": 4 }\\r\\n\\r\\n]\",\"transformers\":null}",
+              "size": 4,
+              "title": "Chart Legend",
+              "queryType": 8,
+              "visualization": "tiles",
+              "tileSettings": {
+                "titleContent": {
+                  "formatter": 5
+                },
+                "leftContent": {
+                  "columnMatch": "Status",
+                  "formatter": 2,
+                  "formatOptions": {
+                    "compositeBarSettings": {
+                      "labelText": "",
+                      "columnSettings": [
+                        {
+                          "columnName": "Color",
+                          "color": "blue"
+                        }
+                      ]
+                    }
+                  }
+                },
+                "secondaryContent": {
+                  "columnMatch": "Color",
+                  "formatter": 18,
+                  "formatOptions": {
+                    "thresholdsOptions": "colors",
+                    "thresholdsGrid": [
+                      {
+                        "operator": "==",
+                        "thresholdValue": "0",
+                        "representation": "green",
+                        "text": ""
+                      },
+                      {
+                        "operator": "==",
+                        "thresholdValue": "1",
+                        "representation": "yellow",
+                        "text": ""
+                      },
+                      {
+                        "operator": "==",
+                        "thresholdValue": "2",
+                        "representation": "red",
+                        "text": ""
+                      },
+                      {
+                        "operator": "==",
+                        "thresholdValue": "3",
+                        "representation": "gray",
+                        "text": ""
+                      },
+                      {
+                        "operator": "==",
+                        "thresholdValue": "4",
+                        "representation": "grayBlue",
+                        "text": ""
+                      },
+                      {
+                        "operator": "Default",
+                        "thresholdValue": null,
+                        "representation": "blue",
+                        "text": ""
+                      }
+                    ]
+                  }
+                },
+                "showBorder": false,
+                "size": "auto"
+              }
+            },
+            "name": "Status Legend"
+          },
+          {
             "type": 12,
             "content": {
               "version": "NotebookGroup/1.0",
@@ -118,9 +209,9 @@
                   "type": 3,
                   "content": {
                     "version": "KqlItem/1.0",
-                    "query": "SapNetweaver_GetSystemInstanceList_CL\r\n| where serverTimestamp_t > ago(14d)\r\n| project dispstatus_s, SID_s, serverTimestamp_t\r\n| extend Status = iff(dispstatus_s == 'SAPControl-GREEN', \"Running\", \"\")\r\n| extend Status = iff(dispstatus_s == 'SAPControl-YELLOW', \"Not Running or Stuck\", Status)\r\n| extend Status = iff(dispstatus_s == 'SAPControl-RED', \"Service could not be started\", Status)\r\n| extend Status = iff(dispstatus_s == 'SAPControl-GRAY', \"Not Running\", Status)\r\n| summarize arg_max(serverTimestamp_t, *) by SID_s\r\n| extend Status = iff(serverTimestamp_t > ago(5m), Status, \"Status Updated 5 mins earlier\")",
+                    "query": "SapNetweaver_GetSystemInstanceList_CL\r\n| where serverTimestamp_t > ago(14d)\r\n| project dispstatus_s, SID_s, serverTimestamp_t\r\n| extend Status = iff(dispstatus_s == 'SAPControl-GREEN', \"Available\", \"\")\r\n| extend Status = iff(dispstatus_s == 'SAPControl-YELLOW', \"Not Functional\", Status)\r\n| extend Status = iff(dispstatus_s == 'SAPControl-RED', \"Error\", Status)\r\n| extend Status = iff(dispstatus_s == 'SAPControl-GRAY', \"Offline\", Status)\r\n| summarize arg_max(serverTimestamp_t, *) by SID_s\r\n| extend Status = iff(serverTimestamp_t > ago(5m), Status, \"Status Updated 5 mins earlier\")",
                     "size": 0,
-                    "title": "SAP NetWeaver Availability Status by SID.",
+                    "title": "SAP NetWeaver Availability Status By SID.",
                     "exportFieldName": "SID_s",
                     "exportParameterName": "selectedSID",
                     "exportDefaultValue": "*",
@@ -150,22 +241,22 @@
                         "thresholdsGrid": [
                           {
                             "operator": "==",
-                            "thresholdValue": "Running",
+                            "thresholdValue": "Available",
                             "representation": "green"
                           },
                           {
                             "operator": "==",
-                            "thresholdValue": "Not Running or Stuck",
+                            "thresholdValue": "Not Functional",
                             "representation": "yellow"
                           },
                           {
                             "operator": "==",
-                            "thresholdValue": "Service could not be started",
+                            "thresholdValue": "Error",
                             "representation": "red"
                           },
                           {
                             "operator": "==",
-                            "thresholdValue": "Not Running",
+                            "thresholdValue": "Offline",
                             "representation": "gray"
                           },
                           {
@@ -175,87 +266,17 @@
                           },
                           {
                             "operator": "Default",
-                            "thresholdValue": null,
-                            "representation": "blue"
+                            "thresholdValue": null
                           }
                         ]
                       },
                       "hivesMargin": 5
                     }
                   },
-                  "customWidth": "81.6",
-                  "name": "CurrentStatusBySID",
+                  "name": "Current Status by SID",
                   "styleSettings": {
                     "showBorder": true
                   }
-                },
-                {
-                  "type": 3,
-                  "content": {
-                    "version": "KqlItem/1.0",
-                    "query": "{\"version\":\"1.0.0\",\"content\":\"[\\r\\n\\t{ \\\"Status\\\": \\\"Running\\\", \\\"Color\\\": 0 },\\r\\n\\t{ \\\"Status\\\": \\\"Not Running or Stuck\\\", \\\"Color\\\": 1 },\\r\\n\\t{ \\\"Status\\\": \\\"Service could not be started\\\", \\\"Color\\\": 2 },\\r\\n\\t{ \\\"Status\\\": \\\"Not Running\\\", \\\"Color\\\": 3 },\\r\\n\\t{ \\\"Status\\\": \\\"Status Updated 5 mins earlier\\\", \\\"Color\\\": 4 }\\r\\n\\r\\n]\",\"transformers\":null}",
-                    "size": 0,
-                    "queryType": 8,
-                    "gridSettings": {
-                      "formatters": [
-                        {
-                          "columnMatch": "Status",
-                          "formatter": 0,
-                          "formatOptions": {
-                            "customColumnWidthSetting": "25.5ch"
-                          }
-                        },
-                        {
-                          "columnMatch": "Color",
-                          "formatter": 18,
-                          "formatOptions": {
-                            "thresholdsOptions": "colors",
-                            "thresholdsGrid": [
-                              {
-                                "operator": "==",
-                                "thresholdValue": "0",
-                                "representation": "green",
-                                "text": ""
-                              },
-                              {
-                                "operator": "==",
-                                "thresholdValue": "1",
-                                "representation": "yellow",
-                                "text": ""
-                              },
-                              {
-                                "operator": "==",
-                                "thresholdValue": "2",
-                                "representation": "red",
-                                "text": ""
-                              },
-                              {
-                                "operator": "==",
-                                "thresholdValue": "3",
-                                "representation": "gray",
-                                "text": ""
-                              },
-                              {
-                                "operator": "==",
-                                "thresholdValue": "4",
-                                "representation": "lightBlue",
-                                "text": ""
-                              },
-                              {
-                                "operator": "Default",
-                                "thresholdValue": null,
-                                "representation": "grayBlue",
-                                "text": ""
-                              }
-                            ],
-                            "customColumnWidthSetting": "9.7ch"
-                          }
-                        }
-                      ]
-                    }
-                  },
-                  "customWidth": "18.4",
-                  "name": "SIDLegend"
                 },
                 {
                   "type": 3,
@@ -287,7 +308,7 @@
                             "max": 100,
                             "palette": "blueDark",
                             "aggregation": "Unique",
-                            "customColumnWidthSetting": "15%"
+                            "customColumnWidthSetting": "20%"
                           },
                           "numberFormat": {
                             "unit": 1,
@@ -298,11 +319,11 @@
                         },
                         {
                           "columnMatch": "availabilityTrend",
-                          "formatter": 9,
+                          "formatter": 21,
                           "formatOptions": {
                             "min": 0,
                             "max": 100,
-                            "palette": "redGreen",
+                            "palette": "green",
                             "customColumnWidthSetting": "75%"
                           },
                           "tooltipFormat": {
@@ -317,7 +338,7 @@
                         },
                         {
                           "columnId": "availability",
-                          "label": "Availability over 15 mins"
+                          "label": "Availability Over 15 Minutes"
                         },
                         {
                           "columnId": "availabilityTrend",
@@ -327,7 +348,7 @@
                     },
                     "sortBy": []
                   },
-                  "name": "SIDAvailabilityPercentage"
+                  "name": "Availability Percentage by SID - 15 minutes"
                 }
               ]
             },
@@ -355,10 +376,11 @@
                         "name": "selectedSID",
                         "label": "SID",
                         "type": 2,
-                        "query": "SapNetweaver_GetSystemInstanceList_CL\r\n| project SID_s\r\n| distinct SID_s",
+                        "query": "SapNetweaver_GetSystemInstanceList_CL\r\n| where serverTimestamp_t > ago(14d)\r\n| project SID_s\r\n| distinct SID_s",
                         "value": null,
                         "typeSettings": {
-                          "additionalResourceOptions": []
+                          "additionalResourceOptions": [],
+                          "showDefault": false
                         },
                         "timeContext": {
                           "durationMs": 86400000
@@ -371,13 +393,13 @@
                     "queryType": 0,
                     "resourceType": "microsoft.operationalinsights/workspaces"
                   },
-                  "name": "parameters - 4"
+                  "name": "SID parameters - Availability Status"
                 },
                 {
                   "type": 3,
                   "content": {
                     "version": "KqlItem/1.0",
-                    "query": "SapNetweaver_GetSystemInstanceList_CL\r\n| where serverTimestamp_t > ago(14d)\r\n| where SID_s == '{selectedSID}'\r\n| project instanceNr_d, hostname_s, serverTimestamp_t, features_s, dispstatus_s, SID_s\r\n| extend instanceNr_s = tostring(toint(instanceNr_d))\r\n| extend instanceNr_s = iff(strlen(instanceNr_s) == 2, instanceNr_s, strcat( \"0\", instanceNr_s))\r\n| extend feature_label = iff(features_s has \"ABAP\", \"ABAP\", \"\")\r\n| extend feature_label = iff(features_s has \"J2EE\", \"J2EE\", feature_label)\r\n| extend feature_label = iff(features_s has \"ENQUE\", \"Enqueue Server\", feature_label)\r\n| extend Status = iff(dispstatus_s == 'SAPControl-GREEN', \"Running\", \"\")\r\n| extend Status = iff(dispstatus_s == 'SAPControl-YELLOW', \"Not Running or Stuck\", Status)\r\n| extend Status = iff(dispstatus_s == 'SAPControl-RED', \"Service could not be started\", Status)\r\n| extend Status = iff(dispstatus_s == 'SAPControl-GRAY', \"Not Running\", Status)\r\n| extend appServer = strcat( hostname_s, \"_\", instanceNr_s)\r\n| summarize arg_max(serverTimestamp_t, *) by appServer\r\n| extend Status = iff(serverTimestamp_t > ago(5m), Status, \"Status Updated 5 mins earlier\")",
+                    "query": "SapNetweaver_GetSystemInstanceList_CL\r\n| where serverTimestamp_t > ago(14d)\r\n| where SID_s == '{selectedSID}'\r\n| project instanceNr_d, hostname_s, serverTimestamp_t, features_s, dispstatus_s, SID_s\r\n| extend instanceNr_s = tostring(toint(instanceNr_d))\r\n| extend instanceNr_s = iff(strlen(instanceNr_s) == 2, instanceNr_s, strcat( \"0\", instanceNr_s))\r\n| extend feature_label = iff(features_s has \"ABAP\", \"ABAP\", \"\")\r\n| extend feature_label = iff(features_s has \"J2EE\", \"J2EE\", feature_label)\r\n| extend feature_label = iff(features_s has \"ENQUE\", \"Enqueue Server\", feature_label)\r\n| extend Status = iff(dispstatus_s == 'SAPControl-GREEN', \"Available\", \"\")\r\n| extend Status = iff(dispstatus_s == 'SAPControl-YELLOW', \"Not Functional\", Status)\r\n| extend Status = iff(dispstatus_s == 'SAPControl-RED', \"Error\", Status)\r\n| extend Status = iff(dispstatus_s == 'SAPControl-GRAY', \"Offline\", Status)\r\n| extend appServer = strcat( hostname_s, \"_\", instanceNr_s)\r\n| summarize arg_max(serverTimestamp_t, *) by appServer\r\n| extend Status = iff(serverTimestamp_t > ago(5m), Status, \"Status Updated 5 mins earlier\")",
                     "size": 0,
                     "title": "SAP NetWeaver Availability Status by Application Server.",
                     "noDataMessage": "Please select an SID to view status.",
@@ -431,22 +453,22 @@
                         "thresholdsGrid": [
                           {
                             "operator": "==",
-                            "thresholdValue": "Running",
+                            "thresholdValue": "Available",
                             "representation": "green"
                           },
                           {
                             "operator": "==",
-                            "thresholdValue": "Not Running or Stuck",
+                            "thresholdValue": "Not Functional",
                             "representation": "yellow"
                           },
                           {
                             "operator": "==",
-                            "thresholdValue": "Service could not be started",
+                            "thresholdValue": "Error",
                             "representation": "red"
                           },
                           {
                             "operator": "==",
-                            "thresholdValue": "Not Running",
+                            "thresholdValue": "Offline",
                             "representation": "gray"
                           },
                           {
@@ -456,87 +478,17 @@
                           },
                           {
                             "operator": "Default",
-                            "thresholdValue": null,
-                            "representation": "grayBlue"
+                            "thresholdValue": null
                           }
                         ]
                       },
                       "hivesMargin": 5
                     }
                   },
-                  "customWidth": "81.6",
-                  "name": "CurrentStatusByAppServer",
+                  "name": "Current Status By AppServer",
                   "styleSettings": {
                     "showBorder": true
                   }
-                },
-                {
-                  "type": 3,
-                  "content": {
-                    "version": "KqlItem/1.0",
-                    "query": "{\"version\":\"1.0.0\",\"content\":\"[\\r\\n\\t{ \\\"Status\\\": \\\"Running\\\", \\\"Color\\\": 0 },\\r\\n\\t{ \\\"Status\\\": \\\"Not Running or Stuck\\\", \\\"Color\\\": 1 },\\r\\n\\t{ \\\"Status\\\": \\\"Service could not be started\\\", \\\"Color\\\": 2 },\\r\\n\\t{ \\\"Status\\\": \\\"Not Running\\\", \\\"Color\\\": 3 },\\r\\n\\t{ \\\"Status\\\": \\\"Status Updated 5 mins earlier\\\", \\\"Color\\\": 4 }\\r\\n\\r\\n]\",\"transformers\":null}",
-                    "size": 0,
-                    "queryType": 8,
-                    "gridSettings": {
-                      "formatters": [
-                        {
-                          "columnMatch": "Status",
-                          "formatter": 0,
-                          "formatOptions": {
-                            "customColumnWidthSetting": "25.5ch"
-                          }
-                        },
-                        {
-                          "columnMatch": "Color",
-                          "formatter": 18,
-                          "formatOptions": {
-                            "thresholdsOptions": "colors",
-                            "thresholdsGrid": [
-                              {
-                                "operator": "==",
-                                "thresholdValue": "0",
-                                "representation": "green",
-                                "text": ""
-                              },
-                              {
-                                "operator": "==",
-                                "thresholdValue": "1",
-                                "representation": "yellow",
-                                "text": ""
-                              },
-                              {
-                                "operator": "==",
-                                "thresholdValue": "2",
-                                "representation": "red",
-                                "text": ""
-                              },
-                              {
-                                "operator": "==",
-                                "thresholdValue": "3",
-                                "representation": "gray",
-                                "text": ""
-                              },
-                              {
-                                "operator": "==",
-                                "thresholdValue": "4",
-                                "representation": "lightBlue",
-                                "text": ""
-                              },
-                              {
-                                "operator": "Default",
-                                "thresholdValue": null,
-                                "representation": "grayBlue",
-                                "text": ""
-                              }
-                            ],
-                            "customColumnWidthSetting": "9.7ch"
-                          }
-                        }
-                      ]
-                    }
-                  },
-                  "customWidth": "18.4",
-                  "name": "AppServerStatusLegend"
                 },
                 {
                   "type": 3,
@@ -570,11 +522,11 @@
                         },
                         {
                           "columnMatch": "AvailabilityTrend",
-                          "formatter": 9,
+                          "formatter": 21,
                           "formatOptions": {
                             "min": 0,
                             "max": 100,
-                            "palette": "redGreen",
+                            "palette": "green",
                             "customColumnWidthSetting": "75ch"
                           },
                           "tooltipFormat": {
@@ -637,7 +589,7 @@
                       "value": "*"
                     }
                   ],
-                  "name": "ProcessAvailabilityStatus"
+                  "name": "Process Availability Status"
                 }
               ]
             },
@@ -751,13 +703,13 @@
               "queryType": 0,
               "resourceType": "microsoft.operationalinsights/workspaces"
             },
-            "name": "AvailabilityParameters"
+            "name": "Availability Parameters"
           },
           {
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "let sidList = dynamic([{AvailabilitySID}]);\r\nlet appServerList = dynamic([{AvailabilityApplicationServer}]);\r\nSapNetweaver_GetSystemInstanceList_CL\r\n| where serverTimestamp_t between (todatetime({AvailabilityTimeRange:start}) .. todatetime({AvailabilityTimeRange:end}))\r\n| where array_length(sidList) == 0 or SID_s in (sidList)\r\n| extend instanceNr_s = tostring(toint(instanceNr_d))\r\n| extend instanceNr_s = iff(strlen(instanceNr_s) == 2, instanceNr_s, strcat( \"0\", instanceNr_s))\r\n| extend appServer = strcat(hostname_s, \"_\", instanceNr_s)\r\n| where array_length(appServerList) == 0 or appServer in (appServerList)\r\n| extend Status = iff(dispstatus_s == 'SAPControl-GREEN', 0, iff(dispstatus_s == 'SAPControl-YELLOW', 1, iff(dispstatus_s == 'SAPControl-RED', 2, 3)))\r\n| summarize availability=countif(Status == 0), total=count() by timestamp_t, SID_s\r\n| extend availability = (availability / total) * 100\r\n| project-away total",
+              "query": "let sidList = dynamic([{AvailabilitySID}]);\r\nlet appServerList = dynamic([{AvailabilityApplicationServer}]);\r\nlet baseQuery = SapNetweaver_GetSystemInstanceList_CL\r\n| where serverTimestamp_t between (todatetime({AvailabilityTimeRange:start}) .. todatetime({AvailabilityTimeRange:end}))\r\n| where array_length(sidList) == 0 or SID_s in (sidList)\r\n| extend instanceNr_s = tostring(toint(instanceNr_d))\r\n| extend instanceNr_s = iff(strlen(instanceNr_s) == 2, instanceNr_s, strcat( \"0\", instanceNr_s))\r\n| extend appServer = strcat(hostname_s, \"_\", instanceNr_s)\r\n| where array_length(appServerList) == 0 or appServer in (appServerList)\r\n| extend Status = iff(dispstatus_s == 'SAPControl-GREEN', 0, iff(dispstatus_s == 'SAPControl-YELLOW', 1, iff(dispstatus_s == 'SAPControl-RED', 2, 3)));\r\nlet timespanCount = baseQuery \r\n| summarize RecordCount=count()\r\n| extend Interval = iff(RecordCount <= 10000, timespan(1m), timespan(1m))\r\n| extend Interval = iff(RecordCount > 10000 and RecordCount < 50000, timespan(5m), Interval)\r\n| extend Interval = iff(RecordCount >= 50000 and RecordCount < 100000, timespan(10m), Interval)\r\n| extend Interval = iff(RecordCount >= 100000 and RecordCount < 150000, timespan(15m), Interval)\r\n| extend Interval = iff(RecordCount >= 150000, timespan(30m), Interval)\r\n| project Interval;\r\nlet timespanInterval = toscalar(timespanCount);\r\nbaseQuery\r\n| summarize availability=countif(Status == 0), total=count() by bin(timestamp_t, timespanInterval), SID_s\r\n| extend availability = (availability / total) * 100\r\n| project-away total",
               "size": 0,
               "aggregation": 3,
               "title": "Availability Status Trend",
@@ -771,10 +723,17 @@
                   "availability"
                 ],
                 "group": "SID_s",
-                "createOtherGroup": null,
+                "createOtherGroup": 0,
                 "ySettings": {
+                  "numberFormatSettings": {
+                    "unit": 1,
+                    "options": {
+                      "style": "decimal",
+                      "useGrouping": true
+                    }
+                  },
                   "min": 0,
-                  "max": 110
+                  "max": 100
                 }
               }
             },
@@ -784,11 +743,12 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "let sidList = dynamic([{AvailabilitySID}]);\r\nlet appServerList = dynamic([{AvailabilityApplicationServer}]);\r\nSapNetweaver_GetProcessList_CL\r\n| project Instance_Process = description_s, SID_s, hostname_s, instanceNr_d, dispstatus_s, serverTimestamp_t\r\n| where serverTimestamp_t between (todatetime({AvailabilityTimeRange:start}) .. todatetime({AvailabilityTimeRange:end}))\r\n| where array_length(sidList) == 0 or SID_s in (sidList)\r\n| extend instanceNr_s = tostring(toint(instanceNr_d))\r\n| extend instanceNr_s = iff(strlen(instanceNr_s) == 2, instanceNr_s, strcat( \"0\", instanceNr_s))\r\n| extend appServer = strcat(hostname_s, \"_\", instanceNr_s)\r\n| where array_length(appServerList) == 0 or appServer in (appServerList)\r\n| extend Status = iff(dispstatus_s == 'SAPControl-GREEN', 0, 1)\r\n| summarize total=count(), failureCount=countif(Status != 0) by Instance_Process, serverTimestamp_t, SID_s\r\n| extend Availability = round(((toreal(total) - toreal(failureCount)) / toreal(total)) * 100, 2)\r\n| summarize Availability = avg(Availability), AvailabilityTrend = make_list(Availability) by Instance_Process, SID_s",
+              "query": "let sidList = dynamic([{AvailabilitySID}]);\r\nlet appServerList = dynamic([{AvailabilityApplicationServer}]);\r\nSapNetweaver_GetProcessList_CL\r\n| project Instance_Process = description_s, SID_s, hostname_s, instanceNr_d, dispstatus_s, serverTimestamp_t\r\n| where serverTimestamp_t between (todatetime({AvailabilityTimeRange:start}) .. todatetime({AvailabilityTimeRange:end}))\r\n| where array_length(sidList) == 0 or SID_s in (sidList)\r\n| extend instanceNr_s = tostring(toint(instanceNr_d))\r\n| extend instanceNr_s = iff(strlen(instanceNr_s) == 2, instanceNr_s, strcat( \"0\", instanceNr_s))\r\n| extend appServer = strcat(hostname_s, \"_\", instanceNr_s)\r\n| where array_length(appServerList) == 0 or appServer in (appServerList)\r\n| extend Status = iff(dispstatus_s == 'SAPControl-GREEN', 0, 1)\r\n| summarize total=count(), failureCount=countif(Status != 0) by Instance_Process, serverTimestamp_t, SID_s\r\n| extend Availability = round(((toreal(total) - toreal(failureCount)) / toreal(total)) * 100, 2)\r\n| summarize Availability = round(avg(Availability), 3), AvailabilityTrend = make_list(Availability) by Instance_Process, SID_s",
               "size": 0,
               "title": "Instance Process Availability",
               "queryType": 0,
               "resourceType": "microsoft.operationalinsights/workspaces",
+              "visualization": "table",
               "gridSettings": {
                 "formatters": [
                   {
@@ -822,11 +782,11 @@
                   },
                   {
                     "columnMatch": "AvailabilityTrend",
-                    "formatter": 9,
+                    "formatter": 21,
                     "formatOptions": {
                       "min": 0,
                       "max": 100,
-                      "palette": "redGreen",
+                      "palette": "green",
                       "customColumnWidthSetting": "75%"
                     },
                     "tooltipFormat": {
@@ -862,7 +822,8 @@
               },
               "sortBy": []
             },
-            "name": "InstanceProcessAvailabilityBySID"
+            "customWidth": "100",
+            "name": "Instance Process Availability By SID"
           }
         ]
       },
@@ -871,7 +832,160 @@
         "comparison": "isEqualTo",
         "value": "Availability"
       },
-      "name": "availabilityGroup"
+      "name": "Availability Group"
+    },
+    {
+      "type": 12,
+      "content": {
+        "version": "NotebookGroup/1.0",
+        "groupType": "editable",
+        "items": [
+          {
+            "type": 9,
+            "content": {
+              "version": "KqlParameterItem/1.0",
+              "parameters": [
+                {
+                  "id": "4771a9ab-a94e-4dc5-96dc-3a0103a38b98",
+                  "version": "KqlParameterItem/1.0",
+                  "name": "PerformanceTimeRange",
+                  "label": "Time Range",
+                  "type": 4,
+                  "value": {
+                    "durationMs": 1800000
+                  },
+                  "typeSettings": {
+                    "selectableValues": [
+                      {
+                        "durationMs": 300000
+                      },
+                      {
+                        "durationMs": 900000
+                      },
+                      {
+                        "durationMs": 1800000
+                      },
+                      {
+                        "durationMs": 3600000
+                      },
+                      {
+                        "durationMs": 14400000
+                      },
+                      {
+                        "durationMs": 43200000
+                      },
+                      {
+                        "durationMs": 86400000
+                      },
+                      {
+                        "durationMs": 172800000
+                      }
+                    ],
+                    "allowCustom": true
+                  },
+                  "timeContext": {
+                    "durationMs": 86400000
+                  }
+                },
+                {
+                  "id": "23b5cb65-34f1-445b-8df5-1bb46a7fda80",
+                  "version": "KqlParameterItem/1.0",
+                  "name": "PerformanceSID",
+                  "label": "SID",
+                  "type": 2,
+                  "query": "SapNetweaver_GetSystemInstanceList_CL\r\n| distinct SID_s",
+                  "value": null,
+                  "typeSettings": {
+                    "additionalResourceOptions": [],
+                    "showDefault": false
+                  },
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces"
+                },
+                {
+                  "id": "42bafe96-35aa-40de-98c5-e1eb1a5047e5",
+                  "version": "KqlParameterItem/1.0",
+                  "name": "PerformanceApplicationServer",
+                  "label": "Application Server",
+                  "type": 2,
+                  "multiSelect": true,
+                  "quote": "'",
+                  "delimiter": ",",
+                  "query": "SapNetweaver_GetSystemInstanceList_CL\r\n| where SID_s == '{PerformanceSID}' or '{PerformanceSID}' == ''\r\n| extend instanceNr_s = tostring(toint(instanceNr_d))\r\n| extend instanceNr_s = iff(strlen(instanceNr_s) == 2, instanceNr_s, strcat( \"0\", instanceNr_s))\r\n| distinct SID_s, hostname_s, instanceNr_s\r\n| project AppServer = strcat(hostname_s, \"_\", instanceNr_s)\r\n| distinct AppServer",
+                  "typeSettings": {
+                    "additionalResourceOptions": [],
+                    "showDefault": false
+                  },
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "value": []
+                },
+                {
+                  "id": "b55c977a-256e-491d-952b-5ab35c20b541",
+                  "version": "KqlParameterItem/1.0",
+                  "name": "performanceWorkProcessType",
+                  "label": "Work Process Type",
+                  "type": 2,
+                  "query": "SapNetweaver_ABAPGetWPTable_CL\r\n| distinct Typ_s",
+                  "value": null,
+                  "typeSettings": {
+                    "additionalResourceOptions": []
+                  },
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces"
+                }
+              ],
+              "style": "pills",
+              "queryType": 0,
+              "resourceType": "microsoft.operationalinsights/workspaces"
+            },
+            "name": "utilization parameters"
+          },
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "let appServerList = dynamic([{PerformanceApplicationServer}]);\r\nlet workProcessType = '{performanceWorkProcessType}';\r\nSapNetweaver_ABAPGetWPTable_CL\r\n| where serverTimestamp_t between (todatetime({PerformanceTimeRange:start}) .. todatetime({PerformanceTimeRange:end}))\r\n| where SID_s == '{PerformanceSID}'\r\n| extend instanceNr_s = tostring(toint(instanceNr_d))\r\n| extend instanceNr_s = iff(strlen(instanceNr_s) == 2, instanceNr_s, strcat( \"0\", instanceNr_s))\r\n| extend appServer = strcat(hostname_s, \"_\", instanceNr_s)\r\n| where array_length(appServerList) == 0 or appServer in (appServerList)\r\n| where Typ_s == workProcessType\r\n| summarize totalWP = count(), freeWP = countif(Status_s == \"Wait\") by bin(timestamp_t, 1m), Typ_s\r\n| extend activeWP = totalWP - freeWP",
+              "size": 0,
+              "aggregation": 3,
+              "title": "Work Process Utilization",
+              "color": "green",
+              "noDataMessage": "No work processes found for the selected filter values.",
+              "queryType": 0,
+              "resourceType": "microsoft.operationalinsights/workspaces",
+              "visualization": "areachart",
+              "chartSettings": {
+                "xAxis": "timestamp_t",
+                "yAxis": [
+                  "activeWP",
+                  "freeWP"
+                ],
+                "group": null,
+                "createOtherGroup": 0,
+                "seriesLabelSettings": [
+                  {
+                    "seriesName": "activeWP",
+                    "label": "Active Work Processes",
+                    "color": "red"
+                  },
+                  {
+                    "seriesName": "freeWP",
+                    "label": "Free Work Processes",
+                    "color": "blue"
+                  }
+                ]
+              }
+            },
+            "name": "Work Process Utilization Trend"
+          }
+        ]
+      },
+      "conditionalVisibility": {
+        "parameterName": "selectedMenu",
+        "comparison": "isEqualTo",
+        "value": "Utilization"
+      },
+      "name": "utilization metrics group"
     },
     {
       "type": 12,
@@ -956,7 +1070,8 @@
                     "showDefault": false
                   },
                   "queryType": 0,
-                  "resourceType": "microsoft.operationalinsights/workspaces"
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "value": []
                 }
               ],
               "style": "pills",
@@ -968,72 +1083,580 @@
           {
             "type": 1,
             "content": {
-              "json": "**Work Process Utilization**"
+              "json": "### Enqueue Lock Statistics"
             },
-            "name": "WorkProcessUtilizationTitle"
-          },
-          {
-            "type": 9,
-            "content": {
-              "version": "KqlParameterItem/1.0",
-              "parameters": [
-                {
-                  "id": "e4924bd0-fdb6-4a53-abf8-94b9430363da",
-                  "version": "KqlParameterItem/1.0",
-                  "name": "performanceWorkProcessType",
-                  "label": "Work Process Type",
-                  "type": 2,
-                  "query": "SapNetweaver_ABAPGetWPTable_CL\r\n| distinct Typ_s",
-                  "value": "DIA",
-                  "typeSettings": {
-                    "additionalResourceOptions": []
-                  },
-                  "timeContext": {
-                    "durationMs": 86400000
-                  },
-                  "queryType": 0,
-                  "resourceType": "microsoft.operationalinsights/workspaces"
-                }
-              ],
-              "style": "pills",
-              "queryType": 0,
-              "resourceType": "microsoft.operationalinsights/workspaces"
-            },
-            "name": "parameters - 4"
+            "name": "text - 12"
           },
           {
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "let appServerList = dynamic([{PerformanceApplicationServer}]);\r\nlet workProcessType = '{performanceWorkProcessType}';\r\nSapNetweaver_ABAPGetWPTable_CL\r\n| where serverTimestamp_t between (todatetime({PerformanceTimeRange:start}) .. todatetime({PerformanceTimeRange:end}))\r\n| where SID_s == '{PerformanceSID}'\r\n| extend instanceNr_s = tostring(toint(instanceNr_d))\r\n| extend instanceNr_s = iff(strlen(instanceNr_s) == 2, instanceNr_s, strcat( \"0\", instanceNr_s))\r\n| extend appServer = strcat(hostname_s, \"_\", instanceNr_s)\r\n| where array_length(appServerList) == 0 or appServer in (appServerList)\r\n| where Typ_s == workProcessType\r\n| summarize totalWP = count(), freeWP = countif(Status_s == \"Wait\") by bin(timestamp_t, 1m), Typ_s\r\n| extend activeWP = totalWP - freeWP",
-              "size": 0,
-              "aggregation": 3,
-              "color": "green",
-              "noDataMessage": "No work processes found for the selected filter values.",
+              "query": "let appServerList = dynamic([{PerformanceApplicationServer}]);\r\nlet baseQuery = SapNetweaver_EnqGetStatistic_CL\r\n| where SID_s == '{PerformanceSID}'\r\n| extend instanceNr_s = tostring(toint(instanceNr_d))\r\n| extend instanceNr_s = iff(strlen(instanceNr_s) == 2, instanceNr_s, strcat( \"0\", instanceNr_s))\r\n| extend appServer = strcat(hostname_s, \"_\", instanceNr_s)\r\n| where array_length(appServerList) == 0 or appServer in (appServerList);\r\nlet thresholdQuery = baseQuery\r\n| where serverTimestamp_t > ago(24h)\r\n| project enqueue_requests_d\r\n| summarize threshold = percentile(enqueue_requests_d, 95);\r\nbaseQuery\r\n| where serverTimestamp_t between (todatetime({PerformanceTimeRange:start}) .. todatetime({PerformanceTimeRange:end}))\r\n| project enqueue_requests_d, serverTimestamp_t\r\n| summarize sum(enqueue_requests_d), arg_max(serverTimestamp_t, enqueue_requests_d)\r\n| extend dummy=1\r\n| join kind=inner ( thresholdQuery | extend dummy=1) on dummy\r\n| extend percentageChange = iff(threshold == 0, toreal(0), (toreal(enqueue_requests_d - threshold) / toreal(threshold) * 100))\r\n| project sum_enqueue_requests_d, percentageChange, displayPercentChange = round(abs(percentageChange), 3)\r\n| extend Title = \"Number Of Lock Requests\"",
+              "size": 4,
               "queryType": 0,
               "resourceType": "microsoft.operationalinsights/workspaces",
-              "visualization": "barchart",
-              "chartSettings": {
-                "xAxis": "timestamp_t",
-                "yAxis": [
-                  "activeWP",
-                  "freeWP"
-                ],
-                "group": null,
-                "createOtherGroup": 0,
-                "seriesLabelSettings": [
-                  {
-                    "seriesName": "activeWP",
-                    "color": "red"
-                  },
-                  {
-                    "seriesName": "freeWP",
-                    "color": "blue"
+              "visualization": "tiles",
+              "tileSettings": {
+                "titleContent": {
+                  "formatter": 2,
+                  "numberFormat": {
+                    "unit": 1,
+                    "options": {
+                      "style": "decimal",
+                      "maximumFractionDigits": 2
+                    }
                   }
-                ]
+                },
+                "leftContent": {
+                  "columnMatch": "sum_enqueue_requests_d",
+                  "formatter": 12,
+                  "formatOptions": {
+                    "palette": "blue"
+                  },
+                  "numberFormat": {
+                    "unit": 17,
+                    "options": {
+                      "style": "decimal",
+                      "useGrouping": false,
+                      "maximumFractionDigits": 2,
+                      "maximumSignificantDigits": 3
+                    }
+                  }
+                },
+                "rightContent": {
+                  "columnMatch": "percentageChange",
+                  "formatter": 18,
+                  "formatOptions": {
+                    "thresholdsOptions": "icons",
+                    "thresholdsGrid": [
+                      {
+                        "operator": ">",
+                        "thresholdValue": "0",
+                        "representation": "up",
+                        "text": "[\"displayPercentChange\"]%"
+                      },
+                      {
+                        "operator": "==",
+                        "thresholdValue": "0",
+                        "text": ""
+                      },
+                      {
+                        "operator": "<",
+                        "thresholdValue": "0",
+                        "representation": "down",
+                        "text": "[\"displayPercentChange\"]%"
+                      },
+                      {
+                        "operator": "Default",
+                        "thresholdValue": null,
+                        "representation": "down",
+                        "text": "[\"displayPercentChange\"]%"
+                      }
+                    ]
+                  }
+                },
+                "secondaryContent": {
+                  "columnMatch": "Title",
+                  "formatter": 1
+                },
+                "showBorder": true,
+                "size": "full"
               }
             },
-            "name": "WorkProcessUtilizationTrend"
+            "customWidth": "33",
+            "name": "Number Of Lock Requests"
+          },
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "let appServerList = dynamic([{PerformanceApplicationServer}]);\r\nlet baseQuery = SapNetweaver_EnqGetStatistic_CL\r\n| where SID_s == '{PerformanceSID}'\r\n| extend instanceNr_s = tostring(toint(instanceNr_d))\r\n| extend instanceNr_s = iff(strlen(instanceNr_s) == 2, instanceNr_s, strcat( \"0\", instanceNr_s))\r\n| extend appServer = strcat(hostname_s, \"_\", instanceNr_s)\r\n| where array_length(appServerList) == 0 or appServer in (appServerList);\r\nlet thresholdQuery = baseQuery\r\n| where serverTimestamp_t > ago(24h)\r\n| project enqueue_rejects_d\r\n| summarize threshold = percentile(enqueue_rejects_d, 95);\r\nbaseQuery\r\n| where serverTimestamp_t between (todatetime({PerformanceTimeRange:start}) .. todatetime({PerformanceTimeRange:end}))\r\n| project enqueue_rejects_d, serverTimestamp_t\r\n| summarize sum(enqueue_rejects_d), arg_max(serverTimestamp_t, enqueue_rejects_d)\r\n| extend dummy=1\r\n| join kind=inner ( thresholdQuery | extend dummy=1) on dummy\r\n| extend percentageChange = iff(threshold == 0, toreal(0), toreal(enqueue_rejects_d - threshold) / toreal(threshold) * 100)\r\n| project sum_enqueue_rejects_d, percentageChange, displayPercentChange = round(abs(percentageChange), 3)\r\n| extend Title = \"Rejected Lock Requests\"",
+              "size": 4,
+              "queryType": 0,
+              "resourceType": "microsoft.operationalinsights/workspaces",
+              "visualization": "tiles",
+              "tileSettings": {
+                "titleContent": {
+                  "formatter": 2,
+                  "numberFormat": {
+                    "unit": 1,
+                    "options": {
+                      "style": "decimal",
+                      "maximumFractionDigits": 2
+                    }
+                  }
+                },
+                "leftContent": {
+                  "columnMatch": "sum_enqueue_rejects_d",
+                  "formatter": 12,
+                  "formatOptions": {
+                    "palette": "blue"
+                  },
+                  "numberFormat": {
+                    "unit": 17,
+                    "options": {
+                      "style": "decimal",
+                      "useGrouping": false,
+                      "maximumFractionDigits": 2,
+                      "maximumSignificantDigits": 3
+                    }
+                  }
+                },
+                "rightContent": {
+                  "columnMatch": "percentageChange",
+                  "formatter": 18,
+                  "formatOptions": {
+                    "thresholdsOptions": "icons",
+                    "thresholdsGrid": [
+                      {
+                        "operator": ">",
+                        "thresholdValue": "0",
+                        "representation": "up",
+                        "text": "[\"displayPercentChange\"]%"
+                      },
+                      {
+                        "operator": "==",
+                        "thresholdValue": "0",
+                        "text": ""
+                      },
+                      {
+                        "operator": "<",
+                        "thresholdValue": "0",
+                        "representation": "down",
+                        "text": "[\"displayPercentChange\"]%"
+                      },
+                      {
+                        "operator": "Default",
+                        "thresholdValue": null,
+                        "representation": "down",
+                        "text": "[\"displayPercentChange\"]%"
+                      }
+                    ]
+                  },
+                  "numberFormat": {
+                    "unit": 0,
+                    "options": {
+                      "style": "decimal",
+                      "useGrouping": false
+                    }
+                  }
+                },
+                "secondaryContent": {
+                  "columnMatch": "Title",
+                  "formatter": 1
+                },
+                "showBorder": true,
+                "size": "full"
+              }
+            },
+            "customWidth": "33",
+            "name": "Rejected Lock Requests"
+          },
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "let appServerList = dynamic([{PerformanceApplicationServer}]);\r\nSapNetweaver_EnqGetStatistic_CL\r\n| where SID_s == '{PerformanceSID}'\r\n| extend instanceNr_s = tostring(toint(instanceNr_d))\r\n| extend instanceNr_s = iff(strlen(instanceNr_s) == 2, instanceNr_s, strcat( \"0\", instanceNr_s))\r\n| extend appServer = strcat(hostname_s, \"_\", instanceNr_s)\r\n| where array_length(appServerList) == 0 or appServer in (appServerList)\r\n| where serverTimestamp_t between (todatetime({PerformanceTimeRange:start}) .. todatetime({PerformanceTimeRange:end}))\r\n| summarize TotalErrors = sum(enqueue_errors_d)\r\n| extend Title = \"Enqueue Errors\"",
+              "size": 4,
+              "queryType": 0,
+              "resourceType": "microsoft.operationalinsights/workspaces",
+              "visualization": "tiles",
+              "tileSettings": {
+                "titleContent": {
+                  "formatter": 2,
+                  "numberFormat": {
+                    "unit": 1,
+                    "options": {
+                      "style": "decimal",
+                      "maximumFractionDigits": 2
+                    }
+                  }
+                },
+                "leftContent": {
+                  "columnMatch": "TotalErrors",
+                  "formatter": 1,
+                  "numberFormat": {
+                    "unit": 17,
+                    "options": {
+                      "style": "decimal",
+                      "useGrouping": false,
+                      "maximumFractionDigits": 2,
+                      "maximumSignificantDigits": 3
+                    }
+                  }
+                },
+                "secondaryContent": {
+                  "columnMatch": "Title",
+                  "formatter": 1
+                },
+                "showBorder": true,
+                "size": "full"
+              }
+            },
+            "customWidth": "33",
+            "name": "Enqueue Errors"
+          },
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "let appServerList = dynamic([{PerformanceApplicationServer}]);\r\nlet baseQuery = SapNetweaver_EnqGetStatistic_CL\r\n| where SID_s == '{PerformanceSID}'\r\n| extend instanceNr_s = tostring(toint(instanceNr_d))\r\n| extend instanceNr_s = iff(strlen(instanceNr_s) == 2, instanceNr_s, strcat( \"0\", instanceNr_s))\r\n| extend appServer = strcat(hostname_s, \"_\", instanceNr_s)\r\n| where array_length(appServerList) == 0 or appServer in (appServerList);\r\nlet thresholdQuery = baseQuery\r\n| where serverTimestamp_t > ago(24h)\r\n| project lock_time_d\r\n| summarize threshold = percentile(lock_time_d, 95)\r\n| project threshold = iff(isnull(threshold), toreal(0), threshold);\r\nbaseQuery\r\n| where serverTimestamp_t between (todatetime({PerformanceTimeRange:start}) .. todatetime({PerformanceTimeRange:end}))\r\n| project lock_time_d, serverTimestamp_t\r\n| summarize avg(lock_time_d), arg_max(serverTimestamp_t, lock_time_d)\r\n| where isnan(avg_lock_time_d) != 1\r\n| extend dummy=1\r\n| join kind=inner ( thresholdQuery | extend dummy=1) on dummy\r\n| extend percentageChange = iff(threshold == 0, toreal(0), (toreal(lock_time_d - threshold) / toreal(threshold) * 100))\r\n| project avg_lock_time_d , percentageChange, displayPercentChange = round(abs(percentageChange), 3)\r\n| extend Title = \"Average Time For Lock Operations\"",
+              "size": 4,
+              "queryType": 0,
+              "resourceType": "microsoft.operationalinsights/workspaces",
+              "visualization": "tiles",
+              "tileSettings": {
+                "titleContent": {
+                  "formatter": 2,
+                  "numberFormat": {
+                    "unit": 1,
+                    "options": {
+                      "style": "decimal",
+                      "maximumFractionDigits": 2
+                    }
+                  }
+                },
+                "leftContent": {
+                  "columnMatch": "avg_lock_time_d",
+                  "formatter": 12,
+                  "formatOptions": {
+                    "palette": "blue"
+                  },
+                  "numberFormat": {
+                    "unit": 24,
+                    "options": {
+                      "style": "decimal",
+                      "useGrouping": false,
+                      "maximumFractionDigits": 2,
+                      "maximumSignificantDigits": 3
+                    }
+                  }
+                },
+                "rightContent": {
+                  "columnMatch": "percentageChange",
+                  "formatter": 18,
+                  "formatOptions": {
+                    "thresholdsOptions": "icons",
+                    "thresholdsGrid": [
+                      {
+                        "operator": ">",
+                        "thresholdValue": "0",
+                        "representation": "up",
+                        "text": "[\"displayPercentChange\"]%"
+                      },
+                      {
+                        "operator": "==",
+                        "thresholdValue": "0",
+                        "text": ""
+                      },
+                      {
+                        "operator": "<",
+                        "thresholdValue": "0",
+                        "representation": "down",
+                        "text": "[\"displayPercentChange\"]%"
+                      },
+                      {
+                        "operator": "Default",
+                        "thresholdValue": null,
+                        "representation": "down",
+                        "text": "[\"displayPercentChange\"]%"
+                      }
+                    ]
+                  }
+                },
+                "secondaryContent": {
+                  "columnMatch": "Title",
+                  "formatter": 1
+                },
+                "showBorder": true,
+                "size": "full"
+              }
+            },
+            "customWidth": "33",
+            "name": "Average Time Taken For Lock Operations"
+          },
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "let appServerList = dynamic([{PerformanceApplicationServer}]);\r\nlet baseQuery = SapNetweaver_EnqGetStatistic_CL\r\n| where SID_s == '{PerformanceSID}'\r\n| extend instanceNr_s = tostring(toint(instanceNr_d))\r\n| extend instanceNr_s = iff(strlen(instanceNr_s) == 2, instanceNr_s, strcat( \"0\", instanceNr_s))\r\n| extend appServer = strcat(hostname_s, \"_\", instanceNr_s)\r\n| where array_length(appServerList) == 0 or appServer in (appServerList);\r\nlet thresholdQuery = baseQuery\r\n| where serverTimestamp_t > ago(24h)\r\n| project lock_wait_time_d\r\n| summarize threshold = percentile(lock_wait_time_d, 95);\r\nbaseQuery\r\n| where serverTimestamp_t between (todatetime({PerformanceTimeRange:start}) .. todatetime({PerformanceTimeRange:end}))\r\n| project lock_wait_time_d, serverTimestamp_t\r\n| summarize avg(lock_wait_time_d), arg_max(serverTimestamp_t, lock_wait_time_d)\r\n| where isnan(avg_lock_wait_time_d) != 1\r\n| extend dummy=1\r\n| join kind=inner ( thresholdQuery | extend dummy=1) on dummy\r\n| extend percentageChange = iff(threshold == 0, toreal(0), toreal(lock_wait_time_d - threshold) / toreal(threshold) * 100)\r\n| project avg_lock_wait_time_d, percentageChange, displayPercentChange = round(abs(percentageChange), 3)\r\n| extend Title = \"Average Time For Lock Operations\"",
+              "size": 4,
+              "queryType": 0,
+              "resourceType": "microsoft.operationalinsights/workspaces",
+              "visualization": "tiles",
+              "tileSettings": {
+                "titleContent": {
+                  "formatter": 2,
+                  "numberFormat": {
+                    "unit": 1,
+                    "options": {
+                      "style": "decimal",
+                      "maximumFractionDigits": 2
+                    }
+                  }
+                },
+                "leftContent": {
+                  "columnMatch": "avg_lock_wait_time_d",
+                  "formatter": 12,
+                  "formatOptions": {
+                    "palette": "blue"
+                  },
+                  "numberFormat": {
+                    "unit": 24,
+                    "options": {
+                      "style": "decimal",
+                      "useGrouping": false,
+                      "maximumFractionDigits": 2,
+                      "maximumSignificantDigits": 3
+                    }
+                  }
+                },
+                "rightContent": {
+                  "columnMatch": "percentageChange",
+                  "formatter": 18,
+                  "formatOptions": {
+                    "thresholdsOptions": "icons",
+                    "thresholdsGrid": [
+                      {
+                        "operator": ">",
+                        "thresholdValue": "0",
+                        "representation": "up",
+                        "text": "[\"displayPercentChange\"]%"
+                      },
+                      {
+                        "operator": "==",
+                        "thresholdValue": "0",
+                        "text": ""
+                      },
+                      {
+                        "operator": "<",
+                        "thresholdValue": "0",
+                        "representation": "down",
+                        "text": "[\"displayPercentChange\"]%"
+                      },
+                      {
+                        "operator": "Default",
+                        "thresholdValue": null,
+                        "representation": "down",
+                        "text": "[\"displayPercentChange\"]%"
+                      }
+                    ]
+                  }
+                },
+                "secondaryContent": {
+                  "columnMatch": "Title",
+                  "formatter": 1
+                },
+                "showBorder": true,
+                "size": "full"
+              }
+            },
+            "customWidth": "33",
+            "name": "Average Waiting Time Taken For Lock Operations"
+          },
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "let appServerList = dynamic([{PerformanceApplicationServer}]);\r\nlet baseQuery = SapNetweaver_EnqGetStatistic_CL\r\n| where SID_s == '{PerformanceSID}'\r\n| extend instanceNr_s = tostring(toint(instanceNr_d))\r\n| extend instanceNr_s = iff(strlen(instanceNr_s) == 2, instanceNr_s, strcat( \"0\", instanceNr_s))\r\n| extend appServer = strcat(hostname_s, \"_\", instanceNr_s)\r\n| where array_length(appServerList) == 0 or appServer in (appServerList);\r\nlet thresholdQuery = baseQuery\r\n| where serverTimestamp_t > ago(24h)\r\n| project server_time_d\r\n| summarize threshold = percentile(server_time_d, 95);\r\nbaseQuery\r\n| where serverTimestamp_t between (todatetime({PerformanceTimeRange:start}) .. todatetime({PerformanceTimeRange:end}))\r\n| project server_time_d, serverTimestamp_t\r\n| summarize avg(server_time_d), arg_max(serverTimestamp_t, server_time_d)\r\n| where isnan(avg_server_time_d) != 1\r\n| extend dummy=1\r\n| join kind=inner ( thresholdQuery | extend dummy=1) on dummy\r\n| extend percentageChange = iff(threshold == 0, toreal(0), toreal(server_time_d - threshold) / toreal(threshold) * 100)\r\n| project avg_server_time_d, percentageChange, displayPercentChange = round(abs(percentageChange), 3)\r\n| extend Title = \"Average Time Taken In Enqueue Server\"",
+              "size": 4,
+              "queryType": 0,
+              "resourceType": "microsoft.operationalinsights/workspaces",
+              "visualization": "tiles",
+              "tileSettings": {
+                "titleContent": {
+                  "formatter": 2,
+                  "numberFormat": {
+                    "unit": 1,
+                    "options": {
+                      "style": "decimal",
+                      "maximumFractionDigits": 2
+                    }
+                  }
+                },
+                "leftContent": {
+                  "columnMatch": "avg_server_time_d",
+                  "formatter": 12,
+                  "formatOptions": {
+                    "palette": "blue"
+                  },
+                  "numberFormat": {
+                    "unit": 24,
+                    "options": {
+                      "style": "decimal",
+                      "useGrouping": false,
+                      "maximumFractionDigits": 2,
+                      "maximumSignificantDigits": 3
+                    }
+                  }
+                },
+                "rightContent": {
+                  "columnMatch": "percentageChange",
+                  "formatter": 18,
+                  "formatOptions": {
+                    "thresholdsOptions": "icons",
+                    "thresholdsGrid": [
+                      {
+                        "operator": ">",
+                        "thresholdValue": "0",
+                        "representation": "up",
+                        "text": "[\"displayPercentChange\"]%"
+                      },
+                      {
+                        "operator": "==",
+                        "thresholdValue": "0",
+                        "text": ""
+                      },
+                      {
+                        "operator": "<",
+                        "thresholdValue": "0",
+                        "representation": "down",
+                        "text": "[\"displayPercentChange\"]%"
+                      },
+                      {
+                        "operator": "Default",
+                        "thresholdValue": null,
+                        "representation": "down",
+                        "text": "[\"displayPercentChange\"]%"
+                      }
+                    ]
+                  },
+                  "numberFormat": {
+                    "unit": 0,
+                    "options": {
+                      "style": "decimal",
+                      "useGrouping": false
+                    }
+                  }
+                },
+                "secondaryContent": {
+                  "columnMatch": "Title",
+                  "formatter": 1
+                },
+                "showBorder": true,
+                "size": "full"
+              }
+            },
+            "customWidth": "33",
+            "name": "Average Time Taken In Enqueue Server"
+          },
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "let appServerList = dynamic([{PerformanceApplicationServer}]);\r\nlet baseQuery = SapNetweaver_EnqGetStatistic_CL\r\n| where SID_s == '{PerformanceSID}'\r\n| extend instanceNr_s = tostring(toint(instanceNr_d))\r\n| extend instanceNr_s = iff(strlen(instanceNr_s) == 2, instanceNr_s, strcat( \"0\", instanceNr_s))\r\n| extend appServer = strcat(hostname_s, \"_\", instanceNr_s)\r\n| where array_length(appServerList) == 0 or appServer in (appServerList);\r\nlet lockQuery = baseQuery\r\n| project locks_now_d, locks_max_d, serverTimestamp_t, arguments_state_s\r\n| summarize arg_max(serverTimestamp_t, arguments_state_s), Average=avg(locks_now_d), Max=max(locks_now_d), ObjectLimit=max(locks_max_d)\r\n| where isnan(Average) != 1\r\n| extend ['Lock Object Type'] = \"Locks\"\r\n| project ['Lock Object Type'], arguments_state_s, Average, Max, ObjectLimit;\r\nlet ownerQuery = baseQuery\r\n| project owner_now_d, owner_max_d, arguments_state_s, serverTimestamp_t\r\n| summarize arg_max(serverTimestamp_t, arguments_state_s), Average=avg(owner_now_d), Max=max(owner_now_d), ObjectLimit=max(owner_max_d)\r\n| where isnan(Average) != 1\r\n| extend ['Lock Object Type'] = \"Owner\"\r\n| project ['Lock Object Type'], arguments_state_s, Average, Max, ObjectLimit;\r\nlet argumentQuery = baseQuery\r\n| project owner_now_d, owner_max_d, arguments_state_s, serverTimestamp_t\r\n| summarize arg_max(serverTimestamp_t, arguments_state_s), Average=avg(owner_now_d), Max=max(owner_now_d), ObjectLimit=max(owner_max_d)\r\n| where isnan(Average) != 1\r\n| extend ['Lock Object Type'] = \"Arguments\"\r\n| project ['Lock Object Type'], arguments_state_s, Average, Max, ObjectLimit;\r\nlet replicationStateQuery = baseQuery\r\n| project replication_state_s, serverTimestamp_t\r\n| summarize arg_max(serverTimestamp_t, replication_state_s)\r\n| project arguments_state_s = replication_state_s\r\n| where isempty(arguments_state_s) != 1\r\n| extend ['Lock Object Type'] = 'Replication State';\r\nlockQuery\r\n| union ownerQuery\r\n| union argumentQuery\r\n| union replicationStateQuery\r\n| extend Status = iff(arguments_state_s == 'SAPControl-GREEN', \"OK\", \"\")\r\n| extend Status = iff(arguments_state_s == 'SAPControl-RED', \"Critical\", Status)\r\n| extend Status = iff(isempty(Status), \"Warning\", Status)\r\n| project ['Lock Object Type'], Status, Average, Max, ObjectLimit\r\n| project-reorder ['Lock Object Type'], Status, Average, Max, ObjectLimit",
+              "size": 1,
+              "noDataMessage": "The query returned no result",
+              "timeContext": {
+                "durationMs": 86400000
+              },
+              "queryType": 0,
+              "resourceType": "microsoft.operationalinsights/workspaces",
+              "visualization": "table",
+              "gridSettings": {
+                "formatters": [
+                  {
+                    "columnMatch": "Lock Object Type",
+                    "formatter": 1
+                  },
+                  {
+                    "columnMatch": "Status",
+                    "formatter": 18,
+                    "formatOptions": {
+                      "thresholdsOptions": "icons",
+                      "thresholdsGrid": [
+                        {
+                          "operator": "==",
+                          "thresholdValue": "OK",
+                          "representation": "success",
+                          "text": "{0}"
+                        },
+                        {
+                          "operator": "==",
+                          "thresholdValue": "Critical",
+                          "representation": "4",
+                          "text": "{0}"
+                        },
+                        {
+                          "operator": "==",
+                          "thresholdValue": "Warning",
+                          "representation": "2",
+                          "text": "{0}"
+                        },
+                        {
+                          "operator": "Default",
+                          "thresholdValue": null,
+                          "representation": "Unknown",
+                          "text": "{0}{1}"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "columnMatch": "Average",
+                    "formatter": 1,
+                    "numberFormat": {
+                      "unit": 0,
+                      "options": {
+                        "style": "decimal",
+                        "maximumFractionDigits": 3
+                      }
+                    }
+                  },
+                  {
+                    "columnMatch": "Max",
+                    "formatter": 1
+                  },
+                  {
+                    "columnMatch": "ObjectLimit",
+                    "formatter": 1,
+                    "numberFormat": {
+                      "unit": 17,
+                      "options": {
+                        "style": "decimal"
+                      }
+                    },
+                    "tooltipFormat": {
+                      "tooltip": "[\"ObjectLimit\"]"
+                    }
+                  }
+                ],
+                "sortBy": [
+                  {
+                    "itemKey": "Lock Object Type",
+                    "sortOrder": 1
+                  }
+                ],
+                "labelSettings": [
+                  {
+                    "columnId": "Lock Object Type"
+                  },
+                  {
+                    "columnId": "Status"
+                  },
+                  {
+                    "columnId": "Average",
+                    "label": "Average Number Of Objects"
+                  },
+                  {
+                    "columnId": "Max",
+                    "label": "Max Number Of Objects"
+                  },
+                  {
+                    "columnId": "ObjectLimit",
+                    "label": "Object Limit"
+                  }
+                ]
+              },
+              "sortBy": [
+                {
+                  "itemKey": "Lock Object Type",
+                  "sortOrder": 1
+                }
+              ]
+            },
+            "customWidth": "100",
+            "name": "Enqueue Lock Statistics Status"
           },
           {
             "type": 3,
@@ -1064,38 +1687,7 @@
                 ]
               }
             },
-            "name": "EnqueueLocksTrend"
-          },
-          {
-            "type": 3,
-            "content": {
-              "version": "KqlItem/1.0",
-              "query": "let extractColumn = dynamic(['95% Percentile', 'Median', 'Average number of locks', 'Max number of Locks', 'Configured High Locks']);\r\nlet appServerList = dynamic([{PerformanceApplicationServer}]);\r\nlet baseQuery = SapNetweaver_EnqGetStatistic_CL\r\n| where SID_s == '{PerformanceSID}'\r\n| extend instanceNr_s = tostring(toint(instanceNr_d))\r\n| extend instanceNr_s = iff(strlen(instanceNr_s) == 2, instanceNr_s, strcat( \"0\", instanceNr_s))\r\n| extend appServer = strcat(hostname_s, \"_\", instanceNr_s)\r\n| where array_length(appServerList) == 0 or appServer in (appServerList);\r\nbaseQuery\r\n| project locks_now_d, locks_max_d\r\n| summarize ['95% Percentile']=percentile(locks_now_d, 95), Median=percentile(locks_now_d, 50), ['Average number of locks']=avg(locks_now_d), ['Max number of Locks'] = max(locks_now_d), ['Configured High Locks'] = max(locks_max_d)\r\n| project properties=pack_all()\r\n| mv-apply name = extractColumn to typeof(string) on \r\n(\r\n    project name, value=properties[name]\r\n)\r\n| project-away properties",
-              "size": 4,
-              "title": "Enqueue Lock Statistics",
-              "queryType": 0,
-              "resourceType": "microsoft.operationalinsights/workspaces",
-              "visualization": "tiles",
-              "tileSettings": {
-                "titleContent": {
-                  "columnMatch": "value",
-                  "formatter": 1,
-                  "numberFormat": {
-                    "unit": 0,
-                    "options": {
-                      "style": "decimal",
-                      "maximumFractionDigits": 3
-                    }
-                  }
-                },
-                "subtitleContent": {
-                  "columnMatch": "name",
-                  "formatter": 1
-                },
-                "showBorder": false
-              }
-            },
-            "name": "EnqueueLockStatistics"
+            "name": "Enqueue Locks Trend"
           }
         ]
       },
@@ -1166,7 +1758,7 @@
                   "label": "SID",
                   "type": 2,
                   "query": "SapNetweaver_GetSystemInstanceList_CL\r\n| distinct SID_s",
-                  "value": "MSX",
+                  "value": null,
                   "typeSettings": {
                     "additionalResourceOptions": [],
                     "showDefault": false
@@ -1189,7 +1781,8 @@
                     "showDefault": false
                   },
                   "queryType": 0,
-                  "resourceType": "microsoft.operationalinsights/workspaces"
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "value": []
                 }
               ],
               "style": "pills",
@@ -1199,215 +1792,158 @@
             "name": "queueStatisticsParameters"
           },
           {
-            "type": 1,
+            "type": 12,
             "content": {
-              "json": "**Queue Utilization Statistics**"
+              "version": "NotebookGroup/1.0",
+              "groupType": "editable",
+              "title": "Queue Utilization Statistics",
+              "items": [
+                {
+                  "type": 3,
+                  "content": {
+                    "version": "KqlItem/1.0",
+                    "query": "let appServerList = dynamic([{PerformanceApplicationServer}]);\r\nlet baseQuery = SapNetweaver_GetQueueStatistic_CL\r\n| where serverTimestamp_t between (todatetime({PerformanceTimeRange:start}) .. todatetime({PerformanceTimeRange:end}))\r\n| where SID_s == '{PerformanceSID}'\r\n| extend instanceNr_s = tostring(toint(instanceNr_d))\r\n| extend instanceNr_s = iff(strlen(instanceNr_s) == 2, instanceNr_s, strcat( \"0\", instanceNr_s))\r\n| extend appServer = strcat(hostname_s, \"_\", instanceNr_s)\r\n| where array_length(appServerList) == 0 or appServer in (appServerList)\r\n| where Typ_s == 'ABAP/UPD'\r\n| summarize AvgRequests = avg(Now_d), QueueLimit = max(Max_d);\r\nlet freeQuery = baseQuery\r\n| project Title = 'Used', Utilization = AvgRequests;\r\nlet utilizationQuery = baseQuery\r\n| project Title = 'Free', Utilization = QueueLimit - AvgRequests;\r\nfreeQuery\r\n| union utilizationQuery",
+                    "size": 1,
+                    "title": "Update Queue (UPD)",
+                    "queryType": 0,
+                    "resourceType": "microsoft.operationalinsights/workspaces",
+                    "visualization": "piechart",
+                    "chartSettings": {
+                      "yAxis": [
+                        "Utilization"
+                      ],
+                      "group": "Title",
+                      "createOtherGroup": null,
+                      "showMetrics": false,
+                      "seriesLabelSettings": [
+                        {
+                          "seriesName": "Free",
+                          "color": "blue"
+                        },
+                        {
+                          "seriesName": "Queue Utilization",
+                          "color": "red"
+                        }
+                      ]
+                    }
+                  },
+                  "customWidth": "25",
+                  "name": "UpdateQueuePieChart"
+                },
+                {
+                  "type": 3,
+                  "content": {
+                    "version": "KqlItem/1.0",
+                    "query": "let appServerList = dynamic([{PerformanceApplicationServer}]);\r\nlet baseQuery = SapNetweaver_GetQueueStatistic_CL\r\n| where serverTimestamp_t between (todatetime({PerformanceTimeRange:start}) .. todatetime({PerformanceTimeRange:end}))\r\n| where SID_s == '{PerformanceSID}'\r\n| extend instanceNr_s = tostring(toint(instanceNr_d))\r\n| extend instanceNr_s = iff(strlen(instanceNr_s) == 2, instanceNr_s, strcat( \"0\", instanceNr_s))\r\n| extend appServer = strcat(hostname_s, \"_\", instanceNr_s)\r\n| where array_length(appServerList) == 0 or appServer in (appServerList)\r\n| where Typ_s == 'ABAP/DIA'\r\n| summarize AvgRequests = avg(Now_d), QueueLimit = max(Max_d);\r\nlet freeQuery = baseQuery\r\n| project Title = 'Used', Utilization = AvgRequests;\r\nlet utilizationQuery = baseQuery\r\n| project Title = 'Free', Utilization = QueueLimit - AvgRequests;\r\nfreeQuery\r\n| union utilizationQuery",
+                    "size": 1,
+                    "title": "Dialog Queue (DIA)",
+                    "queryType": 0,
+                    "resourceType": "microsoft.operationalinsights/workspaces",
+                    "visualization": "piechart",
+                    "chartSettings": {
+                      "yAxis": [
+                        "Utilization"
+                      ],
+                      "group": "Title",
+                      "createOtherGroup": null,
+                      "showMetrics": false,
+                      "seriesLabelSettings": [
+                        {
+                          "seriesName": "Free",
+                          "label": "Free",
+                          "color": "blue"
+                        },
+                        {
+                          "seriesName": "Used",
+                          "label": "Used",
+                          "color": "red"
+                        }
+                      ]
+                    }
+                  },
+                  "customWidth": "25",
+                  "name": "DialogQueuePieChart"
+                },
+                {
+                  "type": 3,
+                  "content": {
+                    "version": "KqlItem/1.0",
+                    "query": "let appServerList = dynamic([{PerformanceApplicationServer}]);\r\nlet baseQuery = SapNetweaver_GetQueueStatistic_CL\r\n| where serverTimestamp_t between (todatetime({PerformanceTimeRange:start}) .. todatetime({PerformanceTimeRange:end}))\r\n| where SID_s == '{PerformanceSID}'\r\n| extend instanceNr_s = tostring(toint(instanceNr_d))\r\n| extend instanceNr_s = iff(strlen(instanceNr_s) == 2, instanceNr_s, strcat( \"0\", instanceNr_s))\r\n| extend appServer = strcat(hostname_s, \"_\", instanceNr_s)\r\n| where array_length(appServerList) == 0 or appServer in (appServerList)\r\n| where Typ_s == 'ABAP/ENQ'\r\n| summarize AvgRequests = avg(Now_d), QueueLimit = max(Max_d);\r\nlet freeQuery = baseQuery\r\n| project Title = 'Used', Utilization = AvgRequests;\r\nlet utilizationQuery = baseQuery\r\n| project Title = 'Free', Utilization = QueueLimit - AvgRequests;\r\nfreeQuery\r\n| union utilizationQuery",
+                    "size": 1,
+                    "title": "Enqueue Queue (ENQ)",
+                    "queryType": 0,
+                    "resourceType": "microsoft.operationalinsights/workspaces",
+                    "visualization": "piechart",
+                    "chartSettings": {
+                      "yAxis": [
+                        "Utilization"
+                      ],
+                      "group": "Title",
+                      "createOtherGroup": null,
+                      "showMetrics": false,
+                      "seriesLabelSettings": [
+                        {
+                          "seriesName": "Free",
+                          "color": "blue"
+                        },
+                        {
+                          "seriesName": "Queue Utilization",
+                          "color": "red"
+                        }
+                      ]
+                    }
+                  },
+                  "customWidth": "25",
+                  "name": "EnqueueQueuePieChart"
+                },
+                {
+                  "type": 3,
+                  "content": {
+                    "version": "KqlItem/1.0",
+                    "query": "let appServerList = dynamic([{PerformanceApplicationServer}]);\r\nlet baseQuery = SapNetweaver_GetQueueStatistic_CL\r\n| where serverTimestamp_t between (todatetime({PerformanceTimeRange:start}) .. todatetime({PerformanceTimeRange:end}))\r\n| where SID_s == '{PerformanceSID}'\r\n| extend instanceNr_s = tostring(toint(instanceNr_d))\r\n| extend instanceNr_s = iff(strlen(instanceNr_s) == 2, instanceNr_s, strcat( \"0\", instanceNr_s))\r\n| extend appServer = strcat(hostname_s, \"_\", instanceNr_s)\r\n| where array_length(appServerList) == 0 or appServer in (appServerList)\r\n| where Typ_s == 'ABAP/BTC'\r\n| summarize AvgRequests = avg(Now_d), QueueLimit = max(Max_d);\r\nlet freeQuery = baseQuery\r\n| project Title = 'Used', Utilization = AvgRequests;\r\nlet utilizationQuery = baseQuery\r\n| project Title = 'Free', Utilization = QueueLimit - AvgRequests;\r\nfreeQuery\r\n| union utilizationQuery",
+                    "size": 1,
+                    "title": "Batch Queue (BTC)",
+                    "queryType": 0,
+                    "resourceType": "microsoft.operationalinsights/workspaces",
+                    "visualization": "piechart",
+                    "chartSettings": {
+                      "yAxis": [
+                        "Utilization"
+                      ],
+                      "group": "Title",
+                      "createOtherGroup": null,
+                      "showMetrics": false,
+                      "seriesLabelSettings": [
+                        {
+                          "seriesName": "Free",
+                          "color": "blue"
+                        },
+                        {
+                          "seriesName": "Queue Utilization",
+                          "color": "red"
+                        }
+                      ]
+                    }
+                  },
+                  "customWidth": "25",
+                  "name": "BatchQueuePieChart"
+                }
+              ]
             },
-            "name": "queueStatisticsTitle - Copy"
+            "name": "Queue Utilization Statistics"
           },
           {
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "let appServerList = dynamic([{PerformanceApplicationServer}]);\r\nlet baseQuery = SapNetweaver_GetQueueStatistic_CL\r\n| where serverTimestamp_t between (todatetime({PerformanceTimeRange:start}) .. todatetime({PerformanceTimeRange:end}))\r\n| where SID_s == '{PerformanceSID}'\r\n| extend instanceNr_s = tostring(toint(instanceNr_d))\r\n| extend instanceNr_s = iff(strlen(instanceNr_s) == 2, instanceNr_s, strcat( \"0\", instanceNr_s))\r\n| extend appServer = strcat(hostname_s, \"_\", instanceNr_s)\r\n| where array_length(appServerList) == 0 or appServer in (appServerList)\r\n| where Typ_s == 'ABAP/UPD'\r\n| project Now_d, High_d, serverTimestamp_t\r\n| extend Utilization = iff(High_d != 0, round(toreal(Now_d) / toreal(High_d), 3) * 100, 0.0)\r\n| extend UtilizationGroup = iff(Utilization <= 20, \"< 20%\", \"\")\r\n| extend UtilizationGroup = iff(Utilization > 20 and Utilization <= 40, \"21-40%\", UtilizationGroup)\r\n| extend UtilizationGroup = iff(Utilization > 40 and Utilization <= 60, \"41-60%\", UtilizationGroup)\r\n| extend UtilizationGroup = iff(Utilization > 60 and Utilization <= 80, \"61-80%\", UtilizationGroup)\r\n| extend UtilizationGroup = iff(Utilization > 80, \">81%\", UtilizationGroup)\r\n| summarize Count = count() by UtilizationGroup;\r\nlet total = baseQuery\r\n| summarize Total=sum(Count);\r\nbaseQuery\r\n| extend dummy=1\r\n| join kind=inner (total | extend dummy=1) on dummy\r\n| extend QueueUtilization = Count\r\n| project QueueUtilization, UtilizationGroup",
+              "query": "let appServerList = dynamic([{PerformanceApplicationServer}]);\r\nlet baseQuery = SapNetweaver_GetQueueStatistic_CL\r\n| where serverTimestamp_t between (todatetime({PerformanceTimeRange:start}) .. todatetime({PerformanceTimeRange:end}))\r\n| where SID_s == '{PerformanceSID}'\r\n| extend instanceNr_s = tostring(toint(instanceNr_d))\r\n| extend instanceNr_s = iff(strlen(instanceNr_s) == 2, instanceNr_s, strcat( \"0\", instanceNr_s))\r\n| extend appServer = strcat(hostname_s, \"_\", instanceNr_s)\r\n| where array_length(appServerList) == 0 or appServer in (appServerList);\r\nlet MaxQuery = baseQuery\r\n| summarize QueueLimit=max(Max_d) by Typ_s;\r\nlet CurrentStatusQuery = baseQuery\r\n| summarize CurrentStatus = arg_max(serverTimestamp_t, Now_d) by Typ_s;\r\nbaseQuery\r\n| summarize AvgRequests = avg(Now_d), MaxRequests = max(Now_d), ReadRequest = sum(Reads_d), WriteRequest = sum(Writes_d) by Typ_s\r\n| join kind=inner MaxQuery on Typ_s\r\n| join kind=inner CurrentStatusQuery on Typ_s\r\n| extend QueueUtilization = iff(QueueLimit != 0, (toreal(Now_d) / toreal(QueueLimit)) * 100, 0.0)\r\n| extend Status = iff(QueueUtilization <= 40, \"OK\", \"\")\r\n| extend Status = iff(QueueUtilization > 40 and QueueUtilization <= 70 , \"Warning\", Status)\r\n| extend Status = iff(QueueUtilization > 70, \"Critical\", Status)\r\n| project Typ_s, Status, AvgRequests, MaxRequests, QueueLimit, WriteRequest, ReadRequest\r\n| project-reorder Typ_s, Status, AvgRequests, MaxRequests, QueueLimit, WriteRequest, ReadRequest",
               "size": 0,
-              "title": "Update Queue (UPD)",
-              "queryType": 0,
-              "resourceType": "microsoft.operationalinsights/workspaces",
-              "visualization": "piechart",
-              "chartSettings": {
-                "yAxis": [
-                  "QueueUtilization"
-                ],
-                "group": "UtilizationGroup",
-                "createOtherGroup": null,
-                "showMetrics": false,
-                "showLegend": true,
-                "seriesLabelSettings": [
-                  {
-                    "seriesName": "< 20%",
-                    "label": "",
-                    "color": "turquoise"
-                  },
-                  {
-                    "seriesName": "61-80%",
-                    "color": "orange"
-                  },
-                  {
-                    "seriesName": "41-60%",
-                    "color": "yellow"
-                  },
-                  {
-                    "seriesName": "21-40%",
-                    "color": "purpleDark"
-                  },
-                  {
-                    "seriesName": ">81%",
-                    "color": "green"
-                  }
-                ]
-              }
-            },
-            "customWidth": "50",
-            "name": "UpdateQueuePieChart"
-          },
-          {
-            "type": 3,
-            "content": {
-              "version": "KqlItem/1.0",
-              "query": "let appServerList = dynamic([{PerformanceApplicationServer}]);\r\nlet baseQuery = SapNetweaver_GetQueueStatistic_CL\r\n| where serverTimestamp_t between (todatetime({PerformanceTimeRange:start}) .. todatetime({PerformanceTimeRange:end}))\r\n| where SID_s == '{PerformanceSID}'\r\n| extend instanceNr_s = tostring(toint(instanceNr_d))\r\n| extend instanceNr_s = iff(strlen(instanceNr_s) == 2, instanceNr_s, strcat( \"0\", instanceNr_s))\r\n| extend appServer = strcat(hostname_s, \"_\", instanceNr_s)\r\n| where array_length(appServerList) == 0 or appServer in (appServerList)\r\n| where Typ_s == 'ABAP/DIA'\r\n| project Now_d, High_d, serverTimestamp_t\r\n| extend Utilization = iff(High_d != 0, round(toreal(Now_d) / toreal(High_d), 3) * 100, 0.0)\r\n| extend UtilizationGroup = iff(Utilization <= 20, \"< 20%\", \"\")\r\n| extend UtilizationGroup = iff(Utilization > 20 and Utilization <= 40, \"21-40%\", UtilizationGroup)\r\n| extend UtilizationGroup = iff(Utilization > 40 and Utilization <= 60, \"41-60%\", UtilizationGroup)\r\n| extend UtilizationGroup = iff(Utilization > 60 and Utilization <= 80, \"61-80%\", UtilizationGroup)\r\n| extend UtilizationGroup = iff(Utilization > 80, \">81%\", UtilizationGroup)\r\n| summarize Count = count() by UtilizationGroup;\r\nlet total = baseQuery\r\n| summarize Total=sum(Count);\r\nbaseQuery\r\n| extend dummy=1\r\n| join kind=inner (total | extend dummy=1) on dummy\r\n| extend QueueUtilization = Count\r\n| project QueueUtilization, UtilizationGroup",
-              "size": 0,
-              "title": "Dialog Queue (DIA)",
-              "queryType": 0,
-              "resourceType": "microsoft.operationalinsights/workspaces",
-              "visualization": "piechart",
-              "chartSettings": {
-                "yAxis": [
-                  "QueueUtilization"
-                ],
-                "group": "UtilizationGroup",
-                "createOtherGroup": null,
-                "showMetrics": false,
-                "showLegend": true,
-                "seriesLabelSettings": [
-                  {
-                    "seriesName": "< 20%",
-                    "label": "",
-                    "color": "turquoise"
-                  },
-                  {
-                    "seriesName": "61-80%",
-                    "color": "orange"
-                  },
-                  {
-                    "seriesName": "41-60%",
-                    "color": "yellow"
-                  },
-                  {
-                    "seriesName": "21-40%",
-                    "color": "purpleDark"
-                  },
-                  {
-                    "seriesName": ">81%",
-                    "color": "green"
-                  }
-                ]
-              }
-            },
-            "customWidth": "50",
-            "name": "DialogQueuePieChart"
-          },
-          {
-            "type": 3,
-            "content": {
-              "version": "KqlItem/1.0",
-              "query": "let appServerList = dynamic([{PerformanceApplicationServer}]);\r\nlet baseQuery = SapNetweaver_GetQueueStatistic_CL\r\n| where serverTimestamp_t between (todatetime({PerformanceTimeRange:start}) .. todatetime({PerformanceTimeRange:end}))\r\n| where SID_s == '{PerformanceSID}'\r\n| extend instanceNr_s = tostring(toint(instanceNr_d))\r\n| extend instanceNr_s = iff(strlen(instanceNr_s) == 2, instanceNr_s, strcat( \"0\", instanceNr_s))\r\n| extend appServer = strcat(hostname_s, \"_\", instanceNr_s)\r\n| where array_length(appServerList) == 0 or appServer in (appServerList)\r\n| where Typ_s == 'ABAP/ENQ'\r\n| project Now_d, High_d, serverTimestamp_t\r\n| extend Utilization = iff(High_d != 0, round(toreal(Now_d) / toreal(High_d), 3) * 100, 0.0)\r\n| extend UtilizationGroup = iff(Utilization <= 20, \"< 20%\", \"\")\r\n| extend UtilizationGroup = iff(Utilization > 20 and Utilization <= 40, \"21-40%\", UtilizationGroup)\r\n| extend UtilizationGroup = iff(Utilization > 40 and Utilization <= 60, \"41-60%\", UtilizationGroup)\r\n| extend UtilizationGroup = iff(Utilization > 60 and Utilization <= 80, \"61-80%\", UtilizationGroup)\r\n| extend UtilizationGroup = iff(Utilization > 80, \">81%\", UtilizationGroup)\r\n| summarize Count = count() by UtilizationGroup;\r\nlet total = baseQuery\r\n| summarize Total=sum(Count);\r\nbaseQuery\r\n| extend dummy=1\r\n| join kind=inner (total | extend dummy=1) on dummy\r\n| extend QueueUtilization = Count\r\n| project QueueUtilization, UtilizationGroup",
-              "size": 0,
-              "title": "Enqueue Queue (ENQ)",
-              "queryType": 0,
-              "resourceType": "microsoft.operationalinsights/workspaces",
-              "visualization": "piechart",
-              "chartSettings": {
-                "yAxis": [
-                  "QueueUtilization"
-                ],
-                "group": "UtilizationGroup",
-                "createOtherGroup": null,
-                "showMetrics": false,
-                "showLegend": true,
-                "seriesLabelSettings": [
-                  {
-                    "seriesName": "< 20%",
-                    "label": "",
-                    "color": "turquoise"
-                  },
-                  {
-                    "seriesName": "61-80%",
-                    "color": "orange"
-                  },
-                  {
-                    "seriesName": "41-60%",
-                    "color": "yellow"
-                  },
-                  {
-                    "seriesName": "21-40%",
-                    "color": "purpleDark"
-                  },
-                  {
-                    "seriesName": ">81%",
-                    "color": "green"
-                  }
-                ]
-              }
-            },
-            "customWidth": "50",
-            "name": "EnqueueQueuePieChart"
-          },
-          {
-            "type": 3,
-            "content": {
-              "version": "KqlItem/1.0",
-              "query": "let appServerList = dynamic([{PerformanceApplicationServer}]);\r\nlet baseQuery = SapNetweaver_GetQueueStatistic_CL\r\n| where serverTimestamp_t between (todatetime({PerformanceTimeRange:start}) .. todatetime({PerformanceTimeRange:end}))\r\n| where SID_s == '{PerformanceSID}'\r\n| extend instanceNr_s = tostring(toint(instanceNr_d))\r\n| extend instanceNr_s = iff(strlen(instanceNr_s) == 2, instanceNr_s, strcat( \"0\", instanceNr_s))\r\n| extend appServer = strcat(hostname_s, \"_\", instanceNr_s)\r\n| where array_length(appServerList) == 0 or appServer in (appServerList)\r\n| where Typ_s == 'ABAP/BTC'\r\n| project Now_d, High_d, serverTimestamp_t\r\n| extend Utilization = iff(High_d != 0, round(toreal(Now_d) / toreal(High_d), 3) * 100, 0.0)\r\n| extend UtilizationGroup = iff(Utilization <= 20, \"< 20%\", \"\")\r\n| extend UtilizationGroup = iff(Utilization > 20 and Utilization <= 40, \"21-40%\", UtilizationGroup)\r\n| extend UtilizationGroup = iff(Utilization > 40 and Utilization <= 60, \"41-60%\", UtilizationGroup)\r\n| extend UtilizationGroup = iff(Utilization > 60 and Utilization <= 80, \"61-80%\", UtilizationGroup)\r\n| extend UtilizationGroup = iff(Utilization > 80, \">81%\", UtilizationGroup)\r\n| summarize Count = count() by UtilizationGroup;\r\nlet total = baseQuery\r\n| summarize Total=sum(Count);\r\nbaseQuery\r\n| extend dummy=1\r\n| join kind=inner (total | extend dummy=1) on dummy\r\n| extend QueueUtilization = Count\r\n| project QueueUtilization, UtilizationGroup",
-              "size": 0,
-              "title": "Batch Queue (BTC)",
-              "queryType": 0,
-              "resourceType": "microsoft.operationalinsights/workspaces",
-              "visualization": "piechart",
-              "chartSettings": {
-                "yAxis": [
-                  "QueueUtilization"
-                ],
-                "group": "UtilizationGroup",
-                "createOtherGroup": null,
-                "showMetrics": false,
-                "showLegend": true,
-                "seriesLabelSettings": [
-                  {
-                    "seriesName": "< 20%",
-                    "label": "",
-                    "color": "turquoise"
-                  },
-                  {
-                    "seriesName": "61-80%",
-                    "color": "orange"
-                  },
-                  {
-                    "seriesName": "41-60%",
-                    "color": "yellow"
-                  },
-                  {
-                    "seriesName": "21-40%",
-                    "color": "purpleDark"
-                  },
-                  {
-                    "seriesName": ">81%",
-                    "color": "green"
-                  }
-                ]
-              }
-            },
-            "customWidth": "50",
-            "name": "BatchQueuePieChart"
-          },
-          {
-            "type": 3,
-            "content": {
-              "version": "KqlItem/1.0",
-              "query": "let appServerList = dynamic([{PerformanceApplicationServer}]);\r\nlet baseQuery = SapNetweaver_GetQueueStatistic_CL\r\n| where serverTimestamp_t between (todatetime({PerformanceTimeRange:start}) .. todatetime({PerformanceTimeRange:end}))\r\n| where SID_s == '{PerformanceSID}'\r\n| extend instanceNr_s = tostring(toint(instanceNr_d))\r\n| extend instanceNr_s = iff(strlen(instanceNr_s) == 2, instanceNr_s, strcat( \"0\", instanceNr_s))\r\n| extend appServer = strcat(hostname_s, \"_\", instanceNr_s)\r\n| where array_length(appServerList) == 0 or appServer in (appServerList);\r\nlet MaxQuery = baseQuery\r\n| summarize QueueLimit=max(Max_d) by Typ_s;\r\nlet CurrentStatusQuery = baseQuery\r\n| summarize CurrentStatus = arg_max(serverTimestamp_t, Now_d) by Typ_s;\r\nbaseQuery\r\n| summarize AvgRequests = avg(Now_d), MaxRequests = max(Now_d), ReadRequest = sum(Reads_d), WriteRequest = sum(Writes_d) by Typ_s\r\n| join kind=inner MaxQuery on Typ_s\r\n| join kind=inner CurrentStatusQuery on Typ_s\r\n| extend QueueUtilization = iff(QueueLimit != 0, (toreal(Now_d) / toreal(QueueLimit)) * 100, 0.0)\r\n| extend Status = iff(QueueUtilization <= 40, \"Ok\", \"\")\r\n| extend Status = iff(QueueUtilization > 40 and QueueUtilization <= 70 , \"Warning\", Status)\r\n| extend Status = iff(QueueUtilization > 70, \"Critical\", Status)\r\n| project Typ_s, Status, AvgRequests, MaxRequests, QueueLimit, WriteRequest, ReadRequest\r\n| project-reorder Typ_s, Status, AvgRequests, MaxRequests, QueueLimit, WriteRequest, ReadRequest",
-              "size": 0,
-              "title": "Queue Detailed Summary",
+              "title": "Queue Statistic Summary",
               "queryType": 0,
               "resourceType": "microsoft.operationalinsights/workspaces",
               "visualization": "table",
               "gridSettings": {
                 "formatters": [
-                  {
-                    "columnMatch": "Typ_s",
-                    "formatter": 0,
-                    "formatOptions": {
-                      "customColumnWidthSetting": "5%"
-                    }
-                  },
                   {
                     "columnMatch": "Status",
                     "formatter": 18,
@@ -1416,7 +1952,7 @@
                       "thresholdsGrid": [
                         {
                           "operator": "==",
-                          "thresholdValue": "Ok",
+                          "thresholdValue": "OK",
                           "representation": "success",
                           "text": "{0}"
                         },
@@ -1438,24 +1974,38 @@
                           "representation": "unknown",
                           "text": "{0}"
                         }
-                      ],
-                      "customColumnWidthSetting": "5%"
+                      ]
                     }
                   },
                   {
                     "columnMatch": "AvgRequests",
-                    "formatter": 2,
+                    "formatter": 1,
                     "numberFormat": {
                       "unit": 0,
                       "options": {
                         "style": "decimal",
+                        "useGrouping": false,
                         "maximumFractionDigits": 2
                       }
                     }
                   },
                   {
+                    "columnMatch": "MaxRequests",
+                    "formatter": 1,
+                    "numberFormat": {
+                      "unit": 0,
+                      "options": {
+                        "style": "decimal"
+                      }
+                    }
+                  },
+                  {
+                    "columnMatch": "QueueLimit",
+                    "formatter": 1
+                  },
+                  {
                     "columnMatch": "WriteRequest",
-                    "formatter": 0,
+                    "formatter": 1,
                     "numberFormat": {
                       "unit": 17,
                       "options": {
@@ -1469,7 +2019,7 @@
                   },
                   {
                     "columnMatch": "ReadRequest",
-                    "formatter": 0,
+                    "formatter": 1,
                     "numberFormat": {
                       "unit": 17,
                       "options": {
@@ -1482,18 +2032,27 @@
                     }
                   }
                 ],
+                "sortBy": [
+                  {
+                    "itemKey": "$gen_number_MaxRequests_3",
+                    "sortOrder": 2
+                  }
+                ],
                 "labelSettings": [
                   {
                     "columnId": "Typ_s",
                     "label": "Queue"
                   },
                   {
+                    "columnId": "Status"
+                  },
+                  {
                     "columnId": "AvgRequests",
-                    "label": "Average Number of Requests in queue"
+                    "label": "Average Number Of Requests In Queue"
                   },
                   {
                     "columnId": "MaxRequests",
-                    "label": "Max Number of Requests in queue"
+                    "label": "Max Number Of Requests In Queue"
                   },
                   {
                     "columnId": "QueueLimit",
@@ -1501,17 +2060,26 @@
                   },
                   {
                     "columnId": "WriteRequest",
-                    "label": "Number of Requests Written"
+                    "label": "Number Of Requests Written"
                   },
                   {
                     "columnId": "ReadRequest",
-                    "label": "Number of requests read"
+                    "label": "Number Of Requests Read"
                   }
                 ]
               },
-              "sortBy": []
+              "sortBy": [
+                {
+                  "itemKey": "$gen_number_MaxRequests_3",
+                  "sortOrder": 2
+                }
+              ]
             },
-            "name": "DetailedQueueSummary"
+            "customWidth": "100",
+            "name": "DetailedQueueSummary",
+            "styleSettings": {
+              "maxWidth": "100%"
+            }
           }
         ]
       },
@@ -1520,7 +2088,7 @@
         "comparison": "isEqualTo",
         "value": "QueueStatistics"
       },
-      "name": "queueStatisticsGroup"
+      "name": "Queue Statistics Group"
     }
   ],
   "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"


### PR DESCRIPTION
## PR Checklist

* [x] Explain your changes, so people looking at the PR know *what* and *why*, the code changes are the *how*.

### If adding or updating templates:
* [x] post a screenshot of templates and/or gallery changes
* [x] ensure all steps have meaningful names
* [x] ensure all parameters and grid columns have display names set so they can be localized
* [x] ensure that parameters id values are unique __or they will fail PR validation__ (parameter ids are used for localization)
* [x] ensure that steps names are unique __or they will fail PR validation__ (step names are used for localization)
* [x] grep `/subscription/` and ensure that your parameters don't have any hardcoded resourceIds __or they will fail PR validation__
* [x] remove `fallbackResourceIds` and `fromTemplateId` fields from your template workbook __or they will fail PR validation__

Workbook Updates
- Move legend tab to top for overview tab.
- change trendlines to area chart.
- group instance process by SIDs.
- Split performance tab content into Utilization and Performance.
- Add queue statistics tab with visualizations for queue utilization.

Workbook Screenshots:-
![overview - 1](https://user-images.githubusercontent.com/72462885/105558946-c433b300-5cc4-11eb-9808-e947303a3bfd.png)
![overview - 2](https://user-images.githubusercontent.com/72462885/105559000-e4637200-5cc4-11eb-9215-fd38071f298d.png)
![availability - 1](https://user-images.githubusercontent.com/72462885/105559007-e7f6f900-5cc4-11eb-9efb-2bf8f0042763.png)
![availability - 2](https://user-images.githubusercontent.com/72462885/105559009-eaf1e980-5cc4-11eb-8e5a-26db2d0e2342.png)
![utilization - 1](https://user-images.githubusercontent.com/72462885/105559016-efb69d80-5cc4-11eb-8bae-0c85ab4c981b.png)
![performance - 1](https://user-images.githubusercontent.com/72462885/105559028-f6451500-5cc4-11eb-8a53-1f1460e85d14.png)
![performance - 2](https://user-images.githubusercontent.com/72462885/105559035-f8a76f00-5cc4-11eb-8822-b24a8b10d158.png)
![queue statistics - 1](https://user-images.githubusercontent.com/72462885/105559041-fba25f80-5cc4-11eb-995e-df658a358cce.png)
