### PR TITLE
Netweaver Alerts

### DIFF
--- a/Workbooks/SapMonitor/SapNetWeaver/SapNetWeaver.workbook
+++ b/Workbooks/SapMonitor/SapNetWeaver/SapNetWeaver.workbook
@@ -55,6 +55,27 @@
             "isHiddenWhenLocked": true,
             "queryType": 0,
             "resourceType": "microsoft.operationalinsights/workspaces"
+          },
+          {
+            "id": "a00ff9e0-9235-4aa2-b617-933d7977bdb6",
+            "version": "KqlParameterItem/1.0",
+            "name": "param_provider_type",
+            "type": 1,
+            "value": "SapNetweaver",
+            "isHiddenWhenLocked": true
+          },
+          {
+            "id": "979c1ab9-90e4-4b19-9c58-7c1f96c38754",
+            "version": "KqlParameterItem/1.0",
+            "name": "param_alert_templates",
+            "type": 1,
+            "value": "[\r\n    {\r\n        \"name\": \"SAP Netweaver service unavailability\",\r\n        \"description\": \"Fired when a SAP NetWeaver Service is not available.\",\r\n        \"author\": \"Microsoft\",\r\n        \"templateId\": \"sapnetweaver-service-unavailability\",\r\n        \"severity\": \"1\",\r\n        \"alertTemplate\": {\r\n            \"query\": \"let InstanceCount = toscalar(SapNetweaver_GetSystemInstanceList_CL | where PROVIDER_INSTANCE_s == '{ProviderInstance}' | count); let MissingInstances = SapNetweaver_GetSystemInstanceList_CL|  where InstanceCount == 0 | summarize AggregatedValue = min(InstanceCount) by bin(TimeGenerated, 2m), serverTimestamp_t;let TotalInstanceAvailability = SapNetweaver_GetSystemInstanceList_CL | where PROVIDER_INSTANCE_s == '{ProviderInstance}' | extend Status = iff(dispstatus_s == 'SAPControl-GREEN', 1, 0) | summarize available=countif(Status == 1), total=count() by PROVIDER_INSTANCE_s, serverTimestamp_t;let ServiceAvailability = TotalInstanceAvailability | join kind = leftouter SapNetweaver_GetSystemInstanceList_CL on $left.PROVIDER_INSTANCE_s == $right.PROVIDER_INSTANCE_s and $left.serverTimestamp_t == $right.serverTimestamp_t | extend Status = iff(dispstatus_s == 'SAPControl-GREEN', 1, 0) | extend ServiceStatus = iff(available == 0, 0, iff(features_s contains 'MESSAGESERVER' and Status == 0, 0, 1)) | summarize AggregatedValue = min(ServiceStatus) by bin(TimeGenerated, 2m), PROVIDER_INSTANCE_s, hostname_s, dispstatus_s, features_s, serverTimestamp_t;union MissingInstances, ServiceAvailability\",\r\n            \"thresholdOperator\": \"LessThan\",\r\n            \"defaultThreshold\": \"1\",\r\n            \"alertUnit\": \"number\",\r\n            \"metricMeasurement\": {\r\n                \"thresholdOperator\": \"GreaterThan\",\r\n                \"threshold\": \"1\",\r\n                \"metricTriggerType\": \"Consecutive\",\r\n                \"metricColumn\": \"PROVIDER_INSTANCE_s\",\r\n                \"frequencyInMinutes\": \"5\",\r\n                \"timeWindowInMinutes\": \"10\"\r\n            }\r\n        }\r\n    },\r\n    {\r\n        \"name\": \"SAP Netweaver instance unavailability\",\r\n        \"description\": \"Fired when a SAP NetWeaver instance is not available.\",\r\n        \"author\": \"Microsoft\",\r\n        \"templateId\": \"sapnetweaver-instance-unavailability\",\r\n        \"severity\": \"2\",\r\n        \"alertTemplate\": {\r\n            \"query\": \"let TotalInstanceAvailability = SapNetweaver_GetSystemInstanceList_CL | where PROVIDER_INSTANCE_s == '{ProviderInstance}' | extend Status = iff(dispstatus_s == 'SAPControl-GREEN', 1, 0) | summarize available=countif(Status == 1), total=count() by PROVIDER_INSTANCE_s, serverTimestamp_t; TotalInstanceAvailability | join kind = leftouter SapNetweaver_GetSystemInstanceList_CL on $left.PROVIDER_INSTANCE_s == $right.PROVIDER_INSTANCE_s and $left.serverTimestamp_t == $right.serverTimestamp_t | where features_s !contains 'MESSAGESERVER' and features_s !contains 'ENQ' | extend InstanceStatus = iff(available != 0 and dispstatus_s == 'SAPControl-GREEN', 1, 0) | summarize AggregatedValue = min(InstanceStatus) by bin(TimeGenerated, 2m), PROVIDER_INSTANCE_s, hostname_s, dispstatus_s, features_s, serverTimestamp_t\",\r\n            \"thresholdOperator\": \"LessThan\",\r\n            \"defaultThreshold\": \"1\",\r\n            \"alertUnit\": \"number\",\r\n            \"metricMeasurement\": {\r\n                \"thresholdOperator\": \"GreaterThan\",\r\n                \"threshold\": \"1\",\r\n                \"metricTriggerType\": \"Consecutive\",\r\n                \"metricColumn\": \"PROVIDER_INSTANCE_s\",\r\n                \"frequencyInMinutes\": \"5\",\r\n                \"timeWindowInMinutes\": \"10\"\r\n            }\r\n        }\r\n    },\r\n    {\r\n        \"name\": \"SAP Netweaver enqueue server unavailability\",\r\n        \"description\": \"Fired when a SAP NetWeaver enqueue server is not available.\",\r\n        \"author\": \"Microsoft\",\r\n        \"templateId\": \"sapnetweaver-enqueue-server-unavailability\",\r\n        \"severity\": \"2\",\r\n        \"alertTemplate\": {\r\n            \"query\": \"SapNetweaver_GetProcessList_CL | where PROVIDER_INSTANCE_s == '{ProviderInstance}' and description_s contains 'Enqueue' | extend Status = iff(dispstatus_s == 'SAPControl-GREEN', 1, 0) | summarize AggregatedValue = min(Status) by bin(TimeGenerated, 2m), PROVIDER_INSTANCE_s, hostname_s, dispstatus_s, description_s, serverTimestamp_t\",\r\n            \"thresholdOperator\": \"LessThan\",\r\n            \"defaultThreshold\": \"1\",\r\n            \"alertUnit\": \"number\",\r\n            \"metricMeasurement\": {\r\n                \"thresholdOperator\": \"GreaterThan\",\r\n                \"threshold\": \"1\",\r\n                \"metricTriggerType\": \"Consecutive\",\r\n                \"metricColumn\": \"PROVIDER_INSTANCE_s\",\r\n                \"frequencyInMinutes\": \"5\",\r\n                \"timeWindowInMinutes\": \"10\"\r\n            }\r\n        }\r\n    },\r\n    {\r\n        \"name\": \"SAP Netweaver work process utilization\",\r\n        \"description\": \"Fired when work process utilization exceeds 90  percent for DIA and BTC work type.\",\r\n        \"author\": \"Microsoft\",\r\n        \"templateId\": \"sapnetweaver-workprocess-utilization\",\r\n        \"severity\": \"2\",\r\n        \"alertTemplate\": {\r\n            \"query\": \"SapNetweaver_ABAPGetWPTable_CL | where PROVIDER_INSTANCE_s == '{ProviderInstance}' | where Typ_s has 'BTC' or Typ_s has 'DIA' | summarize totalWP = count(), freeWP = countif(Status_s == 'Wait') by TimeGenerated, Typ_s, hostname_s, instanceNr_d, serverTimestamp_t | extend UtilizationPctWP = round(toreal(totalWP - freeWP) / toreal(totalWP) * 100, 3) | summarize AggregatedValue = max(UtilizationPctWP) by bin(TimeGenerated, 1m), Typ_s, hostname_s, instanceNr_d, serverTimestamp_t\",\r\n            \"thresholdOperator\": \"GreaterThan\",\r\n            \"defaultThreshold\": \"90\",\r\n            \"alertUnit\": \"percent\",\r\n            \"metricMeasurement\": {\r\n                \"thresholdOperator\": \"GreaterThan\",\r\n                \"threshold\": \"2\",\r\n                \"metricTriggerType\": \"Consecutive\",\r\n                \"metricColumn\": \"PROVIDER_INSTANCE_s\",\r\n                \"frequencyInMinutes\": \"5\",\r\n                \"timeWindowInMinutes\": \"10\"\r\n            }\r\n        }\r\n    },\r\n    {\r\n        \"name\": \"SAP Netweaver queue utilization\",\r\n        \"description\": \"Fired when queue utilization exceeds 70  percent for DIA and BTC work type.\",\r\n        \"author\": \"Microsoft\",\r\n        \"templateId\": \"sapnetweaver-queue-utilization\",\r\n        \"severity\": \"2\",\r\n        \"alertTemplate\": {\r\n            \"query\": \"let baseQuery = SapNetweaver_GetQueueStatistic_CL | where PROVIDER_INSTANCE_s == '{ProviderInstance}' | where Typ_s has 'DIA' or Typ_s has 'BTC'; let auxQuery = baseQuery | summarize QueueLimit=max(Max_d), LatestServerTimestamp = arg_max(serverTimestamp_t, Now_d, TimeGenerated) by hostname_s, instanceNr_d, Typ_s; baseQuery | summarize count() by Typ_s | join kind=inner auxQuery on Typ_s | extend QueueUtilization = iff(QueueLimit != 0, (toreal(Now_d) / toreal(QueueLimit)) * 100, 0.0) | summarize AggregatedValue = max(QueueUtilization) by bin(TimeGenerated, 1m), Typ_s, hostname_s, instanceNr_d, LatestServerTimestamp\",\r\n            \"thresholdOperator\": \"GreaterThan\",\r\n            \"defaultThreshold\": \"70\",\r\n            \"alertUnit\": \"percent\",\r\n            \"metricMeasurement\": {\r\n                \"thresholdOperator\": \"GreaterThan\",\r\n                \"threshold\": \"2\",\r\n                \"metricTriggerType\": \"Consecutive\",\r\n                \"metricColumn\": \"PROVIDER_INSTANCE_s\",\r\n                \"frequencyInMinutes\": \"5\",\r\n                \"timeWindowInMinutes\": \"10\"\r\n            }\r\n        }\r\n    }\r\n]",
+            "isHiddenWhenLocked": true,            
+            "typeSettings": {
+              "multiLineText": true,
+              "editorLanguage": "text",
+              "multiLineHeight": 25
+            }
           }
         ],
         "style": "pills",
