### PR TITLE
Adding visualization for NetWeaver - RFC Short Dump Metrics

### DIFF
--- a/Workbooks/SapMonitor/SapNetWeaver/SapNetWeaver.workbook
+++ b/Workbooks/SapMonitor/SapNetWeaver/SapNetWeaver.workbook
@@ -18,7 +18,7 @@
             "version": "KqlParameterItem/1.0",
             "name": "param_check_error",
             "type": 1,
-            "query": "// 0 = no error\n// 1 = table does not exist (need to add provider)\n// 2 = table exists, but column v1 does not (need to wait)\nlet t = \"SapNetweaver_GetSystemInstanceList_CL\";\nlet c1 = \"hostname_s\";\nlet dummy = \"unmÃ¶glicher-wert!\";\nlet MissingTable = view () { print miss = 1, columnV1 = dummy, records = -1 };\nlet checkRecords =\n  union\n    isfuzzy=true MissingTable,\n    (table(t)\n      | summarize records = count()\n    )\n  | project records\n  | top 1 by records desc\n;\nlet checkTableExists =\n  union\n    isfuzzy=true MissingTable,\n    (table(t)\n      | count\n      | extend miss = 0\n    )\n  | project miss\n  | limit 2\n  | top 1 by miss asc\n;\nlet checkColumnExists =\n  union\n    isfuzzy=true MissingTable,\n    (table(t)\n      | extend miss = 0\n      | extend columnV1 = column_ifexists(c1, dummy)\n    )\n  | project miss, columnV1\n  | limit 2\n | top 1 by miss asc\n;\nlet tableExists = toscalar(checkTableExists | summarize max(miss) != \"1\");\nlet columnV1Exists = toscalar(checkColumnExists | summarize max(columnV1) != dummy);\nlet tableRecords = toscalar(checkRecords | summarize max(records));\nlet x = iif(tableExists, iif(columnV1Exists, iif(tableRecords > 0, \"0\", \"2\"), \"2\"), \"1\");\nprint toscalar(x)",
+            "query": "// 0 = no error\n// 1 = table does not exist (need to add provider)\n// 2 = table exists, but column v1 does not (need to wait)\nlet t = \"SapNetweaver_GetSystemInstanceList_CL\";\nlet c1 = \"hostname_s\";\nlet dummy = \"unmÃ¶glicher-wert!\";\nlet MissingTable = view () { print miss = 1, columnV1 = dummy, records = -1 };\nlet checkRecords =\n  union\n    isfuzzy=true MissingTable,\n    (table(t)\n      | summarize records = count()\n    )\n  | project records\n  | top 1 by records desc\n;\nlet checkTableExists =\n  union\n    isfuzzy=true MissingTable,\n    (table(t)\n      | count\n      | extend miss = 0\n    )\n  | project miss\n  | limit 2\n  | top 1 by miss asc\n;\nlet checkColumnExists =\n  union\n    isfuzzy=true MissingTable,\n    (table(t)\n      | extend miss = 0\n      | extend columnV1 = column_ifexists(c1, dummy)\n    )\n  | project miss, columnV1\n  | limit 2\n | top 1 by miss asc\n;\nlet tableExists = toscalar(checkTableExists | summarize max(miss) != 1);\nlet columnV1Exists = toscalar(checkColumnExists | summarize max(columnV1) != dummy);\nlet tableRecords = toscalar(checkRecords | summarize max(records));\nlet x = iif(tableExists, iif(columnV1Exists, iif(tableRecords > 0, \"0\", \"2\"), \"2\"), \"1\");\nprint toscalar(x)",
             "isHiddenWhenLocked": true,
             "queryType": 0,
             "resourceType": "microsoft.operationalinsights/workspaces"
@@ -166,6 +166,14 @@
             "linkTarget": "parameter",
             "linkLabel": "Queue Statistics",
             "subTarget": "QueueStatistics",
+            "style": "link"
+          },
+          {
+            "id": "49f56ce4-06a1-445d-b4dd-9f3e7b49cef8",
+            "cellValue": "selectedMenu",
+            "linkTarget": "parameter",
+            "linkLabel": "Application",
+            "subTarget": "Application",
             "style": "link"
           }
         ]
@@ -757,7 +765,7 @@
             "version": "KqlParameterItem/1.0",
             "name": "param_check_error_availability",
             "type": 1,
-            "query": "// 0 = no error\n// 1 = table does not exist (need to add provider)\n// 2 = table exists, but column v1 does not (need to wait)\nlet t = \"SapNetweaver_GetProcessList_CL\";\nlet c1 = \"hostname_s\";\nlet dummy = \"unmÃ¶glicher-wert!\";\nlet MissingTable = view () { print miss = 1, columnV1 = dummy, records = -1 };\nlet checkRecords =\n  union\n    isfuzzy=true MissingTable,\n    (table(t)\n      | summarize records = count()\n    )\n  | project records\n  | top 1 by records desc\n;\nlet checkTableExists =\n  union\n    isfuzzy=true MissingTable,\n    (table(t)\n      | count\n      | extend miss = 0\n    )\n  | project miss\n  | limit 2\n  | top 1 by miss asc\n;\nlet checkColumnExists =\n  union\n    isfuzzy=true MissingTable,\n    (table(t)\n      | extend miss = 0\n      | extend columnV1 = column_ifexists(c1, dummy)\n    )\n  | project miss, columnV1\n  | limit 2\n | top 1 by miss asc\n;\nlet tableExists = toscalar(checkTableExists | summarize max(miss) != \"1\");\nlet columnV1Exists = toscalar(checkColumnExists | summarize max(columnV1) != dummy);\nlet tableRecords = toscalar(checkRecords | summarize max(records));\nlet x = iif(tableExists, iif(columnV1Exists, iif(tableRecords > 0, \"0\", \"2\"), \"2\"), \"1\");\nprint toscalar(x)\n",
+            "query": "// 0 = no error\n// 1 = table does not exist (need to add provider)\n// 2 = table exists, but column v1 does not (or) column v1 exists but no data in the table (need to wait)\nlet t = \"SapNetweaver_GetProcessList_CL\";\nlet c1 = \"hostname_s\";\nlet dummy = \"unmÃ¶glicher-wert!\";\nlet MissingTable = view () { print miss = 1, columnV1 = dummy, records = -1 };\nlet checkRecords =\n  union\n    isfuzzy=true MissingTable,\n    (table(t)\n      | summarize records = count()\n    )\n  | project records\n  | top 1 by records desc\n;\nlet checkTableExists =\n  union\n    isfuzzy=true MissingTable,\n    (table(t)\n      | count\n      | extend miss = 0\n    )\n  | project miss\n  | limit 2\n  | top 1 by miss asc\n;\nlet checkColumnExists =\n  union\n    isfuzzy=true MissingTable,\n    (table(t)\n      | extend miss = 0\n      | extend columnV1 = column_ifexists(c1, dummy)\n    )\n  | project miss, columnV1\n  | limit 2\n | top 1 by miss asc\n;\nlet tableExists = toscalar(checkTableExists | summarize max(miss) != 1);\nlet columnV1Exists = toscalar(checkColumnExists | summarize max(columnV1) != dummy);\nlet tableRecords = toscalar(checkRecords | summarize max(records));\nlet x = iif(tableExists, iif(columnV1Exists, iif(tableRecords > 0, \"0\", \"2\"), \"2\"), \"1\");\nprint toscalar(x)\n",
             "isHiddenWhenLocked": true,
             "queryType": 0,
             "resourceType": "microsoft.operationalinsights/workspaces"
@@ -1089,7 +1097,7 @@
             "version": "KqlParameterItem/1.0",
             "name": "param_check_error_utilization",
             "type": 1,
