### PR TITLE
Fixed cache utilization change by day to use avg instead of max

### DIFF
--- a/Workbooks/ADXCluster/AtResourceClusterBoundaries/ResourceClusterBoundaries.workbook
+++ b/Workbooks/ADXCluster/AtResourceClusterBoundaries/ResourceClusterBoundaries.workbook
@@ -1340,7 +1340,7 @@
                   "type": 3,
                   "content": {
                     "version": "KqlItem/1.0",
-                    "query": "AzureMetrics\r\n| where MetricName == \"CacheUtilization\"\r\n| project TimeGenerated, CacheUtilization=Maximum\r\n| summarize CacheUtilization=avg(CacheUtilization) by bin(TimeGenerated, 1d)\r\n| sort by TimeGenerated asc \r\n| serialize \r\n| extend PrevCacheUtilization = prev(CacheUtilization,1)\r\n| extend CacheUtilizationDelta = CacheUtilization - PrevCacheUtilization\r\n| project TimeGenerated, CacheUtilizationDelta\r\n| extend change=iff(CacheUtilizationDelta >= 0, \"Positive\", \"Negative\")\r\n",
+                    "query": "AzureMetrics\r\n| where MetricName == \"CacheUtilization\"\r\n| project TimeGenerated, CacheUtilization=Average\r\n| summarize CacheUtilization=avg(CacheUtilization) by bin(TimeGenerated, 1d)\r\n| sort by TimeGenerated asc \r\n| serialize \r\n| extend PrevCacheUtilization = prev(CacheUtilization,1)\r\n| extend CacheUtilizationDelta = CacheUtilization - PrevCacheUtilization\r\n| project TimeGenerated, CacheUtilizationDelta\r\n| extend change=iff(CacheUtilizationDelta >= 0, \"Positive\", \"Negative\")\r\n",
                     "size": 0,
                     "aggregation": 3,
                     "timeContext": {

--- a/Workbooks/ADXCluster/AtResourceClusterBoundaries/ResourceClusterBoundaries.workbook
+++ b/Workbooks/ADXCluster/AtResourceClusterBoundaries/ResourceClusterBoundaries.workbook
@@ -1340,7 +1340,7 @@
                   "type": 3,
                   "content": {
                     "version": "KqlItem/1.0",
-                    "query": "AzureMetrics\r\n| where MetricName == \"CacheUtilization\"\r\n| project TimeGenerated, CacheUtilization=Maximum\r\n| summarize CacheUtilization=max(CacheUtilization) by bin(TimeGenerated, 1d)\r\n| sort by TimeGenerated asc \r\n| serialize \r\n| extend PrevCacheUtilization = prev(CacheUtilization,1)\r\n| extend CacheUtilizationDelta = CacheUtilization - PrevCacheUtilization\r\n| project TimeGenerated, CacheUtilizationDelta\r\n| extend change=iff(CacheUtilizationDelta >= 0, \"Positive\", \"Negative\")\r\n",
+                    "query": "AzureMetrics\r\n| where MetricName == \"CacheUtilization\"\r\n| project TimeGenerated, CacheUtilization=Maximum\r\n| summarize CacheUtilization=avg(CacheUtilization) by bin(TimeGenerated, 1d)\r\n| sort by TimeGenerated asc \r\n| serialize \r\n| extend PrevCacheUtilization = prev(CacheUtilization,1)\r\n| extend CacheUtilizationDelta = CacheUtilization - PrevCacheUtilization\r\n| project TimeGenerated, CacheUtilizationDelta\r\n| extend change=iff(CacheUtilizationDelta >= 0, \"Positive\", \"Negative\")\r\n",
                     "size": 0,
                     "aggregation": 3,
                     "timeContext": {


### PR DESCRIPTION
Fixed cache utilization change by day to use avg instead of max to align with the other chart which uses avg.
Before - the changes aren't align with the left chart:
![image](https://user-images.githubusercontent.com/41256041/114015203-19b63f80-9872-11eb-80dc-8d5174893519.png)

After:
![image](https://user-images.githubusercontent.com/41256041/114015276-2dfa3c80-9872-11eb-9548-0027c002c0a6.png)
