### PR TITLE
Add correlation to user with long lookback of queries

### DIFF
--- a/Workbooks/ADXCluster/AtResourceCache/ResourceCacheDetails.workbook
+++ b/Workbooks/ADXCluster/AtResourceCache/ResourceCacheDetails.workbook
@@ -22,7 +22,8 @@
                 "value::1"
               ],
               "showDefault": false
-            }
+            },
+            "id": "fddf515c-573a-4435-974d-d6c3b3b50267"
           },
           {
             "version": "KqlParameterItem/1.0",
@@ -65,7 +66,8 @@
                 }
               ],
               "allowCustom": false
-            }
+            },
+            "id": "52d34a64-a5f5-4a12-85f4-d0efef4e3f86"
           }
         ],
         "style": "pills",
@@ -93,7 +95,8 @@
             ],
             "isHiddenWhenLocked": true,
             "queryType": 0,
-            "resourceType": "microsoft.kusto/clusters"
+            "resourceType": "microsoft.kusto/clusters",
+            "id": "d1df9909-20bb-4626-ba6f-a54e27d7b24f"
           },
           {
             "version": "KqlParameterItem/1.0",
@@ -101,16 +104,18 @@
             "type": 1,
             "query": "ADXTableDetails\r\n| summarize minTime=format_datetime(min(TimeGenerated), 'MM/dd/yy [hh:mm tt]')\r\n| extend formatedDate=replace(@'\\[', @',', tostring(minTime))\r\n| extend formatedDate=replace(@'\\]', @'', formatedDate)\r\n| project formatedDate",
             "queryType": 0,
-            "resourceType": "microsoft.kusto/clusters"
+            "resourceType": "microsoft.kusto/clusters",
+            "id": "a34d700c-b695-4c77-8de8-4d5e02305ff6"
           },
           {
             "version": "KqlParameterItem/1.0",
             "name": "cacheRecommendation",
             "type": 1,
             "isRequired": true,
-            "query": "{\"version\":\"ARMEndpoint/1.0\",\"data\":null,\"headers\":[],\"method\":\"GET\",\"path\":\"/subscriptions/{Resource:subscription}/providers/Microsoft.Advisor/recommendations\",\"urlParams\":[{\"key\":\"api-version\",\"value\":\"2017-04-19\"},{\"key\":\"$filter\",\"value\":\" ResourceId eq {Resource:value} and (RecommendationTypeGuid eq 'f011adf6-475a-48c9-bf26-8db051cb6964' or RecommendationTypeGuid eq '947a627a-532d-44f8-8e23-4f365a80a2ba' or RecommendationTypeGuid eq '389653ce-d564-4b95-aac4-ca30e1602536' )\"}],\"batchDisabled\":false,\"transformers\":[{\"type\":\"jsonpath\",\"settings\":{\"tablePath\":\"$.value[*]\",\"columns\":[]}}]}",
+            "query": "{\"version\":\"ARMEndpoint/1.0\",\"data\":null,\"headers\":[],\"method\":\"GET\",\"path\":\"/subscriptions/{Resource:subscription}/providers/Microsoft.Advisor/recommendations\",\"urlParams\":[{\"key\":\"api-version\",\"value\":\"2017-04-19\"},{\"key\":\"$filter\",\"value\":\"RecommendationTypeGuid eq 'f011adf6-475a-48c9-bf26-8db051cb6964' or RecommendationTypeGuid eq '947a627a-532d-44f8-8e23-4f365a80a2ba'\"},{\"key\":\"$filter\",\"value\":\"ResourceId eq {Resource:value}\"}],\"batchDisabled\":false,\"transformers\":[{\"type\":\"jsonpath\",\"settings\":{\"tablePath\":\"$.value[*]\",\"columns\":[]}}]}",
             "isHiddenWhenLocked": true,
-            "queryType": 12
+            "queryType": 12,
+            "id": "16af1499-b771-49ff-9cea-881c2719e221"
           }
         ],
         "style": "above",
