### PR TITLE
Added alert rule ARM templates for SapMonitor

### DIFF
--- a/Workbooks/SapMonitor/Alerts/log-metric-noag.armtemplate
+++ b/Workbooks/SapMonitor/Alerts/log-metric-noag.armtemplate
@@ -1,0 +1,156 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "alertName": {
+            "type": "string",
+            "metadata": {
+                "description": "Name of the alert"
+            }
+        },
+        "alertLocation": {
+            "type": "string",
+            "metadata": {
+                "description": "Location of the alert"
+            }
+        },
+        "dataSourceId": {
+            "type": "string",
+            "metadata": {
+                "description": "Workspace id"
+            }
+        },
+        "alertThreshold": {
+            "type": "string",
+            "defaultValue": "0",
+            "metadata": {
+                "description": "Threshold to use for alert evaluation"
+            }
+        },
+        "alertOperator": {
+            "type": "string",
+            "allowedValues": [
+                "Equals",
+                "NotEquals",
+                "GreaterThan",
+                "GreaterThanOrEqual",
+                "LessThan",
+                "LessThanOrEqual"
+            ],
+            "metadata": {
+                "description": "Operator to use for alert evaluation"
+            }
+        },
+        "alertSeverity": {
+            "type": "string",
+            "defaultValue": "2",
+            "metadata": {
+                "description": "Severity to use for alert evaluation"
+            }
+        },
+        "alertMetricThreshold": {
+            "type": "string",
+            "defaultValue": "0",
+            "metadata": {
+                "description": "Metric threshold to use for alert evaluation"
+            }
+        },
+        "alertMetricOperator": {
+            "type": "string",
+            "allowedValues": [
+                "Equals",
+                "NotEquals",
+                "GreaterThan",
+                "GreaterThanOrEqual",
+                "LessThan",
+                "LessThanOrEqual"
+            ],
+            "metadata": {
+                "description": "Metric operator to use for alert evaluation"
+            }
+        },
+        "alertMetricType": {
+            "type": "string",
+            "defaultValue": "Consecutive",
+            "metadata": {
+                "description": "Trigger type for alert metrics"
+            }
+        },
+        "alertMetricColumn": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "Metric column to use for alert"
+            }
+        },
+        "alertQuery": {
+            "type": "string",
+            "metadata": {
+                "description": "Query filter for alert"
+            }
+        },
+        "alertDescription": {
+            "type": "string",
+            "metadata": {
+                "description": "Description of what the alert does"
+            }
+        },
+        "profileId": {
+            "type": "string",
+            "metadata": {
+                "description": "profile-id tag to set on alert rule"
+            }
+        },
+        "alertTemplateId": {
+            "type": "string",
+            "metadata": {
+                "description": "alert-template-id tag to set on alert rule"
+            }
+        }
+    },
+    "resources": [
+        {
+            "name": "[parameters('alertName')]",
+            "type": "Microsoft.Insights/scheduledQueryRules",
+            "apiVersion": "2018-04-16",
+            "tags": {
+                "profile-id": "[parameters('profileId')]",
+                "alert-template-id": "[parameters('alertTemplateId')]"
+            },
+            "location": "[parameters('alertLocation')]",
+            "properties": {
+                "description": "[parameters('alertDescription')]",
+                "enabled": "true",
+                "source": {
+                    "query": "[parameters('alertQuery')]",
+                    "dataSourceId": "[parameters('dataSourceId')]",
+                    "queryType": "ResultCount"
+                },
+                "schedule": {
+                    "frequencyInMinutes": 5,
+                    "timeWindowInMinutes": 30
+                },
+                "action": {
+                    "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
+                    "severity": "[parameters('alertSeverity')]",
+                    "trigger": {
+                        "thresholdOperator": "[parameters('alertOperator')]",
+                        "threshold": "[parameters('alertThreshold')]",
+                        "metricTrigger": {
+                            "thresholdOperator": "[parameters('alertMetricOperator')]",
+                            "threshold": "[parameters('alertMetricThreshold')]",
+                            "metricColumn": "[parameters('alertMetricColumn')]",
+                            "metricTriggerType": "[parameters('alertMetricType')]"
+                        }
+                    }
+                }
+            }
+        }
+    ],
+    "outputs": {
+        "scheduledQueryRules": {
+            "type": "string",
+            "value": "[resourceId('Microsoft.Insights/scheduledQueryRules', parameters('alertName'))]"
+        }
+    }
+}