-            "query": "// 0 = no error\n// 1 = table does not exist (need to add provider)\n// 2 = table exists, but column v1 does not (need to wait)\nlet t = \"SapNetweaver_ABAPGetWPTable_CL\";\nlet c1 = \"hostname_s\";\nlet dummy = \"unmÃ¶glicher-wert!\";\nlet MissingTable = view () { print miss = 1, columnV1 = dummy, records = -1 };\nlet checkRecords =\n  union\n    isfuzzy=true MissingTable,\n    (table(t)\n      | summarize records = count()\n    )\n  | project records\n  | top 1 by records desc\n;\nlet checkTableExists =\n  union\n    isfuzzy=true MissingTable,\n    (table(t)\n      | count\n      | extend miss = 0\n    )\n  | project miss\n  | limit 2\n  | top 1 by miss asc\n;\nlet checkColumnExists =\n  union\n    isfuzzy=true MissingTable,\n    (table(t)\n      | extend miss = 0\n      | extend columnV1 = column_ifexists(c1, dummy)\n    )\n  | project miss, columnV1\n  | limit 2\n | top 1 by miss asc\n;\nlet tableExists = toscalar(checkTableExists | summarize max(miss) != \"1\");\nlet columnV1Exists = toscalar(checkColumnExists | summarize max(columnV1) != dummy);\nlet tableRecords = toscalar(checkRecords | summarize max(records));\nlet x = iif(tableExists, iif(columnV1Exists, iif(tableRecords > 0, \"0\", \"2\"), \"2\"), \"1\");\nprint toscalar(x)\n",
+            "query": "// 0 = no error\n// 1 = table does not exist (need to add provider)\n// 2 = table exists, but column v1 does not (or) column v1 exists but no data in the table (need to wait)\nlet t = \"SapNetweaver_ABAPGetWPTable_CL\";\nlet c1 = \"hostname_s\";\nlet dummy = \"unmÃ¶glicher-wert!\";\nlet MissingTable = view () { print miss = 1, columnV1 = dummy, records = -1 };\nlet checkRecords =\n  union\n    isfuzzy=true MissingTable,\n    (table(t)\n      | summarize records = count()\n    )\n  | project records\n  | top 1 by records desc\n;\nlet checkTableExists =\n  union\n    isfuzzy=true MissingTable,\n    (table(t)\n      | count\n      | extend miss = 0\n    )\n  | project miss\n  | limit 2\n  | top 1 by miss asc\n;\nlet checkColumnExists =\n  union\n    isfuzzy=true MissingTable,\n    (table(t)\n      | extend miss = 0\n      | extend columnV1 = column_ifexists(c1, dummy)\n    )\n  | project miss, columnV1\n  | limit 2\n | top 1 by miss asc\n;\nlet tableExists = toscalar(checkTableExists | summarize max(miss) != 1);\nlet columnV1Exists = toscalar(checkColumnExists | summarize max(columnV1) != dummy);\nlet tableRecords = toscalar(checkRecords | summarize max(records));\nlet x = iif(tableExists, iif(columnV1Exists, iif(tableRecords > 0, \"0\", \"2\"), \"2\"), \"1\");\nprint toscalar(x)\n",
             "isHiddenWhenLocked": true,
             "queryType": 0,
             "resourceType": "microsoft.operationalinsights/workspaces"
@@ -1427,7 +1435,7 @@
             "version": "KqlParameterItem/1.0",
             "name": "param_check_error_performance",
             "type": 1,
-            "query": "// 0 = no error\n// 1 = table does not exist (need to add provider)\n// 2 = table exists, but column v1 does not (need to wait)\nlet t = \"SapNetweaver_EnqGetStatistic_CL\";\nlet c1 = \"SID_s\";\nlet dummy = \"unmÃ¶glicher-wert!\";\nlet MissingTable = view () { print miss = 1, columnV1 = dummy, records = -1 };\nlet checkRecords =\n  union\n    isfuzzy=true MissingTable,\n    (table(t)\n      | summarize records = count()\n    )\n  | project records\n  | top 1 by records desc\n;\nlet checkTableExists =\n  union\n    isfuzzy=true MissingTable,\n    (table(t)\n      | count\n      | extend miss = 0\n    )\n  | project miss\n  | limit 2\n  | top 1 by miss asc\n;\nlet checkColumnExists =\n  union\n    isfuzzy=true MissingTable,\n    (table(t)\n      | extend miss = 0\n      | extend columnV1 = column_ifexists(c1, dummy)\n    )\n  | project miss, columnV1\n  | limit 2\n | top 1 by miss asc\n;\nlet tableExists = toscalar(checkTableExists | summarize max(miss) != \"1\");\nlet columnV1Exists = toscalar(checkColumnExists | summarize max(columnV1) != dummy);\nlet tableRecords = toscalar(checkRecords | summarize max(records));\nlet x = iif(tableExists, iif(columnV1Exists, iif(tableRecords > 0, \"0\", \"2\"), \"2\"), \"1\");\nprint toscalar(x)\n",
+            "query": "// 0 = no error\n// 1 = table does not exist (need to add provider)\n// 2 = table exists, but column v1 does not (or) column v1 exists but no data in the table (need to wait)\nlet t = \"SapNetweaver_EnqGetStatistic_CL\";\nlet c1 = \"SID_s\";\nlet dummy = \"unmÃ¶glicher-wert!\";\nlet MissingTable = view () { print miss = 1, columnV1 = dummy, records = -1 };\nlet checkRecords =\n  union\n    isfuzzy=true MissingTable,\n    (table(t)\n      | summarize records = count()\n    )\n  | project records\n  | top 1 by records desc\n;\nlet checkTableExists =\n  union\n    isfuzzy=true MissingTable,\n    (table(t)\n      | count\n      | extend miss = 0\n    )\n  | project miss\n  | limit 2\n  | top 1 by miss asc\n;\nlet checkColumnExists =\n  union\n    isfuzzy=true MissingTable,\n    (table(t)\n      | extend miss = 0\n      | extend columnV1 = column_ifexists(c1, dummy)\n    )\n  | project miss, columnV1\n  | limit 2\n | top 1 by miss asc\n;\nlet tableExists = toscalar(checkTableExists | summarize max(miss) != 1);\nlet columnV1Exists = toscalar(checkColumnExists | summarize max(columnV1) != dummy);\nlet tableRecords = toscalar(checkRecords | summarize max(records));\nlet x = iif(tableExists, iif(columnV1Exists, iif(tableRecords > 0, \"0\", \"2\"), \"2\"), \"1\");\nprint toscalar(x)\n",
             "isHiddenWhenLocked": true,
             "queryType": 0,
             "resourceType": "microsoft.operationalinsights/workspaces"
@@ -2230,7 +2238,7 @@
             "version": "KqlParameterItem/1.0",
             "name": "param_check_error_queuestat",
             "type": 1,
