### PR TITLE
add AustraliaEast to the static location

### DIFF
--- a/Workbooks/Workloads/Custom Telegraf/Add monitoring virtual machine/Add monitoring virtual machine.workbook
+++ b/Workbooks/Workloads/Custom Telegraf/Add monitoring virtual machine/Add monitoring virtual machine.workbook
@@ -85,7 +85,7 @@
             "label": "Virtual machine",
             "type": 5,
             "isRequired": true,
-            "query": "Resources\r\n| where type =~ 'microsoft.compute/virtualmachines' and location in (dynamic(['australiasoutheast','centralus', 'eastus','eastus2','eastus2euap','northeurope','southeastasia','uksouth','westeurope','westus','westus2']))\r\n| where properties.storageProfile.osDisk.osType =~ 'Linux'\r\n| order by resourceGroup asc, name asc\r\n| project id\r\n",
+            "query": "Resources\r\n| where type =~ 'microsoft.compute/virtualmachines' and location in (dynamic(['australiasoutheast','centralus', 'eastus','eastus2','eastus2euap','northeurope','southeastasia','uksouth','westeurope','westus','westus2','australiaeast']))\r\n| where properties.storageProfile.osDisk.osType =~ 'Linux'\r\n| order by resourceGroup asc, name asc\r\n| project id\r\n",
             "crossComponentResources": [
               "{Subscription}"
             ],

--- a/Workbooks/Workloads/Custom Telegraf/Create new profile/Create new profile.workbook
+++ b/Workbooks/Workloads/Custom Telegraf/Create new profile/Create new profile.workbook
@@ -115,7 +115,7 @@
               "additionalResourceOptions": [],
               "showDefault": false
             },
-            "jsonData": "[\r\n\"australiacentral\",\r\n\"australiasoutheast\",\r\n\"canadacentral\",\r\n\"centralindia\",\r\n\"centralus\",\r\n\"eastasia\",\r\n\"eastus\",\r\n\"eastus2\",\r\n\"francecentral\",\r\n\"germanywestcentral\",\r\n\"japaneast\",\r\n\"koreacentral\",\r\n\"northcentralus\",\r\n\"northeurope\",\r\n\"southafricanorth\",\r\n\"southcentralus\",\r\n\"southeastasia\",\r\n\"switzerlandnorth\",\r\n\"uksouth\",\r\n\"ukwest\",\r\n\"westcentralus\",\r\n\"westeurope\",\r\n\"westus\",\r\n\"westus2\"\r\n]"
+            "jsonData": "[\r\n\"australiacentral\",\r\n\"australiasoutheast\",\r\n\"canadacentral\",\r\n\"centralindia\",\r\n\"centralus\",\r\n\"eastasia\",\r\n\"eastus\",\r\n\"eastus2\",\r\n\"francecentral\",\r\n\"germanywestcentral\",\r\n\"japaneast\",\r\n\"koreacentral\",\r\n\"northcentralus\",\r\n\"northeurope\",\r\n\"southafricanorth\",\r\n\"southcentralus\",\r\n\"southeastasia\",\r\n\"switzerlandnorth\",\r\n\"uksouth\",\r\n\"ukwest\",\r\n\"westcentralus\",\r\n\"westeurope\",\r\n\"westus\",\r\n\"westus2\",\r\n\"australiaeast\"\r\n]"
           },
           {
             "id": "350cc656-5650-4941-b6c4-455e37f6355c",

--- a/Workbooks/Workloads/SQL/Add monitoring virtual machine/Add monitoring virtual machine.workbook
+++ b/Workbooks/Workloads/SQL/Add monitoring virtual machine/Add monitoring virtual machine.workbook
@@ -86,7 +86,7 @@
             "label": "Virtual machine",
             "type": 5,
             "isRequired": true,
-            "query": "Resources\r\n| where type =~ 'microsoft.compute/virtualmachines' and location in (dynamic([ \"australiacentral\", \"australiaeast\", \"australiasoutheast\", \"canadacentral\", \"centralindia\", \"centralus\", \"eastasia\", \"eastus\", \"eastus2\", \"eastus2euap\", \"francecentral\", \"germanywestcentral\", \"japaneast\", \"koreacentral\", \"northcentralus\", \"northeurope\", \"southafricanorth\", \"southcentralus\", \"southeastasia\", \"switzerlandnorth\", \"uksouth\", \"ukwest\", \"westcentralus\", \"westeurope\", \"westus\", \"westus2\"]))\r\n| where properties.storageProfile.osDisk.osType =~ 'Linux'\r\n| order by resourceGroup asc, name asc\r\n| project id\r\n",
+            "query": "Resources\r\n| where type =~ 'microsoft.compute/virtualmachines' and location in (dynamic([ \"australiacentral\", \"australiaeast\", \"australiasoutheast\", \"canadacentral\", \"centralindia\", \"centralus\", \"eastasia\", \"eastus\", \"eastus2\", \"eastus2euap\", \"francecentral\", \"germanywestcentral\", \"japaneast\", \"koreacentral\", \"northcentralus\", \"northeurope\", \"southafricanorth\", \"southcentralus\", \"southeastasia\", \"switzerlandnorth\", \"uksouth\", \"ukwest\", \"westcentralus\", \"westeurope\", \"westus\", \"westus2\", \"australiaeast\"]))\r\n| where properties.storageProfile.osDisk.osType =~ 'Linux'\r\n| order by resourceGroup asc, name asc\r\n| project id\r\n",
             "crossComponentResources": [
               "{Subscription}"
             ],

--- a/Workbooks/Workloads/SQL/Create new profile/Create new profile.workbook
+++ b/Workbooks/Workloads/SQL/Create new profile/Create new profile.workbook
@@ -116,7 +116,7 @@
               "additionalResourceOptions": [],
               "showDefault": false
             },
