### PR TITLE
fix WDV showing a key instead of a label in azure monitor

### DIFF
--- a/Workbooks/categoryResources.json
+++ b/Workbooks/categoryResources.json
@@ -31,6 +31,16 @@
 			}
 		},
 		{
+			"key": "azureWVDMonitoring",
+			"settings": {
+				"en-us": {
+					"name": "Windows Virtual Desktop",
+					"description": "Provides insights for Windows Virtual Desktop",
+					"order": 2001
+				}
+			}
+		},
+		{
 			"key": "vmInsightsVirtualMachines",
 			"settings": {
 				"en-us": {


### PR DESCRIPTION
WVD is missing an entry in category resources, so it is showing its key instead of a label.