-            "query": "// 0 = no error\n// 1 = table does not exist (need to add provider)\n// 2 = table exists, but column v1 does not (need to wait)\nlet t = \"SapNetweaver_GetQueueStatistic_CL\";\nlet c1 = \"SID_s\";\nlet dummy = \"unmÃ¶glicher-wert!\";\nlet MissingTable = view () { print miss = 1, columnV1 = dummy, records = -1 };\nlet checkRecords =\n  union\n    isfuzzy=true MissingTable,\n    (table(t)\n      | summarize records = count()\n    )\n  | project records\n  | top 1 by records desc\n;\nlet checkTableExists =\n  union\n    isfuzzy=true MissingTable,\n    (table(t)\n      | count\n      | extend miss = 0\n    )\n  | project miss\n  | limit 2\n  | top 1 by miss asc\n;\nlet checkColumnExists =\n  union\n    isfuzzy=true MissingTable,\n    (table(t)\n      | extend miss = 0\n      | extend columnV1 = column_ifexists(c1, dummy)\n    )\n  | project miss, columnV1\n  | limit 2\n | top 1 by miss asc\n;\nlet tableExists = toscalar(checkTableExists | summarize max(miss) != \"1\");\nlet columnV1Exists = toscalar(checkColumnExists | summarize max(columnV1) != dummy);\nlet tableRecords = toscalar(checkRecords | summarize max(records));\nlet x = iif(tableExists, iif(columnV1Exists, iif(tableRecords > 0, \"0\", \"2\"), \"2\"), \"1\");\nprint toscalar(x)\n",
+            "query": "// 0 = no error\n// 1 = table does not exist (need to add provider)\n// 2 = table exists, but column v1 does not (or) column v1 exists but no data in the table (need to wait)\nlet t = \"SapNetweaver_GetQueueStatistic_CL\";\nlet c1 = \"SID_s\";\nlet dummy = \"unmÃ¶glicher-wert!\";\nlet MissingTable = view () { print miss = 1, columnV1 = dummy, records = -1 };\nlet checkRecords =\n  union\n    isfuzzy=true MissingTable,\n    (table(t)\n      | summarize records = count()\n    )\n  | project records\n  | top 1 by records desc\n;\nlet checkTableExists =\n  union\n    isfuzzy=true MissingTable,\n    (table(t)\n      | count\n      | extend miss = 0\n    )\n  | project miss\n  | limit 2\n  | top 1 by miss asc\n;\nlet checkColumnExists =\n  union\n    isfuzzy=true MissingTable,\n    (table(t)\n      | extend miss = 0\n      | extend columnV1 = column_ifexists(c1, dummy)\n    )\n  | project miss, columnV1\n  | limit 2\n | top 1 by miss asc\n;\nlet tableExists = toscalar(checkTableExists | summarize max(miss) != 1);\nlet columnV1Exists = toscalar(checkColumnExists | summarize max(columnV1) != dummy);\nlet tableRecords = toscalar(checkRecords | summarize max(records));\nlet x = iif(tableExists, iif(columnV1Exists, iif(tableRecords > 0, \"0\", \"2\"), \"2\"), \"1\");\nprint toscalar(x)\n",
             "isHiddenWhenLocked": true,
             "queryType": 0,
             "resourceType": "microsoft.operationalinsights/workspaces"
@@ -2773,6 +2781,543 @@
         }
       ],
       "name": "Queue Statistics Group"