-            "jsonData": "[\r\n\"australiacentral\",\r\n\"australiasoutheast\",\r\n\"canadacentral\",\r\n\"centralindia\",\r\n\"centralus\",\r\n\"eastasia\",\r\n\"eastus\",\r\n\"eastus2\",\r\n\"francecentral\",\r\n\"germanywestcentral\",\r\n\"japaneast\",\r\n\"koreacentral\",\r\n\"northcentralus\",\r\n\"northeurope\",\r\n\"southafricanorth\",\r\n\"southcentralus\",\r\n\"southeastasia\",\r\n\"switzerlandnorth\",\r\n\"uksouth\",\r\n\"ukwest\",\r\n\"westcentralus\",\r\n\"westeurope\",\r\n\"westus\",\r\n\"westus2\"\r\n]"
+            "jsonData": "[\r\n\"australiacentral\",\r\n\"australiasoutheast\",\r\n\"canadacentral\",\r\n\"centralindia\",\r\n\"centralus\",\r\n\"eastasia\",\r\n\"eastus\",\r\n\"eastus2\",\r\n\"francecentral\",\r\n\"germanywestcentral\",\r\n\"japaneast\",\r\n\"koreacentral\",\r\n\"northcentralus\",\r\n\"northeurope\",\r\n\"southafricanorth\",\r\n\"southcentralus\",\r\n\"southeastasia\",\r\n\"switzerlandnorth\",\r\n\"uksouth\",\r\n\"ukwest\",\r\n\"westcentralus\",\r\n\"westeurope\",\r\n\"westus\",\r\n\"westus2\",\r\n\"australiaeast\"\r\n]"
           },
           {
             "id": "350cc656-5650-4941-b6c4-455e37f6355c",


### PR DESCRIPTION
## PR Checklist

* [ ] Explain your changes, so people looking at the PR know *what* and *why*, the code changes are the *how*.

This change is adding "Australia East" to the list of supported regions. Create New Profile location will new have this new region.
![image](https://user-images.githubusercontent.com/36055117/118886159-7105f180-b8ad-11eb-9cc6-5051f018f566.png)

[Use this link to test out this change using private deployment build](https://ms.portal.azure.com/?feature.includePreviewTemplates=true&feature.localtemplates=true&feature.workloadinsights=true&feature.workbookGalleryRedirect=https%3A%2F%2Farunamanagedappstorage.blob.core.windows.net%2Fwli-ama-alerts-vu%2Fpackage#blade/Microsoft_Azure_Monitoring/AzureMonitoringBrowseBlade/sqlWorkloadInsights)


### If adding or updating templates:
* [ ] post a screenshot of templates and/or gallery changes
* [ ] ensure your template has a corresponding gallery entry in the gallery folder
* [ ] If you are adding a new template, add your team and template/gallery file(s) to the CODEOWNERS file. CODEOWNERS entries should be teams, not individuals
* [ ] ensure all steps have meaningful names
* [ ] ensure all parameters and grid columns have display names set so they can be localized
* [ ] ensure that parameters id values are unique __or they will fail PR validation__ (parameter ids are used for localization)
* [ ] ensure that steps names are unique __or they will fail PR validation__ (step names are used for localization)
* [ ] grep `/subscription/` and ensure that your parameters don't have any hardcoded resourceIds __or they will fail PR validation__
* [ ] remove `fallbackResourceIds` and `fromTemplateId` fields from your template workbook __or they will fail PR validation__