### PR TITLE
Hide alerts button

### DIFF
--- a/Workbooks/SapMonitor/MsSqlServer/MsSqlServer.workbook
+++ b/Workbooks/SapMonitor/MsSqlServer/MsSqlServer.workbook
@@ -240,6 +240,10 @@
           }
         ]
       },
+      "conditionalVisibility": {
+        "parameterName": "dummy_neverset",
+        "comparison": "isNotEqualTo"
+      },
       "customWidth": "30",
       "name": "links - 23"
     },

--- a/Workbooks/SapMonitor/SapNetWeaver/SapNetWeaver.workbook
+++ b/Workbooks/SapMonitor/SapNetWeaver/SapNetWeaver.workbook
@@ -118,6 +118,7 @@
             "linkTarget": "WorkbookTemplate",
             "linkLabel": "Alerts",
             "style": "primary",
+            "linkIsContextBlade": true,
             "workbookContext": {
               "componentIdSource": "workbook",
               "resourceIdsSource": "workbook",
@@ -158,6 +159,10 @@
           "parameterName": "param_check_provider_error",
           "comparison": "isNotEqualTo",
           "value": "-1"
+        },
+        {
+          "parameterName": "dummy_neverset",
+          "comparison": "isNotEqualTo"
         }
       ],
       "name": "Alert Button Step"


### PR DESCRIPTION
## PR Checklist

* [x] Explain your changes, so people looking at the PR know *what* and *why*, the code changes are the *how*.

### If adding or updating templates:
* [ ] post a screenshot of templates and/or gallery changes
* [ ] ensure your template has a corresponding gallery entry in the gallery folder
* [ ] If you are adding a new template, add your team and template/gallery file(s) to the CODEOWNERS file. CODEOWNERS entries should be teams, not individuals
* [ ] ensure all steps have meaningful names
* [ ] ensure all parameters and grid columns have display names set so they can be localized
* [ ] ensure that parameters id values are unique __or they will fail PR validation__ (parameter ids are used for localization)
* [ ] ensure that steps names are unique __or they will fail PR validation__ (step names are used for localization)
* [ ] grep `/subscription/` and ensure that your parameters don't have any hardcoded resourceIds __or they will fail PR validation__
* [ ] remove `fallbackResourceIds` and `fromTemplateId` fields from your template workbook __or they will fail PR validation__

Need to hide alerts button as we want to release them all at the same time
Fixed Netweaver alert button to open in context pane