+    },
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "parameters": [
+          {
+            "id": "0249fee8-11eb-41b2-868b-3e16b5285eb8",
+            "version": "KqlParameterItem/1.0",
+            "name": "param_check_error_shortdump",
+            "type": 1,
+            "query": "// 0 = no error\n// 1 = table does not exist (need to enable RFC)\n// 2 = table exists, but column v1 does not (or) column v1 exists but no data in the table (need to wait)\nlet t = \"SapNetweaver_ShortDumps_CL\";\nlet c1 = \"SID_s\";\nlet dummy = \"unmÃ¶glicher-wert!\";\nlet MissingTable = view () { print miss = 1, columnV1 = dummy, records = -1 };\nlet checkRecords =\n  union\n    isfuzzy=true MissingTable,\n    (table(t)\n      | summarize records = count()\n    )\n  | project records\n  | top 1 by records desc\n;\nlet checkTableExists =\n  union\n    isfuzzy=true MissingTable,\n    (table(t)\n      | count\n      | extend miss = 0\n    )\n  | project miss\n  | limit 2\n  | top 1 by miss asc\n;\nlet checkColumnExists =\n  union\n    isfuzzy=true MissingTable,\n    (table(t)\n      | extend miss = 0\n      | extend columnV1 = column_ifexists(c1, dummy)\n    )\n  | project miss, columnV1\n  | limit 2\n  | top 1 by miss asc\n ;\nlet tableExists = toscalar(checkTableExists | summarize max(miss) != 1);\nlet columnV1Exists = toscalar(checkColumnExists | summarize max(columnV1) != dummy);\nlet tableRecords = toscalar(checkRecords | summarize max(records));\nlet x = iif(tableExists, iif(columnV1Exists, iif(tableRecords > 0, \"0\", \"2\"), \"2\"), \"1\");\nprint toscalar(x)\n\n",
+            "isHiddenWhenLocked": true,
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          }
+        ],
+        "style": "pills",
+        "queryType": 0,
+        "resourceType": "microsoft.operationalinsights/workspaces"
+      },
+      "conditionalVisibilities": [
+        {
+          "parameterName": "dummy_neverset",
+          "comparison": "isNotEqualTo"
+        },
+        {
+          "parameterName": "selectedMenu",
+          "comparison": "isEqualTo",
+          "value": "Application"
+        }
+      ],
+      "name": "ErrorCheckShortDumpParam"
+    },
+    {
+      "type": 12,
+      "content": {
+        "version": "NotebookGroup/1.0",
+        "groupType": "editable",
+        "items": [
+          {
+            "type": 1,
+            "content": {
+              "json": "These metrics are available when you configure the NetWeaver provider to include support for RFC communication. You will need to add the NetWeaver provider again.",
+              "style": "warning"
+            },
+            "conditionalVisibility": {
+              "parameterName": "param_check_error_shortdump",
+              "comparison": "isEqualTo",
+              "value": "1"
+            },
+            "name": "QueueStatTableCreationError"
+          },
+          {
+            "type": 1,
+            "content": {
+              "json": "It may take up to 15 minutes for the initial telemetry information to be available for review. Please check again later.",
+              "style": "warning"
+            },
+            "conditionalVisibility": {
+              "parameterName": "param_check_error_shortdump",
+              "comparison": "isEqualTo",
+              "value": "2"
+            },
+            "name": "ShortDumpIngestionError"
+          }
+        ]
+      },
+      "conditionalVisibilities": [
+        {
+          "parameterName": "param_check_error_shortdump",
+          "comparison": "isNotEqualTo",
+          "value": "0"
+        },
+        {
+          "parameterName": "selectedMenu",
+          "comparison": "isEqualTo",
+          "value": "Application"
+        }
+      ],
+      "name": "shortdump_group_error"
+    },
+    {
+      "type": 12,
+      "content": {
+        "version": "NotebookGroup/1.0",
+        "groupType": "editable",
+        "items": [
+          {
+            "type": 12,
+            "content": {
+              "version": "NotebookGroup/1.0",
+              "groupType": "editable",
+              "items": [
+                {
+                  "type": 9,
+                  "content": {
+                    "version": "KqlParameterItem/1.0",
+                    "parameters": [
+                      {
+                        "id": "1dc67097-34d6-4ef1-b0c1-2b3b7b16a148",
+                        "version": "KqlParameterItem/1.0",
+                        "name": "ApplicationTimeRange",
+                        "label": "Time Range",
+                        "type": 4,
+                        "value": {
+                          "durationMs": 300000
+                        },
+                        "typeSettings": {
+                          "selectableValues": [
+                            {
+                              "durationMs": 300000
+                            },
+                            {
+                              "durationMs": 900000
+                            },
+                            {
+                              "durationMs": 1800000
+                            },
+                            {
+                              "durationMs": 3600000
+                            },
+                            {
+                              "durationMs": 14400000
+                            },
+                            {
+                              "durationMs": 43200000
+                            },
+                            {
+                              "durationMs": 86400000
+                            },
+                            {
+                              "durationMs": 172800000
+                            }
+                          ],
+                          "allowCustom": true
+                        },
+                        "timeContext": {
+                          "durationMs": 86400000
+                        }
+                      },
+                      {
+                        "id": "6f7246d7-6be3-463b-9a60-0e80f7e21644",
+                        "version": "KqlParameterItem/1.0",
+                        "name": "ApplicationSID",
+                        "label": "SID",
+                        "type": 2,
+                        "multiSelect": true,
+                        "quote": "'",
+                        "delimiter": ",",
+                        "query": "SapNetweaver_GetSystemInstanceList_CL\r\n| distinct SID_s",
+                        "typeSettings": {
+                          "additionalResourceOptions": [
+                            "value::1"
+                          ],
+                          "showDefault": false
+                        },
+                        "defaultValue": "value::1",
+                        "queryType": 0,
+                        "resourceType": "microsoft.operationalinsights/workspaces"
+                      },
+                      {
+                        "id": "fdf84634-1e7a-4d02-86a9-7c200b674179",
+                        "version": "KqlParameterItem/1.0",
+                        "name": "ApplicationServer",
+                        "label": "Application Server",
+                        "type": 2,
+                        "multiSelect": true,
+                        "quote": "'",
+                        "delimiter": ",",
+                        "query": "let sidList = dynamic([{ApplicationSID}]);\r\nSapNetweaver_GetSystemInstanceList_CL\r\n| extend instanceNr_s = tostring(toint(instanceNr_d))\r\n| extend instanceNr_s = iff(strlen(instanceNr_s) == 2, instanceNr_s, strcat( \"0\", instanceNr_s))\r\n| where array_length(sidList) == 0 or SID_s in (sidList)\r\n| distinct SID_s, hostname_s, instanceNr_s\r\n| project AppServer = strcat(hostname_s, \"_\", instanceNr_s)\r\n| distinct AppServer",
+                        "typeSettings": {
+                          "additionalResourceOptions": [
+                            "value::all"
+                          ],
+                          "showDefault": false
+                        },
+                        "defaultValue": "value::all",
+                        "queryType": 0,
+                        "resourceType": "microsoft.operationalinsights/workspaces"
+                      }
+                    ],
+                    "style": "pills",
+                    "queryType": 0,
+                    "resourceType": "microsoft.operationalinsights/workspaces"
+                  },
+                  "name": "Application Parameters"
+                },
+                {
+                  "type": 3,
+                  "content": {
+                    "version": "KqlItem/1.0",
+                    "query": "let appServerList = dynamic([{ApplicationServer}]);\r\nlet sidList = dynamic([{ApplicationSID}]);\r\nlet baseQuery = SapNetweaver_ShortDumps_CL\r\n| where timestamp_t between (todatetime({ApplicationTimeRange:start}) .. todatetime({ApplicationTimeRange:end}))\r\n| where array_length(sidList) == 0 or SID_s in (sidList)\r\n| extend instanceNr_s = iff(strlen(instanceNr_s) == 2, instanceNr_s, strcat( \"0\", instanceNr_s))\r\n| extend appServer = strcat(hostname_s, \"_\", instanceNr_s)\r\n| where array_length(appServerList) == 0 or appServer in (appServerList);\r\nlet percentileQuery = baseQuery\r\n| where timestamp_t > ago(24h)\r\n| summarize totalsd = count()\r\n| summarize percentileValue=percentile(totalsd, 95);\r\nlet timespanCount = baseQuery \r\n| summarize RecordCount=count()\r\n| extend Interval = iff(RecordCount <= 10000, timespan(1m), timespan(1m))\r\n| extend Interval = iff(RecordCount > 10000 and RecordCount < 50000, timespan(5m), Interval)\r\n| extend Interval = iff(RecordCount >= 50000 and RecordCount < 100000, timespan(10m), Interval)\r\n| extend Interval = iff(RecordCount >= 100000 and RecordCount < 150000, timespan(15m), Interval)\r\n| extend Interval = iff(RecordCount >= 150000, timespan(30m), Interval)\r\n| project Interval;\r\nlet timespanInterval = toscalar(timespanCount);\r\nbaseQuery\r\n| extend dummy=1\r\n| join kind=inner (percentileQuery | extend dummy=1) on dummy\r\n| summarize total=count() by bin(timestamp_t, timespanInterval), percentileValue\r\n",
+                    "size": 0,
+                    "aggregation": 3,
+                    "title": "Short Dumps Count",
+                    "queryType": 0,
+                    "resourceType": "microsoft.operationalinsights/workspaces",
+                    "visualization": "linechart",
+                    "chartSettings": {
+                      "xAxis": "timestamp_t",
+                      "seriesLabelSettings": [
+                        {
+                          "seriesName": "total",
+                          "label": "Short Dump Count"
+                        },
+                        {
+                          "seriesName": "percentileValue",
+                          "label": "95th Percentile For 24 Hours"
+                        }
+                      ]
+                    }
+                  },
+                  "name": "shortdump"
+                },
+                {
+                  "type": 12,
+                  "content": {
+                    "version": "NotebookGroup/1.0",
+                    "groupType": "editable",
+                    "title": "Short Dump By Error",
+                    "expandable": true,
+                    "expanded": true,
+                    "items": [
+                      {
+                        "type": 3,
+                        "content": {
+                          "version": "KqlItem/1.0",
+                          "query": "let appServerList = dynamic([{ApplicationServer}]);\r\nlet sidList = dynamic([{ApplicationSID}]);\r\nlet baseQuery = SapNetweaver_ShortDumps_CL\r\n| where timestamp_t between (todatetime({ApplicationTimeRange:start}) .. todatetime({ApplicationTimeRange:end}))\r\n| where array_length(sidList) == 0 or SID_s in (sidList)\r\n| extend instanceNr_s = iff(strlen(instanceNr_s) == 2, instanceNr_s, strcat( \"0\", instanceNr_s))\r\n| extend appServer = strcat(hostname_s, \"_\", instanceNr_s)\r\n| where array_length(appServerList) == 0 or appServer in (appServerList)\r\n| extend Runtime_Error_s;\r\nlet timespanCount = baseQuery \r\n| summarize RecordCount=count()\r\n| extend Interval = iff(RecordCount <= 10, timespan(1m), timespan(1m))\r\n| extend Interval = iff(RecordCount > 10 and RecordCount < 50, timespan(5m), Interval)\r\n| extend Interval = iff(RecordCount >= 50 and RecordCount < 100, timespan(10m), Interval)\r\n| extend Interval = iff(RecordCount >= 100 and RecordCount < 150, timespan(15m), Interval)\r\n| extend Interval = iff(RecordCount >= 150, timespan(30m), Interval)\r\n| project Interval;\r\nlet timespanInterval = toscalar(timespanCount);\r\nbaseQuery\r\n| summarize Count = count() by bin(timestamp_t, timespanInterval), Runtime_Error_s",
+                          "size": 0,
+                          "timeContext": {
+                            "durationMs": 86400000
+                          },
+                          "queryType": 0,
+                          "resourceType": "microsoft.operationalinsights/workspaces",
+                          "visualization": "unstackedbar",
+                          "chartSettings": {
+                            "xAxis": "Runtime_Error_s",
+                            "yAxis": [
+                              "Count"
+                            ],
+                            "group": "Runtime_Error_s",
+                            "createOtherGroup": null,
+                            "showMetrics": false
+                          }
+                        },
+                        "name": "Shortdumpbyerror"
+                      },
+                      {
+                        "type": 3,
+                        "content": {
+                          "version": "KqlItem/1.0",
+                          "query": "let appServerList = dynamic([{ApplicationServer}]);\r\nlet sidList = dynamic([{ApplicationSID}]);\r\nSapNetweaver_ShortDumps_CL\r\n| where timestamp_t between (todatetime({ApplicationTimeRange:start}) .. todatetime({ApplicationTimeRange:end}))\r\n| where array_length(sidList) == 0 or SID_s in (sidList)\r\n| extend instanceNr_s = iff(strlen(instanceNr_s) == 2, instanceNr_s, strcat( \"0\", instanceNr_s))\r\n| extend appServer = strcat(hostname_s, \"_\", instanceNr_s)\r\n| where array_length(appServerList) == 0 or appServer in (appServerList)\r\n| summarize Count=count() by Runtime_Error_s, Error_Short_Text_s, Exception_s, SID_s\r\n| order by Count",
+                          "size": 0,
+                          "timeContext": {
+                            "durationMs": 86400000
+                          },
+                          "queryType": 0,
+                          "resourceType": "microsoft.operationalinsights/workspaces",
+                          "visualization": "table",
+                          "gridSettings": {
+                            "formatters": [
+                              {
+                                "columnMatch": "Runtime_Error_s",
+                                "formatter": 1
+                              },
+                              {
+                                "columnMatch": "Error_Short_Text_s",
+                                "formatter": 1
+                              },
+                              {
+                                "columnMatch": "Exception_s",
+                                "formatter": 1
+                              },
+                              {
+                                "columnMatch": "SID_s",
+                                "formatter": 1
+                              },
+                              {
+                                "columnMatch": "Count",
+                                "formatter": 1
+                              }
+                            ],
+                            "sortBy": [
+                              {
+                                "itemKey": "Runtime_Error_s",
+                                "sortOrder": 1
+                              }
+                            ],
+                            "labelSettings": [
+                              {
+                                "columnId": "Runtime_Error_s",
+                                "label": "Runtime Exceptions"
+                              },
+                              {
+                                "columnId": "Error_Short_Text_s",
+                                "label": "Exception Text"
+                              },
+                              {
+                                "columnId": "Exception_s",
+                                "label": "Exceptions"
+                              },
+                              {
+                                "columnId": "SID_s",
+                                "label": "Source System"
+                              },
+                              {
+                                "columnId": "Count",
+                                "label": "Exception Count"
+                              }
+                            ]
+                          },
+                          "sortBy": [
+                            {
+                              "itemKey": "Runtime_Error_s",
+                              "sortOrder": 1
+                            }
+                          ]
+                        },
+                        "customWidth": "0",
+                        "name": "shortdumpexceptions",
+                        "styleSettings": {
+                          "maxWidth": "100%"
+                        }
+                      }
+                    ]
+                  },
+                  "name": "Shortdumpbyerrorgroup"
+                },
+                {
+                  "type": 12,
+                  "content": {
+                    "version": "NotebookGroup/1.0",
+                    "groupType": "editable",
+                    "title": "Short Dump By Program",
+                    "expandable": true,
+                    "items": [
+                      {
+                        "type": 3,
+                        "content": {
+                          "version": "KqlItem/1.0",
+                          "query": "let appServerList = dynamic([{ApplicationServer}]);\r\nlet sidList = dynamic([{ApplicationSID}]);\r\nlet baseQuery = SapNetweaver_ShortDumps_CL\r\n| where timestamp_t between (todatetime({ApplicationTimeRange:start}) .. todatetime({ApplicationTimeRange:end}))\r\n| where array_length(sidList) == 0 or SID_s in (sidList)\r\n| extend instanceNr_s = iff(strlen(instanceNr_s) == 2, instanceNr_s, strcat( \"0\", instanceNr_s))\r\n| extend appServer = strcat(hostname_s, \"_\", instanceNr_s)\r\n| where array_length(appServerList) == 0 or appServer in (appServerList)\r\n| extend Program_s;\r\nlet timespanCount = baseQuery \r\n| summarize RecordCount=count()\r\n| extend Interval = iff(RecordCount <= 10, timespan(1m), timespan(1m))\r\n| extend Interval = iff(RecordCount > 10 and RecordCount < 50, timespan(5m), Interval)\r\n| extend Interval = iff(RecordCount >= 50 and RecordCount < 100, timespan(10m), Interval)\r\n| extend Interval = iff(RecordCount >= 100 and RecordCount < 150, timespan(15m), Interval)\r\n| extend Interval = iff(RecordCount >= 150, timespan(30m), Interval)\r\n| project Interval;\r\nlet timespanInterval = toscalar(timespanCount);\r\nbaseQuery\r\n| summarize Count = count() by bin(timestamp_t, timespanInterval), Program_s",
+                          "size": 0,
+                          "timeContext": {
+                            "durationMs": 86400000
+                          },
+                          "queryType": 0,
+                          "resourceType": "microsoft.operationalinsights/workspaces",
+                          "visualization": "unstackedbar",
+                          "chartSettings": {
+                            "xAxis": "Program_s",
+                            "yAxis": [
+                              "Count"
+                            ],
+                            "showMetrics": false
+                          }
+                        },
+                        "name": "shortdumpbyprogram"
+                      },
+                      {
+                        "type": 3,
+                        "content": {
+                          "version": "KqlItem/1.0",
+                          "query": "let appServerList = dynamic([{ApplicationServer}]);\r\nlet sidList = dynamic([{ApplicationSID}]);\r\nSapNetweaver_ShortDumps_CL\r\n| where timestamp_t between (todatetime({ApplicationTimeRange:start}) .. todatetime({ApplicationTimeRange:end}))\r\n| where array_length(sidList) == 0 or SID_s in (sidList)\r\n| extend instanceNr_s = iff(strlen(instanceNr_s) == 2, instanceNr_s, strcat( \"0\", instanceNr_s))\r\n| extend appServer = strcat(hostname_s, \"_\", instanceNr_s)\r\n| where array_length(appServerList) == 0 or appServer in (appServerList)\r\n| summarize Count=count() by Program_s, SID_s\r\n| order by Count",
+                          "size": 0,
+                          "timeContext": {
+                            "durationMs": 86400000
+                          },
+                          "queryType": 0,
+                          "resourceType": "microsoft.operationalinsights/workspaces",
+                          "gridSettings": {
+                            "formatters": [
+                              {
+                                "columnMatch": "Program_s",
+                                "formatter": 1
+                              },
+                              {
+                                "columnMatch": "SID_s",
+                                "formatter": 1
+                              },
+                              {
+                                "columnMatch": "Count",
+                                "formatter": 1
+                              }
+                            ],
+                            "sortBy": [
+                              {
+                                "itemKey": "Program_s",
+                                "sortOrder": 1
+                              }
+                            ],
+                            "labelSettings": [
+                              {
+                                "columnId": "Program_s",
+                                "label": "Top Cancelled Programs"
+                              },
+                              {
+                                "columnId": "SID_s",
+                                "label": "Source System"
+                              },
+                              {
+                                "columnId": "Count",
+                                "label": "Cancellation Count​"
+                              }
+                            ]
+                          },
+                          "sortBy": [
+                            {
+                              "itemKey": "Program_s",
+                              "sortOrder": 1
+                            }
+                          ]
+                        },
+                        "customWidth": "0",
+                        "name": "CancelledProgramQuery",
+                        "styleSettings": {
+                          "maxWidth": "100%"
+                        }
+                      }
+                    ]
+                  },
+                  "name": "shortdumpybyproggroup"
+                },
+                {
+                  "type": 12,
+                  "content": {
+                    "version": "NotebookGroup/1.0",
+                    "groupType": "editable",
+                    "title": "Short Dump By User",
+                    "expandable": true,
+                    "items": [
+                      {
+                        "type": 3,
+                        "content": {
+                          "version": "KqlItem/1.0",
+                          "query": "let appServerList = dynamic([{ApplicationServer}]);\r\nlet sidList = dynamic([{ApplicationSID}]);\r\nlet baseQuery = SapNetweaver_ShortDumps_CL\r\n| where timestamp_t between (todatetime({ApplicationTimeRange:start}) .. todatetime({ApplicationTimeRange:end}))\r\n| where array_length(sidList) == 0 or SID_s in (sidList)\r\n| extend instanceNr_s = iff(strlen(instanceNr_s) == 2, instanceNr_s, strcat( \"0\", instanceNr_s))\r\n| extend appServer = strcat(hostname_s, \"_\", instanceNr_s)\r\n| where array_length(appServerList) == 0 or appServer in (appServerList)\r\n| extend E2E_USER_s;\r\nlet timespanCount = baseQuery \r\n| summarize RecordCount=count()\r\n| extend Interval = iff(RecordCount <= 10, timespan(1m), timespan(1m))\r\n| extend Interval = iff(RecordCount > 10 and RecordCount < 50, timespan(5m), Interval)\r\n| extend Interval = iff(RecordCount >= 50 and RecordCount < 100, timespan(10m), Interval)\r\n| extend Interval = iff(RecordCount >= 100 and RecordCount < 150, timespan(15m), Interval)\r\n| extend Interval = iff(RecordCount >= 150, timespan(30m), Interval)\r\n| project Interval;\r\nlet timespanInterval = toscalar(timespanCount);\r\nbaseQuery\r\n| summarize Count = count() by bin(timestamp_t, timespanInterval), E2E_USER_s",
+                          "size": 0,
+                          "timeContext": {
+                            "durationMs": 86400000
+                          },
+                          "queryType": 0,
+                          "resourceType": "microsoft.operationalinsights/workspaces",
+                          "visualization": "barchart",
+                          "chartSettings": {
+                            "xAxis": "E2E_USER_s",
+                            "yAxis": [
+                              "Count"
+                            ],
+                            "showMetrics": false
+                          }
+                        },
+                        "name": "shortdumpbyuser"
+                      },
+                      {
+                        "type": 3,
+                        "content": {
+                          "version": "KqlItem/1.0",
+                          "query": "let appServerList = dynamic([{ApplicationServer}]);\r\nlet sidList = dynamic([{ApplicationSID}]);\r\nSapNetweaver_ShortDumps_CL\r\n| where timestamp_t between (todatetime({ApplicationTimeRange:start}) .. todatetime({ApplicationTimeRange:end}))\r\n| where array_length(sidList) == 0 or SID_s in (sidList)\r\n| extend instanceNr_s = iff(strlen(instanceNr_s) == 2, instanceNr_s, strcat( \"0\", instanceNr_s))\r\n| extend appServer = strcat(hostname_s, \"_\", instanceNr_s)\r\n| where array_length(appServerList) == 0 or appServer in (appServerList)\r\n| summarize Count=count() by E2E_USER_s, SID_s\r\n| order by Count",
+                          "size": 0,
+                          "timeContext": {
+                            "durationMs": 86400000
+                          },
+                          "queryType": 0,
+                          "resourceType": "microsoft.operationalinsights/workspaces",
+                          "gridSettings": {
+                            "formatters": [
+                              {
+                                "columnMatch": "E2E_USER_s",
+                                "formatter": 1
+                              },
+                              {
+                                "columnMatch": "Count",
+                                "formatter": 1
+                              }
+                            ],
+                            "sortBy": [
+                              {
+                                "itemKey": "E2E_USER_s",
+                                "sortOrder": 1
+                              }
+                            ],
+                            "labelSettings": [
+                              {
+                                "columnId": "E2E_USER_s",
+                                "label": "User "
+                              },
+                              {
+                                "columnId": "SID_s",
+                                "label": "Source System"
+                              },
+                              {
+                                "columnId": "Count",
+                                "label": "Short Dumps Count"
+                              }
+                            ]
+                          },
+                          "sortBy": [
+                            {
+                              "itemKey": "E2E_USER_s",
+                              "sortOrder": 1
+                            }
+                          ]
+                        },
+                        "customWidth": "0",
+                        "name": "shortdumpbyusers",
+                        "styleSettings": {
+                          "maxWidth": "100%"
+                        }
+                      }
+                    ]
+                  },
+                  "name": "shortdumpbyuser"
+                }
+              ]
+            },
+            "conditionalVisibility": {
+              "parameterName": "selectedMenu",
+              "comparison": "isEqualTo",
+              "value": "Application"
+            },
+            "name": "Application Group"
+          }
+        ]
+      },
+      "conditionalVisibilities": [
+        {
+          "parameterName": "selectedMenu",
+          "comparison": "isEqualTo",
+          "value": "Application"
+        },
+        {
+          "parameterName": "param_check_error_shortdump",
+          "comparison": "isEqualTo",
+          "value": "0"
+        }
+      ],
+      "name": "applicationgroup"
     }
   ],
   "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"

