### PR TITLE
Change clusters parameter to resource picker type

### DIFF
--- a/Workbooks/Azure Stack HCI/AtScale/Insights.workbook
+++ b/Workbooks/Azure Stack HCI/AtScale/Insights.workbook
@@ -89,7 +89,7 @@
             "id": "0bd8be0a-5391-4e03-9b4b-5eb2643f9b73",
             "version": "KqlParameterItem/1.0",
             "name": "clusters",
-            "type": 9,
+            "type": 5,
             "multiSelect": true,
             "quote": "'",
             "delimiter": ",",
@@ -98,10 +98,17 @@
               "{subscription}"
             ],
             "isHiddenWhenLocked": true,
+            "typeSettings": {
+              "additionalResourceOptions": [
+                "value::all"
+              ],
+              "showDefault": false
+            },
             "timeContext": {
               "durationMs": 86400000
             },
             "timeContextFromParameter": "timeRange",
+            "defaultValue": "value::all",
             "queryType": 0,
             "resourceType": "microsoft.resources/subscriptions"
           },


### PR DESCRIPTION
## PR Checklist

* [x] Explain your changes, so people looking at the PR know *what* and *why*, the code changes are the *how*.
I found an issue that multi-value type parameter is not updated when time range changes even if the query depends on it. But, it works with resource picker so it is fixed by just changing type.

### If adding or updating templates:
* [ ] post a screenshot of templates and/or gallery changes
* [ ] ensure your template has a corresponding gallery entry in the gallery folder
* [ ] If you are adding a new template, add your team and template/gallery file(s) to the CODEOWNERS file. CODEOWNERS entries should be teams, not individuals
* [ ] ensure all steps have meaningful names
* [ ] ensure all parameters and grid columns have display names set so they can be localized
* [ ] ensure that parameters id values are unique __or they will fail PR validation__ (parameter ids are used for localization)
* [ ] ensure that steps names are unique __or they will fail PR validation__ (step names are used for localization)
* [ ] grep `/subscription/` and ensure that your parameters don't have any hardcoded resourceIds __or they will fail PR validation__
* [ ] remove `fallbackResourceIds` and `fromTemplateId` fields from your template workbook __or they will fail PR validation__