@@ -66,6 +87,44 @@
         "comparison": "isNotEqualTo"
       },
       "name": "overview_section_params"
+    },
+    {
+      "type": 11,
+      "content": {
+        "version": "LinkItem/1.0",
+        "style": "nav",
+        "links": [
+          {
+            "id": "2d20d63e-d352-46e8-bcb0-9ca9ce897996",
+            "linkTarget": "WorkbookTemplate",
+            "linkLabel": "Alerts",
+            "style": "primary",
+            "workbookContext": {
+              "componentIdSource": "workbook",
+              "resourceIdsSource": "workbook",
+              "templateIdSource": "static",
+              "templateId": "Community-Workbooks/SapMonitor/Alerts/Alerts",
+              "typeSource": "workbook",
+              "gallerySource": "workbook",
+              "locationSource": "default",
+              "passSpecificParams": true,
+              "templateParameters": [
+                {
+                  "name": "ProviderType",
+                  "source": "parameter",
+                  "value": "param_provider_type"
+                },
+                {
+                  "name": "AlertTemplates",
+                  "source": "parameter",
+                  "value": "param_alert_templates"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "name": "links - 22"
     },
     {
       "type": 12,


### PR DESCRIPTION
## PR Checklist

* [ ] Explain your changes, so people looking at the PR know *what* and *why*, the code changes are the *how*.

### If adding or updating templates:
* [ ] post a screenshot of templates and/or gallery changes
* [ ] ensure your template has a corresponding gallery entry in the gallery folder
* [ ] If you are adding a new template, add your team and template/gallery file(s) to the CODEOWNERS file. CODEOWNERS entries should be teams, not individuals
* [ ] ensure all steps have meaningful names
* [ ] ensure all parameters and grid columns have display names set so they can be localized
* [ ] ensure that parameters id values are unique __or they will fail PR validation__ (parameter ids are used for localization)
* [ ] ensure that steps names are unique __or they will fail PR validation__ (step names are used for localization)
* [ ] grep `/subscription/` and ensure that your parameters don't have any hardcoded resourceIds __or they will fail PR validation__
* [ ] remove `fallbackResourceIds` and `fromTemplateId` fields from your template workbook __or they will fail PR validation__

### NetWeaver workbook updated to support Alerts:
1. Add a parameter - **Provider type**  - SapNetWeaver is supplied as text input always which will be useful to display all the provider instances available in SapNetWeaver in AMS
2. Add a parameter - **Alert template** - This text box will contain the array of json alert templates
3. Add navigation link to button - **Alerts** - which is configured to refer to Alert workbook availabile in sap-monitor

**Note**: All alert queries expect **Aggregated value** column and bin by **Time Generated** 

**Alerts available:**

_**SAP Netweaver service unavailability**_ - Configured as severity 1 alert and it will be fired in three scenarios
- When MESSAGESERVER is down
- When all the servers are down
- When there is no data available for the specified instance in last ten minutes

_**SAP Netweaver instance unavailability**_ - Configured as severity 2 alert and it will be fired in below two scenarios
- When any app server is down other than MESSAGESERVER
- When any app server is down other than Enqueue / Enqueue replicator

_**SAP Netweaver enqueue server unavailability**_ - Configured as severity 2 alert and it will be fired in below two scenarios
- When Enqueue server is down
- When Enqueue replicator is down

_**SAP Netweaver work process utilization**_ - Configured as severity 2 alert and it will be fired in below two scenarios
- when any servers work process utilization is above 90% for DIA work type
- when any servers work process utilization is above 90% for BTC work type

**_SAP Netweaver queue utilization_** - Configured as severity 2 alert and it will be fired in below two scenarios
- when any servers queue utilization exceeds 70  percent for DIA work type
- when any servers queue utilization exceeds 70  percent for BTC work type