--- a/Workbooks/SapMonitor/SapNetWeaver/SapNetWeaver.workbook
+++ b/Workbooks/SapMonitor/SapNetWeaver/SapNetWeaver.workbook
@@ -47,11 +47,12 @@
             "queryType": 12
           },
           {
-            "id": "791b0ca8-eac5-4073-8a9a-330fbce1efb2",
+            "id": "90bcea9a-3fcb-4f45-b88c-98782c711569",
             "version": "KqlParameterItem/1.0",
-            "name": "param_check_provider_error",
+            "name": "param_check_rfc_metrics",
             "type": 1,
-            "query": "print allProviders=parse_json(tostring(\"{param_providers_list:escapejson}\")).value\r\n| mv-expand allProviders\r\n| extend type=parse_json(allProviders.properties).type\r\n| extend state=parse_json(allProviders.properties).provisioningState\r\n| where type==\"SapNetweaver\"\r\n| where state!=\"Failed\"\r\n| summarize iff(count() > 0,count(), -1)",
+            "query": "// 0 = no error\n// 1 = table does not exist (need to enable RFC)\n// 2 = table exists, but column v1 does not (or) column v1 exists but no data in the table (need to wait)\nlet t = \"SapNetweaver_ShortDumps_CL\";\nlet c1 = \"SID_s\";\nlet dummy = \"unmÃ¶glicher-wert!\";\nlet MissingTable = view () { print miss = 1, columnV1 = dummy, records = -1 };\nlet checkRecords =\n  union\n    isfuzzy=true MissingTable,\n    (table(t)\n      | summarize records = count()\n    )\n  | project records\n  | top 1 by records desc\n;\nlet checkTableExists =\n  union\n    isfuzzy=true MissingTable,\n    (table(t)\n      | count\n      | extend miss = 0\n    )\n  | project miss\n  | limit 2\n  | top 1 by miss asc\n;\nlet checkColumnExists =\n  union\n    isfuzzy=true MissingTable,\n    (table(t)\n      | extend miss = 0\n      | extend columnV1 = column_ifexists(c1, dummy)\n    )\n  | project miss, columnV1\n  | limit 2\n  | top 1 by miss asc\n ;\nlet tableExists = toscalar(checkTableExists | summarize max(miss) != 1);\nlet columnV1Exists = toscalar(checkColumnExists | summarize max(columnV1) != dummy);\nlet tableRecords = toscalar(checkRecords | summarize max(records));\nlet x = iif(tableExists, iif(columnV1Exists, iif(tableRecords > 0, \"0\", \"2\"), \"2\"), \"1\");\nprint toscalar(x)\n\n",
+            "isHiddenWhenLocked": true,
             "queryType": 0,
             "resourceType": "microsoft.operationalinsights/workspaces"
           }
