### PR TITLE
remove Selected from tiles showing monitored and unmonitored clusters

### DIFF
--- a/Workbooks/HDInsight/At-Scale/HDInsightAtScale.workbook
+++ b/Workbooks/HDInsight/At-Scale/HDInsightAtScale.workbook
@@ -156,7 +156,7 @@
         "version": "KqlItem/1.0",
         "query": "HDInsightAmbariSystemMetrics\r\n| summarize dcount(_ResourceId)",
         "size": 4,
-        "title": "Monitored Selected Clusters",
+        "title": "Monitored Clusters",
         "timeContext": {
           "durationMs": 0
         },
@@ -199,7 +199,7 @@
         "version": "KqlItem/1.0",
         "query": "let dynamicClusters= dynamic([{Clusters}]);\r\nHDInsightAmbariSystemMetrics\r\n| summarize MonitoredClusters = dcount(_ResourceId) \r\n| extend UnmonitoredClusters = array_length(dynamicClusters) - MonitoredClusters\r\n| project UnmonitoredClusters",
         "size": 4,
-        "title": "Unmonitored Selected Clusters",
+        "title": "Unmonitored Clusters",
         "timeContext": {
           "durationMs": 0
         },


### PR DESCRIPTION
## PR Checklist
Removed "Selected" from monitored and unmonitored tiles.
![image](https://user-images.githubusercontent.com/10980637/113753569-17fa4980-96c3-11eb-9148-3c965fafe916.png)