@@ -132,82 +137,33 @@
           {
             "type": 1,
             "content": {
-              "json": "<span style=\"font-family: Open Sans; font-weight: 620; font-size: 14px;font-style: bold;margin:-10px -304px 0px 0px;position: relative;top:-5px\">&nbsp;&nbsp;Table usage details\r\n</span><br>\r\n&nbsp;&nbsp;This page presents data based on the Time Range parameter. You can change the Time range parameter to present data starting from {TableLogsStartDate} (based on your oldest diagnostic logs data)"
+              "json": "<span style=\"font-family: Open Sans; font-weight: 620; font-size: 14px;font-style: bold;margin:-10px -304px 0px 0px;position: relative;top:-5px\">&nbsp;&nbsp;Table usage details\r\n</span><br>\r\n&nbsp;&nbsp;This page contains data starting from {TableLogsStartDate} (based on the diagnostic logs data), and not affected by the time range parameter. "
             },
             "name": "Header Cache"
-          },
-          {
-            "type": 1,
-            "content": {
-              "json": "<svg viewBox=\"0 0 18 18\" width=\"20\" class=\"fxt-escapeShadow\" role=\"presentation\" focusable=\"false\" xmlns:svg=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" aria-hidden=\"true\"><g><defs></defs><path d=\"M17.5 9.44a3.85 3.85 0 0 0-3.32-3.74A4.85 4.85 0 0 0 9.23 1a5 5 0 0 0-4.75 3.29 4.58 4.58 0 0 0-4 4.46 4.66 4.66 0 0 0 4.79 4.53 3 3 0 0 0 .42 0h7.75a.64.64 0 0 0 .2 0 3.9 3.9 0 0 0 3.86-3.84z\" fill=\"url(#9b4b971a-fb5a-4299-ab97-14581e9298eb)\"></path><path d=\"M14.53 15.14l-2 2.14a.26.26 0 0 1-.44-.14l-1.21-5.9A.26.26 0 0 1 11 11l1.32-.54a.26.26 0 0 1 .33.13l1.95 4.3a.24.24 0 0 1-.07.25z\" fill=\"#37c2b1\"></path><path d=\"M8 15.14l2 2.14a.26.26 0 0 0 .44-.14l1.21-5.9a.26.26 0 0 0-.15-.28l-1.32-.54a.26.26 0 0 0-.33.13l-1.95 4.3a.24.24 0 0 0 .1.29z\" fill=\"#42e8ca\"></path><path d=\"M11.58 6l.26-.22a.41.41 0 0 1 .57.05.37.37 0 0 1 .07.12l.12.32a.42.42 0 0 0 .45.26l.33-.06a.41.41 0 0 1 .47.33.33.33 0 0 1 0 .14l-.06.33a.42.42 0 0 0 .26.45l.32.11a.42.42 0 0 1 .24.53.75.75 0 0 1-.07.12l-.22.25a.42.42 0 0 0 0 .52l.22.26a.4.4 0 0 1-.06.57.41.41 0 0 1-.11.07l-.32.12a.4.4 0 0 0-.26.45l.06.33a.39.39 0 0 1-.33.46.33.33 0 0 1-.14 0h-.33a.4.4 0 0 0-.45.26l-.12.31a.4.4 0 0 1-.52.24.37.37 0 0 1-.12-.07l-.25-.25a.4.4 0 0 0-.52 0l-.26.21a.4.4 0 0 1-.57-.05.24.24 0 0 1-.07-.12l-.12-.31a.39.39 0 0 0-.45-.26l-.33.06a.41.41 0 0 1-.47-.34.29.29 0 0 1 0-.13l.06-.33a.4.4 0 0 0-.26-.45l-.31-.12a.42.42 0 0 1-.29-.5.75.75 0 0 1 .07-.12l.22-.26a.42.42 0 0 0 0-.52l-.22-.25a.41.41 0 0 1 .06-.58.23.23 0 0 1 .12-.06l.31-.12a.42.42 0 0 0 .26-.45L8.8 7a.41.41 0 0 1 .33-.47h.14l.33.06a.41.41 0 0 0 .45-.26l.12-.33a.41.41 0 0 1 .52-.24l.12.07.26.22a.41.41 0 0 0 .51-.05z\" fill=\"#005ba1\"></path><circle cx=\"11.33\" cy=\"9.02\" r=\"2.36\" fill=\"#ffca00\"></circle></g></svg> &nbsp;<span style=\"font-family: Open Sans; font-weight: 620; font-size: 14px;font-style: bold;margin:-10px -304px 0px 0px;position: relative;top:-5px;left:-4px\">Advisor cache recommendations \r\n</span> "
-            },
-            "customWidth": "51",
-            "conditionalVisibility": {
-              "parameterName": "cacheRecommendation",
-              "comparison": "isNotEqualTo"
-            },
-            "name": "cache text"
           },
           {
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "{\"version\":\"ARMEndpoint/1.0\",\"data\":null,\"headers\":[],\"method\":\"GET\",\"path\":\"/subscriptions/{Resource:subscription}/providers/Microsoft.Advisor/recommendations\",\"urlParams\":[{\"key\":\"api-version\",\"value\":\"2017-04-19\"},{\"key\":\"$filter\",\"value\":\" ResourceId eq {Resource:value} and (RecommendationTypeGuid eq 'f011adf6-475a-48c9-bf26-8db051cb6964' or RecommendationTypeGuid eq '947a627a-532d-44f8-8e23-4f365a80a2ba' or RecommendationTypeGuid eq '389653ce-d564-4b95-aac4-ca30e1602536' )\"}],\"batchDisabled\":false,\"transformers\":[{\"type\":\"jsonpath\",\"settings\":{\"tablePath\":\"$.value[*]\",\"columns\":[{\"path\":\"$.properties.shortDescription.solution\",\"columnid\":\"Description\"},{\"path\":\"$.properties.category\",\"columnid\":\"Category\"}]}}]}",
-              "size": 4,
+              "query": "{\"version\":\"ARMEndpoint/1.0\",\"data\":null,\"headers\":[],\"method\":\"GET\",\"path\":\"/subscriptions/{Resource:subscription}/providers/Microsoft.Advisor/recommendations\",\"urlParams\":[{\"key\":\"api-version\",\"value\":\"2017-04-19\"},{\"key\":\"$filter\",\"value\":\"RecommendationTypeGuid eq 'f011adf6-475a-48c9-bf26-8db051cb6964' or RecommendationTypeGuid eq '947a627a-532d-44f8-8e23-4f365a80a2ba'\"},{\"key\":\"$filter\",\"value\":\"ResourceId eq {Resource:value}\"}],\"batchDisabled\":false,\"transformers\":[{\"type\":\"jsonpath\",\"settings\":{\"tablePath\":\"$.value[*]\",\"columns\":[{\"path\":\"$.properties.shortDescription.solution\",\"columnid\":\"Description\"},{\"path\":\"$.properties.category\",\"columnid\":\"Category\"}]}}]}",
+              "size": 3,
+              "title": "Advisor Recommendations",
               "noDataMessage": "You are following all of the cache recommendations for this cluster",
               "noDataMessageStyle": 3,
-              "queryType": 12,
-              "gridSettings": {
-                "formatters": [
-                  {
-                    "columnMatch": "Description",
-                    "formatter": 0,
-                    "formatOptions": {
-                      "customColumnWidthSetting": "68ch"
-                    }
-                  }
-                ]
-              }
+              "queryType": 12
             },
             "customWidth": "50",
             "conditionalVisibility": {
               "parameterName": "cacheRecommendation",
               "comparison": "isNotEqualTo"
             },