--- a/Workbooks/SapMonitor/Alerts/log-metric-noag.armtemplate
+++ b/Workbooks/SapMonitor/Alerts/log-metric-noag.armtemplate
@@ -106,6 +106,20 @@
             "metadata": {
                 "description": "alert-template-id tag to set on alert rule"
             }
+        },
+        "alertFrequencyInMinutes": {
+            "type": "int",
+            "defaultValue": 5,
+            "metadata": {
+                "description": "Frequency at which the alert is evaluated"
+            }
+        },
+        "alertTimeWindowInMinutes": {
+            "type": "int",
+            "defaultValue": 30,
+            "metadata": {
+                "description": "Time window at which the alert is evaluated"
+            }
         }
     },
     "resources": [
@@ -127,8 +141,8 @@
                     "queryType": "ResultCount"
                 },
                 "schedule": {
-                    "frequencyInMinutes": 5,
-                    "timeWindowInMinutes": 30
+                    "frequencyInMinutes": "[parameters('alertFrequencyInMinutes')]",
+                    "timeWindowInMinutes": "[parameters('alertTimeWindowInMinutes')]"
                 },
                 "action": {
                     "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",

--- a/Workbooks/SapMonitor/Alerts/log-metric.armtemplate
+++ b/Workbooks/SapMonitor/Alerts/log-metric.armtemplate
@@ -113,6 +113,20 @@
             "metadata": {
                 "description": "alert-template-id tag to set on alert rule"
             }
+        },
+        "alertFrequencyInMinutes": {
+            "type": "int",
+            "defaultValue": 5,
+            "metadata": {
+                "description": "Frequency at which the alert is evaluated"
+            }
+        },
+        "alertTimeWindowInMinutes": {
+            "type": "int",
+            "defaultValue": 30,
+            "metadata": {
+                "description": "Time window at which the alert is evaluated"
+            }
         }
     },
     "resources": [
@@ -134,8 +148,8 @@
                     "queryType": "ResultCount"
                 },
                 "schedule": {
-                    "frequencyInMinutes": 5,
-                    "timeWindowInMinutes": 30
+                    "frequencyInMinutes": "[parameters('alertFrequencyInMinutes')]",
+                    "timeWindowInMinutes": "[parameters('alertTimeWindowInMinutes')]"
                 },
                 "action": {
                     "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",

--- a/Workbooks/SapMonitor/Alerts/log-metric.armtemplate
+++ b/Workbooks/SapMonitor/Alerts/log-metric.armtemplate
@@ -1,0 +1,169 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "alertName": {
+            "type": "string",
+            "metadata": {
+                "description": "Name of the alert"
+            }
+        },
+        "alertLocation": {
+            "type": "string",
+            "metadata": {
+                "description": "Location of the alert"
+            }
+        },
+        "dataSourceId": {
+            "type": "string",
+            "metadata": {
+                "description": "Workspace id"
+            }
+        },
+        "actionGroupId": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "Action group id"
+            }
+        },
+        "alertSeverity": {
+            "type": "string",
+            "defaultValue": "2",
+            "metadata": {
+                "description": "Severity to use for alert evaluation"
+            }
+        },
+        "alertThreshold": {
+            "type": "string",
+            "defaultValue": "0",
+            "metadata": {
+                "description": "Threshold to use for alert evaluation"
+            }
+        },
+        "alertOperator": {
+            "type": "string",
+            "allowedValues": [
+                "Equals",
+                "NotEquals",
+                "GreaterThan",
+                "GreaterThanOrEqual",
+                "LessThan",
+                "LessThanOrEqual"
+            ],
+            "metadata": {
+                "description": "Operator to use for alert evaluation"
+            }
+        },
+        "alertMetricThreshold": {
+            "type": "string",
+            "defaultValue": "0",
+            "metadata": {
+                "description": "Metric threshold to use for alert evaluation"
+            }
+        },
+        "alertMetricOperator": {
+            "type": "string",
+            "allowedValues": [
+                "Equals",
+                "NotEquals",
+                "GreaterThan",
+                "GreaterThanOrEqual",
+                "LessThan",
+                "LessThanOrEqual"
+            ],
+            "metadata": {
+                "description": "Metric operator to use for alert evaluation"
+            }
+        },
+        "alertMetricType": {
+            "type": "string",
+            "defaultValue": "Consecutive",
+            "metadata": {
+                "description": "Trigger type for alert metrics"
+            }
+        },
+        "alertMetricColumn": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "Metric column to use for alert"
+            }
+        },
+        "alertQuery": {
+            "type": "string",
+            "metadata": {
+                "description": "Query filter for alert"
+            }
+        },
+        "alertDescription": {
+            "type": "string",
+            "metadata": {
+                "description": "Description of what the alert does"
+            }
+        },
+        "profileId": {
+            "type": "string",
+            "metadata": {
+                "description": "profile-id tag to set on alert rule"
+            }
+        },
+        "alertTemplateId": {
+            "type": "string",
+            "metadata": {
+                "description": "alert-template-id tag to set on alert rule"
+            }
+        }
+    },
+    "resources": [
+        {
+            "name": "[parameters('alertName')]",
+            "type": "Microsoft.Insights/scheduledQueryRules",
+            "apiVersion": "2018-04-16",
+            "tags": {
+                "profile-id": "[parameters('profileId')]",
+                "alert-template-id": "[parameters('alertTemplateId')]"
+            },
+            "location": "[parameters('alertLocation')]",
+            "properties": {
+                "description": "[parameters('alertDescription')]",
+                "enabled": "true",
+                "source": {
+                    "query": "[parameters('alertQuery')]",
+                    "dataSourceId": "[parameters('dataSourceId')]",
+                    "queryType": "ResultCount"
+                },
+                "schedule": {
+                    "frequencyInMinutes": 5,
+                    "timeWindowInMinutes": 30
+                },
+                "action": {
+                    "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
+                    "severity": "[parameters('alertSeverity')]",
+                    "aznsAction": {
+                        "actionGroup": [
+                            "[parameters('actionGroupId')]"
+                        ],
+                        "emailSubject": "[concat('Alert Triggered - ', parameters('alertName'))]"
+                    },
+                    "trigger": {
+                        "thresholdOperator": "[parameters('alertOperator')]",
+                        "threshold": "[parameters('alertThreshold')]",
+                        "metricTrigger": {
+                            "thresholdOperator": "[parameters('alertMetricOperator')]",
+                            "threshold": "[parameters('alertMetricThreshold')]",
+                            "metricColumn": "[parameters('alertMetricColumn')]",
+                            "metricTriggerType": "[parameters('alertMetricType')]"
+                        }
+                    }
+                }
+            }
+        }
+    ],
+    "outputs": {
+        "scheduledQueryRules": {
+            "type": "string",
+            "value": "[resourceId('Microsoft.Insights/scheduledQueryRules', parameters('alertName'))]"
+        }
+    }
+}


### PR DESCRIPTION
## PR Checklist

* [x] Explain your changes, so people looking at the PR know *what* and *why*, the code changes are the *how*.

### If adding or updating templates:
* [ ] post a screenshot of templates and/or gallery changes
* [ ] ensure all steps have meaningful names
* [ ] ensure all parameters and grid columns have display names set so they can be localized
* [ ] ensure that parameters id values are unique __or they will fail PR validation__ (parameter ids are used for localization)
* [ ] ensure that steps names are unique __or they will fail PR validation__ (step names are used for localization)
* [ ] grep `/subscription/` and ensure that your parameters don't have any hardcoded resourceIds __or they will fail PR validation__
* [ ] remove `fallbackResourceIds` and `fromTemplateId` fields from your template workbook __or they will fail PR validation__

Adding alert rule ARM templates to SapMonitor workbooks
Will be used by Alerts workbook in the future
They are currently the same as the ones used by SQL insights