### PR TITLE
Add correlation to user with long lookback of queries

### DIFF
--- a/Workbooks/ADXCluster/AtResourceCache/ResourceCacheDetails.workbook
+++ b/Workbooks/ADXCluster/AtResourceCache/ResourceCacheDetails.workbook
@@ -465,6 +465,8 @@
               "size": 0,
               "showAnalytics": true,
               "noDataMessage": "There were no queries on this table",
+              "exportFieldName": "NumberOfDaysBefore",
+              "exportParameterName": "LookbackPeriod",
               "queryType": 0,
               "resourceType": "microsoft.kusto/clusters",
               "gridSettings": {
@@ -565,6 +567,130 @@
               "comparison": "isNotEqualTo"
             },
             "name": "Cache Details per Query Look Back Period",
+            "styleSettings": {
+              "margin": "-50px 0px 0px 0px"
+            }
+                      },
+          {
+            "type": 1,
+            "content": {
+              "json": "<span style=\"font-family: Open Sans; font-weight: 620; font-size: 14px;font-style: bold;margin:-10px -304px 0px 0px;position: relative;top:-5px\">&nbsp;&nbsp;User and query count information per selected query lookback period\r\n\r\n"
+            },
+            "conditionalVisibility": {
+              "parameterName": "DatabaseName",
+              "comparison": "isNotEqualTo"
+            },
+            "name": "Cache Header - Copy"
+          },
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "let defaultRetention = 365d * 10;\r\nADXTableUsageStatistics \r\n    | where DatabaseName == '{DatabaseName}' \r\n    | where TableName == '{TableName}' \r\n    | extend NumberOfDaysBefore = datetime_diff('day', StartedOn, MinCreatedOn)\r\n    | where NumberOfDaysBefore == '{LookbackPeriod}'\r\n    | summarize Count=count() by User, ApplicationName\r\n    | top 10 by Count\r\n",
+              "size": 0,
+              "showAnalytics": true,
+              "noDataMessage": "There were no queries on this table",
+              "queryType": 0,
+              "resourceType": "microsoft.kusto/clusters",
+              "gridSettings": {
+                "formatters": [
+                  {
+                    "columnMatch": "Count",
+                    "formatter": 0,
+                    "numberFormat": {
+                      "unit": 0,
+                      "options": {
+                        "style": "decimal",
+                        "useGrouping": false
+                      }
+                    },
+                    "tooltipFormat": {
+                      "tooltip": "The amount of queries the tuple of user and application ran for the selected lookbackperiod"
+                    }
+                  },
+                  {
+                    "columnMatch": "NumberOfDaysBefore",
+                    "formatter": 1,
+                    "formatOptions": {
+                      "customColumnWidthSetting": "20ch"
+                    },
+                    "numberFormat": {
+                      "unit": 27,
+                      "options": {
+                        "style": "decimal"
+                      }
+                    }
+                  },
+                  {
+                    "columnMatch": "actualQueriesInCache",
+                    "formatter": 4,
+                    "formatOptions": {
+                      "min": 0,
+                      "max": 100,
+                      "palette": "gray",
+                      "customColumnWidthSetting": "363px"
+                    },
+                    "numberFormat": {
+                      "unit": 1,
+                      "options": {
+                        "style": "decimal",
+                        "useGrouping": false
+                      }
+                    }
+                  },
+                  {
+                    "columnMatch": "potentialQueriesInCache",
+                    "formatter": 4,
+                    "formatOptions": {
+                      "min": 0,
+                      "max": 100,
+                      "palette": "gray",
+                      "customColumnWidthSetting": "599px"
+                    },
+                    "numberFormat": {
+                      "unit": 1,
+                      "options": {
+                        "style": "decimal",
+                        "useGrouping": false
+                      }
+                    }
+                  },
+                  {
+                    "columnMatch": "potentialCacheSize",
+                    "formatter": 4,
+                    "formatOptions": {
+                      "palette": "yellow",
+                      "customColumnWidthSetting": "84.7143ch"
+                    },
+                    "numberFormat": {
+                      "unit": 2,
+                      "options": {
+                        "style": "decimal",
+                        "useGrouping": false
+                      }
+                    }
+                  }
+                ],
+                "labelSettings": [
+                  {
+                    "columnId": "User"
+                  },
+                  {
+                    "columnId": "ApplicationName"
+                  },
+                  {
+                    "columnId": "Count",
+                    "label": "Query count for selected LookbackPeriod"
+                  }
+                ]
+              },
+              "sortBy": []
+            },
+            "conditionalVisibility": {
+              "parameterName": "DatabaseName",
+              "comparison": "isNotEqualTo"
+            },
+            "name": "Cache User details per Query Look Back Period",
             "styleSettings": {
               "margin": "-50px 0px 0px 0px"
             }