@@ -133,7 +134,7 @@
             "cellValue": "selectedMenu",
             "linkTarget": "parameter",
             "linkLabel": "Overview",
-            "subTarget": "CurrentStatus",
+            "subTarget": "Overview",
             "style": "link"
           },
           {
@@ -167,10 +168,77 @@
             "linkLabel": "Queue Statistics",
             "subTarget": "QueueStatistics",
             "style": "link"
+          }
+        ]
+      },
+      "conditionalVisibilities": [
+        {
+          "parameterName": "param_check_error",
+          "comparison": "isEqualTo",
+          "value": "0"
+        },
+        {
+          "parameterName": "param_check_provider_error",
+          "comparison": "isNotEqualTo",
+          "value": "-1"
+        },
+        {
+          "parameterName": "param_check_rfc_metrics",
+          "comparison": "isNotEqualTo",
+          "value": "0"
+        }
+      ],
+      "name": "Main Navigation Links"
+    },
+    {
+      "type": 11,
+      "content": {
+        "version": "LinkItem/1.0",
+        "style": "tabs",
+        "links": [
+          {
+            "id": "c69bbaf6-d2a9-4ebf-8985-a14e22643035",
+            "cellValue": "selectedMenuRFC",
+            "linkTarget": "parameter",
+            "linkLabel": "Overview",
+            "subTarget": "Overview",
+            "style": "link"
           },
           {
-            "id": "49f56ce4-06a1-445d-b4dd-9f3e7b49cef8",
-            "cellValue": "selectedMenu",
+            "id": "e3361f7f-1175-46da-b0b9-c39368c8b29b",
+            "cellValue": "selectedMenuRFC",
+            "linkTarget": "parameter",
+            "linkLabel": "Availability",
+            "subTarget": "Availability",
+            "style": "link"
+          },
+          {
+            "id": "166ff82a-8eb9-443c-b28c-12746c3b86e9",
+            "cellValue": "selectedMenuRFC",
+            "linkTarget": "parameter",
+            "linkLabel": "Utilization",
+            "subTarget": "Utilization",
+            "style": "link"
+          },
+          {
+            "id": "6a312e51-76b6-4afc-a948-1f22094c392e",
+            "cellValue": "selectedMenuRFC",
+            "linkTarget": "parameter",
+            "linkLabel": "Enqueue Statistics",
+            "subTarget": "EnqueueStatistics",
+            "style": "link"
+          },
+          {
+            "id": "0155da79-79b5-4e35-91d3-3aeb2ac640e8",
+            "cellValue": "selectedMenuRFC",
+            "linkTarget": "parameter",
+            "linkLabel": "Queue Statistics",
+            "subTarget": "QueueStatistics",
+            "style": "link"
+          },
+          {
+            "id": "0e04320b-60b3-463a-afc2-ff6546e574c7",
+            "cellValue": "selectedMenuRFC",
             "linkTarget": "parameter",
             "linkLabel": "Application",
             "subTarget": "Application",
@@ -188,9 +256,36 @@
           "parameterName": "param_check_provider_error",
           "comparison": "isNotEqualTo",
           "value": "-1"
+        },
+        {
+          "parameterName": "param_check_rfc_metrics",
+          "comparison": "isEqualTo",
+          "value": "0"
         }
       ],
-      "name": "Main Navigation Links"
+      "name": "Main Navigation Links - RFC"
+    },
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "parameters": [
+          {
+            "id": "aa8ab18f-5d36-4f34-8a54-f0f2e25ecbb8",
+            "version": "KqlParameterItem/1.0",
+            "name": "SelectedTab",
+            "type": 1,
+            "query": "let selMenu = dynamic(\"{selectedMenu}\");\nlet selMenuRFC = dynamic(\"{selectedMenuRFC}\");\nlet rfcCheckParam = dynamic(\"{param_check_rfc_metrics}\");\nlet selTabValue = case(selMenu == \"Overview\", \"Overview\", \n                        selMenu == \"Availability\", \"Availability\" , \n                        selMenu == \"Utilization\", \"Utilization\" , \n                        selMenu == \"EnqueueStatistics\", \"EnqueueStatistics\" ,\n                        selMenu == \"QueueStatistics\", \"QueueStatistics\",    \n                        \"\");\nlet selTabRFCValue = case(selMenuRFC == \"Overview\", \"Overview\", \n                          selMenuRFC == \"Availability\", \"Availability\" ,\n                          selMenuRFC == \"Utilization\", \"Utilization\" , \n                          selMenuRFC == \"EnqueueStatistics\", \"EnqueueStatistics\" ,\n                          selMenuRFC == \"QueueStatistics\", \"QueueStatistics\" ,\n                          selMenuRFC == \"Application\", \"Application\" ,\n                          selMenuRFC == \"CPUMemoryUtilization\", \"CPUMemoryUtilization\" ,\n                            \"\");    \n\nlet chooseTab = iff((rfcCheckParam == 1),selTabValue, selTabRFCValue);\nprint toscalar(chooseTab);\n",
+            "isHiddenWhenLocked": true,
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          }
+        ],
+        "style": "pills",
+        "queryType": 0,
+        "resourceType": "microsoft.operationalinsights/workspaces"
+      },
+      "name": "SelectedTabParameter"
     },
     {
       "type": 12,
@@ -738,9 +833,9 @@
       },
       "conditionalVisibilities": [
         {
-          "parameterName": "selectedMenu",
+          "parameterName": "SelectedTab",
           "comparison": "isEqualTo",
-          "value": "CurrentStatus"
+          "value": "Overview"
         },
         {
           "parameterName": "param_check_error",
@@ -777,7 +872,7 @@
       },
       "conditionalVisibilities": [
         {
-          "parameterName": "selectedMenu",
+          "parameterName": "SelectedTab",
           "comparison": "isEqualTo",
           "value": "Availability"
         },
@@ -829,7 +924,7 @@
           "value": "0"
         },
         {
-          "parameterName": "selectedMenu",
+          "parameterName": "SelectedTab",
           "comparison": "isEqualTo",
           "value": "Availability"
         }
@@ -1065,7 +1160,7 @@
               ]
             },
             "conditionalVisibility": {
-              "parameterName": "selectedMenu",
+              "parameterName": "SelectedTab",
               "comparison": "isEqualTo",
               "value": "Availability"
             },
