### PR TITLE
Localization script fix: LocProject contains duplicate entries 

### DIFF
--- a/scripts/extractStrings.js
+++ b/scripts/extractStrings.js
@@ -433,15 +433,14 @@ for (var d in directories) {
     // Parse the template for localizeable strings
     const fileData = openFile(filePath);
     extractStringsFromFile(fileData, fileType, localizeableStrings, templatePath);
+  }
+  if (Object.keys(localizeableStrings).length > 0 && !templatePath.endsWith("\\")) {
+    // Add LocProject entry
+    const locProjectEntry = generateLocProjectEntry(templatePath, resjonOutputPath, rootDirectory);
+    locProjectOutput.push(locProjectEntry);
 
-    if (Object.keys(localizeableStrings).length > 0 && !templatePath.endsWith("\\")) {
-      // Add LocProject entry
-      const locProjectEntry = generateLocProjectEntry(templatePath, resjonOutputPath, rootDirectory);
-      locProjectOutput.push(locProjectEntry);
-
-      // Write localizeable strings to file
-      writeToFileRESJSON(localizeableStrings, resjonOutputPath);
-    }
+    // Write localizeable strings to file
+    writeToFileRESJSON(localizeableStrings, resjonOutputPath);
   }
 }
 


### PR DESCRIPTION
Move block out one level because logic was supposed to happen once per directory, not per file.