--- a/Workbooks/ADXCluster/AtResourceCache/ResourceCacheDetails.workbook
+++ b/Workbooks/ADXCluster/AtResourceCache/ResourceCacheDetails.workbook
@@ -563,7 +563,7 @@
               ]
             },
             "conditionalVisibility": {
-              "parameterName": "LookbackPeriod",
+              "parameterName": "DatabaseName",
               "comparison": "isNotEqualTo"
             },
             "name": "Cache Details per Query Look Back Period",
@@ -576,10 +576,16 @@
             "content": {
               "json": "💡 Click on a row on the above table to see details"
             },
-            "conditionalVisibility": {
-              "parameterName": "LookbackPeriod",
-              "comparison": "isEqualTo"
-            },
+            "conditionalVisibilities": [
+              {
+                "parameterName": "LookbackPeriod",
+                "comparison": "isEqualTo"
+              },
+              {
+                "parameterName": "DatabaseName",
+                "comparison": "isNotEqualTo"
+              }
+            ],
             "name": "ClickOnTheCacheLookbackGridText"
           },
           {
@@ -597,7 +603,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "let defaultRetention = 365d * 10;\r\nADXTableUsageStatistics \r\n    | where DatabaseName == '{DatabaseName}' \r\n    | where TableName == '{TableName}' \r\n    | extend NumberOfDaysBefore = datetime_diff('day', StartedOn, MinCreatedOn)\r\n    | where NumberOfDaysBefore == '{LookbackPeriod}'\r\n    | summarize Count=count() by User, ApplicationName\r\n    | top 10 by Count\r\n",
+              "query": "let defaultRetention = 365d * 10;\r\nADXTableUsageStatistics \r\n    | where TimeGenerated > ago(defaultRetention)\r\n    | where DatabaseName == '{DatabaseName}' \r\n    | where TableName == '{TableName}' \r\n    | extend NumberOfDaysBefore = datetime_diff('day', StartedOn, MinCreatedOn)\r\n    | where NumberOfDaysBefore == '{LookbackPeriod}'\r\n    | summarize Count=count() by User, ApplicationName\r\n    | top 10 by Count\r\n",
               "size": 0,
               "showAnalytics": true,
               "noDataMessage": "There were no queries on this table",
@@ -607,7 +613,7 @@
                 "formatters": [
                   {
                     "columnMatch": "Count",
-                    "formatter": 0,
+                    "formatter": 1,
                     "numberFormat": {
                       "unit": 0,
                       "options": {
@@ -691,14 +697,14 @@
                   },
                   {
                     "columnId": "Count",
-                    "label": "Query count for selected LookbackPeriod"
+                    "label": "Query count for selected lookback period"
                   }
                 ]
               },
               "sortBy": []
             },
             "conditionalVisibility": {
-              "parameterName": "DatabaseName",
+              "parameterName": "LookbackPeriod",
               "comparison": "isNotEqualTo"
             },
             "name": "Cache User details per Query Look Back Period",

--- a/Workbooks/ADXCluster/AtResourceCache/ResourceCacheDetails.workbook
+++ b/Workbooks/ADXCluster/AtResourceCache/ResourceCacheDetails.workbook
@@ -563,24 +563,35 @@
               ]
             },
             "conditionalVisibility": {
-              "parameterName": "DatabaseName",
+              "parameterName": "LookbackPeriod",
               "comparison": "isNotEqualTo"
             },
             "name": "Cache Details per Query Look Back Period",
             "styleSettings": {
               "margin": "-50px 0px 0px 0px"
             }
-                      },
+          },
+          {
+            "type": 1,
+            "content": {
+              "json": "💡 Click on a row on the above table to see details"
+            },
+            "conditionalVisibility": {
+              "parameterName": "LookbackPeriod",
+              "comparison": "isEqualTo"
+            },
+            "name": "ClickOnTheCacheLookbackGridText"
+          },
           {
             "type": 1,
             "content": {
               "json": "<span style=\"font-family: Open Sans; font-weight: 620; font-size: 14px;font-style: bold;margin:-10px -304px 0px 0px;position: relative;top:-5px\">&nbsp;&nbsp;User and query count information per selected query lookback period\r\n\r\n"
             },
             "conditionalVisibility": {
-              "parameterName": "DatabaseName",
+              "parameterName": "LookbackPeriod",
               "comparison": "isNotEqualTo"
             },
-            "name": "Cache Header - Copy"
+            "name": "User Details Cache Header"
           },
           {
             "type": 3,


### PR DESCRIPTION
Like in Anita, they used to show users that are running queries with long lookback. can maybe correlate between the id in commands and queries.

Anita had the "Detailed View" Button.
It opens a grid (under the histogram) with columns for: User, application, Number of queries.
Once you clicked on a bar, the grid changed accordingly and showed the top users (by query count) who ran the queries for the selected lookback period (per day)

![image](https://user-images.githubusercontent.com/28060851/114030515-3149f400-9883-11eb-84b0-a5d3fdc08e9b.png)

