### PR TITLE
remove deploying VMInsights solution as no longer needed

### DIFF
--- a/Workbooks/Workloads/SQL/Create new profile/CreateNewProfile.armtemplate
+++ b/Workbooks/Workloads/SQL/Create new profile/CreateNewProfile.armtemplate
@@ -33,39 +33,6 @@
     },
     "resources": [
         {
-            "apiVersion": "2020-06-01",
-            "name": "vmSolutionNestedTemplate",
-            "type": "Microsoft.Resources/deployments",
-            "subscriptionId": "[split(parameters('workspaceResourceId'),'/')[2]]",
-            "resourceGroup": "[split(parameters('workspaceResourceId'),'/')[4]]",
-            "properties": {
-                "mode": "Incremental",
-                "template": {
-                    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-                    "contentVersion": "1.0.0.0",
-                    "parameters": {
-                    },
-                    "resources": [
-                        {
-                            "type": "Microsoft.OperationsManagement/solutions",
-                            "name": "[Concat('VMInsights', '(', split(parameters('workspaceResourceId'),'/')[8], ')')]",
-                            "apiVersion": "2015-11-01-preview",
-                            "location": "[parameters('dcrLocation')]",
-                            "properties": {
-                                "workspaceResourceId": "[parameters('workspaceResourceId')]"
-                            },
-                            "plan": {
-                                "name": "[Concat('VMInsights', '(', split(parameters('workspaceResourceId'),'/')[8], ')')]",
-                                "product": "[Concat('OMSGallery/', 'VMInsights')]",
-                                "promotionCode": "",
-                                "publisher": "Microsoft"
-                            }
-                        }
-                    ]
-                }
-            }
-        },
-        {
             "type": "Microsoft.Insights/dataCollectionRules",
             "name": "[parameters('dcrName')]",
             "location": "[parameters('dcrLocation')]",


### PR DESCRIPTION
## PR Checklist

remove deploying VMInsights solution as no longer needed if using DCR for data collection.

### If adding or updating templates:
* [ ] post a screenshot of templates and/or gallery changes
* [ ] ensure your template has a corresponding gallery entry in the gallery folder
* [ ] If you are adding a new template, add your team and template/gallery file(s) to the CODEOWNERS file. CODEOWNERS entries should be teams, not individuals
* [ ] ensure all steps have meaningful names
* [ ] ensure all parameters and grid columns have display names set so they can be localized
* [ ] ensure that parameters id values are unique __or they will fail PR validation__ (parameter ids are used for localization)
* [ ] ensure that steps names are unique __or they will fail PR validation__ (step names are used for localization)
* [ ] grep `/subscription/` and ensure that your parameters don't have any hardcoded resourceIds __or they will fail PR validation__
* [ ] remove `fallbackResourceIds` and `fromTemplateId` fields from your template workbook __or they will fail PR validation__