### PR TITLE
Allow threshold to be added to the query template

### DIFF
--- a/Workbooks/SapMonitor/Alerts/Create Alert rule (step 1 of 2)/Create Alert rule (step 1 of 2).workbook
+++ b/Workbooks/SapMonitor/Alerts/Create Alert rule (step 1 of 2)/Create Alert rule (step 1 of 2).workbook
@@ -627,7 +627,7 @@
             "version": "KqlParameterItem/1.0",
             "name": "QueryWithProviderInstance",
             "type": 1,
-            "query": "Resources\r\n| take 1\r\n| project templateQuery = dynamic(\"{AlertQuery}\")\r\n| extend query = tostring(templateQuery)\r\n| extend pInstance = replace(@'\\{ProviderInstance\\}', @'{ProviderInstance}', query)\r\n| extend replaceAggregate = replace(@'\\{Aggregate\\}', @'{AggregateKustoParameter}', pInstance)\r\n| project id=replaceAggregate",
+            "query": "Resources\r\n| take 1\r\n| project templateQuery = dynamic(\"{AlertQuery}\")\r\n| extend query = tostring(templateQuery)\r\n| extend pInstance = replace(@'\\{ProviderInstance\\}', @'{ProviderInstance}', query)\r\n| extend replaceAggregate = replace(@'\\{Aggregate\\}', @'{AggregateKustoParameter}', pInstance)\r\n| extend replaceThreshold = replace(@'\\{AlertThreshold\\}', @'{AlertThreshold}', replaceAggregate)\r\n| project id=replaceThreshold",
             "crossComponentResources": [
               "value::all"
             ],


### PR DESCRIPTION
## PR Checklist

* [x] Explain your changes, so people looking at the PR know *what* and *why*, the code changes are the *how*.

### If adding or updating templates:
* [ ] post a screenshot of templates and/or gallery changes
* [ ] ensure your template has a corresponding gallery entry in the gallery folder
* [ ] If you are adding a new template, add your team and template/gallery file(s) to the CODEOWNERS file. CODEOWNERS entries should be teams, not individuals
* [ ] ensure all steps have meaningful names
* [ ] ensure all parameters and grid columns have display names set so they can be localized
* [ ] ensure that parameters id values are unique __or they will fail PR validation__ (parameter ids are used for localization)
* [ ] ensure that steps names are unique __or they will fail PR validation__ (step names are used for localization)
* [x] grep `/subscription/` and ensure that your parameters don't have any hardcoded resourceIds __or they will fail PR validation__
* [x] remove `fallbackResourceIds` and `fromTemplateId` fields from your template workbook __or they will fail PR validation__

Allow alert threshold to be added to the query template
No UI change
Manually tested, saw {AlertThreshold} got replaced with the actual threshold value