### PR TITLE
Update RedisCache workbook locations & CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -68,6 +68,10 @@
 
 /Workbooks/Azure*Stack*HCI/** @microsoft/azure-stack-hci
 
+/Workbooks/RedisCache/** @microsoft/azure-cache-for-redis @microsoft/applicationinsights-devtools
+/Workbooks/Insights/RedisCache/** @microsoft/azure-cache-for-redis @microsoft/applicationinsights-devtools
+/Workbooks/Resource*Insights/RedisCache/** @microsoft/azure-cache-for-redis @microsoft/applicationinsights-devtools
+
 # Section for gallery files
 /gallery/workbook/Azure*Monitor.json @microsoft/applicationinsights-devtools
 /gallery/workbook/Microsoft.HDInsight-Clusters.json @microsoft/hdinsight-workbooks-team
@@ -80,6 +84,7 @@
 /gallery/container-insights/** @microsoft/container-insights-workbook-contributors @microsoft/applicationinsights-devtools
 /gallery/backup-insights/** @microsoft/azure-backup-workbook
 /gallery/hci-insights/** @microsoft/azure-stack-hci
+/gallery/workbook/microsoft.cache-redis.json @microsoft/azure-cache-for-redis @microsoft/applicationinsights-devtools
 
 # leave this at the bottom!
 # EVERYTHING ending with resjson* is for loc, and is owned by the workbooks team and the loc team

--- a/Workbooks/RedisCache/AtResource/ResourceInsights.workbook
+++ b/Workbooks/RedisCache/AtResource/ResourceInsights.workbook
@@ -1,0 +1,1474 @@
+{
+  "version": "Notebook/1.0",
+  "items": [
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "parameters": [
+          {
+            "id": "f3c4e9cb-8f5c-45ef-9ff9-9517d2a4aa19",
+            "version": "KqlParameterItem/1.0",
+            "name": "Resource",
+            "label": "Redis Cache",
+            "type": 5,
+            "isRequired": true,
+            "value": "value::1",
+            "isHiddenWhenLocked": true,
+            "typeSettings": {
+              "resourceTypeFilter": {
+                "microsoft.cache/redis": true
+              },
+              "additionalResourceOptions": [
+                "value::1"
+              ]
+            }
+          },
+          {
+            "id": "e317c0a5-18fa-4dbf-b394-9b09267be6c9",
+            "version": "KqlParameterItem/1.0",
+            "name": "TimeRange",
+            "label": "Time Range",
+            "type": 4,
+            "isRequired": true,
+            "value": {
+              "durationMs": 14400000
+            },
+            "typeSettings": {
+              "selectableValues": [
+                {
+                  "durationMs": 300000
+                },
+                {
+                  "durationMs": 900000
+                },
+                {
+                  "durationMs": 1800000
+                },
+                {
+                  "durationMs": 3600000
+                },
+                {
+                  "durationMs": 14400000
+                },
+                {
+                  "durationMs": 43200000
+                },
+                {
+                  "durationMs": 86400000
+                },
+                {
+                  "durationMs": 172800000
+                },
+                {
+                  "durationMs": 259200000
+                },
+                {
+                  "durationMs": 604800000
+                },
+                {
+                  "durationMs": 1209600000
+                },
+                {
+                  "durationMs": 2419200000
+                },
+                {
+                  "durationMs": 2592000000
+                },
+                {
+                  "durationMs": 5184000000
+                },
+                {
+                  "durationMs": 7776000000
+                }
+              ]
+            }
+          }
+        ],
+        "style": "pills",
+        "queryType": 0,
+        "resourceType": "microsoft.insights/components"
+      },
+      "name": "parameters - 8"
+    },
+    {
+      "type": 11,
+      "content": {
+        "version": "LinkItem/1.0",
+        "style": "tabs",
+        "links": [
+          {
+            "cellValue": "tab",
+            "linkTarget": "parameter",
+            "linkLabel": "Overview",
+            "subTarget": "overview",
+            "preText": "",
+            "style": "link"
+          },
+          {
+            "cellValue": "tab",
+            "linkTarget": "parameter",
+            "linkLabel": "Performance",
+            "subTarget": "performance",
+            "style": "link"
+          },
+          {
+            "cellValue": "tab",
+            "linkTarget": "parameter",
+            "linkLabel": "Operations",
+            "subTarget": "operations",
+            "style": "link"
+          }
+        ]
+      },
+      "name": "links - 3"
+    },
+    {
+      "type": 12,
+      "content": {
+        "version": "NotebookGroup/1.0",
+        "groupType": "editable",
+        "items": [
+          {
+            "type": 10,
+            "content": {
+              "chartId": "workbook7b475670-4421-486e-b158-a46da04ba378",
+              "version": "MetricsItem/2.0",
+              "size": 4,
+              "chartType": -1,
+              "resourceType": "microsoft.cache/redis",
+              "metricScope": 0,
+              "resourceParameter": "Resource",
+              "resourceIds": [
+                "{Resource}"
+              ],
+              "timeContextFromParameter": "TimeRange",
+              "timeContext": {
+                "durationMs": 0
+              },
+              "metrics": [
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--serverLoad",
+                  "aggregation": 3
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--percentProcessorTime",
+                  "aggregation": 3
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--usedmemory",
+                  "aggregation": 3
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--connectedclients",
+                  "aggregation": 3
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--errors",
+                  "aggregation": 4
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--expiredkeys",
+                  "aggregation": 3
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--evictedkeys",
+                  "aggregation": 3
+                }
+              ],
+              "gridFormatType": 1,
+              "tileSettings": {
+                "titleContent": {
+                  "columnMatch": "Metric",
+                  "formatter": 13,
+                  "formatOptions": {
+                    "linkTarget": null,
+                    "showIcon": false
+                  }
+                },
+                "leftContent": {
+                  "columnMatch": "Value",
+                  "formatter": 12,
+                  "formatOptions": {
+                    "palette": "auto"
+                  },
+                  "numberFormat": {
+                    "unit": 17,
+                    "options": {
+                      "maximumSignificantDigits": 3,
+                      "maximumFractionDigits": 2
+                    }
+                  }
+                },
+                "secondaryContent": {
+                  "columnMatch": "Timeline",
+                  "formatter": 9
+                },
+                "showBorder": false,
+                "size": "auto"
+              },
+              "gridSettings": {
+                "rowLimit": 10000
+              }
+            },
+            "name": "metric - 4"
+          },
+          {
+            "type": 10,
+            "content": {
+              "chartId": "workbook11988d6a-5d1d-48b8-83d0-044d7341608c",
+              "version": "MetricsItem/2.0",
+              "size": 0,
+              "chartType": 2,
+              "resourceType": "microsoft.cache/redis",
+              "metricScope": 0,
+              "resourceParameter": "Resource",
+              "resourceIds": [
+                "{Resource}"
+              ],
+              "timeContext": {
+                "durationMs": 14400000
+              },
+              "metrics": [
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--serverLoad0",
+                  "aggregation": 3,
+                  "splitBy": null
+                }
+              ],
+              "title": "Server Load",
+              "showOpenInMe": true,
+              "gridSettings": {
+                "rowLimit": 10000
+              }
+            },
+            "customWidth": "33",
+            "showPin": true,
+            "name": "metric - 6"
+          },
+          {
+            "type": 10,
+            "content": {
+              "chartId": "workbook11988d6a-5d1d-48b8-83d0-044d7341608c",
+              "version": "MetricsItem/2.0",
+              "size": 0,
+              "chartType": 2,
+              "resourceType": "microsoft.cache/redis",
+              "metricScope": 0,
+              "resourceParameter": "Resource",
+              "resourceIds": [
+                "{Resource}"
+              ],
+              "timeContext": {
+                "durationMs": 14400000
+              },
+              "metrics": [
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--percentProcessorTime0",
+                  "aggregation": 3,
+                  "splitBy": null
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--percentProcessorTime1",
+                  "aggregation": 3
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--percentProcessorTime2",
+                  "aggregation": 3
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--percentProcessorTime3",
+                  "aggregation": 3
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--percentProcessorTime4",
+                  "aggregation": 3
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--percentProcessorTime5",
+                  "aggregation": 3
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--percentProcessorTime6",
+                  "aggregation": 3
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--percentProcessorTime7",
+                  "aggregation": 3
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--percentProcessorTime8",
+                  "aggregation": 3
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--percentProcessorTime9",
+                  "aggregation": 3
+                }
+              ],
+              "title": "CPU by Shard",
+              "showOpenInMe": true,
+              "gridSettings": {
+                "rowLimit": 10000
+              }
+            },
+            "customWidth": "33",
+            "showPin": true,
+            "name": "metric - 6 - Copy"
+          },
+          {
+            "type": 10,
+            "content": {
+              "chartId": "workbook11988d6a-5d1d-48b8-83d0-044d7341608c",
+              "version": "MetricsItem/2.0",
+              "size": 0,
+              "chartType": 2,
+              "resourceType": "microsoft.cache/redis",
+              "metricScope": 0,
+              "resourceParameter": "Resource",
+              "resourceIds": [
+                "{Resource}"
+              ],
+              "timeContext": {
+                "durationMs": 14400000
+              },
+              "metrics": [
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--usedmemory0",
+                  "aggregation": 1,
+                  "splitBy": null
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--usedmemory1",
+                  "aggregation": 1
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--usedmemory2",
+                  "aggregation": 1
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--usedmemory3",
+                  "aggregation": 1
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--usedmemory4",
+                  "aggregation": 1
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--usedmemory5",
+                  "aggregation": 1
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--usedmemory6",
+                  "aggregation": 1
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--usedmemory7",
+                  "aggregation": 1
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--usedmemory8",
+                  "aggregation": 1
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--usedmemory9",
+                  "aggregation": 1
+                }
+              ],
+              "title": "Used Memory",
+              "showOpenInMe": true,
+              "gridSettings": {
+                "rowLimit": 10000
+              }
+            },
+            "customWidth": "33",
+            "showPin": true,
+            "name": "metric - 7"
+          },
+          {
+            "type": 10,
+            "content": {
+              "chartId": "workbook11988d6a-5d1d-48b8-83d0-044d7341608c",
+              "version": "MetricsItem/2.0",
+              "size": 0,
+              "chartType": 1,
+              "resourceType": "microsoft.cache/redis",
+              "metricScope": 0,
+              "resourceParameter": "Resource",
+              "resourceIds": [
+                "{Resource}"
+              ],
+              "timeContextFromParameter": "TimeRange",
+              "timeContext": {
+                "durationMs": 0
+              },
+              "metrics": [
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--connectedclients",
+                  "aggregation": 1,
+                  "splitBy": null
+                }
+              ],
+              "title": "Connected Clients",
+              "showOpenInMe": true,
+              "gridSettings": {
+                "rowLimit": 10000
+              }
+            },
+            "customWidth": "25",
+            "showPin": true,
+            "name": "metric - 3"
+          },
+          {
+            "type": 10,
+            "content": {
+              "chartId": "workbook11988d6a-5d1d-48b8-83d0-044d7341608c",
+              "version": "MetricsItem/2.0",
+              "size": 0,
+              "chartType": 1,
+              "resourceType": "microsoft.cache/redis",
+              "metricScope": 0,
+              "resourceParameter": "Resource",
+              "resourceIds": [
+                "{Resource}"
+              ],
+              "timeContextFromParameter": "TimeRange",
+              "timeContext": {
+                "durationMs": 0
+              },
+              "metrics": [
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--errors",
+                  "aggregation": 1,
+                  "splitBy": null
+                }
+              ],
+              "title": "Errors",
+              "showOpenInMe": true,
+              "gridSettings": {
+                "rowLimit": 10000
+              }
+            },
+            "customWidth": "25",
+            "showPin": true,
+            "name": "metric - 0"
+          },
+          {
+            "type": 10,
+            "content": {
+              "chartId": "workbook11988d6a-5d1d-48b8-83d0-044d7341608c",
+              "version": "MetricsItem/2.0",
+              "size": 0,
+              "chartType": 1,
+              "resourceType": "microsoft.cache/redis",
+              "metricScope": 0,
+              "resourceParameter": "Resource",
+              "resourceIds": [
+                "{Resource}"
+              ],
+              "timeContextFromParameter": "TimeRange",
+              "timeContext": {
+                "durationMs": 0
+              },
+              "metrics": [
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--expiredkeys",
+                  "aggregation": 1,
+                  "splitBy": null
+                }
+              ],
+              "title": "Expired Keys",
+              "showOpenInMe": true,
+              "gridSettings": {
+                "rowLimit": 10000
+              }
+            },
+            "customWidth": "25",
+            "showPin": true,
+            "name": "metric - 1"
+          },
+          {
+            "type": 10,
+            "content": {
+              "chartId": "workbook11988d6a-5d1d-48b8-83d0-044d7341608c",
+              "version": "MetricsItem/2.0",
+              "size": 0,
+              "chartType": 2,
+              "resourceType": "microsoft.cache/redis",
+              "metricScope": 0,
+              "resourceParameter": "Resource",
+              "resourceIds": [
+                "{Resource}"
+              ],
+              "timeContextFromParameter": "TimeRange",
+              "timeContext": {
+                "durationMs": 0
+              },
+              "metrics": [
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--evictedkeys",
+                  "aggregation": 1,
+                  "splitBy": null
+                }
+              ],
+              "title": "Evicted Keys",
+              "showOpenInMe": true,
+              "gridSettings": {
+                "rowLimit": 10000
+              }
+            },
+            "customWidth": "25",
+            "showPin": true,
+            "name": "metric - 2"
+          }
+        ]
+      },
+      "conditionalVisibility": {
+        "parameterName": "tab",
+        "comparison": "isEqualTo",
+        "value": "overview"
+      },
+      "name": "Overview"
+    },
+    {
+      "type": 12,
+      "content": {
+        "version": "NotebookGroup/1.0",
+        "groupType": "editable",
+        "items": [
+          {
+            "type": 10,
+            "content": {
+              "chartId": "workbook9b15f2b0-76b4-4914-bee8-6c938f3e783c",
+              "version": "MetricsItem/2.0",
+              "size": 4,
+              "chartType": -1,
+              "resourceType": "microsoft.cache/redis",
+              "metricScope": 0,
+              "resourceParameter": "Resource",
+              "resourceIds": [
+                "{Resource}"
+              ],
+              "timeContextFromParameter": "TimeRange",
+              "timeContext": {
+                "durationMs": 14400000
+              },
+              "metrics": [
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--cachehits",
+                  "aggregation": 1
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--cachemisses",
+                  "aggregation": 1
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--cacheWrite",
+                  "aggregation": 1
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--cacheRead",
+                  "aggregation": 7
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--cacheLatency",
+                  "aggregation": 4
+                }
+              ],
+              "gridFormatType": 1,
+              "tileSettings": {
+                "titleContent": {
+                  "columnMatch": "Metric",
+                  "formatter": 13,
+                  "formatOptions": {
+                    "linkTarget": null,
+                    "showIcon": false
+                  }
+                },
+                "leftContent": {
+                  "columnMatch": "Value",
+                  "formatter": 12,
+                  "formatOptions": {
+                    "palette": "auto"
+                  },
+                  "numberFormat": {
+                    "unit": 17,
+                    "options": {
+                      "style": "decimal",
+                      "useGrouping": false,
+                      "maximumFractionDigits": 2,
+                      "maximumSignificantDigits": 3
+                    }
+                  }
+                },
+                "secondaryContent": {
+                  "columnMatch": "Timeline",
+                  "formatter": 9,
+                  "formatOptions": {}
+                },
+                "showBorder": false
+              },
+              "gridSettings": {
+                "rowLimit": 10000
+              }
+            },
+            "name": "metric - 4"
+          },
+          {
+            "type": 10,
+            "content": {
+              "chartId": "workbook11988d6a-5d1d-48b8-83d0-044d7341608c",
+              "version": "MetricsItem/2.0",
+              "size": 0,
+              "chartType": 2,
+              "resourceType": "microsoft.cache/redis",
+              "metricScope": 0,
+              "resourceParameter": "Resource",
+              "resourceIds": [
+                "{Resource}"
+              ],
+              "timeContext": {
+                "durationMs": 14400000
+              },
+              "metrics": [
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--cacheRead",
+                  "aggregation": 1,
+                  "splitBy": null
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--cacheWrite",
+                  "aggregation": 1
+                }
+              ],
+              "title": "Cache Read and Write",
+              "showOpenInMe": true,
+              "gridSettings": {
+                "rowLimit": 10000
+              }
+            },
+            "customWidth": "50",
+            "showPin": true,
+            "name": "metric - 4"
+          },
+          {
+            "type": 10,
+            "content": {
+              "chartId": "workbook11988d6a-5d1d-48b8-83d0-044d7341608c",
+              "version": "MetricsItem/2.0",
+              "size": 0,
+              "chartType": 2,
+              "resourceType": "microsoft.cache/redis",
+              "metricScope": 0,
+              "resourceParameter": "Resource",
+              "resourceIds": [
+                "{Resource}"
+              ],
+              "timeContext": {
+                "durationMs": 14400000
+              },
+              "metrics": [
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--cachehits",
+                  "aggregation": 1,
+                  "splitBy": null
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--cachemisses",
+                  "aggregation": 1
+                }
+              ],
+              "title": "Cache Hit and Miss",
+              "showOpenInMe": true,
+              "gridSettings": {
+                "rowLimit": 10000
+              }
+            },
+            "customWidth": "50",
+            "showPin": true,
+            "name": "metric - 5"
+          },
+          {
+            "type": 10,
+            "content": {
+              "chartId": "workbook11988d6a-5d1d-48b8-83d0-044d7341608c",
+              "version": "MetricsItem/2.0",
+              "size": 0,
+              "chartType": 1,
+              "resourceType": "microsoft.cache/redis",
+              "metricScope": 0,
+              "resourceParameter": "Resource",
+              "resourceIds": [
+                "{Resource}"
+              ],
+              "timeContextFromParameter": "TimeRange",
+              "timeContext": {
+                "durationMs": 14400000
+              },
+              "metrics": [
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--cachehits0",
+                  "aggregation": 1,
+                  "splitBy": null
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--cachehits1",
+                  "aggregation": 1
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--cachehits2",
+                  "aggregation": 1
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--cachehits3",
+                  "aggregation": 1
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--cachehits4",
+                  "aggregation": 1
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--cachehits5",
+                  "aggregation": 1
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--cachehits6",
+                  "aggregation": 1
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--cachehits7",
+                  "aggregation": 3
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--cachehits8",
+                  "aggregation": 1
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--cachehits9",
+                  "aggregation": 1
+                }
+              ],
+              "title": "Cache Hits",
+              "showOpenInMe": true,
+              "gridSettings": {
+                "rowLimit": 10000
+              }
+            },
+            "customWidth": "50",
+            "showPin": true,
+            "name": "metric - 0"
+          },
+          {
+            "type": 10,
+            "content": {
+              "chartId": "workbook11988d6a-5d1d-48b8-83d0-044d7341608c",
+              "version": "MetricsItem/2.0",
+              "size": 0,
+              "chartType": 1,
+              "resourceType": "microsoft.cache/redis",
+              "metricScope": 0,
+              "resourceParameter": "Resource",
+              "resourceIds": [
+                "{Resource}"
+              ],
+              "timeContextFromParameter": "TimeRange",
+              "timeContext": {
+                "durationMs": 14400000
+              },
+              "metrics": [
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--cachemisses0",
+                  "aggregation": 1,
+                  "splitBy": null
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--cachemisses1",
+                  "aggregation": 1
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--cachemisses2",
+                  "aggregation": 1
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--cachemisses3",
+                  "aggregation": 1
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--cachemisses4",
+                  "aggregation": 1
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--cachemisses5",
+                  "aggregation": 1
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--cachemisses6",
+                  "aggregation": 1
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--cachemisses7",
+                  "aggregation": 3
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--cachemisses8",
+                  "aggregation": 1
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--cachemisses9",
+                  "aggregation": 1
+                }
+              ],
+              "title": "Cache Misses",
+              "showOpenInMe": true,
+              "gridSettings": {
+                "rowLimit": 10000
+              }
+            },
+            "customWidth": "50",
+            "showPin": true,
+            "name": "metric - 1"
+          },
+          {
+            "type": 10,
+            "content": {
+              "chartId": "workbook11988d6a-5d1d-48b8-83d0-044d7341608c",
+              "version": "MetricsItem/2.0",
+              "size": 0,
+              "chartType": 1,
+              "resourceType": "microsoft.cache/redis",
+              "metricScope": 0,
+              "resourceParameter": "Resource",
+              "resourceIds": [
+                "{Resource}"
+              ],
+              "timeContextFromParameter": "TimeRange",
+              "timeContext": {
+                "durationMs": 14400000
+              },
+              "metrics": [
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--cacheRead0",
+                  "aggregation": 1,
+                  "splitBy": null
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--cacheRead1",
+                  "aggregation": 1
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--cacheRead2",
+                  "aggregation": 1
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--cacheRead3",
+                  "aggregation": 1
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--cacheRead4",
+                  "aggregation": 1
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--cacheRead5",
+                  "aggregation": 1
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--cacheRead6",
+                  "aggregation": 1
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--cacheRead7",
+                  "aggregation": 3
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--cacheRead8",
+                  "aggregation": 1
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--cacheRead9",
+                  "aggregation": 1
+                }
+              ],
+              "title": "Cache Reads",
+              "showOpenInMe": true,
+              "gridSettings": {
+                "rowLimit": 10000
+              }
+            },
+            "customWidth": "50",
+            "showPin": true,
+            "name": "metric - 2"
+          },
+          {
+            "type": 10,
+            "content": {
+              "chartId": "workbook11988d6a-5d1d-48b8-83d0-044d7341608c",
+              "version": "MetricsItem/2.0",
+              "size": 0,
+              "chartType": 1,
+              "resourceType": "microsoft.cache/redis",
+              "metricScope": 0,
+              "resourceParameter": "Resource",
+              "resourceIds": [
+                "{Resource}"
+              ],
+              "timeContextFromParameter": "TimeRange",
+              "timeContext": {
+                "durationMs": 14400000
+              },
+              "metrics": [
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--cacheWrite0",
+                  "aggregation": 1,
+                  "splitBy": null
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--cacheWrite1",
+                  "aggregation": 1
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--cacheWrite2",
+                  "aggregation": 1
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--cacheWrite3",
+                  "aggregation": 1
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--cacheWrite4",
+                  "aggregation": 1
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--cacheWrite5",
+                  "aggregation": 1
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--cacheWrite6",
+                  "aggregation": 1
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--cacheWrite7",
+                  "aggregation": 3
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--cacheWrite8",
+                  "aggregation": 1
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--cacheWrite9",
+                  "aggregation": 1
+                }
+              ],
+              "title": "Cache Writes",
+              "showOpenInMe": true,
+              "gridSettings": {
+                "rowLimit": 10000
+              }
+            },
+            "customWidth": "50",
+            "showPin": true,
+            "name": "metric - 3"
+          }
+        ]
+      },
+      "conditionalVisibility": {
+        "parameterName": "tab",
+        "comparison": "isEqualTo",
+        "value": "performance"
+      },
+      "name": "Performance"
+    },
+    {
+      "type": 12,
+      "content": {
+        "version": "NotebookGroup/1.0",
+        "groupType": "editable",
+        "items": [
+          {
+            "type": 10,
+            "content": {
+              "chartId": "workbookdc9131f9-1498-455b-89e1-03695d077124",
+              "version": "MetricsItem/2.0",
+              "size": 4,
+              "chartType": -1,
+              "resourceType": "microsoft.cache/redis",
+              "metricScope": 0,
+              "resourceParameter": "Resource",
+              "resourceIds": [
+                "{Resource}"
+              ],
+              "timeContextFromParameter": "TimeRange",
+              "timeContext": {
+                "durationMs": 14400000
+              },
+              "metrics": [
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--totalcommandsprocessed",
+                  "aggregation": 1
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--operationsPerSecond",
+                  "aggregation": 1
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--getcommands",
+                  "aggregation": 1
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--setcommands",
+                  "aggregation": 1
+                }
+              ],
+              "gridFormatType": 1,
+              "tileSettings": {
+                "titleContent": {
+                  "columnMatch": "Metric",
+                  "formatter": 13,
+                  "formatOptions": {
+                    "linkTarget": null,
+                    "showIcon": false
+                  }
+                },
+                "leftContent": {
+                  "columnMatch": "Value",
+                  "formatter": 12,
+                  "formatOptions": {
+                    "palette": "auto"
+                  },
+                  "numberFormat": {
+                    "unit": 17,
+                    "options": {
+                      "maximumSignificantDigits": 3,
+                      "maximumFractionDigits": 2
+                    }
+                  }
+                },
+                "secondaryContent": {
+                  "columnMatch": "Timeline",
+                  "formatter": 9,
+                  "formatOptions": {}
+                },
+                "showBorder": false
+              },
+              "gridSettings": {
+                "rowLimit": 10000
+              }
+            },
+            "name": "metric - 4"
+          },
+          {
+            "type": 10,
+            "content": {
+              "chartId": "workbook11988d6a-5d1d-48b8-83d0-044d7341608c",
+              "version": "MetricsItem/2.0",
+              "size": 0,
+              "chartType": 1,
+              "resourceType": "microsoft.cache/redis",
+              "metricScope": 0,
+              "resourceParameter": "Resource",
+              "resourceIds": [
+                "{Resource}"
+              ],
+              "timeContextFromParameter": "TimeRange",
+              "timeContext": {
+                "durationMs": 14400000
+              },
+              "metrics": [
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--totalcommandsprocessed0",
+                  "aggregation": 1,
+                  "splitBy": null
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--totalcommandsprocessed1",
+                  "aggregation": 1
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--totalcommandsprocessed2",
+                  "aggregation": 1
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--totalcommandsprocessed3",
+                  "aggregation": 1
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--totalcommandsprocessed4",
+                  "aggregation": 1
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--totalcommandsprocessed5",
+                  "aggregation": 1
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--totalcommandsprocessed6",
+                  "aggregation": 1
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--totalcommandsprocessed7",
+                  "aggregation": 1
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--totalcommandsprocessed8",
+                  "aggregation": 1
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--totalcommandsprocessed9",
+                  "aggregation": 1
+                }
+              ],
+              "title": "Total Operations",
+              "showOpenInMe": true,
+              "gridSettings": {
+                "rowLimit": 10000
+              }
+            },
+            "customWidth": "50",
+            "showPin": true,
+            "name": "metric - 0"
+          },
+          {
+            "type": 10,
+            "content": {
+              "chartId": "workbook11988d6a-5d1d-48b8-83d0-044d7341608c",
+              "version": "MetricsItem/2.0",
+              "size": 0,
+              "chartType": 2,
+              "resourceType": "microsoft.cache/redis",
+              "metricScope": 0,
+              "resourceParameter": "Resource",
+              "resourceIds": [
+                "{Resource}"
+              ],
+              "timeContextFromParameter": "TimeRange",
+              "timeContext": {
+                "durationMs": 14400000
+              },
+              "metrics": [
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--operationsPerSecond0",
+                  "aggregation": 1,
+                  "splitBy": null
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--operationsPerSecond1",
+                  "aggregation": 1
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--operationsPerSecond2",
+                  "aggregation": 1
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--operationsPerSecond3",
+                  "aggregation": 1
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--operationsPerSecond4",
+                  "aggregation": 1
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--operationsPerSecond5",
+                  "aggregation": 1
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--operationsPerSecond6",
+                  "aggregation": 1
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--operationsPerSecond7",
+                  "aggregation": 1
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--operationsPerSecond8",
+                  "aggregation": 1
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--operationsPerSecond9",
+                  "aggregation": 1
+                }
+              ],
+              "title": "Operation Rate",
+              "showOpenInMe": true,
+              "gridSettings": {
+                "rowLimit": 10000
+              }
+            },
+            "customWidth": "50",
+            "showPin": true,
+            "name": "metric - 1"
+          },
+          {
+            "type": 10,
+            "content": {
+              "chartId": "workbook11988d6a-5d1d-48b8-83d0-044d7341608c",
+              "version": "MetricsItem/2.0",
+              "size": 0,
+              "chartType": 1,
+              "resourceType": "microsoft.cache/redis",
+              "metricScope": 0,
+              "resourceParameter": "Resource",
+              "resourceIds": [
+                "{Resource}"
+              ],
+              "timeContextFromParameter": "TimeRange",
+              "timeContext": {
+                "durationMs": 14400000
+              },
+              "metrics": [
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--getcommands0",
+                  "aggregation": 1,
+                  "splitBy": null
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--getcommands1",
+                  "aggregation": 1
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--getcommands2",
+                  "aggregation": 1
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--getcommands3",
+                  "aggregation": 1
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--getcommands4",
+                  "aggregation": 1
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--getcommands5",
+                  "aggregation": 1
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--getcommands6",
+                  "aggregation": 1
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--getcommands7",
+                  "aggregation": 1
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--getcommands8",
+                  "aggregation": 1
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--getcommands9",
+                  "aggregation": 1
+                }
+              ],
+              "title": "Gets",
+              "showOpenInMe": true,
+              "gridSettings": {
+                "rowLimit": 10000
+              }
+            },
+            "customWidth": "50",
+            "showPin": true,
+            "name": "metric - 2"
+          },
+          {
+            "type": 10,
+            "content": {
+              "chartId": "workbook11988d6a-5d1d-48b8-83d0-044d7341608c",
+              "version": "MetricsItem/2.0",
+              "size": 0,
+              "chartType": 1,
+              "resourceType": "microsoft.cache/redis",
+              "metricScope": 0,
+              "resourceParameter": "Resource",
+              "resourceIds": [
+                "{Resource}"
+              ],
+              "timeContextFromParameter": "TimeRange",
+              "timeContext": {
+                "durationMs": 14400000
+              },
+              "metrics": [
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--setcommands0",
+                  "aggregation": 1,
+                  "splitBy": null
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--setcommands1",
+                  "aggregation": 1
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--setcommands2",
+                  "aggregation": 1
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--setcommands3",
+                  "aggregation": 1
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--setcommands4",
+                  "aggregation": 1
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--setcommands5",
+                  "aggregation": 1
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--setcommands6",
+                  "aggregation": 1
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--setcommands7",
+                  "aggregation": 1
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--setcommands8",
+                  "aggregation": 1
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--setcommands9",
+                  "aggregation": 1
+                }
+              ],
+              "title": "Sets",
+              "showOpenInMe": true,
+              "gridSettings": {
+                "rowLimit": 10000
+              }
+            },
+            "customWidth": "50",
+            "showPin": true,
+            "name": "metric - 3"
+          }
+        ]
+      },
+      "conditionalVisibility": {
+        "parameterName": "tab",
+        "comparison": "isEqualTo",
+        "value": "operations"
+      },
+      "name": "Operations"
+    }
+  ],
+  "workbookPin": "metric - 4",
+  "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
+}

--- a/Workbooks/RedisCache/AtScale/Insights.workbook
+++ b/Workbooks/RedisCache/AtScale/Insights.workbook
@@ -1,0 +1,1197 @@
+{
+  "version": "Notebook/1.0",
+  "items": [
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "crossComponentResources": [
+          "{Subscription}"
+        ],
+        "parameters": [
+          {
+            "id": "1f74ed9a-e3ed-498d-bd5b-f68f3836a117",
+            "version": "KqlParameterItem/1.0",
+            "name": "Subscription",
+            "label": "Subscriptions",
+            "type": 6,
+            "description": "All subscriptions with Azure Cache for Redis",
+            "isRequired": true,
+            "multiSelect": true,
+            "quote": "'",
+            "delimiter": ",",
+            "query": "Resources\r\n| where type =~ 'microsoft.cache/redis'\r\n| summarize Count = count() by subscriptionId\r\n| order by Count desc\r\n| extend Rank = row_number()\r\n| project value = subscriptionId, label = subscriptionId, selected = Rank == 1",
+            "crossComponentResources": [
+              "value::selected"
+            ],
+            "typeSettings": {
+              "additionalResourceOptions": [],
+              "showDefault": false
+            },
+            "queryType": 1,
+            "resourceType": "microsoft.resourcegraph/resources"
+          },
+          {
+            "id": "f60ea0a0-3703-44ca-a59b-df0246423f41",
+            "version": "KqlParameterItem/1.0",
+            "name": "Resources",
+            "label": "Azure Cache for Redis",
+            "type": 5,
+            "isRequired": true,
+            "multiSelect": true,
+            "quote": "'",
+            "delimiter": ",",
+            "query": "Resources\r\n| where type =~ 'microsoft.cache/redis'\r\n| order by name asc\r\n| extend Rank = row_number()\r\n| project value = id, label = name, selected = Rank <= 5",
+            "crossComponentResources": [
+              "{Subscription}"
+            ],
+            "typeSettings": {
+              "additionalResourceOptions": [
+                "value::all"
+              ],
+              "showDefault": false
+            },
+            "queryType": 1,
+            "resourceType": "microsoft.resourcegraph/resources"
+          },
+          {
+            "id": "182d6324-854c-4cc0-802a-de4f3bee9f76",
+            "version": "KqlParameterItem/1.0",
+            "name": "TimeRange",
+            "label": "Time range",
+            "type": 4,
+            "isRequired": true,
+            "value": {
+              "durationMs": 14400000
+            },
+            "typeSettings": {
+              "selectableValues": [
+                {
+                  "durationMs": 300000
+                },
+                {
+                  "durationMs": 900000
+                },
+                {
+                  "durationMs": 1800000
+                },
+                {
+                  "durationMs": 3600000
+                },
+                {
+                  "durationMs": 14400000
+                },
+                {
+                  "durationMs": 43200000
+                },
+                {
+                  "durationMs": 86400000
+                },
+                {
+                  "durationMs": 172800000
+                },
+                {
+                  "durationMs": 259200000
+                },
+                {
+                  "durationMs": 604800000
+                }
+              ],
+              "allowCustom": true
+            }
+          },
+          {
+            "id": "5ab45df9-371b-4dba-8ee3-6ec9fbb33ff9",
+            "version": "KqlParameterItem/1.0",
+            "name": "Message",
+            "type": 1,
+            "query": "where type  =~ 'microsoft.cache/redis'\r\n| summarize Selected = countif(id in ({Resources:value})), Total = count()\r\n| extend Selected = iff(Selected > 200, 200, Selected)\r\n| project Message = strcat('# ', Selected, ' / ', Total)",
+            "crossComponentResources": [
+              "{Subscription}"
+            ],
+            "isHiddenWhenLocked": true,
+            "queryType": 1,
+            "resourceType": "microsoft.resourcegraph/resources"
+          },
+          {
+            "id": "46dfcfa4-d5d4-47c2-9dfd-ca0fcb935dc7",
+            "version": "KqlParameterItem/1.0",
+            "name": "ResourceName",
+            "type": 1,
+            "description": "Used for 'No Subscriptions' workbook template",
+            "value": "Azure Cache for Redis",
+            "isHiddenWhenLocked": true,
+            "criteriaData": [
+              {
+                "condition": "else result = 'Azure Cache for Redis'",
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "static",
+                  "resultVal": "Azure Cache for Redis"
+                }
+              }
+            ]
+          },
+          {
+            "id": "1c84117c-7449-4484-b693-00f41a578bd6",
+            "version": "KqlParameterItem/1.0",
+            "name": "ResourceImageUrl",
+            "type": 1,
+            "description": "Used for 'No Subscriptions' workbook template",
+            "isHiddenWhenLocked": true,
+            "timeContext": {
+              "durationMs": 0
+            },
+            "timeContextFromParameter": "TimeRange"
+          }
+        ],
+        "style": "above",
+        "queryType": 0,
+        "resourceType": "microsoft.operationalinsights/workspaces"
+      },
+      "name": "parameters - 0",
+      "styleSettings": {
+        "margin": "15px 0 0 0"
+      }
+    },
+    {
+      "type": 12,
+      "content": {
+        "version": "NotebookGroup/1.0",
+        "groupType": "template",
+        "loadFromTemplateId": "community-Workbooks/Common/noSubscriptions",
+        "items": []
+      },
+      "conditionalVisibility": {
+        "parameterName": "Subscription",
+        "comparison": "isEqualTo",
+        "value": ""
+      },
+      "name": "No Subscriptions group"
+    },
+    {
+      "type": 12,
+      "content": {
+        "version": "NotebookGroup/1.0",
+        "groupType": "editable",
+        "items": [
+          {
+            "type": 1,
+            "content": {
+              "json": "{Message}\r\n_Azure Cache for Redis_\r\n<br />\r\n<br />"
+            },
+            "name": "text - 5",
+            "styleSettings": {
+              "margin": "15px 0 10px 10px"
+            }
+          },
+          {
+            "type": 11,
+            "content": {
+              "version": "LinkItem/1.0",
+              "style": "tabs",
+              "links": [
+                {
+                  "cellValue": "selectedTab",
+                  "linkTarget": "parameter",
+                  "linkLabel": "Overview",
+                  "subTarget": "Overview",
+                  "style": "link"
+                },
+                {
+                  "cellValue": "selectedTab",
+                  "linkTarget": "parameter",
+                  "linkLabel": "Operations",
+                  "subTarget": "Operations",
+                  "style": "link"
+                },
+                {
+                  "cellValue": "selectedTab",
+                  "linkTarget": "parameter",
+                  "linkLabel": "Usage",
+                  "subTarget": "Usage",
+                  "style": "link",
+                  "workbookContext": {},
+                  "alertRuleContext": {}
+                },
+                {
+                  "cellValue": "selectedTab",
+                  "linkTarget": "parameter",
+                  "linkLabel": "Failures",
+                  "subTarget": "Failures",
+                  "style": "link"
+                }
+              ]
+            },
+            "name": "links - 2",
+            "styleSettings": {
+              "margin": "-15px 0px -15px 0px"
+            }
+          },
+          {
+            "type": 10,
+            "content": {
+              "chartId": "workbook19356bdc-cfd5-47c7-8e70-05bbd3f39558",
+              "version": "MetricsItem/2.0",
+              "size": 2,
+              "chartType": 0,
+              "resourceIds": [
+                "{Resources}"
+              ],
+              "timeContext": {
+                "durationMs": 0
+              },
+              "timeContextFromParameter": "TimeRange",
+              "resourceType": "microsoft.cache/redis",
+              "resourceParameter": "Resources",
+              "metrics": [
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--usedmemory",
+                  "aggregation": 3,
+                  "splitBy": null
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--usedmemorypercentage",
+                  "aggregation": 3,
+                  "splitBy": null
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--serverLoad",
+                  "aggregation": 3,
+                  "splitBy": null
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--percentProcessorTime",
+                  "aggregation": 3,
+                  "splitBy": null
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--connectedclients",
+                  "aggregation": 3,
+                  "splitBy": null
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--cachemisses",
+                  "aggregation": 1,
+                  "splitBy": null
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--errors",
+                  "aggregation": 3,
+                  "splitBy": null
+                }
+              ],
+              "gridSettings": {
+                "formatters": [
+                  {
+                    "columnMatch": "$gen_group",
+                    "formatter": 13,
+                    "formatOptions": {
+                      "linkTarget": "Resource",
+                      "subTarget": "insights",
+                      "showIcon": true
+                    }
+                  },
+                  {
+                    "columnMatch": "Subscription",
+                    "formatter": 5,
+                    "formatOptions": {
+                      "showIcon": true
+                    }
+                  },
+                  {
+                    "columnMatch": "Name",
+                    "formatter": 5,
+                    "formatOptions": {
+                      "showIcon": true
+                    }
+                  },
+                  {
+                    "columnMatch": "microsoft.cache/redis--usedmemorypercentage",
+                    "formatter": 8,
+                    "formatOptions": {
+                      "min": 0,
+                      "max": 100,
+                      "palette": "blue",
+                      "showIcon": true
+                    },
+                    "numberFormat": {
+                      "unit": 1,
+                      "options": {
+                        "style": "decimal",
+                        "useGrouping": false,
+                        "maximumFractionDigits": 1
+                      }
+                    }
+                  },
+                  {
+                    "columnMatch": "microsoft.cache/redis--usedmemorypercentage Timeline",
+                    "formatter": 5,
+                    "formatOptions": {
+                      "min": 0,
+                      "palette": "blue",
+                      "showIcon": true
+                    }
+                  },
+                  {
+                    "columnMatch": "microsoft.cache/redis--usedmemory",
+                    "formatter": 1,
+                    "formatOptions": {
+                      "showIcon": true,
+                      "aggregation": "Sum"
+                    },
+                    "numberFormat": {
+                      "unit": 36,
+                      "options": {
+                        "style": "decimal",
+                        "useGrouping": false,
+                        "maximumFractionDigits": 1
+                      }
+                    }
+                  },
+                  {
+                    "columnMatch": "microsoft.cache/redis--usedmemory Timeline",
+                    "formatter": 5,
+                    "formatOptions": {
+                      "showIcon": true
+                    }
+                  },
+                  {
+                    "columnMatch": "microsoft.cache/redis--serverLoad",
+                    "formatter": 8,
+                    "formatOptions": {
+                      "min": 0,
+                      "max": 100,
+                      "palette": "blue",
+                      "showIcon": true
+                    },
+                    "numberFormat": {
+                      "unit": 1,
+                      "options": {
+                        "style": "decimal"
+                      }
+                    }
+                  },
+                  {
+                    "columnMatch": "microsoft.cache/redis--serverLoad Timeline",
+                    "formatter": 21,
+                    "formatOptions": {
+                      "showIcon": true
+                    }
+                  },
+                  {
+                    "columnMatch": "microsoft.cache/redis--percentProcessorTime",
+                    "formatter": 8,
+                    "formatOptions": {
+                      "min": 0,
+                      "max": 100,
+                      "palette": "blue",
+                      "showIcon": true
+                    },
+                    "numberFormat": {
+                      "unit": 1,
+                      "options": {
+                        "style": "decimal",
+                        "maximumFractionDigits": 1
+                      }
+                    }
+                  },
+                  {
+                    "columnMatch": "microsoft.cache/redis--percentProcessorTime Timeline",
+                    "formatter": 5,
+                    "formatOptions": {
+                      "palette": "blue",
+                      "showIcon": true
+                    }
+                  },
+                  {
+                    "columnMatch": "microsoft.cache/redis--connectedclients",
+                    "formatter": 4,
+                    "formatOptions": {
+                      "min": 0,
+                      "palette": "blue",
+                      "showIcon": true
+                    },
+                    "numberFormat": {
+                      "unit": 17,
+                      "options": {
+                        "style": "decimal",
+                        "useGrouping": false,
+                        "maximumFractionDigits": 1
+                      }
+                    }
+                  },
+                  {
+                    "columnMatch": "microsoft.cache/redis--connectedclients Timeline",
+                    "formatter": 5,
+                    "formatOptions": {
+                      "showIcon": true
+                    }
+                  },
+                  {
+                    "columnMatch": "microsoft.cache/redis--cachemisses",
+                    "formatter": 4,
+                    "formatOptions": {
+                      "min": 0,
+                      "palette": "red",
+                      "showIcon": true
+                    },
+                    "numberFormat": {
+                      "unit": 17,
+                      "options": {
+                        "style": "decimal",
+                        "useGrouping": false,
+                        "maximumFractionDigits": 2
+                      }
+                    }
+                  },
+                  {
+                    "columnMatch": "microsoft.cache/redis--cachemisses Timeline",
+                    "formatter": 5,
+                    "formatOptions": {
+                      "showIcon": true
+                    }
+                  },
+                  {
+                    "columnMatch": "microsoft.cache/redis--errors",
+                    "formatter": 4,
+                    "formatOptions": {
+                      "showIcon": true
+                    },
+                    "numberFormat": {
+                      "unit": 17,
+                      "options": {
+                        "style": "decimal",
+                        "maximumFractionDigits": 1
+                      }
+                    }
+                  },
+                  {
+                    "columnMatch": "microsoft.cache/redis--errors Timeline",
+                    "formatter": 5,
+                    "formatOptions": {
+                      "showIcon": true
+                    }
+                  }
+                ],
+                "rowLimit": 10000,
+                "filter": true,
+                "hierarchySettings": {
+                  "treeType": 1,
+                  "groupBy": [
+                    "Subscription"
+                  ],
+                  "expandTopLevel": true,
+                  "finalBy": "Name"
+                },
+                "labelSettings": [
+                  {
+                    "columnId": "Subscription",
+                    "label": "Subscription"
+                  },
+                  {
+                    "columnId": "Name"
+                  },
+                  {
+                    "columnId": "microsoft.cache/redis--usedmemory",
+                    "label": "Used Memory"
+                  },
+                  {
+                    "columnId": "microsoft.cache/redis--usedmemory Timeline",
+                    "label": "Used Memory Timeline"
+                  },
+                  {
+                    "columnId": "microsoft.cache/redis--usedmemorypercentage",
+                    "label": "Used Memory Percentage"
+                  },
+                  {
+                    "columnId": "microsoft.cache/redis--usedmemorypercentage Timeline",
+                    "label": "Used Memory Percentage Timeline"
+                  },
+                  {
+                    "columnId": "microsoft.cache/redis--serverLoad",
+                    "label": "Server Load"
+                  },
+                  {
+                    "columnId": "microsoft.cache/redis--serverLoad Timeline",
+                    "label": "Server Load Timeline"
+                  },
+                  {
+                    "columnId": "microsoft.cache/redis--percentProcessorTime",
+                    "label": "CPU"
+                  },
+                  {
+                    "columnId": "microsoft.cache/redis--percentProcessorTime Timeline",
+                    "label": "CPU Timeline"
+                  },
+                  {
+                    "columnId": "microsoft.cache/redis--connectedclients",
+                    "label": "Connected Clients"
+                  },
+                  {
+                    "columnId": "microsoft.cache/redis--connectedclients Timeline",
+                    "label": "Connected Clients Timeline"
+                  },
+                  {
+                    "columnId": "microsoft.cache/redis--cachemisses",
+                    "label": "Cache Misses"
+                  },
+                  {
+                    "columnId": "microsoft.cache/redis--cachemisses Timeline",
+                    "label": "Cache Misses Timeline"
+                  },
+                  {
+                    "columnId": "microsoft.cache/redis--errors",
+                    "label": "Errors (Max)"
+                  },
+                  {
+                    "columnId": "microsoft.cache/redis--errors Timeline",
+                    "label": "Errors Timeline"
+                  }
+                ]
+              },
+              "sortBy": [],
+              "showExportToExcel": true
+            },
+            "conditionalVisibility": {
+              "parameterName": "selectedTab",
+              "comparison": "isEqualTo",
+              "value": "Overview"
+            },
+            "showPin": true,
+            "name": "Overview"
+          },
+          {
+            "type": 10,
+            "content": {
+              "chartId": "workbook19356bdc-cfd5-47c7-8e70-05bbd3f39558",
+              "version": "MetricsItem/2.0",
+              "size": 2,
+              "chartType": 0,
+              "resourceIds": [
+                "{Resources}"
+              ],
+              "timeContext": {
+                "durationMs": 0
+              },
+              "timeContextFromParameter": "TimeRange",
+              "resourceType": "microsoft.cache/redis",
+              "resourceParameter": "Resources",
+              "metrics": [
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--totalcommandsprocessed",
+                  "aggregation": 3,
+                  "splitBy": null
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--operationsPerSecond",
+                  "aggregation": 3,
+                  "splitBy": null
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--getcommands",
+                  "aggregation": 1,
+                  "splitBy": null
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--setcommands",
+                  "aggregation": 1,
+                  "splitBy": null
+                }
+              ],
+              "gridSettings": {
+                "formatters": [
+                  {
+                    "columnMatch": "$gen_group",
+                    "formatter": 13,
+                    "formatOptions": {
+                      "linkTarget": "Resource",
+                      "subTarget": "insights",
+                      "showIcon": true
+                    }
+                  },
+                  {
+                    "columnMatch": "Subscription",
+                    "formatter": 5,
+                    "formatOptions": {
+                      "showIcon": true
+                    }
+                  },
+                  {
+                    "columnMatch": "Name",
+                    "formatter": 5,
+                    "formatOptions": {
+                      "showIcon": true
+                    }
+                  },
+                  {
+                    "columnMatch": "microsoft.cache/redis--totalcommandsprocessed",
+                    "formatter": 8,
+                    "formatOptions": {
+                      "min": 0,
+                      "palette": "blue",
+                      "showIcon": true,
+                      "aggregation": "Sum"
+                    },
+                    "numberFormat": {
+                      "unit": 17,
+                      "options": {
+                        "style": "decimal",
+                        "useGrouping": false,
+                        "maximumFractionDigits": 1
+                      }
+                    }
+                  },
+                  {
+                    "columnMatch": "microsoft.cache/redis--totalcommandsprocessed Timeline",
+                    "formatter": 21,
+                    "formatOptions": {
+                      "min": 0,
+                      "palette": "blue",
+                      "showIcon": true
+                    }
+                  },
+                  {
+                    "columnMatch": "microsoft.cache/redis--operationsPerSecond",
+                    "formatter": 4,
+                    "formatOptions": {
+                      "min": 0,
+                      "palette": "blue",
+                      "showIcon": true
+                    },
+                    "numberFormat": {
+                      "unit": 31,
+                      "options": {
+                        "style": "decimal"
+                      }
+                    }
+                  },
+                  {
+                    "columnMatch": "microsoft.cache/redis--operationsPerSecond Timeline",
+                    "formatter": 5,
+                    "formatOptions": {
+                      "showIcon": true
+                    }
+                  },
+                  {
+                    "columnMatch": "microsoft.cache/redis--getcommands",
+                    "formatter": 4,
+                    "formatOptions": {
+                      "min": 0,
+                      "palette": "blue",
+                      "showIcon": true,
+                      "aggregation": "Sum"
+                    },
+                    "numberFormat": {
+                      "unit": 17,
+                      "options": {
+                        "style": "decimal",
+                        "maximumFractionDigits": 1
+                      }
+                    }
+                  },
+                  {
+                    "columnMatch": "microsoft.cache/redis--getcommands Timeline",
+                    "formatter": 5,
+                    "formatOptions": {
+                      "showIcon": true
+                    }
+                  },
+                  {
+                    "columnMatch": "microsoft.cache/redis--setcommands",
+                    "formatter": 4,
+                    "formatOptions": {
+                      "min": 0,
+                      "palette": "blue",
+                      "showIcon": true,
+                      "aggregation": "Sum"
+                    },
+                    "numberFormat": {
+                      "unit": 17,
+                      "options": {
+                        "style": "decimal",
+                        "maximumFractionDigits": 1
+                      }
+                    }
+                  },
+                  {
+                    "columnMatch": "microsoft.cache/redis--setcommands Timeline",
+                    "formatter": 5,
+                    "formatOptions": {
+                      "showIcon": true
+                    }
+                  }
+                ],
+                "rowLimit": 10000,
+                "filter": true,
+                "hierarchySettings": {
+                  "treeType": 1,
+                  "groupBy": [
+                    "Subscription"
+                  ],
+                  "expandTopLevel": true,
+                  "finalBy": "Name"
+                },
+                "sortBy": [
+                  {
+                    "itemKey": "$gen_heatmap_microsoft.cache/redis--totalcommandsprocessed_3",
+                    "sortOrder": 2
+                  }
+                ],
+                "labelSettings": [
+                  {
+                    "columnId": "Subscription",
+                    "label": "Subscription"
+                  },
+                  {
+                    "columnId": "Name"
+                  },
+                  {
+                    "columnId": "microsoft.cache/redis--totalcommandsprocessed",
+                    "label": "Total Operations"
+                  },
+                  {
+                    "columnId": "microsoft.cache/redis--totalcommandsprocessed Timeline",
+                    "label": "Total Operations Timeline"
+                  },
+                  {
+                    "columnId": "microsoft.cache/redis--operationsPerSecond",
+                    "label": "Operations Per Second"
+                  },
+                  {
+                    "columnId": "microsoft.cache/redis--operationsPerSecond Timeline",
+                    "label": "Operations Per Second Timeline"
+                  },
+                  {
+                    "columnId": "microsoft.cache/redis--getcommands",
+                    "label": "Gets"
+                  },
+                  {
+                    "columnId": "microsoft.cache/redis--getcommands Timeline",
+                    "label": "Gets Timeline"
+                  },
+                  {
+                    "columnId": "microsoft.cache/redis--setcommands",
+                    "label": "Sets"
+                  },
+                  {
+                    "columnId": "microsoft.cache/redis--setcommands Timeline",
+                    "label": "Sets Timeline"
+                  }
+                ]
+              },
+              "sortBy": [
+                {
+                  "itemKey": "$gen_heatmap_microsoft.cache/redis--totalcommandsprocessed_3",
+                  "sortOrder": 2
+                }
+              ],
+              "showExportToExcel": true
+            },
+            "conditionalVisibility": {
+              "parameterName": "selectedTab",
+              "comparison": "isEqualTo",
+              "value": "Operations"
+            },
+            "showPin": true,
+            "name": "Operations"
+          },
+          {
+            "type": 10,
+            "content": {
+              "chartId": "workbook19356bdc-cfd5-47c7-8e70-05bbd3f39558",
+              "version": "MetricsItem/2.0",
+              "size": 2,
+              "chartType": 0,
+              "resourceIds": [
+                "{Resources}"
+              ],
+              "timeContext": {
+                "durationMs": 0
+              },
+              "timeContextFromParameter": "TimeRange",
+              "resourceType": "microsoft.cache/redis",
+              "resourceParameter": "Resources",
+              "metrics": [
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--cacheRead",
+                  "aggregation": 3,
+                  "splitBy": null
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--cacheWrite",
+                  "aggregation": 3,
+                  "splitBy": null
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--cachehits",
+                  "aggregation": 1,
+                  "splitBy": null
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--cachemisses",
+                  "aggregation": 1,
+                  "splitBy": null
+                }
+              ],
+              "gridSettings": {
+                "formatters": [
+                  {
+                    "columnMatch": "$gen_group",
+                    "formatter": 13,
+                    "formatOptions": {
+                      "linkTarget": "Resource",
+                      "subTarget": "insights",
+                      "showIcon": true
+                    }
+                  },
+                  {
+                    "columnMatch": "Subscription",
+                    "formatter": 5,
+                    "formatOptions": {
+                      "showIcon": true
+                    }
+                  },
+                  {
+                    "columnMatch": "Name",
+                    "formatter": 5,
+                    "formatOptions": {
+                      "showIcon": true
+                    }
+                  },
+                  {
+                    "columnMatch": "microsoft.cache/redis--cacheRead",
+                    "formatter": 8,
+                    "formatOptions": {
+                      "palette": "blue",
+                      "showIcon": true,
+                      "aggregation": "Sum"
+                    },
+                    "numberFormat": {
+                      "unit": 45,
+                      "options": {
+                        "style": "decimal",
+                        "useGrouping": false,
+                        "maximumFractionDigits": 1
+                      }
+                    }
+                  },
+                  {
+                    "columnMatch": "microsoft.cache/redis--cacheRead Timeline",
+                    "formatter": 21,
+                    "formatOptions": {
+                      "showIcon": true
+                    }
+                  },
+                  {
+                    "columnMatch": "microsoft.cache/redis--cacheWrite",
+                    "formatter": 8,
+                    "formatOptions": {
+                      "palette": "blue",
+                      "showIcon": true
+                    },
+                    "numberFormat": {
+                      "unit": 45,
+                      "options": {
+                        "style": "decimal",
+                        "useGrouping": false,
+                        "maximumFractionDigits": 1
+                      }
+                    }
+                  },
+                  {
+                    "columnMatch": "microsoft.cache/redis--cacheWrite Timeline",
+                    "formatter": 21,
+                    "formatOptions": {
+                      "palette": "blue",
+                      "showIcon": true
+                    }
+                  },
+                  {
+                    "columnMatch": "microsoft.cache/redis--cachehits",
+                    "formatter": 4,
+                    "formatOptions": {
+                      "min": 0,
+                      "palette": "blue",
+                      "showIcon": true
+                    },
+                    "numberFormat": {
+                      "unit": 17,
+                      "options": {
+                        "style": "decimal",
+                        "maximumFractionDigits": 2
+                      }
+                    }
+                  },
+                  {
+                    "columnMatch": "microsoft.cache/redis--cachehits Timeline",
+                    "formatter": 5,
+                    "formatOptions": {
+                      "showIcon": true
+                    }
+                  },
+                  {
+                    "columnMatch": "microsoft.cache/redis--cachemisses",
+                    "formatter": 4,
+                    "formatOptions": {
+                      "min": 0,
+                      "palette": "red",
+                      "showIcon": true
+                    },
+                    "numberFormat": {
+                      "unit": 17,
+                      "options": {
+                        "style": "decimal",
+                        "maximumFractionDigits": 2
+                      }
+                    }
+                  },
+                  {
+                    "columnMatch": "microsoft.cache/redis--cachemisses Timeline",
+                    "formatter": 5,
+                    "formatOptions": {
+                      "showIcon": true
+                    }
+                  }
+                ],
+                "rowLimit": 10000,
+                "filter": true,
+                "hierarchySettings": {
+                  "treeType": 1,
+                  "groupBy": [
+                    "Subscription"
+                  ],
+                  "expandTopLevel": true,
+                  "finalBy": "Name"
+                },
+                "sortBy": [
+                  {
+                    "itemKey": "$gen_heatmap_microsoft.cache/redis--cacheRead_3",
+                    "sortOrder": 2
+                  }
+                ],
+                "labelSettings": [
+                  {
+                    "columnId": "Subscription",
+                    "label": "Subscription"
+                  },
+                  {
+                    "columnId": "Name"
+                  },
+                  {
+                    "columnId": "microsoft.cache/redis--cacheRead",
+                    "label": "Cache Read"
+                  },
+                  {
+                    "columnId": "microsoft.cache/redis--cacheRead Timeline",
+                    "label": "Cache Read Timeline"
+                  },
+                  {
+                    "columnId": "microsoft.cache/redis--cacheWrite",
+                    "label": "Cache Write"
+                  },
+                  {
+                    "columnId": "microsoft.cache/redis--cacheWrite Timeline",
+                    "label": "Cache Write Timeline"
+                  },
+                  {
+                    "columnId": "microsoft.cache/redis--cachehits",
+                    "label": "Cache Hits"
+                  },
+                  {
+                    "columnId": "microsoft.cache/redis--cachehits Timeline",
+                    "label": "Cache Hits Timeline"
+                  },
+                  {
+                    "columnId": "microsoft.cache/redis--cachemisses",
+                    "label": "Cache Misses"
+                  },
+                  {
+                    "columnId": "microsoft.cache/redis--cachemisses Timeline",
+                    "label": "Cache Misses Timeline"
+                  }
+                ]
+              },
+              "sortBy": [
+                {
+                  "itemKey": "$gen_heatmap_microsoft.cache/redis--cacheRead_3",
+                  "sortOrder": 2
+                }
+              ],
+              "showExportToExcel": true
+            },
+            "conditionalVisibility": {
+              "parameterName": "selectedTab",
+              "comparison": "isEqualTo",
+              "value": "Usage"
+            },
+            "showPin": true,
+            "name": "Usage"
+          },
+          {
+            "type": 10,
+            "content": {
+              "chartId": "workbook19356bdc-cfd5-47c7-8e70-05bbd3f39558",
+              "version": "MetricsItem/2.0",
+              "size": 2,
+              "chartType": 0,
+              "resourceIds": [
+                "{Resources}"
+              ],
+              "timeContext": {
+                "durationMs": 0
+              },
+              "timeContextFromParameter": "TimeRange",
+              "resourceType": "microsoft.cache/redis",
+              "resourceParameter": "Resources",
+              "metrics": [
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--errors",
+                  "aggregation": 1,
+                  "splitBy": null
+                },
+                {
+                  "namespace": "microsoft.cache/redis",
+                  "metric": "microsoft.cache/redis--errors",
+                  "aggregation": 1,
+                  "splitBy": "ErrorType",
+                  "splitBySortOrder": -1,
+                  "splitByLimit": 7
+                }
+              ],
+              "gridSettings": {
+                "formatters": [
+                  {
+                    "columnMatch": "$gen_group",
+                    "formatter": 13,
+                    "formatOptions": {
+                      "linkTarget": "Resource",
+                      "subTarget": "insights",
+                      "showIcon": true
+                    }
+                  },
+                  {
+                    "columnMatch": "Subscription",
+                    "formatter": 5,
+                    "formatOptions": {
+                      "showIcon": true
+                    }
+                  },
+                  {
+                    "columnMatch": "Name",
+                    "formatter": 5,
+                    "formatOptions": {
+                      "showIcon": true
+                    }
+                  },
+                  {
+                    "columnMatch": "microsoft.cache/redis--errors",
+                    "formatter": 4,
+                    "formatOptions": {
+                      "palette": "red",
+                      "showIcon": true,
+                      "aggregation": "Sum"
+                    },
+                    "numberFormat": {
+                      "unit": 17,
+                      "options": {
+                        "style": "decimal",
+                        "useGrouping": false,
+                        "maximumFractionDigits": 1
+                      }
+                    }
+                  },
+                  {
+                    "columnMatch": "microsoft.cache/redis--errors Timeline",
+                    "formatter": 5,
+                    "formatOptions": {
+                      "showIcon": true
+                    }
+                  },
+                  {
+                    "columnMatch": ".*\\/Errors$",
+                    "formatter": 4,
+                    "formatOptions": {
+                      "palette": "red",
+                      "showIcon": true,
+                      "aggregation": "Sum"
+                    },
+                    "numberFormat": {
+                      "unit": 17,
+                      "options": {
+                        "style": "decimal",
+                        "maximumFractionDigits": 1
+                      },
+                      "emptyValCustomText": "-"
+                    }
+                  }
+                ],
+                "rowLimit": 10000,
+                "filter": true,
+                "hierarchySettings": {
+                  "treeType": 1,
+                  "groupBy": [
+                    "Subscription"
+                  ],
+                  "expandTopLevel": true,
+                  "finalBy": "Name"
+                },
+                "labelSettings": [
+                  {
+                    "columnId": "Subscription",
+                    "label": "Subscription"
+                  },
+                  {
+                    "columnId": "Name"
+                  },
+                  {
+                    "columnId": "microsoft.cache/redis--errors",
+                    "label": "Total Errors"
+                  },
+                  {
+                    "columnId": "microsoft.cache/redis--errors Timeline",
+                    "label": "Errors Timeline"
+                  }
+                ]
+              },
+              "sortBy": [],
+              "showExportToExcel": true
+            },
+            "conditionalVisibility": {
+              "parameterName": "selectedTab",
+              "comparison": "isEqualTo",
+              "value": "Failures"
+            },
+            "showPin": true,
+            "name": "Failures"
+          }
+        ]
+      },
+      "conditionalVisibility": {
+        "parameterName": "Subscription",
+        "comparison": "isNotEqualTo",
+        "value": ""
+      },
+      "name": "Azure Cache for Redis Resources"
+    }
+  ],
+  "workbookPin": "Overview",
+  "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
+}

--- a/gallery/rediscache-insights/Azure Monitor.json
+++ b/gallery/rediscache-insights/Azure Monitor.json
@@ -3,11 +3,11 @@
 	"version": "TemplateGallery/1.0",
 	"categories": [
 		{
-			"id": "Insights",
-			"name": "Insights",
+			"id": "RedisCache",
+			"name": "Azure Cache for Redis Insights",
 			"templates": [
 				{
-					"id": "Workbooks/Insights/RedisCache",
+					"id": "Workbooks/RedisCache/AtScale",
 					"author": "Microsoft",
 					"description": "Performance, operations, usage, and failures of all your Azure Cache for Redis",
 					"name": "Azure Cache for Redis Overview"

--- a/gallery/workbook/Azure Monitor.json
+++ b/gallery/workbook/Azure Monitor.json
@@ -201,7 +201,7 @@
 					"name": "Key Vault Overview"
 				},
 				{
-					"id": "Workbooks/Insights/RedisCache",
+					"id": "Workbooks/RedisCache/AtScale",
 					"author": "Microsoft",
 					"description": "Performance, operations, usage, and failures of all your Azure Cache for Redis",
 					"name": "Azure Cache for Redis Overview"

--- a/gallery/workbook/microsoft.cache-redis.json
+++ b/gallery/workbook/microsoft.cache-redis.json
@@ -3,11 +3,11 @@
 	"version": "TemplateGallery/1.0",
 	"categories": [
 		{
-			"id": "Resource Insights",
-			"name": "Resource Insights",
+			"id": "RedisCache",
+			"name": "Azure Cache for Redis Insights",
 			"templates": [
 				{
-					"id": "Workbooks/Resource Insights/RedisCache",
+					"id": "Workbooks/RedisCache/AtResource",
 					"author": "Microsoft",
 					"name": "Azure Cache For Redis Resource Overview"
 				}


### PR DESCRIPTION
* Copy the RedisCache workbooks to new locations to match other
  workbooks.
* Update the gallery entries to use the new locations.
* Add the azure-cache-for-redis team as a code owner for both the old
  and new locations.
* Update the `id` and `name` properties in the Azure Cache for Redis
  gallery files to more closely match the naming styles that other
  services use for those properties.

Commits f22208b7, 6631860d, and cef04530 moved the workbooks for
ADXCluster, EventHub, and ServiceBus out of the Workbooks/Insights and
Workbooks/Resource Insights directories into per-team directories. The
RedisCache workbooks had not yet been moved from those old directories
to a per-team directory, so they can now be copied into a per-team
directory.

One reason to copy the workbooks into the new directory instead of
moving them is that the Azure Monitor menu and Azure Cache for Redis
resource menu in the Azure portal currently still link to the old
locations. Later, after the new workbook locations become available,
those menus can be updated, and then the content in the old workbook
locations can be replaced with links to the new workbook locations.

## PR Checklist

* [x] Explain your changes, so people looking at the PR know *what* and *why*, the code changes are the *how*.

### If adding or updating templates:
* [x] post a screenshot of templates and/or gallery changes
  * The gallery entry for the at-resource workbook will change categories from **Resource Insights**:
    ![image](https://user-images.githubusercontent.com/4934473/115487521-dd49f280-a226-11eb-8da9-427b9550d5a5.png)
    ... to **Azure Cache for Redis Insights**:
    ![image](https://user-images.githubusercontent.com/4934473/115487585-0074a200-a227-11eb-8adf-eb73bcd5b91d.png)
  * The gallery entry for the at-scale workbook will not change.
  * None of the content of the workbook templates themselves will change.
* [x] ensure your template has a corresponding gallery entry in the gallery folder
* [x] If you are adding a new template, add your team and template/gallery file(s) to the CODEOWNERS file. CODEOWNERS entries should be teams, not individuals
* [x] ensure all steps have meaningful names
  * N/A since this PR just duplicates existing workbooks
* [x] ensure all parameters and grid columns have display names set so they can be localized
  * N/A since there are no new names compared to the old workbooks
* [x] ensure that parameters id values are unique __or they will fail PR validation__ (parameter ids are used for localization)
* [x] ensure that steps names are unique __or they will fail PR validation__ (step names are used for localization)
* [x] grep `/subscription/` and ensure that your parameters don't have any hardcoded resourceIds __or they will fail PR validation__
* [x] remove `fallbackResourceIds` and `fromTemplateId` fields from your template workbook __or they will fail PR validation__