@@ -1075,7 +1170,7 @@
       },
       "conditionalVisibilities": [
         {
-          "parameterName": "selectedMenu",
+          "parameterName": "SelectedTab",
           "comparison": "isEqualTo",
           "value": "Availability"
         },
@@ -1085,7 +1180,7 @@
           "value": "0"
         }
       ],
-      "name": "Availability Group Items"
+      "name": "AvailabilityGroupItems"
     },
     {
       "type": 9,
@@ -1161,7 +1256,7 @@
           "value": "0"
         },
         {
-          "parameterName": "selectedMenu",
+          "parameterName": "SelectedTab",
           "comparison": "isEqualTo",
           "value": "Utilization"
         }
@@ -1403,7 +1498,7 @@
               ]
             },
             "conditionalVisibility": {
-              "parameterName": "selectedMenu",
+              "parameterName": "SelectedTab",
               "comparison": "isEqualTo",
               "value": "Utilization"
             },
@@ -1413,7 +1508,7 @@
       },
       "conditionalVisibilities": [
         {
-          "parameterName": "selectedMenu",
+          "parameterName": "SelectedTab",
           "comparison": "isEqualTo",
           "value": "Utilization"
         },
@@ -1433,7 +1528,7 @@
           {
             "id": "5cce3807-e36c-460d-bd2a-bc7d03e2e11b",
             "version": "KqlParameterItem/1.0",
-            "name": "param_check_error_performance",
+            "name": "param_check_error_enqStat",
             "type": 1,
             "query": "// 0 = no error\n// 1 = table does not exist (need to add provider)\n// 2 = table exists, but column v1 does not (or) column v1 exists but no data in the table (need to wait)\nlet t = \"SapNetweaver_EnqGetStatistic_CL\";\nlet c1 = \"SID_s\";\nlet dummy = \"unmÃ¶glicher-wert!\";\nlet MissingTable = view () { print miss = 1, columnV1 = dummy, records = -1 };\nlet checkRecords =\n  union\n    isfuzzy=true MissingTable,\n    (table(t)\n      | summarize records = count()\n    )\n  | project records\n  | top 1 by records desc\n;\nlet checkTableExists =\n  union\n    isfuzzy=true MissingTable,\n    (table(t)\n      | count\n      | extend miss = 0\n    )\n  | project miss\n  | limit 2\n  | top 1 by miss asc\n;\nlet checkColumnExists =\n  union\n    isfuzzy=true MissingTable,\n    (table(t)\n      | extend miss = 0\n      | extend columnV1 = column_ifexists(c1, dummy)\n    )\n  | project miss, columnV1\n  | limit 2\n | top 1 by miss asc\n;\nlet tableExists = toscalar(checkTableExists | summarize max(miss) != 1);\nlet columnV1Exists = toscalar(checkColumnExists | summarize max(columnV1) != dummy);\nlet tableRecords = toscalar(checkRecords | summarize max(records));\nlet x = iif(tableExists, iif(columnV1Exists, iif(tableRecords > 0, \"0\", \"2\"), \"2\"), \"1\");\nprint toscalar(x)\n",
             "isHiddenWhenLocked": true,
@@ -1451,12 +1546,12 @@
           "comparison": "isNotEqualTo"
         },
         {
-          "parameterName": "selectedMenu",
+          "parameterName": "SelectedTab",
           "comparison": "isEqualTo",
-          "value": "Performance"
+          "value": "EnqueueStatistics"
         }
       ],