-            "name": "Advisor Cache Recommendations",
-            "styleSettings": {
-              "margin": "-20px 0px 0px 0px"
-            }
-          },
-          {
-            "type": 11,
-            "content": {
-              "version": "LinkItem/1.0",
-              "style": "paragraph",
-              "links": [
-                {
-                  "id": "e8716647-17ec-4ec6-a18b-8612b04c770b",
-                  "cellValue": "{Resource}",
-                  "linkTarget": "Resource",
-                  "linkLabel": "Advisor recommendations page >",
-                  "subTarget": "resourceadvisor",
-                  "style": "link",
-                  "linkIsContextBlade": true
-                }
-              ]
-            },
-            "customWidth": "51",
-            "conditionalVisibility": {
-              "parameterName": "cacheRecommendation",
-              "comparison": "isNotEqualTo"
-            },
-            "name": "advisor link"
+            "name": "Advisor Cache Recommendations"
           },
           {
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "\r\nlet TableUsageStatsWithLookBack = ADXTableUsageStatistics\r\n| where TimeGenerated  {TimeRange}\r\n| extend LookBackPeriod = datetime_diff('day', StartedOn, MinCreatedOn) \r\n| summarize CountQueries=count() by DatabaseName, TableName, LookBackPeriod;\r\n\r\nlet sumAllQueries = TableUsageStatsWithLookBack | summarize sumQueries=sum(CountQueries) by DatabaseName, TableName;\r\n\r\nlet percentileLookBackTable= TableUsageStatsWithLookBack | summarize percentile_LookbackDuration_ = percentilesw(LookBackPeriod, CountQueries, 95) by DatabaseName, TableName;\r\n\r\nlet defaultRetention = 365d * 10;\r\n\r\nADXTableDetails \r\n| where TimeGenerated>=ago(1d) // so we filter out tables that are deprecated\r\n| summarize arg_max(TimeGenerated, *) by DatabaseName, TableName\r\n| extend RetentionPolicy = iff(isnull(RetentionPolicy) or RetentionPolicy == \"null\", defaultRetention, totimespan(parse_json(tostring(RetentionPolicy)).SoftDeletePeriod)),\r\n        CachingPolicy = iff(isnull(CachingPolicy) or RetentionPolicy == \"null\", defaultRetention, totimespan(parse_json(tostring(CachingPolicy)).DataHotSpan))\r\n        | extend ActiveCachingPolicy = min_of(CachingPolicy, RetentionPolicy)\r\n| join kind = leftouter (percentileLookBackTable) on DatabaseName, TableName\r\n| join kind = leftouter (sumAllQueries) on DatabaseName, TableName\r\n| where DatabaseName != \"KustoMonitoringPersistentDatabase\"\r\n| top 351 by HotExtentSize desc\r\n| project DatabaseName, TableName, CacheSize = HotExtentSize, format_timespan(ActiveCachingPolicy, 'd'),  \r\nsumQueries=sumQueries,QueryPeriod = percentile_LookbackDuration_",
+              "query": "\r\nlet TableUsageStatsWithLookBack = ADXTableUsageStatistics \r\n| extend LookBackPeriod = datetime_diff('day', StartedOn, MinCreatedOn) \r\n| summarize CountQueries=count() by DatabaseName, TableName, LookBackPeriod;\r\n\r\nlet sumAllQueries = TableUsageStatsWithLookBack | summarize sumQueries=sum(CountQueries) by DatabaseName, TableName;\r\n\r\nlet percentileLookBackTable= TableUsageStatsWithLookBack | summarize percentile_LookbackDuration_ = percentilesw(LookBackPeriod, CountQueries, 95) by DatabaseName, TableName;\r\n\r\nlet defaultRetention = 365d * 10;\r\n\r\nADXTableDetails \r\n| where TimeGenerated>=ago(1d)\r\n| summarize arg_max(TimeGenerated, *) by DatabaseName, TableName\r\n| extend RetentionPolicy = iff(isnull(RetentionPolicy) or RetentionPolicy == \"null\", defaultRetention, totimespan(parse_json(tostring(RetentionPolicy)).SoftDeletePeriod)),\r\n        CachingPolicy = iff(isnull(CachingPolicy) or RetentionPolicy == \"null\", defaultRetention, totimespan(parse_json(tostring(CachingPolicy)).DataHotSpan))\r\n        | extend ActiveCachingPolicy = min_of(CachingPolicy, RetentionPolicy)\r\n| join kind = leftouter (percentileLookBackTable) on DatabaseName, TableName\r\n| join kind = leftouter (sumAllQueries) on DatabaseName, TableName\r\n| where DatabaseName != \"KustoMonitoringPersistentDatabase\"\r\n| top 351 by HotExtentSize desc\r\n| project DatabaseName, TableName, CacheSize = HotExtentSize, format_timespan(ActiveCachingPolicy, 'd'),  \r\nsumQueries=sumQueries,QueryPeriod = percentile_LookbackDuration_",
               "size": 0,
               "showAnalytics": true,
               "exportedParameters": [
@@ -376,7 +332,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "\r\nlet defaultRetention = 365d * 10;\r\n\r\nlet CachePolicyTable= ADXTableDetails \r\n| where TimeGenerated>=ago(1d)\r\n| where DatabaseName == '{DatabaseName}'  \r\n| where TableName == '{TableName}' | summarize arg_max(TimeGenerated, *) by DatabaseName, TableName\r\n| extend RetentionPolicy = iff(isnull(RetentionPolicy) or RetentionPolicy == \"null\", defaultRetention, totimespan(parse_json(tostring(RetentionPolicy)).SoftDeletePeriod)),\r\nCachingPolicy = iff(isnull(CachingPolicy) or RetentionPolicy == \"null\", defaultRetention, totimespan(parse_json(tostring(CachingPolicy)).DataHotSpan))\r\n| extend ActiveCachingPolicy = min_of(CachingPolicy, RetentionPolicy)\r\n| project DatabaseName, TableName,activeCachePolicyInDays =ActiveCachingPolicy;\r\n\r\nADXTableUsageStatistics\r\n| where TimeGenerated  {TimeRange} \r\n| where DatabaseName == '{DatabaseName}' \r\n| where TableName == '{TableName}' \r\n| extend NumberOfDaysBefore = datetime_diff('day', StartedOn, MinCreatedOn)\r\n| summarize Count=count() by DatabaseName, TableName,NumberOfDaysBefore \r\n| join kind = leftouter (CachePolicyTable) on DatabaseName, TableName\r\n| extend activeCacheInDays= activeCachePolicyInDays/1d\r\n| sort by NumberOfDaysBefore asc\r\n| extend CacheType = iff(NumberOfDaysBefore < activeCacheInDays, 'InCache', 'OutOfCache')\r\n| extend CumSum = row_cumsum(Count);",
+              "query": "\r\nlet defaultRetention = 365d * 10;\r\n\r\nlet CachePolicyTable= ADXTableDetails \r\n| where DatabaseName == '{DatabaseName}'  \r\n| where TableName == '{TableName}' | summarize arg_max(TimeGenerated, *) by DatabaseName, TableName\r\n| extend RetentionPolicy = iff(isnull(RetentionPolicy) or RetentionPolicy == \"null\", defaultRetention, totimespan(parse_json(tostring(RetentionPolicy)).SoftDeletePeriod)),\r\nCachingPolicy = iff(isnull(CachingPolicy) or RetentionPolicy == \"null\", defaultRetention, totimespan(parse_json(tostring(CachingPolicy)).DataHotSpan))\r\n| extend ActiveCachingPolicy = min_of(CachingPolicy, RetentionPolicy)\r\n| project DatabaseName, TableName,activeCachePolicyInDays =ActiveCachingPolicy;\r\n\r\nADXTableUsageStatistics \r\n| where DatabaseName == '{DatabaseName}' \r\n| where TableName == '{TableName}' \r\n| extend NumberOfDaysBefore = datetime_diff('day', StartedOn, MinCreatedOn)\r\n| summarize Count=count() by DatabaseName, TableName,NumberOfDaysBefore \r\n| join kind = leftouter (CachePolicyTable) on DatabaseName, TableName\r\n| extend activeCacheInDays= activeCachePolicyInDays/1d\r\n| sort by NumberOfDaysBefore asc\r\n| extend CacheType = iff(NumberOfDaysBefore < activeCacheInDays, 'InCache', 'OutOfCache')\r\n| extend CumSum = row_cumsum(Count);",
               "size": 0,
               "showAnalytics": true,
               "noDataMessage": "There were no queries on this table",
@@ -461,10 +417,12 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "let defaultRetention = 365d * 10;\r\n// calculation for potential cache saving (valid only for tables with steady ingestion)\r\n//let DataInCacheOneDay = toscalar(ADXTableDetails\r\n//| where DatabaseName == '{DatabaseName}' \r\n//| where TableName == '{TableName}'\r\n//| summarize arg_max(TimeGenerated, *) by '{DatabaseName}', '{TableName}'\r\n//| extend RetentionPolicy = iff(isnull(RetentionPolicy) or RetentionPolicy == \"null\", defaultRetention, totimespan(parse_json(tostring(RetentionPolicy)).SoftDeletePeriod)),CachingPolicy = iff(isnull(CachingPolicy) or RetentionPolicy == \"null\", defaultRetention, totimespan(parse_json(tostring(CachingPolicy)).DataHotSpan))\r\n//        | extend ActiveCachingPolicy = min_of(CachingPolicy, RetentionPolicy)\r\n//      | extend CacheStart = now() - ActiveCachingPolicy , CacheEnd = now() \r\n//    | extend DataInCacheStart = iff(isnull(MinExtentsCreationTime), MinExtentsCreationTime, max_of(CacheStart, MinExtentsCreationTime)), DataInCacheEnd = iff(isnull(MaxExtentsCreationTime), MaxExtentsCreationTime, min_of(CacheEnd, MaxExtentsCreationTime)) \r\n//      | extend TimespanOfDataInCache = iff(HotExtentSize == 0, time(0m), bin(DataInCacheEnd - DataInCacheStart, 1d) +1d) \r\n//| extend ActualCachingeTimeInDays = TimespanOfDataInCache/1d \r\n//| project DataInCacheSizeForOneDay = iff(ActualCachingeTimeInDays > 1, HotExtentSize/ActualCachingeTimeInDays, HotExtentSize));\r\n\r\nlet QueriesPerDaysBeforeTable = ADXTableUsageStatistics \r\n| where TimeGenerated  {TimeRange}\r\n| where DatabaseName == '{DatabaseName}' \r\n| where TableName == '{TableName}' \r\n| extend NumberOfDaysBefore = datetime_diff('day', StartedOn, MinCreatedOn)\r\n| summarize Count=count() by DatabaseName, TableName,NumberOfDaysBefore \r\n| sort by NumberOfDaysBefore asc\r\n| extend CumSum = row_cumsum(Count);\r\n\r\nlet total = toscalar(QueriesPerDaysBeforeTable | summarize max(CumSum));\r\n\r\nQueriesPerDaysBeforeTable | project NumberOfDaysBefore,  actualQueriesInCache = Count / toreal(total)*100.0, potentialQueriesInCache = CumSum / toreal(total)*100.0  //, potentialCacheSize = DataInCacheOneDay*NumberOfDaysBefore;\r\n",
+              "query": "let defaultRetention = 365d * 10;\r\n// calculation for potential cache saving (valid only for tables with steady ingestion)\r\n//let DataInCacheOneDay = toscalar(ADXTableDetails\r\n//| where DatabaseName == '{DatabaseName}' \r\n//| where TableName == '{TableName}'\r\n//| summarize arg_max(TimeGenerated, *) by '{DatabaseName}', '{TableName}'\r\n//| extend RetentionPolicy = iff(isnull(RetentionPolicy) or RetentionPolicy == \"null\", defaultRetention, totimespan(parse_json(tostring(RetentionPolicy)).SoftDeletePeriod)),CachingPolicy = iff(isnull(CachingPolicy) or RetentionPolicy == \"null\", defaultRetention, totimespan(parse_json(tostring(CachingPolicy)).DataHotSpan))\r\n//        | extend ActiveCachingPolicy = min_of(CachingPolicy, RetentionPolicy)\r\n//      | extend CacheStart = now() - ActiveCachingPolicy , CacheEnd = now() \r\n//    | extend DataInCacheStart = iff(isnull(MinExtentsCreationTime), MinExtentsCreationTime, max_of(CacheStart, MinExtentsCreationTime)), DataInCacheEnd = iff(isnull(MaxExtentsCreationTime), MaxExtentsCreationTime, min_of(CacheEnd, MaxExtentsCreationTime)) \r\n//      | extend TimespanOfDataInCache = iff(HotExtentSize == 0, time(0m), bin(DataInCacheEnd - DataInCacheStart, 1d) +1d) \r\n//| extend ActualCachingeTimeInDays = TimespanOfDataInCache/1d \r\n//| project DataInCacheSizeForOneDay = iff(ActualCachingeTimeInDays > 1, HotExtentSize/ActualCachingeTimeInDays, HotExtentSize));\r\n\r\nlet QueriesPerDaysBeforeTable = ADXTableUsageStatistics \r\n| where DatabaseName == '{DatabaseName}' \r\n| where TableName == '{TableName}' \r\n| extend NumberOfDaysBefore = datetime_diff('day', StartedOn, MinCreatedOn)\r\n| summarize Count=count() by DatabaseName, TableName,NumberOfDaysBefore \r\n| sort by NumberOfDaysBefore asc\r\n| extend CumSum = row_cumsum(Count);\r\n\r\nlet total = toscalar(QueriesPerDaysBeforeTable | summarize max(CumSum));\r\n\r\nQueriesPerDaysBeforeTable | project NumberOfDaysBefore,  actualQueriesInCache = Count / toreal(total)*100.0, potentialQueriesInCache = CumSum / toreal(total)*100.0  //, potentialCacheSize = DataInCacheOneDay*NumberOfDaysBefore;\r\n",
               "size": 0,
               "showAnalytics": true,
               "noDataMessage": "There were no queries on this table",
+              "exportFieldName": "NumberOfDaysBefore",
+              "exportParameterName": "LookbackPeriod",
               "queryType": 0,
               "resourceType": "microsoft.kusto/clusters",
               "gridSettings": {
@@ -568,6 +526,130 @@
             "styleSettings": {
               "margin": "-50px 0px 0px 0px"
             }
+          },
+          {
+            "type": 1,
+            "content": {
+              "json": "<span style=\"font-family: Open Sans; font-weight: 620; font-size: 14px;font-style: bold;margin:-10px -304px 0px 0px;position: relative;top:-5px\">&nbsp;&nbsp;User and query count information per selected query lookback period\r\n\r\n"
+            },
+            "conditionalVisibility": {
+              "parameterName": "DatabaseName",
+              "comparison": "isNotEqualTo"
+            },
+            "name": "Cache Header - Copy"
+          },
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "let defaultRetention = 365d * 10;\r\nADXTableUsageStatistics \r\n    | where DatabaseName == '{DatabaseName}' \r\n    | where TableName == '{TableName}' \r\n    | extend NumberOfDaysBefore = datetime_diff('day', StartedOn, MinCreatedOn)\r\n    | where NumberOfDaysBefore == '{LookbackPeriod}'\r\n    | summarize Count=count() by User, ApplicationName\r\n    | top 10 by Count\r\n",
+              "size": 0,
+              "showAnalytics": true,
+              "noDataMessage": "There were no queries on this table",
+              "queryType": 0,
+              "resourceType": "microsoft.kusto/clusters",
+              "gridSettings": {
+                "formatters": [
+                  {
+                    "columnMatch": "Count",
+                    "formatter": 0,
+                    "numberFormat": {
+                      "unit": 0,
+                      "options": {
+                        "style": "decimal",
+                        "useGrouping": false
+                      }
+                    },
+                    "tooltipFormat": {
+                      "tooltip": "The amount of queries the tuple of user and application ran for the selected lookbackperiod"
+                    }
+                  },
+                  {
+                    "columnMatch": "NumberOfDaysBefore",
+                    "formatter": 1,
+                    "formatOptions": {
+                      "customColumnWidthSetting": "20ch"
+                    },
+                    "numberFormat": {
+                      "unit": 27,
+                      "options": {
+                        "style": "decimal"
+                      }
+                    }
+                  },
+                  {
+                    "columnMatch": "actualQueriesInCache",
+                    "formatter": 4,
+                    "formatOptions": {
+                      "min": 0,
+                      "max": 100,
+                      "palette": "gray",
+                      "customColumnWidthSetting": "363px"
+                    },
+                    "numberFormat": {
+                      "unit": 1,
+                      "options": {
+                        "style": "decimal",
+                        "useGrouping": false
+                      }
+                    }
+                  },
+                  {
+                    "columnMatch": "potentialQueriesInCache",
+                    "formatter": 4,
+                    "formatOptions": {
+                      "min": 0,
+                      "max": 100,
+                      "palette": "gray",
+                      "customColumnWidthSetting": "599px"
+                    },
+                    "numberFormat": {
+                      "unit": 1,
+                      "options": {
+                        "style": "decimal",
+                        "useGrouping": false
+                      }
+                    }
+                  },
+                  {
+                    "columnMatch": "potentialCacheSize",
+                    "formatter": 4,
+                    "formatOptions": {
+                      "palette": "yellow",
+                      "customColumnWidthSetting": "84.7143ch"
+                    },
+                    "numberFormat": {
+                      "unit": 2,
+                      "options": {
+                        "style": "decimal",
+                        "useGrouping": false
+                      }
+                    }
+                  }
+                ],
+                "labelSettings": [
+                  {
+                    "columnId": "User"
+                  },
+                  {
+                    "columnId": "ApplicationName"
+                  },
+                  {
+                    "columnId": "Count",
+                    "label": "Query count for selected LookbackPeriod"
+                  }
+                ]
+              },
+              "sortBy": []
+            },
+            "conditionalVisibility": {
+              "parameterName": "DatabaseName",
+              "comparison": "isNotEqualTo"
+            },
+            "name": "Cache User details per Query Look Back Period",
+            "styleSettings": {
+              "margin": "-50px 0px 0px 0px"
+            }
           }
         ]
       },
@@ -641,5 +723,9 @@
       "name": "On Boarding Message Group-Tables - Copy"
     }
   ],
+  "fallbackResourceIds": [
+    "/subscriptions/1f0d19a6-ad7b-45e9-b1c1-67aecd73046c/resourceGroups/test/providers/Microsoft.Kusto/Clusters/autoradeprod"
+  ],
+  "fromTemplateId": "Community-Workbooks/ADXCluster/AtResource",
   "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
 }


### PR DESCRIPTION
Like in Anita, they used to show users that are running queries with long lookback. can maybe correlate between the id in commands and queries. 

Anita had the "Detailed View" Button.
It opens a grid (under the histogram) with columns for: User, application, Number of queries.
Once you clicked on a bar, the grid changed accordingly and showed the top users (by query count) who ran the queries for the selected lookback period (per day)

![image](https://user-images.githubusercontent.com/28060851/114027973-a0721900-9880-11eb-9425-ea81687f8ef3.png)
