### PR TITLE
fix case for update where metrics are not collected

### DIFF
--- a/Workbooks/Workloads-AMA/Collection logs/Collection logs.workbook
+++ b/Workbooks/Workloads-AMA/Collection logs/Collection logs.workbook
@@ -225,7 +225,7 @@
           {
             "type": 1,
             "content": {
-              "json": "The WLI extension on this machine is below the recommended version ({WLIVersionRequired}). Please update by going to the previous page and clicking on `Update` for the VM `{OnboardedComputers}`",
+              "json": "The WLI extension on this machine is below the recommended version ({WLIVersionRequired}). To update, go to the previous page and click on `Update` for the VM `{OnboardedComputers}`",
               "style": "warning"
             },
             "conditionalVisibility": {

--- a/Workbooks/Workloads-AMA/Enable monitoring/Enable monitoring.workbook
+++ b/Workbooks/Workloads-AMA/Enable monitoring/Enable monitoring.workbook
@@ -292,7 +292,7 @@
           {
             "type": 1,
             "content": {
-              "json": "One or more machines have an older version of the WLI Extension. Please click on the 'Update' link besides the virtual machine to update the WLI Extension.",
+              "json": "One or more VMs have an outdated version of the WLI extension. Click on `Update` to get the latest version.",
               "style": "warning"
             },
             "conditionalVisibility": {
@@ -306,7 +306,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "Operation\r\n| where Detail !contains \"mssql: Incorrect syntax near ','.\"\r\n| summarize Errors = countif(OperationStatus == 'Error'), All = count() by _ResourceId\r\n| join kind=fullouter(\r\n    InsightsMetrics\r\n    | extend Tags = todynamic(Tags)\r\n    {HealthQuery}\r\n    | summarize by _ResourceId, HasMetrics = true)\r\n    on _ResourceId\r\n| join kind = leftouter(\r\n    InsightsMetrics\r\n    | extend Tags = todynamic(Tags)\r\n    | where Namespace == 'Computer'\r\n    | summarize (Time, WLI) = argmax(TimeGenerated, tostring(Tags.wli)) by _ResourceId\r\n    | extend WLI_Minor = extract('[0-9]+.([0-9]+.[0-9]+)', 1, WLI), WLI_Major = extract('([0-9]+).[0-9]+.[0-9]+', 1, WLI), WLI_Minor_req = extract('[0-9]+.([0-9]+.[0-9]+)', 1, '{WLIVersionRequired}'), WLI_Major_req = extract('([0-9]+).[0-9]+.[0-9]+', 1, '{WLIVersionRequired}'))\r\n    on _ResourceId\r\n| project Vm = iff(isempty(_ResourceId), _ResourceId1, _ResourceId), Errors, All, HasMetrics, Status = iff(HasMetrics or isnotempty(HasMetrics), iff(Errors < 1 or isempty(Errors), 'Collecting', 'Collecting with errors'), 'Not Collecting'), LogsFilter = iff(Errors < 1 or isempty(Errors), \"All Logs\", \"Errors\"), WLI, Action = iff(isempty(WLI_Major) or (todouble(WLI_Major) >= todouble(WLI_Major_req) and todouble(WLI_Minor) >= todouble(WLI_Minor_req)), 'Configure', 'Update')",
+              "query": "Operation\r\n| where Detail !contains \"mssql: Incorrect syntax near ','.\"\r\n| summarize Errors = countif(OperationStatus == 'Error'), All = count() by _ResourceId\r\n| join kind=fullouter(\r\n    InsightsMetrics\r\n    | extend Tags = todynamic(Tags)\r\n    {HealthQuery}\r\n    | summarize by _ResourceId, HasMetrics = true)\r\n    on _ResourceId\r\n| join kind = fullouter(\r\n    InsightsMetrics\r\n    | extend Tags = todynamic(Tags)\r\n    | where Namespace == 'Computer'\r\n    | summarize (Time, WLI) = argmax(TimeGenerated, tostring(Tags.wli)) by _ResourceId\r\n    | extend WLI_Minor = extract('[0-9]+.([0-9]+.[0-9]+)', 1, WLI), WLI_Major = extract('([0-9]+).[0-9]+.[0-9]+', 1, WLI), WLI_Minor_req = extract('[0-9]+.([0-9]+.[0-9]+)', 1, '{WLIVersionRequired}'), WLI_Major_req = extract('([0-9]+).[0-9]+.[0-9]+', 1, '{WLIVersionRequired}'))\r\n    on _ResourceId\r\n| project Vm = case(isnotempty(_ResourceId), _ResourceId, isnotempty(_ResourceId1), _ResourceId1, _ResourceId2), Errors, All, HasMetrics, Status = iff(HasMetrics or isnotempty(HasMetrics), iff(Errors < 1 or isempty(Errors), 'Collecting', 'Collecting with errors'), 'Not Collecting'), LogsFilter = iff(Errors < 1 or isempty(Errors), \"All Logs\", \"Errors\"), WLI, Action = iff(isempty(WLI_Major) or (todouble(WLI_Major) >= todouble(WLI_Major_req) and todouble(WLI_Minor) >= todouble(WLI_Minor_req)), 'Configure', 'Update')",
               "size": 0,
               "title": "VMs receiving metrics in the last 10 minutes",
               "noDataMessage": "No SQL Insights metrics are being sent to this workspace",


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/7664931/108887409-1109f280-75bf-11eb-8852-26079d540c33.png)

After:
![image](https://user-images.githubusercontent.com/7664931/108887338-f9326e80-75be-11eb-8891-c3890df58ad4.png)


## PR Checklist

* [ ] Explain your changes, so people looking at the PR know *what* and *why*, the code changes are the *how*.

### If adding or updating templates:
* [ ] post a screenshot of templates and/or gallery changes
* [ ] ensure all steps have meaningful names
* [ ] ensure all parameters and grid columns have display names set so they can be localized
* [ ] ensure that parameters id values are unique __or they will fail PR validation__ (parameter ids are used for localization)
* [ ] ensure that steps names are unique __or they will fail PR validation__ (step names are used for localization)
* [ ] grep `/subscription/` and ensure that your parameters don't have any hardcoded resourceIds __or they will fail PR validation__
* [ ] remove `fallbackResourceIds` and `fromTemplateId` fields from your template workbook __or they will fail PR validation__