-      "name": "ErrorCheckPerfParam"
+      "name": "ErrorCheckEnqStatParam"
     },
     {
       "type": 12,
@@ -1471,7 +1566,7 @@
               "style": "warning"
             },
             "conditionalVisibility": {
-              "parameterName": "param_check_error_performance",
+              "parameterName": "param_check_error_enqStat",
               "comparison": "isEqualTo",
               "value": "1"
             },
@@ -1484,7 +1579,7 @@
               "style": "warning"
             },
             "conditionalVisibility": {
-              "parameterName": "param_check_error_performance",
+              "parameterName": "param_check_error_enqStat",
               "comparison": "isEqualTo",
               "value": "2"
             },
@@ -1494,17 +1589,17 @@
       },
       "conditionalVisibilities": [
         {
-          "parameterName": "param_check_error_performance",
+          "parameterName": "param_check_error_enqStat",
           "comparison": "isNotEqualTo",
           "value": "0"
         },
         {
-          "parameterName": "selectedMenu",
+          "parameterName": "SelectedTab",
           "comparison": "isEqualTo",
-          "value": "Performance"
+          "value": "EnqueueStatistics"
         }
       ],
-      "name": "perf_group_error"
+      "name": "enqStat_group_error"
     },
     {
       "type": 12,
@@ -1601,7 +1696,7 @@
               "queryType": 0,
               "resourceType": "microsoft.operationalinsights/workspaces"
             },
-            "name": "performanceParameters"
+            "name": "enqStatParameters"
           },
           {
             "type": 1,
@@ -2216,12 +2311,12 @@
       },
       "conditionalVisibilities": [
         {
-          "parameterName": "selectedMenu",
+          "parameterName": "SelectedTab",
           "comparison": "isEqualTo",
           "value": "EnqueueStatistics"
         },
         {
-          "parameterName": "param_check_error_performance",
+          "parameterName": "param_check_error_enqStat",
           "comparison": "isEqualTo",
           "value": "0"
         }
@@ -2254,7 +2349,7 @@
           "comparison": "isNotEqualTo"
         },
         {
-          "parameterName": "selectedMenu",
+          "parameterName": "SelectedTab",
           "comparison": "isEqualTo",
           "value": "QueueStatistics"
         }
@@ -2302,7 +2397,7 @@
           "value": "0"
         },
         {
-          "parameterName": "selectedMenu",
+          "parameterName": "SelectedTab",
           "comparison": "isEqualTo",
           "value": "QueueStatistics"
         }
@@ -2770,7 +2865,7 @@
       },
       "conditionalVisibilities": [
         {
-          "parameterName": "selectedMenu",
+          "parameterName": "SelectedTab",
           "comparison": "isEqualTo",
           "value": "QueueStatistics"
         },
@@ -2808,7 +2903,7 @@
           "comparison": "isNotEqualTo"
         },
         {
-          "parameterName": "selectedMenu",
+          "parameterName": "SelectedTab",
           "comparison": "isEqualTo",
           "value": "Application"
         }
@@ -2856,7 +2951,7 @@
           "value": "0"
         },
         {
-          "parameterName": "selectedMenu",
+          "parameterName": "SelectedTab",
           "comparison": "isEqualTo",
           "value": "Application"
         }
@@ -2887,7 +2982,7 @@
                         "label": "Time Range",
                         "type": 4,
                         "value": {
-                          "durationMs": 300000
+                          "durationMs": 1800000
                         },
                         "typeSettings": {
                           "selectableValues": [
@@ -3003,7 +3098,6 @@
                     "groupType": "editable",
                     "title": "Short Dump By Error",
                     "expandable": true,
-                    "expanded": true,
                     "items": [
                       {
                         "type": 3,
@@ -3297,7 +3391,7 @@
               ]
             },
             "conditionalVisibility": {
-              "parameterName": "selectedMenu",
+              "parameterName": "SelectedTab",
               "comparison": "isEqualTo",
               "value": "Application"
             },
@@ -3307,7 +3401,7 @@
       },
       "conditionalVisibilities": [
         {
-          "parameterName": "selectedMenu",
+          "parameterName": "SelectedTab",
           "comparison": "isEqualTo",
           "value": "Application"
         },


### PR DESCRIPTION
## PR Checklist

* [x] Explain your changes, so people looking at the PR know *what* and *why*, the code changes are the *how*.

### If adding or updating templates:
* [x] post a screenshot of templates and/or gallery changes
* [x] ensure your template has a corresponding gallery entry in the gallery folder
* [x] If you are adding a new template, add your team and template/gallery file(s) to the CODEOWNERS file. CODEOWNERS entries should be teams, not individuals
* [x] ensure all steps have meaningful names
* [x] ensure all parameters and grid columns have display names set so they can be localized
* [x] ensure that parameters id values are unique __or they will fail PR validation__ (parameter ids are used for localization)
* [x] ensure that steps names are unique __or they will fail PR validation__ (step names are used for localization)
* [x] grep `/subscription/` and ensure that your parameters don't have any hardcoded resourceIds __or they will fail PR validation__
* [x] remove `fallbackResourceIds` and `fromTemplateId` fields from your template workbook __or they will fail PR validation__
1. Code changes to add a new 'Application' tab for including Short Dump visualization'
![image](https://user-images.githubusercontent.com/74435183/116625397-2a0c8800-a90f-11eb-873e-e915956fee91.png)
![image](https://user-images.githubusercontent.com/74435183/116625482-50cabe80-a90f-11eb-93bb-4dc06ed2168e.png)
![image](https://user-images.githubusercontent.com/74435183/116625498-59bb9000-a90f-11eb-8b51-1e2bf9ed7629.png)
![image](https://user-images.githubusercontent.com/74435183/116625508-6213cb00-a90f-11eb-861c-ba037ceaf111.png)
2. Validation error message for the user to enable the RFC Metrics
![image](https://user-images.githubusercontent.com/74435183/116625571-7ce63f80-a90f-11eb-8289-91916a04cb75.png)
3. Some small query changes in the previously included error messages for other metrics.
4. Logic to hide/show the navigation menu based on the RFC Metrics.
5. Some more code clean up related to the rename 'Performance' to 'EnqueueStatistics'
