### PR TITLE
Workbooks for visualizing SQL Query Store data collected by telegraf

### DIFF
--- a/Workbooks/Workloads/QDS/AlertRule.json
+++ b/Workbooks/Workloads/QDS/AlertRule.json
@@ -1,0 +1,165 @@
+{
+  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "workbookNames": {
+      "type": "object",
+      "defaultValue": {
+        "AlertRule": "[guid(resourceGroup().id, 'Alert Rule')]"
+      }
+    }
+  },
+  "variables": {
+    "workbookMarkup": {
+      "version": "Notebook/1.0",
+      "items": [
+        {
+          "type": 9,
+          "content": {
+            "version": "KqlParameterItem/1.0",
+            "parameters": [
+              {
+                "id": "bfaeb080-dacd-443c-85c0-648a42df1671",
+                "version": "KqlParameterItem/1.0",
+                "name": "database",
+                "type": 1
+              },
+              {
+                "id": "34a33a3b-8300-4054-9c97-2b862b419b1c",
+                "version": "KqlParameterItem/1.0",
+                "name": "MetricNamespace",
+                "type": 1
+              },
+              {
+                "id": "6bcc76c9-a88e-48b0-bca0-7ceba0d5bd02",
+                "version": "KqlParameterItem/1.0",
+                "name": "MetricCategory",
+                "type": 1,
+                "value": ""
+              },
+              {
+                "id": "3f7c4a4e-01c3-4ddd-944d-6a737ad3d9af",
+                "version": "KqlParameterItem/1.0",
+                "name": "MetricName",
+                "type": 1
+              },
+              {
+                "id": "a3e55cdd-b16b-4e1a-a36c-dcb6b99ecfb4",
+                "version": "KqlParameterItem/1.0",
+                "name": "databaseInternal",
+                "type": 5,
+                "query": "{\"version\":\"1.0.0\",\"content\":\"{\\\"value\\\":\\\"{database}\\\", \\\"selected\\\" : true}\",\"transformers\":null}",
+                "typeSettings": {
+                  "additionalResourceOptions": [],
+                  "showDefault": false
+                },
+                "queryType": 8
+              },
+              {
+                "id": "85764f02-345b-4860-b9ca-c97485b15cac",
+                "version": "KqlParameterItem/1.0",
+                "name": "LocalizedName",
+                "type": 1,
+                "query": "{\"version\":\"ARMEndpoint/1.0\",\"data\":null,\"headers\":[],\"method\":\"GET\",\"path\":\"{database}/providers/microsoft.insights/metricDefinitions?api-version=2018-01-01\",\"urlParams\":[],\"batchDisabled\":false,\"transformers\":[{\"type\":\"jsonpath\",\"settings\":{\"tablePath\":\"$.value[?(@.namespace.toLowerCase()==\\\"{MetricNamespace}\\\".toLowerCase() && @.name.value==\\\"{MetricName}\\\")].name.localizedValue\",\"columns\":[]}}]}",
+                "queryType": 12
+              },
+              {
+                "id": "c4e8b869-6ec0-40c1-82b3-f178a3eb8dbf",
+                "version": "KqlParameterItem/1.0",
+                "name": "AlertRuleMetricId",
+                "type": 1,
+                "query": "{\"version\":\"1.0.0\",\"content\":\"\\\"{MetricNamespace}-{MetricCategory}-{MetricName}\\\"\",\"transformers\":null}",
+                "queryType": 8
+              }
+            ],
+            "style": "pills",
+            "queryType": 12
+          },
+          "conditionalVisibility": {
+            "parameterName": "hide",
+            "comparison": "isNotEqualTo"
+          },
+          "name": "parameters"
+        },
+        {
+          "type": 1,
+          "content": {
+            "json": "# Alert Rules\r\n## Database: {databaseInternal:name}  \r\n## Metric: {LocalizedName}"
+          },
+          "name": "text - 1"
+        },
+        {
+          "type": 3,
+          "content": {
+            "version": "KqlItem/1.0",
+            "query": "where type =~ 'microsoft.insights/metricalerts'\r\n| where properties.scopes[0] =~ '{database}'\r\n| where properties.criteria.allOf[0].metricNamespace =~ '{MetricNamespace}'\r\n| where properties.criteria.allOf[0].metricName =~ '{MetricName}'\r\n| extend linkParams = pack(\"alertId\", id, \"alertRule\", pack(\"id\",id, \"name\", name, \"location\", location, \"tags\", tags, \"properties\",properties))\r\n| project Name = name, Aggregation = properties.criteria.allOf[0].timeAggregation, Operator = properties.criteria.allOf[0].operator, Threshold = properties.criteria.allOf[0].threshold, link = strcat(\"https://ms.portal.azure.com/#blade/Microsoft_Azure_Monitoring/UpdateVNextAlertRuleBlade/ruleInputs/\", replace(\"\\\\+\", \"%20\", url_encode(tostring(linkParams))))",
+            "size": 0,
+            "queryType": 1,
+            "resourceType": "microsoft.resourcegraph/resources",
+            "crossComponentResources": [
+              "value::all"
+            ],
+            "gridSettings": {
+              "formatters": [
+                {
+                  "columnMatch": "Name",
+                  "formatter": 1,
+                  "formatOptions": {
+                    "linkColumn": "link",
+                    "linkTarget": "Url",
+                    "bladeOpenContext": {
+                      "bladeName": "UpdateVNextAlertRuleBlade",
+                      "extensionName": "Microsoft_Azure_Monitoring",
+                      "bladeParameters": []
+                    }
+                  }
+                },
+                {
+                  "columnMatch": "Aggregation",
+                  "formatter": 1
+                },
+                {
+                  "columnMatch": "Operator",
+                  "formatter": 1
+                },
+                {
+                  "columnMatch": "Threshold",
+                  "formatter": 1
+                },
+                {
+                  "columnMatch": "link",
+                  "formatter": 5
+                }
+              ]
+            }
+          },
+          "name": "query - 2"
+        }
+      ],
+      "fallbackResourceIds": [
+      ],
+      "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
+    },
+    "workbookDisplayName": "Alert Rule",
+    "workbookName": "[parameters('workbookNames').AlertRule]"
+  },
+  "resources": [
+    {
+      "name": "[variables('workbookName')]",
+      "type": "microsoft.insights/workbooks",
+      "location": "[resourceGroup().location]",
+      "apiVersion": "2018-06-17-preview",
+      "kind": "shared",
+      "properties": {
+        "displayName": "[variables('workbookDisplayName')]",
+        "serializedData": "[string(variables('workbookMarkup'))]",
+        "version": "Notebook/1.0",
+        "sourceId": "[resourceGroup().id]",
+        "category": "workbook"
+      },
+      "tags": {
+        "hidden-title": "[variables('workbookDisplayName')]"
+      }
+    }
+  ]
+}

--- a/Workbooks/Workloads/QDS/Blocking.json
+++ b/Workbooks/Workloads/QDS/Blocking.json
@@ -1,0 +1,368 @@
+{
+  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "workbookNames": {
+      "type": "object",
+      "defaultValue": {
+        "Blocking": "[guid(resourceGroup().id, 'Blocking')]",
+        "Query": "[guid(resourceGroup().id, 'Query')]"
+      }
+    }
+  },
+  "variables": {
+    "workbookMarkup": {
+      "version": "Notebook/1.0",
+      "items": [
+        {
+          "type": 9,
+          "content": {
+            "version": "KqlParameterItem/1.0",
+            "crossComponentResources": [
+              "{WsResourcesInternal}"
+            ],
+            "parameters": [
+              {
+                "id": "7300e9ec-01ec-4c96-8d24-12b843750628",
+                "version": "KqlParameterItem/1.0",
+                "name": "ResourceId",
+                "type": 1
+              },
+              {
+                "id": "4ecc9f52-2e3f-4c8e-b9ea-f3e2f2583f5b",
+                "version": "KqlParameterItem/1.0",
+                "name": "WsResources",
+                "type": 1
+              },
+              {
+                "id": "f3e20cbc-b692-4b3d-8916-2fd0662ecfe6",
+                "version": "KqlParameterItem/1.0",
+                "name": "WsResourcesInternal",
+                "type": 5,
+                "query": "where id in~ ({WsResources})\r\n| project id, selected=1",
+                "crossComponentResources": [
+                  "value::all"
+                ],
+                "typeSettings": {
+                  "additionalResourceOptions": [],
+                  "showDefault": false
+                },
+                "queryType": 1,
+                "resourceType": "microsoft.resourcegraph/resources"
+              },
+              {
+                "id": "30b86356-1bba-4603-83d1-835b99171066",
+                "version": "KqlParameterItem/1.0",
+                "name": "Timerange",
+                "type": 4,
+                "value": {
+                  "durationMs": 86400000
+                },
+                "typeSettings": {
+                  "selectableValues": [
+                    {
+                      "durationMs": 300000
+                    },
+                    {
+                      "durationMs": 900000
+                    },
+                    {
+                      "durationMs": 1800000
+                    },
+                    {
+                      "durationMs": 3600000
+                    },
+                    {
+                      "durationMs": 14400000
+                    },
+                    {
+                      "durationMs": 43200000
+                    },
+                    {
+                      "durationMs": 86400000
+                    },
+                    {
+                      "durationMs": 172800000
+                    },
+                    {
+                      "durationMs": 259200000
+                    },
+                    {
+                      "durationMs": 604800000
+                    },
+                    {
+                      "durationMs": 1209600000
+                    },
+                    {
+                      "durationMs": 2419200000
+                    },
+                    {
+                      "durationMs": 2592000000
+                    },
+                    {
+                      "durationMs": 5184000000
+                    },
+                    {
+                      "durationMs": 7776000000
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "2d2c915f-1d47-4be1-b17f-13d0ac55ce43",
+                "version": "KqlParameterItem/1.0",
+                "name": "EventTime",
+                "type": 1
+              },
+              {
+                "id": "128bda6f-44a9-4ea7-94b8-f070763bc568",
+                "version": "KqlParameterItem/1.0",
+                "name": "QueryWorkbook",
+                "type": 1,
+                "value": "[resourceId('microsoft.insights/workbooks', parameters('workbookNames').Query)]"
+              },
+              {
+                "id": "bbc89d92-c4bb-4aef-98cf-39c9a18a92fc",
+                "version": "KqlParameterItem/1.0",
+                "name": "Type",
+                "type": 1
+              },
+              {
+                "id": "668f1adb-a570-4865-99f2-0bb82d52e3bd",
+                "version": "KqlParameterItem/1.0",
+                "name": "SessionId",
+                "type": 1
+              },
+              {
+                "id": "61f30f48-ad25-4e59-9689-5652864b2262",
+                "version": "KqlParameterItem/1.0",
+                "name": "BlockingSessionId",
+                "type": 1
+              },
+              {
+                "id": "d9c0892a-b504-470b-a707-dca8ad3585a1",
+                "version": "KqlParameterItem/1.0",
+                "name": "dbType",
+                "type": 1,
+                "value": "AzureSQLDB"
+              },
+              {
+                "id": "f007585c-c99e-47f2-ad48-6400068214a1",
+                "version": "KqlParameterItem/1.0",
+                "name": "BlockingHash",
+                "type": 1,
+                "query": "InsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace == 'sqlserver_requests'\r\n| where TimeGenerated == '{EventTime}'\r\n| summarize make_bag(pack(Name, Val)), make_list(pack('name', Name, 'value', Val)) by Tags\r\n| evaluate bag_unpack(bag_)\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| where session_id == '{BlockingSessionId}'\r\n| project query_hash",
+                "crossComponentResources": [
+                  "{WsResourcesInternal}"
+                ],
+                "timeContext": {
+                  "durationMs": 0
+                },
+                "timeContextFromParameter": "Timerange",
+                "queryType": 0,
+                "resourceType": "microsoft.operationalinsights/workspaces"
+              },
+              {
+                "version": "KqlParameterItem/1.0",
+                "name": "BlockedHash",
+                "type": 1,
+                "query": "InsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace == 'sqlserver_requests'\r\n| where TimeGenerated == '{EventTime}'\r\n| summarize make_bag(pack(Name, Val)), make_list(pack('name', Name, 'value', Val)) by Tags\r\n| evaluate bag_unpack(bag_)\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| where session_id == '{SessionId}'\r\n| project query_hash",
+                "crossComponentResources": [
+                  "{WsResourcesInternal}"
+                ],
+                "timeContext": {
+                  "durationMs": 0
+                },
+                "timeContextFromParameter": "Timerange",
+                "queryType": 0,
+                "resourceType": "microsoft.operationalinsights/workspaces",
+                "id": "747c532b-d4e3-4cac-9fa4-f26385e10632"
+              }
+            ],
+            "style": "pills",
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          },
+          "conditionalVisibility": {
+            "parameterName": "hide",
+            "comparison": "isNotEqualTo"
+          },
+          "name": "parameters - 0"
+        },
+        {
+          "type": 1,
+          "content": {
+            "json": "# Blocking\r\nTime: {EventTime}"
+          },
+          "name": "text - 3"
+        },
+        {
+          "type": 11,
+          "content": {
+            "version": "LinkItem/1.0",
+            "style": "list",
+            "links": [
+              {
+                "id": "e406ea87-bbac-479e-b126-8959f8a6f298",
+                "cellValue": "{QueryWorkbook}",
+                "linkTarget": "WorkbookTemplate",
+                "linkLabel": "{BlockedHash}",
+                "preText": "Blocked query:",
+                "style": "link",
+                "workbookContext": {
+                  "componentIdSource": "workbook",
+                  "resourceIdsSource": "workbook",
+                  "templateIdSource": "cell",
+                  "templateId": "wbLink",
+                  "typeSource": "workbook",
+                  "gallerySource": "workbook",
+                  "locationSource": "default",
+                  "passSpecificParams": true,
+                  "templateParameters": [
+                    {
+                      "name": "WsResources",
+                      "source": "parameter",
+                      "value": "WsResources"
+                    },
+                    {
+                      "name": "Timerange",
+                      "source": "parameter",
+                      "value": "Timerange"
+                    },
+                    {
+                      "name": "QueryHash",
+                      "source": "parameter",
+                      "value": "BlockedHash"
+                    },
+                    {
+                      "name": "dbType",
+                      "source": "parameter",
+                      "value": "dbType"
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "9f1aac38-b8ce-4b81-b545-981e08cb82e5",
+                "cellValue": "{QueryWorkbook}",
+                "linkTarget": "WorkbookTemplate",
+                "linkLabel": "{BlockingHash}",
+                "preText": "Blocking query:",
+                "style": "link",
+                "workbookContext": {
+                  "componentIdSource": "workbook",
+                  "resourceIdsSource": "workbook",
+                  "templateIdSource": "cell",
+                  "templateId": "wbLink",
+                  "typeSource": "workbook",
+                  "gallerySource": "workbook",
+                  "locationSource": "default",
+                  "passSpecificParams": true,
+                  "templateParameters": [
+                    {
+                      "name": "WsResources",
+                      "source": "parameter",
+                      "value": "WsResources"
+                    },
+                    {
+                      "name": "Timerange",
+                      "source": "parameter",
+                      "value": "Timerange"
+                    },
+                    {
+                      "name": "QueryHash",
+                      "source": "parameter",
+                      "value": "BlockingHash"
+                    },
+                    {
+                      "name": "dbType",
+                      "source": "parameter",
+                      "value": "dbType"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "name": "links - 3"
+        },
+        {
+          "type": 3,
+          "content": {
+            "version": "KqlItem/1.0",
+            "query": "let data = InsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace == 'sqlserver_requests'\r\n| where TimeGenerated == '{EventTime}'\r\n| summarize make_bag(pack(Name, Val)), make_list(pack('name', Name, 'value', Val)) by Tags\r\n| evaluate bag_unpack(bag_)\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| where session_id in ('{SessionId}', '{BlockingSessionId}')\r\n| extend Type = case(session_id =='{SessionId}', 'Blocked', 'Blocking');\r\nlet tags = \r\ndata\r\n| summarize buildschema(todynamic(Tags)) by Tags, Type\r\n| mv-expand schema_Tags\r\n| extend Tags = todynamic(Tags)\r\n| extend tag = extract(@'\\{\"([^\"]+)\":\".+\"\\}', 1, tostring(schema_Tags))\r\n| project name = strcat(toupper(substring(tag,0,1)), replace(@'^(.)',@'', replace('_',' ',tag))), Value = Tags[tag], Type;\r\nlet blocking_tags = \r\ntags\r\n| where Type == 'Blocking'\r\n| project name, Blocking = Value;\r\nlet blocked_tags = \r\ntags\r\n| where Type == 'Blocked'\r\n| project name, Blocked = Value;\r\nlet joined_tags = \r\nblocking_tags\r\n| join blocked_tags on name\r\n| project name, Blocking, Blocked;\r\nlet measures = data\r\n| mv-expand list_\r\n| extend name = tostring(list_.name)\r\n| project name = strcat(toupper(substring(name,0,1)), replace(@'^(.)',@'', replace('_',' ',name))), Value = list_.value, Type;\r\nlet blocking_measures = \r\nmeasures\r\n| where Type == 'Blocking'\r\n| project name, Blocking = Value;\r\nlet blocked_measures = \r\nmeasures\r\n| where Type == 'Blocked'\r\n| project name, Blocked = Value;\r\nlet joined_measures = \r\nblocked_measures\r\n| join blocking_measures on name\r\n| project name, Blocking, Blocked;\r\njoined_tags\r\n| union joined_measures",
+            "size": 3,
+            "title": "Details",
+            "timeContext": {
+              "durationMs": 86400000
+            },
+            "timeContextFromParameter": "Timerange",
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces",
+            "crossComponentResources": [
+              "{WsResourcesInternal}"
+            ],
+            "gridSettings": {
+              "formatters": [
+                {
+                  "columnMatch": "name",
+                  "formatter": 18,
+                  "formatOptions": {
+                    "thresholdsOptions": "colors",
+                    "thresholdsGrid": [
+                      {
+                        "operator": "Default",
+                        "thresholdValue": null,
+                        "representation": "gray",
+                        "text": "{0}{1}"
+                      }
+                    ],
+                    "customColumnWidthSetting": "25ch"
+                  }
+                }
+              ],
+              "labelSettings": [
+                {
+                  "columnId": "name",
+                  "label": " "
+                },
+                {
+                  "columnId": "Blocking"
+                },
+                {
+                  "columnId": "Blocked"
+                }
+              ]
+            },
+            "sortBy": []
+          },
+          "name": "query - 1 - Copy"
+        }
+      ],
+      "fallbackResourceIds": [
+      ],
+      "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
+    },
+    "workbookDisplayName": "Blocking",
+    "workbookName": "[parameters('workbookNames').Blocking]"
+  },
+  "resources": [
+    {
+      "name": "[variables('workbookName')]",
+      "type": "microsoft.insights/workbooks",
+      "location": "[resourceGroup().location]",
+      "apiVersion": "2018-06-17-preview",
+      "kind": "shared",
+      "properties": {
+        "displayName": "[variables('workbookDisplayName')]",
+        "serializedData": "[string(variables('workbookMarkup'))]",
+        "version": "Notebook/1.0",
+        "sourceId": "[resourceGroup().id]",
+        "category": "workbook"
+      },
+      "tags": {
+        "hidden-title": "[variables('workbookDisplayName')]"
+      }
+    }
+  ]
+}

--- a/Workbooks/Workloads/QDS/Blockings.json
+++ b/Workbooks/Workloads/QDS/Blockings.json
@@ -1,0 +1,972 @@
+{
+  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "workbookNames": {
+      "type": "object",
+      "defaultValue": {
+        "Blockings": "[guid(resourceGroup().id, 'Blockings')]",
+        "Database": "[guid(resourceGroup().id, 'Database')]",
+        "Blocking": "[guid(resourceGroup().id, 'Blocking')]"
+      }
+    }
+  },
+  "variables": {
+    "workbookMarkup": {
+      "version": "Notebook/1.0",
+      "items": [
+        {
+          "type": 9,
+          "content": {
+            "version": "KqlParameterItem/1.0",
+            "crossComponentResources": [
+              "{WsResourcesInternal}"
+            ],
+            "parameters": [
+              {
+                "id": "4ecc9f52-2e3f-4c8e-b9ea-f3e2f2583f5b",
+                "version": "KqlParameterItem/1.0",
+                "name": "WsResources",
+                "type": 1
+              },
+              {
+                "id": "f3e20cbc-b692-4b3d-8916-2fd0662ecfe6",
+                "version": "KqlParameterItem/1.0",
+                "name": "WsResourcesInternal",
+                "type": 5,
+                "multiSelect": true,
+                "quote": "'",
+                "delimiter": ",",
+                "query": "where id in~ ({WsResources})\r\n| project id, selected=1",
+                "crossComponentResources": [
+                  "value::all"
+                ],
+                "typeSettings": {
+                  "additionalResourceOptions": [],
+                  "showDefault": false
+                },
+                "queryType": 1,
+                "resourceType": "microsoft.resourcegraph/resources"
+              },
+              {
+                "id": "30b86356-1bba-4603-83d1-835b99171066",
+                "version": "KqlParameterItem/1.0",
+                "name": "Timerange",
+                "type": 4,
+                "value": {
+                  "durationMs": 86400000
+                },
+                "typeSettings": {
+                  "selectableValues": [
+                    {
+                      "durationMs": 300000
+                    },
+                    {
+                      "durationMs": 900000
+                    },
+                    {
+                      "durationMs": 1800000
+                    },
+                    {
+                      "durationMs": 3600000
+                    },
+                    {
+                      "durationMs": 14400000
+                    },
+                    {
+                      "durationMs": 43200000
+                    },
+                    {
+                      "durationMs": 86400000
+                    },
+                    {
+                      "durationMs": 172800000
+                    },
+                    {
+                      "durationMs": 259200000
+                    },
+                    {
+                      "durationMs": 604800000
+                    },
+                    {
+                      "durationMs": 1209600000
+                    },
+                    {
+                      "durationMs": 2419200000
+                    },
+                    {
+                      "durationMs": 2592000000
+                    },
+                    {
+                      "durationMs": 5184000000
+                    },
+                    {
+                      "durationMs": 7776000000
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "f2ae16b9-0bea-4ad0-b14e-93a51424fab9",
+                "version": "KqlParameterItem/1.0",
+                "name": "DBWorkbook",
+                "type": 1,
+                "value": "[resourceId('microsoft.insights/workbooks', parameters('workbookNames').Database)]"
+              },
+              {
+                "id": "58ec8e26-5dac-4c4c-9441-47daa7adf18f",
+                "version": "KqlParameterItem/1.0",
+                "name": "SubscriptionId",
+                "type": 1,
+                "value": ""
+              },
+              {
+                "id": "d2d2fa1b-070a-45d8-94ec-411c60379803",
+                "version": "KqlParameterItem/1.0",
+                "name": "ServerId",
+                "type": 1,
+                "value": ""
+              },
+              {
+                "id": "be50e0a3-ec3a-4b7d-bd17-006135b6e356",
+                "version": "KqlParameterItem/1.0",
+                "name": "blockingDetailsLink",
+                "type": 1,
+                "value": "[resourceId('microsoft.insights/workbooks', parameters('workbookNames').Blocking)]"
+              },
+              {
+                "id": "4adf7337-0c81-48ab-97a9-5917de6da6c0",
+                "version": "KqlParameterItem/1.0",
+                "name": "DbId",
+                "type": 1
+              },
+              {
+                "id": "4feafee7-0cd9-435e-a42e-11f31984c024",
+                "version": "KqlParameterItem/1.0",
+                "name": "Type",
+                "type": 1
+              },
+              {
+                "id": "55c27380-5130-4c43-97da-155327e6bc93",
+                "version": "KqlParameterItem/1.0",
+                "name": "TypeInternal",
+                "type": 7,
+                "query": "{\"version\":\"1.0.0\",\"content\":\"{\\\"value\\\":\\\"{Type}\\\", \\\"selected\\\":true}\",\"transformers\":null}",
+                "typeSettings": {
+                  "additionalResourceOptions": [],
+                  "showDefault": false
+                },
+                "queryType": 8
+              },
+              {
+                "id": "104bb4aa-c4b1-4ff5-a53f-4cb22d20e009",
+                "version": "KqlParameterItem/1.0",
+                "name": "dbType",
+                "type": 1
+              },
+              {
+                "id": "d8bb41fb-46fc-4cd8-a8a6-cead75ba2a32",
+                "version": "KqlParameterItem/1.0",
+                "name": "MonitoredResources",
+                "type": 9,
+                "multiSelect": true,
+                "quote": "'",
+                "delimiter": ",",
+                "query": "InsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace == 'sqlserver_performance'\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| project dbName = tolower(strcat(extract(\"^([^\\\\.]+)\\\\.?\", 1, sql_instance), '/', database_name))\r\n| distinct dbName",
+                "crossComponentResources": [
+                  "{WsResourcesInternal}"
+                ],
+                "timeContext": {
+                  "durationMs": 0
+                },
+                "timeContextFromParameter": "Timerange",
+                "queryType": 0,
+                "resourceType": "microsoft.operationalinsights/workspaces"
+              },
+              {
+                "id": "3f3783df-3615-4c1d-a49d-236526c12704",
+                "version": "KqlParameterItem/1.0",
+                "name": "Resources_blockings",
+                "type": 9,
+                "multiSelect": true,
+                "quote": "",
+                "delimiter": ",",
+                "query": "where type contains '{Type}'\r\n| extend ResourceId = tolower(id)\r\n| extend name = tolower(strcat(extract(tolower('/{Type}/([^/]+)/'), 1, ResourceId), '/', name))\r\n| where name in ({MonitoredResources})\r\n| project strcat('{\"name\":\"',name, '\" , \"subscription\": \"', subscriptionId, '\", \"resourceGroup\": \"', resourceGroup, '\"}')",
+                "crossComponentResources": [
+                  "value::all"
+                ],
+                "timeContext": {
+                  "durationMs": 0
+                },
+                "timeContextFromParameter": "Timerange",
+                "queryType": 1,
+                "resourceType": "microsoft.resourcegraph/resources"
+              }
+            ],
+            "style": "pills",
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          },
+          "conditionalVisibility": {
+            "parameterName": "hide",
+            "comparison": "isNotEqualTo"
+          },
+          "name": "parameters - 0"
+        },
+        {
+          "type": 1,
+          "content": {
+            "json": "# Blockings"
+          },
+          "name": "text - 3"
+        },
+        {
+          "type": 1,
+          "content": {
+            "json": "Data is loading",
+            "style": "info"
+          },
+          "conditionalVisibility": {
+            "parameterName": "Resources_blockings",
+            "comparison": "isEqualTo"
+          },
+          "name": "text - 3"
+        },
+        {
+          "type": 12,
+          "content": {
+            "version": "NotebookGroup/1.0",
+            "groupType": "editable",
+            "items": [
+              {
+                "type": 1,
+                "content": {
+                  "json": "## Subscriptions"
+                },
+                "name": "text - 9"
+              },
+              {
+                "type": 3,
+                "content": {
+                  "version": "KqlItem/1.0",
+                  "query": "let resources = print dynamic([{Resources_blockings}])\r\n| mv-expand print_0\r\n| evaluate bag_unpack(print_0);\r\nInsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace == 'sqlserver_performance'\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| where counter == 'Lock Waits/sec'\r\n| extend resourceName = tolower(strcat(extract(\"^([^\\\\.]+)\\\\.?\", 1, sql_instance), '/', database_name))\r\n| join kind=leftouter (resources| extend resourceName = name)on resourceName\r\n| order by resourceName, TimeGenerated asc\r\n| serialize\r\n| extend delta = case(prev(resourceName) == resourceName, Val - prev(Val), real(null))\r\n| summarize Blockings = sum(delta) by subscription\r\n| sort by Blockings desc",
+                  "size": 1,
+                  "timeContext": {
+                    "durationMs": 86400000
+                  },
+                  "timeContextFromParameter": "Timerange",
+                  "exportFieldName": "subscription",
+                  "exportParameterName": "SubscriptionId",
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "crossComponentResources": [
+                    "{WsResourcesInternal}"
+                  ],
+                  "gridSettings": {
+                    "formatters": [
+                      {
+                        "columnMatch": "subscription",
+                        "formatter": 15,
+                        "formatOptions": {
+                          "linkTarget": null,
+                          "showIcon": true
+                        }
+                      }
+                    ],
+                    "labelSettings": [
+                      {
+                        "columnId": "subscription",
+                        "label": "Subscription"
+                      },
+                      {
+                        "columnId": "Blockings",
+                        "label": ""
+                      }
+                    ]
+                  }
+                },
+                "customWidth": "40",
+                "name": "query - 4"
+              },
+              {
+                "type": 3,
+                "content": {
+                  "version": "KqlItem/1.0",
+                  "query": "let resources = print dynamic([{Resources_blockings}])\r\n| mv-expand print_0\r\n| evaluate bag_unpack(print_0);\r\nInsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace == 'sqlserver_performance'\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| where counter == 'Lock Waits/sec'\r\n| extend resourceName = tolower(strcat(extract(\"^([^\\\\.]+)\\\\.?\", 1, sql_instance), '/', database_name))\r\n| join kind=leftouter (resources| extend resourceName = name)on resourceName\r\n| where tostring(subscription) contains '{SubscriptionId}'\r\n| order by resourceName, TimeGenerated asc\r\n| serialize\r\n| extend delta = case(prev(resourceName) == resourceName, case(Val>=prev(Val), Val - prev(Val), Val), real(null))\r\n| project tostring(subscription), blockings = delta, bin(TimeGenerated, {Timerange:grain})\r\n| summarize sum(blockings) by subscription, TimeGenerated",
+                  "size": 1,
+                  "showAnalytics": true,
+                  "timeContext": {
+                    "durationMs": 86400000
+                  },
+                  "timeContextFromParameter": "Timerange",
+                  "exportFieldName": "SubscriptionId",
+                  "exportParameterName": "SubscriptionId",
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "crossComponentResources": [
+                    "{WsResourcesInternal}"
+                  ],
+                  "visualization": "barchart",
+                  "gridSettings": {
+                    "formatters": [
+                      {
+                        "columnMatch": "SubscriptionId",
+                        "formatter": 15,
+                        "formatOptions": {
+                          "linkTarget": null,
+                          "customColumnWidthSetting": "24ch"
+                        }
+                      },
+                      {
+                        "columnMatch": "max_duration",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "14ch"
+                        },
+                        "numberFormat": {
+                          "unit": 24,
+                          "options": {
+                            "style": "decimal",
+                            "useGrouping": false
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "avg_duration",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "14ch"
+                        },
+                        "numberFormat": {
+                          "unit": 24,
+                          "options": {
+                            "style": "decimal",
+                            "useGrouping": false
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "avg_cpu",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "14ch"
+                        },
+                        "numberFormat": {
+                          "unit": 24,
+                          "options": {
+                            "style": "decimal"
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "executions_count",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "13ch"
+                        },
+                        "numberFormat": {
+                          "unit": 17,
+                          "options": {
+                            "style": "decimal"
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "ResourceIdPrefix",
+                        "formatter": 5
+                      }
+                    ],
+                    "labelSettings": [
+                      {
+                        "columnId": "SubscriptionId",
+                        "label": "Subscription"
+                      },
+                      {
+                        "columnId": "max_duration",
+                        "label": "Max"
+                      },
+                      {
+                        "columnId": "avg_duration",
+                        "label": "Avg"
+                      },
+                      {
+                        "columnId": "avg_cpu",
+                        "label": "CPU"
+                      },
+                      {
+                        "columnId": "executions_count",
+                        "label": "Execs"
+                      },
+                      {
+                        "columnId": "ResourceIdPrefix"
+                      }
+                    ]
+                  }
+                },
+                "customWidth": "60",
+                "name": "query - 4 - Copy"
+              },
+              {
+                "type": 1,
+                "content": {
+                  "json": "## {TypeInternal:label}s"
+                },
+                "name": "text - 10"
+              },
+              {
+                "type": 1,
+                "content": {
+                  "json": "SubscriptionID: {SubscriptionId}"
+                },
+                "conditionalVisibility": {
+                  "parameterName": "SubscriptionId",
+                  "comparison": "isNotEqualTo"
+                },
+                "name": "text - 11"
+              },
+              {
+                "type": 3,
+                "content": {
+                  "version": "KqlItem/1.0",
+                  "query": "let resources = print dynamic([{Resources_blockings}])\r\n| mv-expand print_0\r\n| evaluate bag_unpack(print_0);\r\nInsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace == 'sqlserver_performance'\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| where counter == 'Lock Waits/sec'\r\n| extend resourceName = tolower(strcat(extract(\"^([^\\\\.]+)\\\\.?\", 1, sql_instance), '/', database_name))\r\n| join kind=leftouter (resources| extend resourceName = name)on resourceName\r\n| where tostring(subscription) contains '{SubscriptionId}'\r\n| order by resourceName, TimeGenerated asc\r\n| serialize\r\n| extend delta = case(prev(resourceName) == resourceName, Val - prev(Val), real(null))\r\n| summarize Blockings = sum(delta) by sql_instance\r\n| project Type = '{Type}', ['{TypeInternal:label}'] = sql_instance, Blockings, sql_instance\r\n| sort by Blockings desc",
+                  "size": 1,
+                  "timeContext": {
+                    "durationMs": 86400000
+                  },
+                  "timeContextFromParameter": "Timerange",
+                  "exportFieldName": "sql_instance",
+                  "exportParameterName": "ServerId",
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "crossComponentResources": [
+                    "{WsResourcesInternal}"
+                  ],
+                  "gridSettings": {
+                    "formatters": [
+                      {
+                        "columnMatch": "Type",
+                        "formatter": 16,
+                        "formatOptions": {
+                          "showIcon": true,
+                          "customColumnWidthSetting": "4ch"
+                        }
+                      },
+                      {
+                        "columnMatch": "SQL",
+                        "formatter": 1
+                      },
+                      {
+                        "columnMatch": "sql_instance",
+                        "formatter": 5
+                      }
+                    ],
+                    "labelSettings": [
+                      {
+                        "columnId": "Type",
+                        "label": " "
+                      },
+                      {
+                        "columnId": "SQL server"
+                      },
+                      {
+                        "columnId": "Blockings",
+                        "label": ""
+                      },
+                      {
+                        "columnId": "sql_instance"
+                      }
+                    ]
+                  }
+                },
+                "customWidth": "40",
+                "name": "query - 4 - Copy"
+              },
+              {
+                "type": 3,
+                "content": {
+                  "version": "KqlItem/1.0",
+                  "query": "let resources = print dynamic([{Resources_blockings}])\r\n| mv-expand print_0\r\n| evaluate bag_unpack(print_0);\r\nInsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace == 'sqlserver_performance'\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| where counter == 'Lock Waits/sec'\r\n| extend resourceName = tolower(strcat(extract(\"^([^\\\\.]+)\\\\.?\", 1, sql_instance), '/', database_name))\r\n| join kind=leftouter (resources| extend resourceName = name)on resourceName\r\n| where tostring(subscription) contains '{SubscriptionId}'\r\n| where tostring(sql_instance) contains '{ServerId}'\r\n| order by resourceName, TimeGenerated asc\r\n| serialize\r\n| extend delta = case(prev(resourceName) == resourceName, case(Val>=prev(Val), Val - prev(Val), Val), real(null))\r\n| project sql_instance, blockings = delta, bin(TimeGenerated, {Timerange:grain})\r\n| summarize sum(blockings) by sql_instance, TimeGenerated",
+                  "size": 1,
+                  "showAnalytics": true,
+                  "timeContext": {
+                    "durationMs": 86400000
+                  },
+                  "timeContextFromParameter": "Timerange",
+                  "exportFieldName": "SubscriptionId",
+                  "exportParameterName": "SubscriptionId",
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "crossComponentResources": [
+                    "{WsResourcesInternal}"
+                  ],
+                  "visualization": "barchart",
+                  "gridSettings": {
+                    "formatters": [
+                      {
+                        "columnMatch": "SubscriptionId",
+                        "formatter": 15,
+                        "formatOptions": {
+                          "linkTarget": null,
+                          "customColumnWidthSetting": "24ch"
+                        }
+                      },
+                      {
+                        "columnMatch": "max_duration",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "14ch"
+                        },
+                        "numberFormat": {
+                          "unit": 24,
+                          "options": {
+                            "style": "decimal",
+                            "useGrouping": false
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "avg_duration",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "14ch"
+                        },
+                        "numberFormat": {
+                          "unit": 24,
+                          "options": {
+                            "style": "decimal",
+                            "useGrouping": false
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "avg_cpu",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "14ch"
+                        },
+                        "numberFormat": {
+                          "unit": 24,
+                          "options": {
+                            "style": "decimal"
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "executions_count",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "13ch"
+                        },
+                        "numberFormat": {
+                          "unit": 17,
+                          "options": {
+                            "style": "decimal"
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "ResourceIdPrefix",
+                        "formatter": 5
+                      }
+                    ],
+                    "labelSettings": [
+                      {
+                        "columnId": "SubscriptionId",
+                        "label": "Subscription"
+                      },
+                      {
+                        "columnId": "max_duration",
+                        "label": "Max"
+                      },
+                      {
+                        "columnId": "avg_duration",
+                        "label": "Avg"
+                      },
+                      {
+                        "columnId": "avg_cpu",
+                        "label": "CPU"
+                      },
+                      {
+                        "columnId": "executions_count",
+                        "label": "Execs"
+                      },
+                      {
+                        "columnId": "ResourceIdPrefix"
+                      }
+                    ]
+                  }
+                },
+                "customWidth": "60",
+                "name": "query - 4 - Copy - Copy"
+              },
+              {
+                "type": 1,
+                "content": {
+                  "json": "## Databases"
+                },
+                "name": "text - 12"
+              },
+              {
+                "type": 1,
+                "content": {
+                  "json": "Subscription ID: {SubscriptionId}"
+                },
+                "conditionalVisibility": {
+                  "parameterName": "SuubscriptionId",
+                  "comparison": "isNotEqualTo"
+                },
+                "name": "text - 13"
+              },
+              {
+                "type": 1,
+                "content": {
+                  "json": "Server: {ServerId:name}"
+                },
+                "conditionalVisibility": {
+                  "parameterName": "ServerId",
+                  "comparison": "isNotEqualTo"
+                },
+                "name": "text - 14"
+              },
+              {
+                "type": 3,
+                "content": {
+                  "version": "KqlItem/1.0",
+                  "query": "let resources = print dynamic([{Resources_blockings}])\r\n| mv-expand print_0\r\n| evaluate bag_unpack(print_0);\r\nInsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace == 'sqlserver_performance'\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| where counter == 'Lock Waits/sec'\r\n| extend resourceName = tolower(strcat(extract(\"^([^\\\\.]+)\\\\.?\", 1, sql_instance), '/', database_name))\r\n| join kind=leftouter (resources| extend resourceName = name)on resourceName\r\n| where tostring(subscription) contains '{SubscriptionId}'\r\n| where tostring(sql_instance) contains '{ServerId}'\r\n| order by resourceName, TimeGenerated asc\r\n| serialize\r\n| extend delta = case(prev(resourceName) == resourceName, Val - prev(Val), real(null))\r\n| summarize Blockings = sum(delta) by resourceName\r\n| project Type = '{Type}/DATABASES', ResourceId = resourceName, Blockings,    \r\n    wbLink = '{DBWorkbook}'\r\n| sort by Blockings desc",
+                  "size": 1,
+                  "timeContext": {
+                    "durationMs": 86400000
+                  },
+                  "timeContextFromParameter": "Timerange",
+                  "exportedParameters": [
+                    {
+                      "fieldName": "ResourceId",
+                      "parameterName": "DbId"
+                    },
+                    {
+                      "fieldName": "ResourceId",
+                      "parameterName": "ResourceId",
+                      "parameterType": 1
+                    }
+                  ],
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "crossComponentResources": [
+                    "{WsResourcesInternal}"
+                  ],
+                  "gridSettings": {
+                    "formatters": [
+                      {
+                        "columnMatch": "Type",
+                        "formatter": 16,
+                        "formatOptions": {
+                          "showIcon": true,
+                          "customColumnWidthSetting": "4ch"
+                        }
+                      },
+                      {
+                        "columnMatch": "ResourceId",
+                        "formatter": 7,
+                        "formatOptions": {
+                          "linkColumn": "wbLink",
+                          "linkTarget": "WorkbookTemplate",
+                          "workbookContext": {
+                            "componentIdSource": "workbook",
+                            "resourceIdsSource": "workbook",
+                            "templateIdSource": "column",
+                            "templateId": "wbLink",
+                            "typeSource": "workbook",
+                            "gallerySource": "workbook",
+                            "locationSource": "default"
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "wbLink",
+                        "formatter": 5
+                      }
+                    ],
+                    "labelSettings": [
+                      {
+                        "columnId": "Type",
+                        "label": " "
+                      },
+                      {
+                        "columnId": "ResourceId",
+                        "label": "Database"
+                      },
+                      {
+                        "columnId": "Blockings",
+                        "label": ""
+                      },
+                      {
+                        "columnId": "wbLink"
+                      }
+                    ]
+                  },
+                  "sortBy": []
+                },
+                "customWidth": "40",
+                "name": "query - 4 - Copy - Copy"
+              },
+              {
+                "type": 3,
+                "content": {
+                  "version": "KqlItem/1.0",
+                  "query": "let resources = print dynamic([{Resources_blockings}])\r\n| mv-expand print_0\r\n| evaluate bag_unpack(print_0);\r\nInsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace == 'sqlserver_performance'\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| where counter == 'Lock Waits/sec'\r\n| extend resourceName = tolower(strcat(extract(\"^([^\\\\.]+)\\\\.?\", 1, sql_instance), '/', database_name))\r\n| join kind=leftouter (resources| extend resourceName = name)on resourceName\r\n| where tostring(subscription) contains '{SubscriptionId}'\r\n| where tostring(sql_instance) contains '{ServerId}'\r\n| where tostring(resourceName) contains '{DbId}'\r\n| order by resourceName, TimeGenerated asc\r\n| serialize\r\n| extend delta = case(prev(resourceName) == resourceName, case(Val>=prev(Val), Val - prev(Val), Val), real(null))\r\n| project resourceName, blockings = delta, bin(TimeGenerated, {Timerange:grain})\r\n| summarize sum(blockings) by resourceName, TimeGenerated",
+                  "size": 1,
+                  "showAnalytics": true,
+                  "timeContext": {
+                    "durationMs": 86400000
+                  },
+                  "timeContextFromParameter": "Timerange",
+                  "exportFieldName": "SubscriptionId",
+                  "exportParameterName": "SubscriptionId",
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "crossComponentResources": [
+                    "{WsResourcesInternal}"
+                  ],
+                  "visualization": "barchart",
+                  "gridSettings": {
+                    "formatters": [
+                      {
+                        "columnMatch": "SubscriptionId",
+                        "formatter": 15,
+                        "formatOptions": {
+                          "linkTarget": null,
+                          "customColumnWidthSetting": "24ch"
+                        }
+                      },
+                      {
+                        "columnMatch": "max_duration",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "14ch"
+                        },
+                        "numberFormat": {
+                          "unit": 24,
+                          "options": {
+                            "style": "decimal",
+                            "useGrouping": false
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "avg_duration",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "14ch"
+                        },
+                        "numberFormat": {
+                          "unit": 24,
+                          "options": {
+                            "style": "decimal",
+                            "useGrouping": false
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "avg_cpu",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "14ch"
+                        },
+                        "numberFormat": {
+                          "unit": 24,
+                          "options": {
+                            "style": "decimal"
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "executions_count",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "13ch"
+                        },
+                        "numberFormat": {
+                          "unit": 17,
+                          "options": {
+                            "style": "decimal"
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "ResourceIdPrefix",
+                        "formatter": 5
+                      }
+                    ],
+                    "labelSettings": [
+                      {
+                        "columnId": "SubscriptionId",
+                        "label": "Subscription"
+                      },
+                      {
+                        "columnId": "max_duration",
+                        "label": "Max"
+                      },
+                      {
+                        "columnId": "avg_duration",
+                        "label": "Avg"
+                      },
+                      {
+                        "columnId": "avg_cpu",
+                        "label": "CPU"
+                      },
+                      {
+                        "columnId": "executions_count",
+                        "label": "Execs"
+                      },
+                      {
+                        "columnId": "ResourceIdPrefix"
+                      }
+                    ]
+                  }
+                },
+                "customWidth": "60",
+                "name": "query - 4 - Copy - Copy - Copy"
+              },
+              {
+                "type": 1,
+                "content": {
+                  "json": "## Blockings"
+                },
+                "name": "text - 14"
+              },
+              {
+                "type": 3,
+                "content": {
+                  "version": "KqlItem/1.0",
+                  "query": "let resources = print dynamic([{Resources_blockings}])\r\n| mv-expand print_0\r\n| evaluate bag_unpack(print_0);\r\nInsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace == 'sqlserver_requests'\r\n| summarize make_bag(pack(Name, Val)) by Tags, TimeGenerated\r\n| evaluate bag_unpack(bag_)\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| where blocking_session_id !=0\r\n| extend resourceName = tolower(strcat(extract(\"^([^\\\\.]+)\\\\.?\", 1, sql_instance), '/', database_name))\r\n| join kind=leftouter (resources| extend resourceName = name)on resourceName\r\n| where tostring(subscription) contains '{SubscriptionId}'\r\n| where tostring(sql_instance) contains '{ServerId}'\r\n| where tostring(resourceName) contains '{DbId}'\r\n| project\r\n    Type = '{Type}/DATABASES',\r\n    resourceName,\r\n    TimeGenerated,\r\n    Duration = total_elapsed_time_ms / 1000,\r\n    Details = '{blockingDetailsLink}',\r\n    blocking_session_id,\r\n    session_id\r\n| sort by TimeGenerated desc",
+                  "size": 0,
+                  "timeContext": {
+                    "durationMs": 86400000
+                  },
+                  "timeContextFromParameter": "Timerange",
+                  "exportedParameters": [
+                    {
+                      "fieldName": "TimeGenerated",
+                      "parameterName": "EventTime",
+                      "parameterType": 1
+                    },
+                    {
+                      "fieldName": "session_id",
+                      "parameterName": "SessionId",
+                      "parameterType": 1
+                    },
+                    {
+                      "fieldName": "blocking_session_id",
+                      "parameterName": "BlockingSessionId",
+                      "parameterType": 1
+                    },
+                    {
+                      "fieldName": "resourceName",
+                      "parameterName": "ResourceId",
+                      "parameterType": 1
+                    }
+                  ],
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "crossComponentResources": [
+                    "{WsResourcesInternal}"
+                  ],
+                  "gridSettings": {
+                    "formatters": [
+                      {
+                        "columnMatch": "Type",
+                        "formatter": 16,
+                        "formatOptions": {
+                          "showIcon": true,
+                          "customColumnWidthSetting": "4ch"
+                        }
+                      },
+                      {
+                        "columnMatch": "Duration",
+                        "formatter": 0,
+                        "numberFormat": {
+                          "unit": 24,
+                          "options": {
+                            "style": "decimal"
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "Details",
+                        "formatter": 7,
+                        "formatOptions": {
+                          "linkTarget": "WorkbookTemplate",
+                          "linkLabel": "View",
+                          "linkIsContextBlade": true
+                        }
+                      },
+                      {
+                        "columnMatch": "session_id",
+                        "formatter": 5
+                      },
+                      {
+                        "columnMatch": "query_hash",
+                        "formatter": 5
+                      }
+                    ],
+                    "labelSettings": [
+                      {
+                        "columnId": "Type",
+                        "label": " "
+                      },
+                      {
+                        "columnId": "resourceName",
+                        "label": "Database"
+                      },
+                      {
+                        "columnId": "TimeGenerated",
+                        "label": "Time"
+                      },
+                      {
+                        "columnId": "Duration"
+                      },
+                      {
+                        "columnId": "Details"
+                      }
+                    ]
+                  }
+                },
+                "customWidth": "60",
+                "name": "query - 15"
+              }
+            ]
+          },
+          "conditionalVisibility": {
+            "parameterName": "Resources_blockings",
+            "comparison": "isNotEqualTo"
+          },
+          "name": "group - 16"
+        }
+      ],
+      "fallbackResourceIds": [
+      ],
+      "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
+    },
+    "workbookDisplayName": "Blockings",
+    "workbookName": "[parameters('workbookNames').Blockings]"
+  },
+  "resources": [
+    {
+      "name": "[variables('workbookName')]",
+      "type": "microsoft.insights/workbooks",
+      "location": "[resourceGroup().location]",
+      "apiVersion": "2018-06-17-preview",
+      "kind": "shared",
+      "properties": {
+        "displayName": "[variables('workbookDisplayName')]",
+        "serializedData": "[string(variables('workbookMarkup'))]",
+        "version": "Notebook/1.0",
+        "sourceId": "[resourceGroup().id]",
+        "category": "workbook"
+      },
+      "tags": {
+        "hidden-title": "[variables('workbookDisplayName')]"
+      }
+    }
+  ]
+}

--- a/Workbooks/Workloads/QDS/Database.json
+++ b/Workbooks/Workloads/QDS/Database.json
@@ -1,0 +1,1783 @@
+﻿{
+  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "workbookNames": {
+      "type": "object",
+      "defaultValue": {
+        "Database": "[guid(resourceGroup().id, 'Database')]",
+        "Query": "[guid(resourceGroup().id, 'Query')]",
+        "AlertRules": "[guid(resourceGroup().id, 'Alert Rules')]"
+      }
+    }
+  },
+  "variables": {
+    "workbookMarkup": {
+      "version": "Notebook/1.0",
+      "items": [
+        {
+          "type": 9,
+          "content": {
+            "version": "KqlParameterItem/1.0",
+            "parameters": [
+              {
+                "id": "7300e9ec-01ec-4c96-8d24-12b843750628",
+                "version": "KqlParameterItem/1.0",
+                "name": "ResourceId",
+                "type": 1
+              },
+              {
+                "id": "4ecc9f52-2e3f-4c8e-b9ea-f3e2f2583f5b",
+                "version": "KqlParameterItem/1.0",
+                "name": "WsResources",
+                "type": 1
+              },
+              {
+                "id": "f3e20cbc-b692-4b3d-8916-2fd0662ecfe6",
+                "version": "KqlParameterItem/1.0",
+                "name": "WsResourcesInternal",
+                "type": 5,
+                "multiSelect": true,
+                "quote": "'",
+                "delimiter": ",",
+                "query": "where id in~ ({WsResources})\r\n| project id, selected=1",
+                "crossComponentResources": [
+                  "value::all"
+                ],
+                "typeSettings": {
+                  "additionalResourceOptions": [],
+                  "showDefault": false
+                },
+                "queryType": 1,
+                "resourceType": "microsoft.resourcegraph/resources"
+              },
+              {
+                "id": "30b86356-1bba-4603-83d1-835b99171066",
+                "version": "KqlParameterItem/1.0",
+                "name": "Timerange",
+                "type": 4,
+                "value": {
+                  "durationMs": 86400000
+                },
+                "typeSettings": {
+                  "selectableValues": [
+                    {
+                      "durationMs": 300000
+                    },
+                    {
+                      "durationMs": 900000
+                    },
+                    {
+                      "durationMs": 1800000
+                    },
+                    {
+                      "durationMs": 3600000
+                    },
+                    {
+                      "durationMs": 14400000
+                    },
+                    {
+                      "durationMs": 43200000
+                    },
+                    {
+                      "durationMs": 86400000
+                    },
+                    {
+                      "durationMs": 172800000
+                    },
+                    {
+                      "durationMs": 259200000
+                    },
+                    {
+                      "durationMs": 604800000
+                    },
+                    {
+                      "durationMs": 1209600000
+                    },
+                    {
+                      "durationMs": 2419200000
+                    },
+                    {
+                      "durationMs": 2592000000
+                    },
+                    {
+                      "durationMs": 5184000000
+                    },
+                    {
+                      "durationMs": 7776000000
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "4e9f82e1-d302-466b-8f85-2c1966916cf1",
+                "version": "KqlParameterItem/1.0",
+                "name": "QueryWorkbook",
+                "type": 1,
+                "value": "[resourceId('microsoft.insights/workbooks', parameters('workbookNames').Query)]"
+              },
+              {
+                "id": "ff5b14c5-1738-41b2-9b66-947b46f65cf3",
+                "version": "KqlParameterItem/1.0",
+                "name": "Type",
+                "type": 1,
+                "value": "MICROSOFT.SQL/SERVERS"
+              },
+              {
+                "id": "2f2432a8-bd82-4e71-8465-fac1a22179dd",
+                "version": "KqlParameterItem/1.0",
+                "name": "database",
+                "type": 5,
+                "query": "where type contains '{Type}'\r\n| extend ResourceId = tolower(id)\r\n| extend name = tolower(strcat(extract('/servers/([^/]+)/', 1, ResourceId), '/', name))\r\n| where name =~ '{ResourceId}'\r\n| project id, selected = 1",
+                "crossComponentResources": [
+                  "value::all"
+                ],
+                "typeSettings": {
+                  "additionalResourceOptions": [],
+                  "showDefault": false
+                },
+                "queryType": 1,
+                "resourceType": "microsoft.resourcegraph/resources"
+              },
+              {
+                "id": "df10cbbd-01db-4f19-89ea-5acd68cf0019",
+                "version": "KqlParameterItem/1.0",
+                "name": "Resources_database",
+                "type": 9,
+                "multiSelect": true,
+                "quote": "",
+                "delimiter": ",",
+                "query": "where type contains '{Type}'\r\n| extend ResourceId = tolower(id)\r\n| extend name = tolower(strcat(extract('/servers/([^/]+)/', 1, ResourceId), '/', name))\r\n| where name =~ '{ResourceId}'\r\n| project strcat('{\"name\":\"',name, '\" , \"subscription\": \"', subscriptionId, '\", \"resourceGroup\": \"', resourceGroup, '\"}')",
+                "crossComponentResources": [
+                  "value::all"
+                ],
+                "queryType": 1,
+                "resourceType": "microsoft.resourcegraph/resources"
+              },
+              {
+                "id": "af11a588-d4c1-4c0f-9f17-6411e3b2cb25",
+                "version": "KqlParameterItem/1.0",
+                "name": "dbType",
+                "type": 1,
+                "value": "AzureSQLDB"
+              },
+              {
+                "id": "7178b012-3cdb-4c3f-8b9c-a402fc6e2ecf",
+                "version": "KqlParameterItem/1.0",
+                "name": "AlertRulesWorkbook",
+                "type": 1,
+                "value": "[resourceId('microsoft.insights/workbooks', parameters('workbookNames').AlertRules)]"
+              }
+            ],
+            "style": "pills",
+            "queryType": 0,
+            "resourceType": "microsoft.resourcegraph/resources"
+          },
+          "conditionalVisibility": {
+            "parameterName": "hide",
+            "comparison": "isNotEqualTo"
+          },
+          "name": "parameters"
+        },
+        {
+          "type": 1,
+          "content": {
+            "json": "# Database\r\n{database:name}"
+          },
+          "name": "text - 1"
+        },
+        {
+          "type": 1,
+          "content": {
+            "json": "QUERIES"
+          },
+          "name": "text - 6"
+        },
+        {
+          "type": 9,
+          "content": {
+            "version": "KqlParameterItem/1.0",
+            "parameters": [
+              {
+                "id": "913bacd0-f883-483f-b286-75d61236e95e",
+                "version": "KqlParameterItem/1.0",
+                "name": "query_hash",
+                "type": 1,
+                "isHiddenWhenLocked": true,
+                "timeContext": {
+                  "durationMs": 86400000
+                }
+              }
+            ],
+            "style": "pills",
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          },
+          "name": "parameters - 17"
+        },
+        {
+          "type": 3,
+          "content": {
+            "version": "KqlItem/1.0",
+            "query": "set truncationmaxrecords=5000;\r\nInsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace == 'sqlserver_azuredb_querystore_runtime_stats'\r\n| summarize make_bag( pack(Name, Val)) by Tags, TimeGenerated\r\n| evaluate bag_unpack(bag_)\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| summarize max_duration = max(max_duration)/1000000,\r\navg_duration = sum(avg_duration*count_executions)/sum(count_executions)/1000000,\r\navg_cpu = sum(avg_cpu_time*count_executions)/sum(count_executions)/1000000,\r\nexecutions_count = sum(count_executions)\r\n    by query_hash\r\n| join kind=fullouter (\r\n    InsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace == 'sqlserver_azuredb_querystore_wait_stats'\r\n| summarize make_bag(pack(Name, Val)) by Tags, TimeGenerated\r\n| evaluate bag_unpack(bag_)\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n    | summarize\r\n        avg_wait_duration = sum(total_query_wait_time_ms)/sum(count_executions) / 1000,\r\n        max_wait_duration = max(max_query_wait_time_ms)/1000\r\n        by wait_category, query_hash\r\n    | summarize arg_max(avg_wait_duration, max_wait_duration, wait_category)\r\n        by query_hash\r\n) on query_hash\r\n| project query_hash,\r\n    metric = \"Duration\",\r\n    max_duration,\r\n    avg_duration,\r\n    avg_cpu,\r\n    executions_count,\r\n    wait_category, max_wait_duration, avg_wait_duration,\r\n    wbLink = '{QueryWorkbook}'\r\n| extend resourceIdPrefix = \"{ResourceId}\"\r\n| sort by avg_duration desc",
+            "size": 2,
+            "showAnalytics": true,
+            "timeContext": {
+              "durationMs": 86400000
+            },
+            "timeContextFromParameter": "Timerange",
+            "exportedParameters": [
+              {
+                "fieldName": "query_hash",
+                "parameterName": "QueryHash"
+              },
+              {
+                "fieldName": "query_hash",
+                "parameterName": "query_hash",
+                "parameterType": 1
+              }
+            ],
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces",
+            "crossComponentResources": [
+              "{WsResourcesInternal}"
+            ],
+            "gridSettings": {
+              "formatters": [
+                {
+                  "columnMatch": "query_hash",
+                  "formatter": 7,
+                  "formatOptions": {
+                    "linkTarget": "WorkbookTemplate",
+                    "workbookContext": {
+                      "componentIdSource": "workbook",
+                      "resourceIdsSource": "workbook",
+                      "templateIdSource": "column",
+                      "templateId": "wbLink",
+                      "typeSource": "workbook",
+                      "gallerySource": "workbook",
+                      "locationSource": "default"
+                    }
+                  }
+                },
+                {
+                  "columnMatch": "max_duration",
+                  "formatter": 0,
+                  "formatOptions": {
+                    "customColumnWidthSetting": "15ch"
+                  },
+                  "numberFormat": {
+                    "unit": 24,
+                    "options": {
+                      "style": "decimal"
+                    }
+                  }
+                },
+                {
+                  "columnMatch": "avg_duration",
+                  "formatter": 0,
+                  "formatOptions": {
+                    "customColumnWidthSetting": "15ch"
+                  },
+                  "numberFormat": {
+                    "unit": 24,
+                    "options": {
+                      "style": "decimal"
+                    }
+                  }
+                },
+                {
+                  "columnMatch": "avg_cpu",
+                  "formatter": 0,
+                  "formatOptions": {
+                    "customColumnWidthSetting": "15ch"
+                  },
+                  "numberFormat": {
+                    "unit": 24,
+                    "options": {
+                      "style": "decimal"
+                    }
+                  }
+                },
+                {
+                  "columnMatch": "executions_count",
+                  "formatter": 0,
+                  "formatOptions": {
+                    "customColumnWidthSetting": "10ch"
+                  },
+                  "numberFormat": {
+                    "unit": 17,
+                    "options": {
+                      "style": "decimal"
+                    }
+                  }
+                },
+                {
+                  "columnMatch": "wait_category",
+                  "formatter": 0,
+                  "formatOptions": {
+                    "customColumnWidthSetting": "20ch"
+                  }
+                },
+                {
+                  "columnMatch": "max_wait_duration",
+                  "formatter": 0,
+                  "formatOptions": {
+                    "customColumnWidthSetting": "15ch"
+                  },
+                  "numberFormat": {
+                    "unit": 24,
+                    "options": {
+                      "style": "decimal"
+                    }
+                  }
+                },
+                {
+                  "columnMatch": "avg_wait_duration",
+                  "formatter": 0,
+                  "formatOptions": {
+                    "customColumnWidthSetting": "15ch"
+                  },
+                  "numberFormat": {
+                    "unit": 24,
+                    "options": {
+                      "style": "decimal"
+                    }
+                  }
+                },
+                {
+                  "columnMatch": "wbLink",
+                  "formatter": 5
+                },
+                {
+                  "columnMatch": "resourceIdPrefix",
+                  "formatter": 5
+                }
+              ],
+              "labelSettings": [
+                {
+                  "columnId": "query_hash",
+                  "label": "Query Hash"
+                },
+                {
+                  "columnId": "metric",
+                  "label": "Metric"
+                },
+                {
+                  "columnId": "max_duration",
+                  "label": "Max"
+                },
+                {
+                  "columnId": "avg_duration",
+                  "label": "Avg"
+                },
+                {
+                  "columnId": "avg_cpu",
+                  "label": "CPU"
+                },
+                {
+                  "columnId": "executions_count",
+                  "label": "Execs"
+                },
+                {
+                  "columnId": "wait_category",
+                  "label": "Dominant Wait"
+                },
+                {
+                  "columnId": "max_wait_duration",
+                  "label": "Max"
+                },
+                {
+                  "columnId": "avg_wait_duration",
+                  "label": "Avg"
+                },
+                {
+                  "columnId": "wbLink"
+                },
+                {
+                  "columnId": "resourceIdPrefix"
+                }
+              ]
+            }
+          },
+          "customWidth": "60",
+          "name": "query - 7"
+        },
+        {
+          "type": 12,
+          "content": {
+            "version": "NotebookGroup/1.0",
+            "groupType": "editable",
+            "items": [
+              {
+                "type": 3,
+                "content": {
+                  "version": "KqlItem/1.0",
+                  "query": "let resources = print dynamic([{Resources_database}])\r\n| mv-expand print_0\r\n| evaluate bag_unpack(print_0);\r\nInsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace == 'sqlserver_azuredb_querystore_runtime_stats'\r\n| summarize make_bag( pack(Name, Val)) by Tags, TimeGenerated\r\n| evaluate bag_unpack(bag_)\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| extend resourceName = tolower(strcat(sql_instance, '/', database_name))\r\n| join kind=leftouter (resources| extend resourceName = name)on resourceName\r\n| where tostring(resourceName) contains '{ResourceId}'\r\n| where tostring(query_hash) contains '{query_hash}'\r\n| project interval_start_time, max_duration, cpu_time_d = avg_cpu_time*count_executions, duration_d = avg_duration*count_executions, count_executions_d = count_executions\r\n| summarize avg_duration = sum(duration_d)/sum(count_executions_d)/1000000,\r\navg_cpu = sum(cpu_time_d)/sum(count_executions_d)/1000000\r\n    by bin(interval_start_time, {Timerange:grain})",
+                  "size": 0,
+                  "aggregation": 3,
+                  "showAnalytics": true,
+                  "title": "Query Duration",
+                  "timeContext": {
+                    "durationMs": 86400000
+                  },
+                  "timeContextFromParameter": "Timerange",
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "crossComponentResources": [
+                    "{WsResourcesInternal}"
+                  ],
+                  "visualization": "linechart",
+                  "chartSettings": {
+                    "ySettings": {
+                      "numberFormatSettings": {
+                        "unit": 24,
+                        "options": {
+                          "style": "decimal",
+                          "useGrouping": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "name": "query - 2 - Copy"
+              },
+              {
+                "type": 3,
+                "content": {
+                  "version": "KqlItem/1.0",
+                  "query": "let resources = print dynamic([{Resources_database}])\r\n| mv-expand print_0\r\n| evaluate bag_unpack(print_0);\r\nInsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace == 'sqlserver_azuredb_querystore_wait_stats'\r\n| summarize make_bag(pack(Name, Val)) by Tags, TimeGenerated\r\n| evaluate bag_unpack(bag_)\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| extend resourceName = tolower(strcat(sql_instance, '/', database_name))\r\n| join kind=leftouter (resources\r\n| extend resourceName = name)\r\non resourceName\r\n| where tostring(resourceName) contains '{ResourceId}'\r\n| where tostring(query_hash) contains '{query_hash}'\r\n| summarize total_wait_time = sum(total_query_wait_time_ms)/1000\r\n    by wait_category, bin(interval_start_time, {Timerange:grain})\r\n| top 1000 by total_wait_time desc\r\n| evaluate pivot(wait_category, sum(total_wait_time))\r\n",
+                  "size": 0,
+                  "showAnalytics": true,
+                  "title": "Query Waits",
+                  "timeContext": {
+                    "durationMs": 86400000
+                  },
+                  "timeContextFromParameter": "Timerange",
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "crossComponentResources": [
+                    "{WsResourcesInternal}"
+                  ],
+                  "visualization": "barchart",
+                  "chartSettings": {
+                    "ySettings": {
+                      "numberFormatSettings": {
+                        "unit": 23,
+                        "options": {
+                          "style": "decimal",
+                          "useGrouping": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "name": "query - 2 - Copy - Copy"
+              }
+            ]
+          },
+          "customWidth": "40",
+          "name": "group - 7"
+        },
+        {
+          "type": 1,
+          "content": {
+            "json": "DATABASE WAITS"
+          },
+          "name": "text - 8"
+        },
+        {
+          "type": 9,
+          "content": {
+            "version": "KqlParameterItem/1.0",
+            "parameters": [
+              {
+                "id": "2e848e04-a014-4e23-b087-c8d89daca1da",
+                "version": "KqlParameterItem/1.0",
+                "name": "wait_type",
+                "type": 1,
+                "isHiddenWhenLocked": true,
+                "timeContext": {
+                  "durationMs": 86400000
+                }
+              }
+            ],
+            "style": "pills",
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          },
+          "name": "parameters - 18"
+        },
+        {
+          "type": 3,
+          "content": {
+            "version": "KqlItem/1.0",
+            "query": "let resources = print dynamic([{Resources_database}])\r\n| mv-expand print_0\r\n| evaluate bag_unpack(print_0);\r\nInsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace == 'sqlserver_azuredb_waitstats'\r\n| summarize make_bag(pack(Name,Val)) by Tags, TimeGenerated\r\n| evaluate bag_unpack(bag_)\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| where database_name!=''\r\n| extend resourceName = tolower(strcat(sql_instance, '/', database_name))\r\n| join kind=leftouter (resources\r\n| extend resourceName = name)\r\non resourceName\r\n| where tostring(resourceName) contains '{ResourceId}'\r\n| order by resourceName, wait_type, TimeGenerated asc\r\n| serialize \r\n| extend delta_wait_time_ms = case(prev(resourceName) == resourceName and prev(wait_type) == wait_type, wait_time_ms - prev(wait_time_ms), real(null))\r\n| summarize Total = sum(delta_wait_time_ms) / 1000\r\nby wait_type\r\n| project ['Wait Type'] = strcat('⏳ ', wait_type), Total, wait_type\r\n| where Total > 0\r\n| sort by Total",
+            "size": 0,
+            "showAnalytics": true,
+            "timeContext": {
+              "durationMs": 86400000
+            },
+            "timeContextFromParameter": "Timerange",
+            "exportFieldName": "wait_type",
+            "exportParameterName": "wait_type",
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces",
+            "crossComponentResources": [
+              "{WsResourcesInternal}"
+            ],
+            "gridSettings": {
+              "formatters": [
+                {
+                  "columnMatch": "Total",
+                  "formatter": 0,
+                  "numberFormat": {
+                    "unit": 24,
+                    "options": {
+                      "style": "decimal",
+                      "useGrouping": false
+                    }
+                  }
+                },
+                {
+                  "columnMatch": "wait_type",
+                  "formatter": 5
+                }
+              ]
+            }
+          },
+          "customWidth": "60",
+          "name": "query - 2 - Copy - Copy"
+        },
+        {
+          "type": 3,
+          "content": {
+            "version": "KqlItem/1.0",
+            "query": "let resources = print dynamic([{Resources_database}])\r\n| mv-expand print_0\r\n| evaluate bag_unpack(print_0);\r\nInsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace == 'sqlserver_azuredb_waitstats'\r\n| summarize make_bag(pack(Name, Val)) by Tags, TimeGenerated\r\n| evaluate bag_unpack(bag_)\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| where database_name!=''\r\n| extend resourceName = tolower(strcat(sql_instance, '/', database_name))\r\n| join kind=leftouter (resources\r\n| extend resourceName = name)\r\non resourceName\r\n| where tostring(resourceName) contains '{ResourceId}'\r\n| order by resourceName, wait_type, TimeGenerated asc\r\n| serialize \r\n| extend delta_wait_time_ms = case(prev(resourceName) == resourceName and prev(wait_type) == wait_type, wait_time_ms - prev(wait_time_ms), real(null)), wait_type\r\n| summarize total_wait_time_in_ms = sum(delta_wait_time_ms) / 1000\r\n    by wait_type, bin(TimeGenerated, {Timerange:grain})\r\n| where tostring(wait_type) contains '{wait_type}'\r\n| top 1000 by total_wait_time_in_ms desc\r\n| evaluate pivot(wait_type, sum(total_wait_time_in_ms))",
+            "size": 0,
+            "showAnalytics": true,
+            "timeContext": {
+              "durationMs": 86400000
+            },
+            "timeContextFromParameter": "Timerange",
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces",
+            "crossComponentResources": [
+              "{WsResourcesInternal}"
+            ],
+            "visualization": "barchart",
+            "chartSettings": {
+              "ySettings": {
+                "numberFormatSettings": {
+                  "unit": 24,
+                  "options": {
+                    "style": "decimal",
+                    "useGrouping": true
+                  }
+                }
+              }
+            }
+          },
+          "customWidth": "40",
+          "name": "query - 2 - Copy"
+        },
+        {
+          "type": 1,
+          "content": {
+            "json": "QUERY EXECUTIONS"
+          },
+          "name": "text - 11"
+        },
+        {
+          "type": 3,
+          "content": {
+            "version": "KqlItem/1.0",
+            "query": "InsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace == 'sqlserver_azuredb_querystore_runtime_stats'\r\n| summarize make_bag( pack(Name, Val)) by Tags, TimeGenerated\r\n| evaluate bag_unpack(bag_)\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| extend resourceName = tolower(strcat(sql_instance, '/', database_name))\r\n| where tostring(resourceName) contains '{ResourceId}'\r\n| summarize regular = sumif(count_executions, execution_type==0), errors = sumif(count_executions, execution_type==4), aborted = sumif(count_executions, execution_type==3) by query_hash\r\n| extend wbLink = '{QueryWorkbook}'\r\n| order by errors desc, query_hash",
+            "size": 0,
+            "showAnalytics": true,
+            "timeContext": {
+              "durationMs": 86400000
+            },
+            "timeContextFromParameter": "Timerange",
+            "exportFieldName": "query_hash",
+            "exportParameterName": "QueryHash",
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces",
+            "crossComponentResources": [
+              "{WsResourcesInternal}"
+            ],
+            "gridSettings": {
+              "formatters": [
+                {
+                  "columnMatch": "query_hash",
+                  "formatter": 7,
+                  "formatOptions": {
+                    "linkTarget": "WorkbookTemplate",
+                    "workbookContext": {
+                      "componentIdSource": "workbook",
+                      "resourceIdsSource": "workbook",
+                      "templateIdSource": "column",
+                      "templateId": "wbLink",
+                      "typeSource": "workbook",
+                      "gallerySource": "workbook",
+                      "locationSource": "default"
+                    }
+                  }
+                },
+                {
+                  "columnMatch": "wbLink",
+                  "formatter": 5,
+                  "formatOptions": {
+                    "linkTarget": "WorkbookTemplate",
+                    "linkLabel": "View",
+                    "linkIsContextBlade": true
+                  }
+                }
+              ],
+              "labelSettings": [
+                {
+                  "columnId": "query_hash",
+                  "label": "Query"
+                },
+                {
+                  "columnId": "regular",
+                  "label": "Regular"
+                },
+                {
+                  "columnId": "errors",
+                  "label": "Aborted by Exception"
+                },
+                {
+                  "columnId": "aborted",
+                  "label": "Aborted by Client"
+                },
+                {
+                  "columnId": "wbLink"
+                }
+              ]
+            }
+          },
+          "customWidth": "60",
+          "name": "query - 2 - Copy - Copy - Copy"
+        },
+        {
+          "type": 3,
+          "content": {
+            "version": "KqlItem/1.0",
+            "query": "InsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace == 'sqlserver_azuredb_querystore_runtime_stats'\r\n| summarize make_bag( pack(Name, Val)) by Tags, TimeGenerated\r\n| evaluate bag_unpack(bag_)\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == 'AzureSQLDB'\r\n| extend resourceName = tolower(strcat(sql_instance, '/', database_name))\r\n| where tostring(resourceName) contains '{ResourceId}'\r\n| summarize regular = sumif(count_executions, execution_type==0), aborted = sumif(count_executions, execution_type==3), errors = sumif(count_executions, execution_type==4) by TimeGenerated = bin(interval_start_time, {Timerange:grain})",
+            "size": 0,
+            "showAnalytics": true,
+            "timeContext": {
+              "durationMs": 86400000
+            },
+            "timeContextFromParameter": "Timerange",
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces",
+            "crossComponentResources": [
+              "{WsResourcesInternal}"
+            ],
+            "visualization": "unstackedbar",
+            "chartSettings": {
+              "seriesLabelSettings": [
+                {
+                  "seriesName": "regular",
+                  "label": "Regular"
+                },
+                {
+                  "seriesName": "aborted",
+                  "label": "Aborted by Client"
+                },
+                {
+                  "seriesName": "errors",
+                  "label": "Aborted by Exception"
+                }
+              ]
+            }
+          },
+          "customWidth": "40",
+          "name": "query - 2 - Copy - Copy"
+        },
+        {
+          "type": 1,
+          "content": {
+            "json": "DATABASE METRICS"
+          },
+          "name": "text - 14"
+        },
+        {
+          "type": 3,
+          "content": {
+            "version": "KqlItem/1.0",
+            "query": "set truncationmaxrecords=5000;\r\nlet metrics = InsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace == 'sqlserver_azure_db_resource_stats'\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| extend dbName = strcat(sql_instance,\"/\",database_name);\r\nmetrics \r\n| where dbName =~ '{ResourceId}'\r\n| summarize list_a = makelist(Val) by bin(TimeGenerated, ({Timerange:grain}/2)), dbName, Name\r\n| mvexpand list_a\r\n| summarize avg = avg(todouble(list_a)),\r\n    max = max(todouble(list_a)) by bin(TimeGenerated, 1h), Name\r\n| summarize max = max(max), avg = avg(avg), percentile = percentile(max, 80) by Name\r\n| project Name, max, percentile, avg, ResourceIdPrefix = \"{ResourceId}\"\r\n| sort by max desc",
+            "size": 3,
+            "showAnalytics": true,
+            "timeContext": {
+              "durationMs": 86400000
+            },
+            "timeContextFromParameter": "Timerange",
+            "exportFieldName": "Name",
+            "exportParameterName": "MetricName",
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces",
+            "crossComponentResources": [
+              "{WsResourcesInternal}"
+            ],
+            "gridSettings": {
+              "formatters": [
+                {
+                  "columnMatch": "Name",
+                  "formatter": 0,
+                  "formatOptions": {
+                    "customColumnWidthSetting": "27ch"
+                  }
+                },
+                {
+                  "columnMatch": "max",
+                  "formatter": 0,
+                  "formatOptions": {
+                    "customColumnWidthSetting": "11ch"
+                  },
+                  "numberFormat": {
+                    "unit": 1,
+                    "options": {
+                      "style": "decimal",
+                      "useGrouping": false
+                    }
+                  }
+                },
+                {
+                  "columnMatch": "percentile",
+                  "formatter": 0,
+                  "formatOptions": {
+                    "customColumnWidthSetting": "18ch"
+                  },
+                  "numberFormat": {
+                    "unit": 1,
+                    "options": {
+                      "style": "decimal",
+                      "useGrouping": false
+                    }
+                  }
+                },
+                {
+                  "columnMatch": "avg",
+                  "formatter": 0,
+                  "formatOptions": {
+                    "customColumnWidthSetting": "12ch"
+                  },
+                  "numberFormat": {
+                    "unit": 1,
+                    "options": {
+                      "style": "decimal"
+                    }
+                  }
+                },
+                {
+                  "columnMatch": "ResourceIdPrefix",
+                  "formatter": 5
+                },
+                {
+                  "columnMatch": "Alert Rule",
+                  "formatter": 7,
+                  "formatOptions": {
+                    "linkTarget": "WorkbookTemplate",
+                    "linkLabel": "Create/Edit",
+                    "linkIsContextBlade": false,
+                    "bladeOpenContext": {
+                      "bladeParameters": []
+                    },
+                    "customColumnWidthSetting": "15ch"
+                  }
+                }
+              ],
+              "labelSettings": [
+                {
+                  "columnId": "Name",
+                  "label": "Metric"
+                },
+                {
+                  "columnId": "max",
+                  "label": "Max"
+                },
+                {
+                  "columnId": "percentile",
+                  "label": "80th Percentile"
+                },
+                {
+                  "columnId": "avg",
+                  "label": "Average"
+                },
+                {
+                  "columnId": "ResourceIdPrefix"
+                }
+              ]
+            }
+          },
+          "customWidth": "40",
+          "name": "query - 15"
+        },
+        {
+          "type": 12,
+          "content": {
+            "version": "NotebookGroup/1.0",
+            "groupType": "editable",
+            "items": [
+              {
+                "type": 11,
+                "content": {
+                  "version": "LinkItem/1.0",
+                  "style": "list",
+                  "links": [
+                    {
+                      "id": "86847c2e-3853-46b4-a784-9dd4faa8db3a",
+                      "cellValue": "{database}",
+                      "linkTarget": "Resource",
+                      "linkLabel": "Query Performance Insights",
+                      "subTarget": "queryPerformanceInsight",
+                      "style": "primary"
+                    }
+                  ]
+                },
+                "name": "links - 17"
+              },
+              {
+                "type": 1,
+                "content": {
+                  "json": "### DTU utilization (%)"
+                },
+                "customWidth": "33",
+                "name": "text - 11"
+              },
+              {
+                "type": 1,
+                "content": {
+                  "json": "### CPU utilization (%)"
+                },
+                "customWidth": "33",
+                "name": "text - 11 - Copy"
+              },
+              {
+                "type": 1,
+                "content": {
+                  "json": "### Sessions (%)"
+                },
+                "customWidth": "33",
+                "name": "text - 11 - Copy - Copy"
+              },
+              {
+                "type": 11,
+                "content": {
+                  "version": "LinkItem/1.0",
+                  "style": "nav",
+                  "links": [
+                    {
+                      "id": "5ebe0005-46bf-45ed-8269-c1b5996559ae",
+                      "cellValue": "{database}",
+                      "linkTarget": "AlertCreation",
+                      "linkLabel": "New Alert Rule",
+                      "preText": "",
+                      "style": "link",
+                      "alertRuleContext": {
+                        "alertType": "Metric",
+                        "namespace": "microsoft.sql/servers/databases",
+                        "metricId": "microsoft.sql/servers/databases-Basic-dtu_consumption_percent",
+                        "aggregation": 4
+                      }
+                    },
+                    {
+                      "id": "7d1b1f9e-8de4-4cd0-a4c4-9e6b8a5fe1ee",
+                      "cellValue": "{AlertRulesWorkbook}",
+                      "linkTarget": "WorkbookTemplate",
+                      "linkLabel": "Edit Alert Rules",
+                      "style": "link",
+                      "linkIsContextBlade": true,
+                      "workbookContext": {
+                        "componentIdSource": "workbook",
+                        "resourceIdsSource": "workbook",
+                        "templateIdSource": "cell",
+                        "templateId": "wbLink",
+                        "typeSource": "workbook",
+                        "gallerySource": "workbook",
+                        "locationSource": "default",
+                        "passSpecificParams": true,
+                        "templateParameters": [
+                          {
+                            "name": "database",
+                            "source": "parameter",
+                            "value": "database"
+                          },
+                          {
+                            "name": "MetricNamespace",
+                            "source": "static",
+                            "value": "{Type}/databases"
+                          },
+                          {
+                            "name": "MetricCategory",
+                            "source": "static",
+                            "value": "Basic"
+                          },
+                          {
+                            "name": "MetricName",
+                            "source": "static",
+                            "value": "dtu_consumption_percent"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                },
+                "customWidth": "33",
+                "name": "links - 8"
+              },
+              {
+                "type": 11,
+                "content": {
+                  "version": "LinkItem/1.0",
+                  "style": "nav",
+                  "links": [
+                    {
+                      "id": "6703652a-1962-43ce-9c08-31c09a52dbde",
+                      "cellValue": "{database}",
+                      "linkTarget": "AlertCreation",
+                      "linkLabel": "New Alert Rule",
+                      "style": "link",
+                      "alertRuleContext": {
+                        "alertType": "Metric",
+                        "namespace": "microsoft.sql/servers/databases",
+                        "metricId": "microsoft.sql/servers/databases-Basic-cpu_percent",
+                        "aggregation": 4
+                      }
+                    },
+                    {
+                      "id": "7d1b1f9e-8de4-4cd0-a4c4-9e6b8a5fe1ee",
+                      "cellValue": "{AlertRulesWorkbook}",
+                      "linkTarget": "WorkbookTemplate",
+                      "linkLabel": "Edit Alert Rules",
+                      "style": "link",
+                      "linkIsContextBlade": true,
+                      "workbookContext": {
+                        "componentIdSource": "workbook",
+                        "resourceIdsSource": "workbook",
+                        "templateIdSource": "cell",
+                        "templateId": "wbLink",
+                        "typeSource": "workbook",
+                        "gallerySource": "workbook",
+                        "locationSource": "default",
+                        "passSpecificParams": true,
+                        "templateParameters": [
+                          {
+                            "name": "database",
+                            "source": "parameter",
+                            "value": "database"
+                          },
+                          {
+                            "name": "MetricNamespace",
+                            "source": "static",
+                            "value": "{Type}/databases"
+                          },
+                          {
+                            "name": "MetricCategory",
+                            "source": "static",
+                            "value": "Basic"
+                          },
+                          {
+                            "name": "MetricName",
+                            "source": "static",
+                            "value": "cpu_percent"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                },
+                "customWidth": "33",
+                "name": "links - 8 - Copy"
+              },
+              {
+                "type": 11,
+                "content": {
+                  "version": "LinkItem/1.0",
+                  "style": "nav",
+                  "links": [
+                    {
+                      "id": "db22cdaf-e353-4479-b939-c160d9546604",
+                      "cellValue": "{database}",
+                      "linkTarget": "AlertCreation",
+                      "linkLabel": "New Alert Rule",
+                      "style": "link",
+                      "alertRuleContext": {
+                        "alertType": "Metric",
+                        "namespace": "microsoft.sql/servers/databases",
+                        "metricId": "microsoft.sql/servers/databases-Basic-sessions_percent",
+                        "aggregation": 4
+                      }
+                    },
+                    {
+                      "id": "7d1b1f9e-8de4-4cd0-a4c4-9e6b8a5fe1ee",
+                      "cellValue": "{AlertRulesWorkbook}",
+                      "linkTarget": "WorkbookTemplate",
+                      "linkLabel": "Edit Alert Rules",
+                      "style": "link",
+                      "linkIsContextBlade": true,
+                      "workbookContext": {
+                        "componentIdSource": "workbook",
+                        "resourceIdsSource": "workbook",
+                        "templateIdSource": "cell",
+                        "templateId": "wbLink",
+                        "typeSource": "workbook",
+                        "gallerySource": "workbook",
+                        "locationSource": "default",
+                        "passSpecificParams": true,
+                        "templateParameters": [
+                          {
+                            "name": "database",
+                            "source": "parameter",
+                            "value": "database"
+                          },
+                          {
+                            "name": "MetricNamespace",
+                            "source": "static",
+                            "value": "{Type}/databases"
+                          },
+                          {
+                            "name": "MetricCategory",
+                            "source": "static",
+                            "value": "Basic"
+                          },
+                          {
+                            "name": "MetricName",
+                            "source": "static",
+                            "value": "sessions_percent"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                },
+                "customWidth": "33",
+                "name": "links - 8 - Copy - Copy"
+              },
+              {
+                "type": 3,
+                "content": {
+                  "version": "KqlItem/1.0",
+                  "query": "set truncationmaxrecords=5000;\r\nlet metrics = InsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace == 'sqlserver_azure_db_resource_stats'\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| extend dbName = strcat(sql_instance,\"/\",database_name);\r\nmetrics \r\n| where dbName =~ '{ResourceId}' \r\n| where Name in ('avg_cpu_percent', 'avg_data_io_percent', 'avg_log_write_percent')\r\n| summarize avg = min_of(avg(Val), 100.0), max = min_of(max(Val), 100.0) by bin(TimeGenerated, {Timerange:grain}), Name\r\n| summarize avg = min_of(max(avg), 100.0), max = min_of(max(max), 100.0) by TimeGenerated\r\n| sort by TimeGenerated desc",
+                  "size": 1,
+                  "aggregation": 3,
+                  "showAnalytics": true,
+                  "timeContext": {
+                    "durationMs": 86400000
+                  },
+                  "timeContextFromParameter": "Timerange",
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "crossComponentResources": [
+                    "{WsResourcesInternal}"
+                  ],
+                  "visualization": "linechart",
+                  "gridSettings": {
+                    "formatters": [
+                      {
+                        "columnMatch": "ResourceIdPrefix",
+                        "formatter": 5
+                      }
+                    ],
+                    "labelSettings": [
+                      {
+                        "columnId": "avg",
+                        "label": "Average"
+                      },
+                      {
+                        "columnId": "max",
+                        "label": "MAX"
+                      }
+                    ]
+                  },
+                  "chartSettings": {
+                    "ySettings": {
+                      "numberFormatSettings": {
+                        "unit": 1,
+                        "options": {
+                          "style": "decimal",
+                          "useGrouping": true
+                        }
+                      },
+                      "min": 0,
+                      "max": 100
+                    }
+                  }
+                },
+                "customWidth": "33",
+                "name": "query - 15 - Copy"
+              },
+              {
+                "type": 3,
+                "content": {
+                  "version": "KqlItem/1.0",
+                  "query": "set truncationmaxrecords=5000;\r\nlet metrics = InsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace == 'sqlserver_azure_db_resource_stats'\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| extend dbName = strcat(sql_instance,\"/\",database_name);\r\nmetrics \r\n| where dbName =~ '{ResourceId}' \r\n| where Name=='avg_cpu_percent' \r\n| summarize avg = min_of(avg(Val), 100.0), max = min_of(max(Val), 100.0) by bin(TimeGenerated, {Timerange:grain})\r\n| sort by TimeGenerated desc",
+                  "size": 1,
+                  "aggregation": 3,
+                  "showAnalytics": true,
+                  "timeContext": {
+                    "durationMs": 86400000
+                  },
+                  "timeContextFromParameter": "Timerange",
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "crossComponentResources": [
+                    "{WsResourcesInternal}"
+                  ],
+                  "visualization": "linechart",
+                  "gridSettings": {
+                    "formatters": [
+                      {
+                        "columnMatch": "ResourceIdPrefix",
+                        "formatter": 5
+                      }
+                    ],
+                    "labelSettings": [
+                      {
+                        "columnId": "avg",
+                        "label": "Average"
+                      },
+                      {
+                        "columnId": "max",
+                        "label": "MAX"
+                      }
+                    ]
+                  },
+                  "chartSettings": {
+                    "ySettings": {
+                      "numberFormatSettings": {
+                        "unit": 1,
+                        "options": {
+                          "style": "decimal",
+                          "useGrouping": true
+                        }
+                      },
+                      "min": 0,
+                      "max": 100
+                    }
+                  }
+                },
+                "customWidth": "33",
+                "name": "query - 15 - Copy - Copy"
+              },
+              {
+                "type": 3,
+                "content": {
+                  "version": "KqlItem/1.0",
+                  "query": "set truncationmaxrecords=5000;\r\nlet metrics = InsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace == 'sqlserver_azure_db_resource_stats'\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| extend dbName = strcat(sql_instance,\"/\",database_name);\r\nmetrics \r\n| where dbName =~ '{ResourceId}' \r\n| where Name=='max_session_percent' \r\n| summarize avg = min_of(avg(Val), 100.0), max = min_of(max(Val), 100.0) by bin(TimeGenerated, {Timerange:grain})\r\n| sort by TimeGenerated desc",
+                  "size": 1,
+                  "aggregation": 3,
+                  "showAnalytics": true,
+                  "timeContext": {
+                    "durationMs": 86400000
+                  },
+                  "timeContextFromParameter": "Timerange",
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "crossComponentResources": [
+                    "{WsResourcesInternal}"
+                  ],
+                  "visualization": "linechart",
+                  "gridSettings": {
+                    "formatters": [
+                      {
+                        "columnMatch": "ResourceIdPrefix",
+                        "formatter": 5
+                      }
+                    ],
+                    "labelSettings": [
+                      {
+                        "columnId": "avg",
+                        "label": "Average"
+                      },
+                      {
+                        "columnId": "max",
+                        "label": "MAX"
+                      }
+                    ]
+                  },
+                  "chartSettings": {
+                    "ySettings": {
+                      "numberFormatSettings": {
+                        "unit": 1,
+                        "options": {
+                          "style": "decimal",
+                          "useGrouping": true
+                        }
+                      },
+                      "min": 0,
+                      "max": 100
+                    }
+                  }
+                },
+                "customWidth": "33",
+                "name": "query - 15 - Copy - Copy - Copy"
+              },
+              {
+                "type": 1,
+                "content": {
+                  "json": "### Storage usage (%)"
+                },
+                "customWidth": "33",
+                "name": "text - 11 - Copy - Copy - Copy"
+              },
+              {
+                "type": 1,
+                "content": {
+                  "json": "### DataIO (%)"
+                },
+                "customWidth": "33",
+                "name": "text - 11 - Copy - Copy - Copy - Copy"
+              },
+              {
+                "type": 1,
+                "content": {
+                  "json": "### Workers (%)"
+                },
+                "customWidth": "33",
+                "name": "text - 11 - Copy - Copy - Copy - Copy - Copy"
+              },
+              {
+                "type": 11,
+                "content": {
+                  "version": "LinkItem/1.0",
+                  "style": "nav",
+                  "links": [
+                    {
+                      "id": "b8498467-c865-4018-aa30-0ea54528d3a6",
+                      "cellValue": "{database}",
+                      "linkTarget": "AlertCreation",
+                      "linkLabel": "New Alert Rule",
+                      "style": "link",
+                      "alertRuleContext": {
+                        "alertType": "Metric",
+                        "namespace": "microsoft.sql/servers/databases",
+                        "metricId": "microsoft.sql/servers/databases-Basic-storage",
+                        "aggregation": 4
+                      }
+                    },
+                    {
+                      "id": "f19a8a2d-f1af-4a02-865d-677232ca579f",
+                      "cellValue": "{AlertRulesWorkbook}",
+                      "linkTarget": "WorkbookTemplate",
+                      "linkLabel": "Edit Alert Rules",
+                      "style": "link",
+                      "linkIsContextBlade": true,
+                      "workbookContext": {
+                        "componentIdSource": "workbook",
+                        "resourceIdsSource": "workbook",
+                        "templateIdSource": "cell",
+                        "templateId": "wbLink",
+                        "typeSource": "workbook",
+                        "gallerySource": "workbook",
+                        "locationSource": "default",
+                        "passSpecificParams": true,
+                        "templateParameters": [
+                          {
+                            "name": "database",
+                            "source": "parameter",
+                            "value": "database"
+                          },
+                          {
+                            "name": "MetricNamespace",
+                            "source": "static",
+                            "value": "{Type}/databases"
+                          },
+                          {
+                            "name": "MetricCategory",
+                            "source": "static",
+                            "value": "Basic"
+                          },
+                          {
+                            "name": "MetricName",
+                            "source": "static",
+                            "value": "storage"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                },
+                "customWidth": "33",
+                "name": "links - 8 - Copy - Copy - Copy"
+              },
+              {
+                "type": 11,
+                "content": {
+                  "version": "LinkItem/1.0",
+                  "style": "nav",
+                  "links": [
+                    {
+                      "id": "93c0e05a-0db6-45d2-88a5-2528a97c3e91",
+                      "cellValue": "{database}",
+                      "linkTarget": "AlertCreation",
+                      "linkLabel": "New Alert Rule",
+                      "style": "link",
+                      "alertRuleContext": {
+                        "alertType": "Metric",
+                        "namespace": "microsoft.sql/servers/databases",
+                        "metricId": "microsoft.sql/servers/databases-Basic-physical_data_read_percent",
+                        "aggregation": 4
+                      }
+                    },
+                    {
+                      "id": "44efa730-1be0-4bfc-a7c6-d3570475ebdd",
+                      "cellValue": "{AlertRulesWorkbook}",
+                      "linkTarget": "WorkbookTemplate",
+                      "linkLabel": "Edit Alert Rules",
+                      "style": "link",
+                      "linkIsContextBlade": true,
+                      "workbookContext": {
+                        "componentIdSource": "workbook",
+                        "resourceIdsSource": "workbook",
+                        "templateIdSource": "cell",
+                        "templateId": "wbLink",
+                        "typeSource": "workbook",
+                        "gallerySource": "workbook",
+                        "locationSource": "default",
+                        "passSpecificParams": true,
+                        "templateParameters": [
+                          {
+                            "name": "database",
+                            "source": "parameter",
+                            "value": "database"
+                          },
+                          {
+                            "name": "MetricNamespace",
+                            "source": "static",
+                            "value": "{Type}/databases"
+                          },
+                          {
+                            "name": "MetricCategory",
+                            "source": "static",
+                            "value": "Basic"
+                          },
+                          {
+                            "name": "MetricName",
+                            "source": "static",
+                            "value": "physical_data_read_percent"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                },
+                "customWidth": "33",
+                "name": "links - 8 - Copy - Copy - Copy - Copy"
+              },
+              {
+                "type": 11,
+                "content": {
+                  "version": "LinkItem/1.0",
+                  "style": "nav",
+                  "links": [
+                    {
+                      "id": "acd92940-99d8-4751-a061-659afaae5253",
+                      "cellValue": "{database}",
+                      "linkTarget": "AlertCreation",
+                      "linkLabel": "New Alert Rule",
+                      "style": "link",
+                      "alertRuleContext": {
+                        "alertType": "Metric",
+                        "namespace": "microsoft.sql/servers/databases",
+                        "metricId": "microsoft.sql/servers/databases-Basic-workers_percent",
+                        "aggregation": 4
+                      }
+                    },
+                    {
+                      "id": "7abeb714-eef2-4568-a1b7-76d57d7d5c68",
+                      "cellValue": "{AlertRulesWorkbook}",
+                      "linkTarget": "WorkbookTemplate",
+                      "linkLabel": "Edit Alert Rules",
+                      "style": "link",
+                      "linkIsContextBlade": true,
+                      "workbookContext": {
+                        "componentIdSource": "workbook",
+                        "resourceIdsSource": "workbook",
+                        "templateIdSource": "cell",
+                        "templateId": "wbLink",
+                        "typeSource": "workbook",
+                        "gallerySource": "workbook",
+                        "locationSource": "default",
+                        "passSpecificParams": true,
+                        "templateParameters": [
+                          {
+                            "name": "database",
+                            "source": "parameter",
+                            "value": "database"
+                          },
+                          {
+                            "name": "MetricNamespace",
+                            "source": "static",
+                            "value": "{Type}/databases"
+                          },
+                          {
+                            "name": "MetricCategory",
+                            "source": "static",
+                            "value": "Basic"
+                          },
+                          {
+                            "name": "MetricName",
+                            "source": "static",
+                            "value": "workers_percent"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                },
+                "customWidth": "33",
+                "name": "links - 8 - Copy - Copy - Copy - Copy"
+              },
+              {
+                "type": 3,
+                "content": {
+                  "version": "KqlItem/1.0",
+                  "query": "set truncationmaxrecords=5000;\r\nlet metrics = InsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace == 'sqlserver_azure_db_resource_stats'\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| extend dbName = strcat(sql_instance,\"/\",database_name);\r\nmetrics \r\n| where dbName =~ '{ResourceId}' \r\n| where Name=='xtp_storage_percent' \r\n| summarize avg = min_of(avg(Val), 100.0), max = min_of(max(Val), 100.0) by bin(TimeGenerated, {Timerange:grain})\r\n| sort by TimeGenerated desc",
+                  "size": 1,
+                  "aggregation": 3,
+                  "showAnalytics": true,
+                  "timeContext": {
+                    "durationMs": 86400000
+                  },
+                  "timeContextFromParameter": "Timerange",
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "crossComponentResources": [
+                    "{WsResourcesInternal}"
+                  ],
+                  "visualization": "linechart",
+                  "gridSettings": {
+                    "formatters": [
+                      {
+                        "columnMatch": "ResourceIdPrefix",
+                        "formatter": 5
+                      }
+                    ],
+                    "labelSettings": [
+                      {
+                        "columnId": "avg",
+                        "label": "Average"
+                      },
+                      {
+                        "columnId": "max",
+                        "label": "MAX"
+                      }
+                    ]
+                  },
+                  "chartSettings": {
+                    "ySettings": {
+                      "numberFormatSettings": {
+                        "unit": 1,
+                        "options": {
+                          "style": "decimal",
+                          "useGrouping": true
+                        }
+                      },
+                      "min": 0,
+                      "max": 100
+                    }
+                  }
+                },
+                "customWidth": "33",
+                "name": "query - 15 - Copy - Copy - Copy - Copy"
+              },
+              {
+                "type": 3,
+                "content": {
+                  "version": "KqlItem/1.0",
+                  "query": "set truncationmaxrecords=5000;\r\nlet metrics = InsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace == 'sqlserver_azure_db_resource_stats'\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| extend dbName = strcat(sql_instance,\"/\",database_name);\r\nmetrics \r\n| where dbName =~ '{ResourceId}' \r\n| where Name=='avg_data_io_percent' \r\n| summarize avg = min_of(avg(Val), 100.0), max = min_of(max(Val), 100.0) by bin(TimeGenerated, {Timerange:grain})\r\n| sort by TimeGenerated desc",
+                  "size": 1,
+                  "aggregation": 3,
+                  "showAnalytics": true,
+                  "timeContext": {
+                    "durationMs": 86400000
+                  },
+                  "timeContextFromParameter": "Timerange",
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "crossComponentResources": [
+                    "{WsResourcesInternal}"
+                  ],
+                  "visualization": "linechart",
+                  "gridSettings": {
+                    "formatters": [
+                      {
+                        "columnMatch": "ResourceIdPrefix",
+                        "formatter": 5
+                      }
+                    ],
+                    "labelSettings": [
+                      {
+                        "columnId": "avg",
+                        "label": "Average"
+                      },
+                      {
+                        "columnId": "max",
+                        "label": "MAX"
+                      }
+                    ]
+                  },
+                  "chartSettings": {
+                    "ySettings": {
+                      "numberFormatSettings": {
+                        "unit": 1,
+                        "options": {
+                          "style": "decimal",
+                          "useGrouping": true
+                        }
+                      },
+                      "min": 0,
+                      "max": 100
+                    }
+                  }
+                },
+                "customWidth": "33",
+                "name": "query - 15 - Copy - Copy - Copy - Copy - Copy"
+              },
+              {
+                "type": 3,
+                "content": {
+                  "version": "KqlItem/1.0",
+                  "query": "set truncationmaxrecords=5000;\r\nlet metrics = InsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace == 'sqlserver_azure_db_resource_stats'\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| extend dbName = strcat(sql_instance,\"/\",database_name);\r\nmetrics \r\n| where dbName =~ '{ResourceId}' \r\n| where Name=='max_worker_percent' \r\n| summarize avg = min_of(avg(Val), 100.0), max = min_of(max(Val), 100.0) by bin(TimeGenerated, {Timerange:grain})\r\n| sort by TimeGenerated desc",
+                  "size": 1,
+                  "aggregation": 3,
+                  "showAnalytics": true,
+                  "timeContext": {
+                    "durationMs": 86400000
+                  },
+                  "timeContextFromParameter": "Timerange",
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "crossComponentResources": [
+                    "{WsResourcesInternal}"
+                  ],
+                  "visualization": "linechart",
+                  "gridSettings": {
+                    "formatters": [
+                      {
+                        "columnMatch": "ResourceIdPrefix",
+                        "formatter": 5
+                      }
+                    ],
+                    "labelSettings": [
+                      {
+                        "columnId": "avg",
+                        "label": "Average"
+                      },
+                      {
+                        "columnId": "max",
+                        "label": "MAX"
+                      }
+                    ]
+                  },
+                  "chartSettings": {
+                    "ySettings": {
+                      "numberFormatSettings": {
+                        "unit": 1,
+                        "options": {
+                          "style": "decimal",
+                          "useGrouping": true
+                        }
+                      },
+                      "min": 0,
+                      "max": 100
+                    }
+                  }
+                },
+                "customWidth": "33",
+                "name": "query - 15 - Copy - Copy - Copy - Copy - Copy - Copy"
+              },
+              {
+                "type": 1,
+                "content": {
+                  "json": "### LogIO(%)"
+                },
+                "customWidth": "33",
+                "name": "text - 11 - Copy - Copy - Copy - Copy - Copy - Copy"
+              },
+              {
+                "type": 1,
+                "content": {
+                  "json": ""
+                },
+                "customWidth": "33",
+                "name": "text - 11 - Copy - Copy - Copy - Copy - Copy - Copy - Copy"
+              },
+              {
+                "type": 1,
+                "content": {
+                  "json": ""
+                },
+                "customWidth": "33",
+                "name": "text - 11 - Copy - Copy - Copy - Copy - Copy - Copy - Copy - Copy"
+              },
+              {
+                "type": 11,
+                "content": {
+                  "version": "LinkItem/1.0",
+                  "style": "nav",
+                  "links": [
+                    {
+                      "id": "ac809840-e942-45c6-993e-9f9815784bd5",
+                      "cellValue": "{database}",
+                      "linkTarget": "AlertCreation",
+                      "linkLabel": "New Alert Rule",
+                      "style": "link",
+                      "alertRuleContext": {
+                        "alertType": "Metric",
+                        "namespace": "microsoft.sql/servers/databases",
+                        "metricId": "microsoft.sql/servers/databases-Basic-log_write_percent",
+                        "aggregation": 4
+                      }
+                    },
+                    {
+                      "id": "cbc8a8ed-ac7c-4fd9-bd7e-89c1dfd74aa0",
+                      "cellValue": "{AlertRulesWorkbook}",
+                      "linkTarget": "WorkbookTemplate",
+                      "linkLabel": "Edit Alert Rules",
+                      "style": "link",
+                      "linkIsContextBlade": true,
+                      "workbookContext": {
+                        "componentIdSource": "workbook",
+                        "resourceIdsSource": "workbook",
+                        "templateIdSource": "cell",
+                        "templateId": "wbLink",
+                        "typeSource": "workbook",
+                        "gallerySource": "workbook",
+                        "locationSource": "default",
+                        "passSpecificParams": true,
+                        "templateParameters": [
+                          {
+                            "name": "database",
+                            "source": "parameter",
+                            "value": "database"
+                          },
+                          {
+                            "name": "MetricNamespace",
+                            "source": "static",
+                            "value": "{Type}/databases"
+                          },
+                          {
+                            "name": "MetricCategory",
+                            "source": "static",
+                            "value": "Basic"
+                          },
+                          {
+                            "name": "MetricName",
+                            "source": "static",
+                            "value": "log_write_percent"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                },
+                "customWidth": "33",
+                "name": "links - 8 - Copy - Copy - Copy - Copy"
+              },
+              {
+                "type": 1,
+                "content": {
+                  "json": ""
+                },
+                "customWidth": "33",
+                "name": "text - 11 - Copy - Copy - Copy - Copy - Copy - Copy - Copy - Copy"
+              },
+              {
+                "type": 1,
+                "content": {
+                  "json": ""
+                },
+                "customWidth": "33",
+                "name": "text - 11 - Copy - Copy - Copy - Copy - Copy - Copy - Copy - Copy - Copy"
+              },
+              {
+                "type": 3,
+                "content": {
+                  "version": "KqlItem/1.0",
+                  "query": "set truncationmaxrecords=5000;\r\nlet metrics = InsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace == 'sqlserver_azure_db_resource_stats'\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| extend dbName = strcat(sql_instance,\"/\",database_name);\r\nmetrics \r\n| where dbName =~ '{ResourceId}' \r\n| where Name=='avg_log_write_percent' \r\n| summarize avg = min_of(avg(Val), 100.0), max = min_of(max(Val), 100.0) by bin(TimeGenerated, {Timerange:grain})\r\n| sort by TimeGenerated desc",
+                  "size": 1,
+                  "aggregation": 3,
+                  "showAnalytics": true,
+                  "timeContext": {
+                    "durationMs": 86400000
+                  },
+                  "timeContextFromParameter": "Timerange",
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "crossComponentResources": [
+                    "{WsResourcesInternal}"
+                  ],
+                  "visualization": "linechart",
+                  "gridSettings": {
+                    "formatters": [
+                      {
+                        "columnMatch": "ResourceIdPrefix",
+                        "formatter": 5
+                      }
+                    ],
+                    "labelSettings": [
+                      {
+                        "columnId": "avg",
+                        "label": "Average"
+                      },
+                      {
+                        "columnId": "max",
+                        "label": "MAX"
+                      }
+                    ]
+                  },
+                  "chartSettings": {
+                    "ySettings": {
+                      "numberFormatSettings": {
+                        "unit": 1,
+                        "options": {
+                          "style": "decimal",
+                          "useGrouping": true
+                        }
+                      },
+                      "min": 0,
+                      "max": 100
+                    }
+                  }
+                },
+                "customWidth": "33",
+                "name": "query - 15 - Copy - Copy - Copy - Copy - Copy - Copy - Copy"
+              }
+            ]
+          },
+          "customWidth": "60",
+          "name": "group - 18"
+        }
+      ],
+      "fallbackResourceIds": [
+      ],
+      "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
+    },
+    "workbookDisplayName": "Database",
+    "workbookName": "[parameters('workbookNames').Database]"
+  },
+  "resources": [
+    {
+      "name": "[variables('workbookName')]",
+      "type": "microsoft.insights/workbooks",
+      "location": "[resourceGroup().location]",
+      "apiVersion": "2018-06-17-preview",
+      "kind": "shared",
+      "properties": {
+        "displayName": "[variables('workbookDisplayName')]",
+        "serializedData": "[string(variables('workbookMarkup'))]",
+        "version": "Notebook/1.0",
+        "sourceId": "[resourceGroup().id]",
+        "category": "workbook"
+      },
+      "tags": {
+        "hidden-title": "[variables('workbookDisplayName')]"
+      }
+    }
+  ]
+}

--- a/Workbooks/Workloads/QDS/DatabaseWaits.json
+++ b/Workbooks/Workloads/QDS/DatabaseWaits.json
@@ -1,0 +1,581 @@
+﻿{
+  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "workbookNames": {
+      "type": "object",
+      "defaultValue": {
+        "DatabaseWaits": "[guid(resourceGroup().id, 'Database Waits')]",
+        "Database": "[guid(resourceGroup().id, 'Database')]",
+        "Query": "[guid(resourceGroup().id, 'Query')]"
+      }
+    }
+  },
+  "variables": {
+    "workbookMarkup": {
+      "version": "Notebook/1.0",
+      "items": [
+        {
+          "type": 9,
+          "content": {
+            "version": "KqlParameterItem/1.0",
+            "crossComponentResources": [
+              "{WsResourcesInternal}"
+            ],
+            "parameters": [
+              {
+                "id": "4ecc9f52-2e3f-4c8e-b9ea-f3e2f2583f5b",
+                "version": "KqlParameterItem/1.0",
+                "name": "WsResources",
+                "type": 1
+              },
+              {
+                "id": "f3e20cbc-b692-4b3d-8916-2fd0662ecfe6",
+                "version": "KqlParameterItem/1.0",
+                "name": "WsResourcesInternal",
+                "type": 5,
+                "multiSelect": true,
+                "quote": "'",
+                "delimiter": ",",
+                "query": "where id in~ ({WsResources})\r\n| project id, selected=1",
+                "crossComponentResources": [
+                  "value::all"
+                ],
+                "typeSettings": {
+                  "additionalResourceOptions": [],
+                  "showDefault": false
+                },
+                "queryType": 1,
+                "resourceType": "microsoft.resourcegraph/resources"
+              },
+              {
+                "id": "30b86356-1bba-4603-83d1-835b99171066",
+                "version": "KqlParameterItem/1.0",
+                "name": "Timerange",
+                "type": 4,
+                "value": {
+                  "durationMs": 86400000
+                },
+                "typeSettings": {
+                  "selectableValues": [
+                    {
+                      "durationMs": 300000
+                    },
+                    {
+                      "durationMs": 900000
+                    },
+                    {
+                      "durationMs": 1800000
+                    },
+                    {
+                      "durationMs": 3600000
+                    },
+                    {
+                      "durationMs": 14400000
+                    },
+                    {
+                      "durationMs": 43200000
+                    },
+                    {
+                      "durationMs": 86400000
+                    },
+                    {
+                      "durationMs": 172800000
+                    },
+                    {
+                      "durationMs": 259200000
+                    },
+                    {
+                      "durationMs": 604800000
+                    },
+                    {
+                      "durationMs": 1209600000
+                    },
+                    {
+                      "durationMs": 2419200000
+                    },
+                    {
+                      "durationMs": 2592000000
+                    },
+                    {
+                      "durationMs": 5184000000
+                    },
+                    {
+                      "durationMs": 7776000000
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "f2ae16b9-0bea-4ad0-b14e-93a51424fab9",
+                "version": "KqlParameterItem/1.0",
+                "name": "DBWorkbook",
+                "type": 1,
+                "value": "[resourceId('microsoft.insights/workbooks', parameters('workbookNames').Database)]"
+              },
+              {
+                "id": "58ec8e26-5dac-4c4c-9441-47daa7adf18f",
+                "version": "KqlParameterItem/1.0",
+                "name": "SubscriptionId",
+                "type": 1,
+                "value": ""
+              },
+              {
+                "id": "d2d2fa1b-070a-45d8-94ec-411c60379803",
+                "version": "KqlParameterItem/1.0",
+                "name": "ServerId",
+                "type": 1,
+                "value": ""
+              },
+              {
+                "id": "be50e0a3-ec3a-4b7d-bd17-006135b6e356",
+                "version": "KqlParameterItem/1.0",
+                "name": "QueryWorkbook",
+                "type": 1,
+                "value": "[resourceId('microsoft.insights/workbooks', parameters('workbookNames').Query)]"
+              },
+              {
+                "id": "492c11ca-b5a5-45f2-85e5-1ab9a857072a",
+                "version": "KqlParameterItem/1.0",
+                "name": "ResourceId",
+                "type": 1,
+                "value": ""
+              },
+              {
+                "id": "1ad21b75-d765-4756-823e-3c37538374f4",
+                "version": "KqlParameterItem/1.0",
+                "name": "Type",
+                "type": 1
+              },
+              {
+                "id": "a61f2f01-00c7-4706-a0e0-7f187d4ac424",
+                "version": "KqlParameterItem/1.0",
+                "name": "TypeInternal",
+                "type": 7,
+                "query": "{\"version\":\"1.0.0\",\"content\":\"{\\\"value\\\":\\\"{Type}\\\", \\\"selected\\\":true}\",\"transformers\":null}",
+                "typeSettings": {
+                  "additionalResourceOptions": [],
+                  "showDefault": false
+                },
+                "queryType": 8
+              },
+              {
+                "id": "16798829-2d8c-4e10-8cb2-5020451a8571",
+                "version": "KqlParameterItem/1.0",
+                "name": "dbType",
+                "type": 1
+              },
+              {
+                "id": "e0be3faa-c16f-478d-8c28-a57d91e68407",
+                "version": "KqlParameterItem/1.0",
+                "name": "MonitoredResources",
+                "type": 9,
+                "multiSelect": true,
+                "quote": "'",
+                "delimiter": ",",
+                "query": "InsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace == 'sqlserver_azuredb_waitstats'\r\n| distinct Tags\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| where database_name != ''\r\n| project dbName = tolower(strcat(sql_instance, '/', database_name))\r\n| distinct dbName",
+                "crossComponentResources": [
+                  "{WsResourcesInternal}"
+                ],
+                "timeContext": {
+                  "durationMs": 0
+                },
+                "timeContextFromParameter": "Timerange",
+                "queryType": 0,
+                "resourceType": "microsoft.operationalinsights/workspaces"
+              },
+              {
+                "id": "89358b96-036c-40a7-bd58-bd3ff0361e34",
+                "version": "KqlParameterItem/1.0",
+                "name": "Resources_database_waits",
+                "type": 9,
+                "multiSelect": true,
+                "quote": "",
+                "delimiter": ",",
+                "query": "where type contains '{Type}'\r\n| extend ResourceId = tolower(id)\r\n| extend name = tolower(strcat(extract('/servers/([^/]+)/', 1, ResourceId), '/', name))\r\n| where name in ({MonitoredResources})\r\n| project strcat('{\"name\":\"',name, '\" , \"subscription\": \"', subscriptionId, '\", \"resourceGroup\": \"', resourceGroup, '\"}')",
+                "crossComponentResources": [
+                  "value::all"
+                ],
+                "queryType": 1,
+                "resourceType": "microsoft.resourcegraph/resources"
+              }
+            ],
+            "style": "pills",
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          },
+          "conditionalVisibility": {
+            "parameterName": "hide",
+            "comparison": "isNotEqualTo"
+          },
+          "name": "parameters - 0"
+        },
+        {
+          "type": 1,
+          "content": {
+            "json": "# Database waits"
+          },
+          "name": "text - 3"
+        },
+        {
+          "type": 1,
+          "content": {
+            "json": "Data is loading",
+            "style": "info"
+          },
+          "conditionalVisibility": {
+            "parameterName": "Resources_database_waits",
+            "comparison": "isEqualTo"
+          },
+          "name": "text - 3"
+        },
+        {
+          "type": 12,
+          "content": {
+            "version": "NotebookGroup/1.0",
+            "groupType": "editable",
+            "items": [
+              {
+                "type": 3,
+                "content": {
+                  "version": "KqlItem/1.0",
+                  "query": "let resources = print dynamic([{Resources_database_waits}])\r\n| mv-expand print_0\r\n| evaluate bag_unpack(print_0);\r\nInsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace == 'sqlserver_azuredb_waitstats'\r\n| summarize make_bag(pack(Name, Val)) by Tags, TimeGenerated\r\n| evaluate bag_unpack(bag_)\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| where database_name!=''\r\n| extend resourceName = tolower(strcat(sql_instance, '/', database_name))\r\n| join kind=leftouter (resources| extend resourceName = name)on resourceName\r\n| order by resourceName, wait_type, TimeGenerated asc\r\n| serialize \r\n| extend wait_time_ms = case(prev(resourceName) == resourceName and prev(wait_type) == wait_type, wait_time_ms - prev(wait_time_ms), real(null))\r\n| summarize Total = sum(wait_time_ms)/1000\r\nby subscription\r\n| extend ResourceIdPrefix = strcat(\"/SUBSCRIPTIONS/\", subscription, \"/\")\r\n| project SubscriptionId = subscription, Total, ResourceIdPrefix\r\n| sort by Total desc",
+                  "size": 1,
+                  "title": "Subscriptions",
+                  "timeContext": {
+                    "durationMs": 86400000
+                  },
+                  "timeContextFromParameter": "Timerange",
+                  "exportFieldName": "SubscriptionId",
+                  "exportParameterName": "SubscriptionId",
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "crossComponentResources": [
+                    "{WsResourcesInternal}"
+                  ],
+                  "gridSettings": {
+                    "formatters": [
+                      {
+                        "columnMatch": "SubscriptionId",
+                        "formatter": 15,
+                        "formatOptions": {
+                          "linkTarget": null,
+                          "showIcon": true,
+                          "customColumnWidthSetting": "24ch"
+                        }
+                      },
+                      {
+                        "columnMatch": "Total",
+                        "formatter": 0,
+                        "numberFormat": {
+                          "unit": 24,
+                          "options": {
+                            "style": "decimal"
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "ResourceIdPrefix",
+                        "formatter": 5
+                      }
+                    ],
+                    "labelSettings": [
+                      {
+                        "columnId": "SubscriptionId",
+                        "label": "Subscription"
+                      },
+                      {
+                        "columnId": "ResourceIdPrefix"
+                      }
+                    ]
+                  }
+                },
+                "customWidth": "33",
+                "name": "query - 4"
+              },
+              {
+                "type": 1,
+                "content": {
+                  "json": ""
+                },
+                "customWidth": "67",
+                "name": "text - 7"
+              },
+              {
+                "type": 3,
+                "content": {
+                  "version": "KqlItem/1.0",
+                  "query": "let resources = print dynamic([{Resources_database_waits}])\r\n| mv-expand print_0\r\n| evaluate bag_unpack(print_0);\r\nInsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace == 'sqlserver_azuredb_waitstats'\r\n| summarize make_bag(pack(Name, Val)) by Tags, TimeGenerated\r\n| evaluate bag_unpack(bag_)\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| where database_name!=''\r\n| extend resourceName = tolower(strcat(sql_instance, '/', database_name))\r\n| join kind=leftouter (resources| extend resourceName = name)on resourceName\r\n| where tostring(subscription) contains '{SubscriptionId}'\r\n| order by resourceName, wait_type, TimeGenerated asc\r\n| serialize \r\n| extend wait_time_ms = case(prev(resourceName) == resourceName and prev(wait_type) == wait_type, wait_time_ms - prev(wait_time_ms), real(null))\r\n| summarize Total = sum(wait_time_ms)/1000\r\n    by subscription, resourceGroup, sql_instance\r\n| extend ResourceIdPrefix = strcat(\"/SUBSCRIPTIONS/\", subscription, \"/RESOURCEGROUPS/\", resourceGroup, \"/PROVIDERS/{Type}/\", sql_instance) \r\n| project Type = '{Type}', ['{TypeInternal:label}'] = sql_instance, sql_instance, Total\r\n| sort by Total desc",
+                  "size": 1,
+                  "title": "{TypeInternal:label}s",
+                  "timeContext": {
+                    "durationMs": 86400000
+                  },
+                  "timeContextFromParameter": "Timerange",
+                  "exportFieldName": "sql_instance",
+                  "exportParameterName": "ServerId",
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "crossComponentResources": [
+                    "{WsResourcesInternal}"
+                  ],
+                  "gridSettings": {
+                    "formatters": [
+                      {
+                        "columnMatch": "Type",
+                        "formatter": 16,
+                        "formatOptions": {
+                          "showIcon": true,
+                          "customColumnWidthSetting": "4ch"
+                        }
+                      },
+                      {
+                        "columnMatch": "SQL",
+                        "formatter": 1
+                      },
+                      {
+                        "columnMatch": "sql_instance",
+                        "formatter": 5
+                      },
+                      {
+                        "columnMatch": "Total",
+                        "formatter": 0,
+                        "numberFormat": {
+                          "unit": 24,
+                          "options": {
+                            "style": "decimal",
+                            "useGrouping": false
+                          }
+                        }
+                      }
+                    ],
+                    "labelSettings": [
+                      {
+                        "columnId": "Type",
+                        "label": " "
+                      },
+                      {
+                        "columnId": "SQL server"
+                      },
+                      {
+                        "columnId": "sql_instance"
+                      },
+                      {
+                        "columnId": "Total"
+                      }
+                    ]
+                  }
+                },
+                "customWidth": "33",
+                "name": "query - 4 - Copy"
+              },
+              {
+                "type": 1,
+                "content": {
+                  "json": ""
+                },
+                "customWidth": "67",
+                "name": "text - 8"
+              },
+              {
+                "type": 3,
+                "content": {
+                  "version": "KqlItem/1.0",
+                  "query": "let resources = print dynamic([{Resources_database_waits}])\r\n| mv-expand print_0\r\n| evaluate bag_unpack(print_0);\r\nInsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace == 'sqlserver_azuredb_waitstats'\r\n| summarize make_bag(pack(Name, Val)) by Tags, TimeGenerated\r\n| evaluate bag_unpack(bag_)\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| where database_name!=''\r\n| extend resourceName = tolower(strcat(sql_instance, '/', database_name))\r\n| join kind=leftouter (resources| extend resourceName = name)on resourceName\r\n| where tostring(subscription) contains '{SubscriptionId}'\r\n| where tostring(sql_instance) contains '{ServerId}'\r\n| order by resourceName, wait_type, TimeGenerated asc\r\n| serialize \r\n| extend wait_time_ms = case(prev(resourceName) == resourceName and prev(wait_type) == wait_type, wait_time_ms - prev(wait_time_ms), real(null))\r\n| summarize Total = sum(wait_time_ms)/1000\r\nby subscription, resourceGroup, sql_instance, database_name, resourceName\r\n| project Type = '{Type}/DATABASES', ResourceId = resourceName, Total, \r\n    wbLink = '{DBWorkbook}'\r\n| sort by Total desc\r\n",
+                  "size": 1,
+                  "title": "Databases",
+                  "timeContext": {
+                    "durationMs": 86400000
+                  },
+                  "timeContextFromParameter": "Timerange",
+                  "exportFieldName": "ResourceId",
+                  "exportParameterName": "ResourceId",
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "crossComponentResources": [
+                    "{WsResourcesInternal}"
+                  ],
+                  "gridSettings": {
+                    "formatters": [
+                      {
+                        "columnMatch": "Type",
+                        "formatter": 16,
+                        "formatOptions": {
+                          "showIcon": true,
+                          "customColumnWidthSetting": "4ch"
+                        }
+                      },
+                      {
+                        "columnMatch": "ResourceId",
+                        "formatter": 7,
+                        "formatOptions": {
+                          "linkColumn": "wbLink",
+                          "linkTarget": "WorkbookTemplate",
+                          "workbookContext": {
+                            "componentIdSource": "workbook",
+                            "resourceIdsSource": "workbook",
+                            "templateIdSource": "column",
+                            "templateId": "wbLink",
+                            "typeSource": "workbook",
+                            "gallerySource": "workbook",
+                            "locationSource": "default"
+                          },
+                          "customColumnWidthSetting": "24ch"
+                        }
+                      },
+                      {
+                        "columnMatch": "Total",
+                        "formatter": 0,
+                        "numberFormat": {
+                          "unit": 24,
+                          "options": {
+                            "style": "decimal"
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "wbLink",
+                        "formatter": 5
+                      }
+                    ],
+                    "labelSettings": [
+                      {
+                        "columnId": "Type",
+                        "label": " "
+                      },
+                      {
+                        "columnId": "ResourceId",
+                        "label": "Database"
+                      },
+                      {
+                        "columnId": "Total"
+                      },
+                      {
+                        "columnId": "wbLink"
+                      }
+                    ]
+                  },
+                  "sortBy": []
+                },
+                "customWidth": "33",
+                "name": "query - 4 - Copy - Copy"
+              },
+              {
+                "type": 3,
+                "content": {
+                  "version": "KqlItem/1.0",
+                  "query": "let resources = print dynamic([{Resources_database_waits}])\r\n| mv-expand print_0\r\n| evaluate bag_unpack(print_0);\r\n\r\nInsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace == 'sqlserver_azuredb_waitstats'\r\n| summarize make_bag(pack(Name, Val)) by Tags, TimeGenerated\r\n| evaluate bag_unpack(bag_)\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| where database_name!=''\r\n| extend resourceName = tolower(strcat(sql_instance, '/', database_name))\r\n| join kind=leftouter (resources| extend resourceName = name)on resourceName\r\n| where tostring(subscription) contains '{SubscriptionId}'\r\n| where tostring(sql_instance) contains '{ServerId}'\r\n| where tostring(resourceName) contains '{ResourceId}'\r\n| order by resourceName, wait_type, TimeGenerated asc\r\n| serialize \r\n| extend wait_time_ms = case(prev(resourceName) == resourceName and prev(wait_type) == wait_type, wait_time_ms - prev(wait_time_ms), real(null))\r\n| summarize total_wait_time_in_ms = sum(wait_time_ms)\r\n    by wait_type, bin(TimeGenerated, {Timerange:grain})\r\n| top 1000 by total_wait_time_in_ms desc\r\n| evaluate pivot(wait_type, sum(total_wait_time_in_ms))",
+                  "size": 0,
+                  "aggregation": 3,
+                  "showAnalytics": true,
+                  "title": "Database waits",
+                  "timeContext": {
+                    "durationMs": 86400000
+                  },
+                  "timeContextFromParameter": "Timerange",
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "crossComponentResources": [
+                    "{WsResourcesInternal}"
+                  ],
+                  "visualization": "barchart",
+                  "chartSettings": {
+                    "ySettings": {
+                      "numberFormatSettings": {
+                        "unit": 23,
+                        "options": {
+                          "style": "decimal",
+                          "useGrouping": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "customWidth": "67",
+                "name": "query - 2",
+                "styleSettings": {
+                  "margin": "-550px 0px 0px 0px"
+                }
+              },
+              {
+                "type": 3,
+                "content": {
+                  "version": "KqlItem/1.0",
+                  "query": "let resources = print dynamic([{Resources_database_waits}])\r\n| mv-expand print_0\r\n| evaluate bag_unpack(print_0);\r\nInsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace == 'sqlserver_azuredb_waitstats'\r\n| summarize make_bag(pack(Name, Val)) by Tags, TimeGenerated\r\n| evaluate bag_unpack(bag_)\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| where database_name!=''\r\n| extend resourceName = tolower(strcat(sql_instance, '/', database_name))\r\n| join kind=leftouter (resources| extend resourceName = name)on resourceName\r\n| where tostring(subscription) contains '{SubscriptionId}'\r\n| where tostring(sql_instance) contains '{ServerId}'\r\n| where tostring(resourceName) contains '{ResourceId}'\r\n| order by resourceName, wait_type, TimeGenerated asc\r\n| serialize \r\n| extend wait_time_ms = case(prev(resourceName) == resourceName and prev(wait_type) == wait_type, wait_time_ms - prev(wait_time_ms), real(null))\r\n| summarize Total = sum(wait_time_ms) / 1000\r\nby wait_type\r\n| project ['Wait Type'] = strcat('⏳ ', wait_type), Total\r\n| sort by Total",
+                  "size": 1,
+                  "title": "Database waits",
+                  "timeContext": {
+                    "durationMs": 86400000
+                  },
+                  "timeContextFromParameter": "Timerange",
+                  "exportedParameters": [
+                    {
+                      "fieldName": "query_hash",
+                      "parameterName": "QueryHash"
+                    },
+                    {
+                      "fieldName": "ResourceId",
+                      "parameterName": "ResourceId",
+                      "parameterType": 1
+                    }
+                  ],
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "crossComponentResources": [
+                    "{WsResourcesInternal}"
+                  ],
+                  "gridSettings": {
+                    "formatters": [
+                      {
+                        "columnMatch": "Total",
+                        "formatter": 0,
+                        "numberFormat": {
+                          "unit": 24,
+                          "options": {
+                            "style": "decimal"
+                          }
+                        }
+                      }
+                    ]
+                  },
+                  "sortBy": []
+                },
+                "customWidth": "33",
+                "name": "query - 4 - Copy - Copy - Copy"
+              }
+            ]
+          },
+          "conditionalVisibility": {
+            "parameterName": "Resources_database_waits",
+            "comparison": "isNotEqualTo"
+          },
+          "name": "group - 9"
+        }
+      ],
+      "fallbackResourceIds": [
+      ],
+      "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
+    },
+    "workbookDisplayName": "Database Waits",
+    "workbookName": "[parameters('workbookNames').DatabaseWaits]"
+  },
+  "resources": [
+    {
+      "name": "[variables('workbookName')]",
+      "type": "microsoft.insights/workbooks",
+      "location": "[resourceGroup().location]",
+      "apiVersion": "2018-06-17-preview",
+      "kind": "shared",
+      "properties": {
+        "displayName": "[variables('workbookDisplayName')]",
+        "serializedData": "[string(variables('workbookMarkup'))]",
+        "version": "Notebook/1.0",
+        "sourceId": "[resourceGroup().id]",
+        "category": "workbook"
+      },
+      "tags": {
+        "hidden-title": "[variables('workbookDisplayName')]"
+      }
+    }
+  ]
+}

--- a/Workbooks/Workloads/QDS/Deadlocks.json
+++ b/Workbooks/Workloads/QDS/Deadlocks.json
@@ -1,0 +1,859 @@
+{
+  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "workbookNames": {
+      "type": "object",
+      "defaultValue": {
+        "Deadlocks": "[guid(resourceGroup().id, 'Deadlocks')]",
+        "Database": "[guid(resourceGroup().id, 'Database')]"
+      }
+    }
+  },
+  "variables": {
+    "workbookMarkup": {
+      "version": "Notebook/1.0",
+      "items": [
+        {
+          "type": 9,
+          "content": {
+            "version": "KqlParameterItem/1.0",
+            "crossComponentResources": [
+              "value::all"
+            ],
+            "parameters": [
+              {
+                "id": "4ecc9f52-2e3f-4c8e-b9ea-f3e2f2583f5b",
+                "version": "KqlParameterItem/1.0",
+                "name": "WsResources",
+                "type": 1
+              },
+              {
+                "id": "f3e20cbc-b692-4b3d-8916-2fd0662ecfe6",
+                "version": "KqlParameterItem/1.0",
+                "name": "WsResourcesInternal",
+                "type": 5,
+                "multiSelect": true,
+                "quote": "'",
+                "delimiter": ",",
+                "query": "where id in~ ({WsResources})\r\n| project id, selected=1",
+                "crossComponentResources": [
+                  "value::all"
+                ],
+                "typeSettings": {
+                  "additionalResourceOptions": [],
+                  "showDefault": false
+                },
+                "queryType": 1,
+                "resourceType": "microsoft.resourcegraph/resources"
+              },
+              {
+                "id": "30b86356-1bba-4603-83d1-835b99171066",
+                "version": "KqlParameterItem/1.0",
+                "name": "Timerange",
+                "type": 4,
+                "value": {
+                  "durationMs": 86400000
+                },
+                "typeSettings": {
+                  "selectableValues": [
+                    {
+                      "durationMs": 300000
+                    },
+                    {
+                      "durationMs": 900000
+                    },
+                    {
+                      "durationMs": 1800000
+                    },
+                    {
+                      "durationMs": 3600000
+                    },
+                    {
+                      "durationMs": 14400000
+                    },
+                    {
+                      "durationMs": 43200000
+                    },
+                    {
+                      "durationMs": 86400000
+                    },
+                    {
+                      "durationMs": 172800000
+                    },
+                    {
+                      "durationMs": 259200000
+                    },
+                    {
+                      "durationMs": 604800000
+                    },
+                    {
+                      "durationMs": 1209600000
+                    },
+                    {
+                      "durationMs": 2419200000
+                    },
+                    {
+                      "durationMs": 2592000000
+                    },
+                    {
+                      "durationMs": 5184000000
+                    },
+                    {
+                      "durationMs": 7776000000
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "f2ae16b9-0bea-4ad0-b14e-93a51424fab9",
+                "version": "KqlParameterItem/1.0",
+                "name": "DBWorkbook",
+                "type": 1,
+                "value": "[resourceId('microsoft.insights/workbooks', parameters('workbookNames').Database)]"
+              },
+              {
+                "id": "58ec8e26-5dac-4c4c-9441-47daa7adf18f",
+                "version": "KqlParameterItem/1.0",
+                "name": "SubscriptionId",
+                "type": 1,
+                "value": ""
+              },
+              {
+                "id": "d2d2fa1b-070a-45d8-94ec-411c60379803",
+                "version": "KqlParameterItem/1.0",
+                "name": "ServerId",
+                "type": 1,
+                "value": ""
+              },
+              {
+                "id": "4adf7337-0c81-48ab-97a9-5917de6da6c0",
+                "version": "KqlParameterItem/1.0",
+                "name": "DbId",
+                "type": 1
+              },
+              {
+                "id": "4feafee7-0cd9-435e-a42e-11f31984c024",
+                "version": "KqlParameterItem/1.0",
+                "name": "Type",
+                "type": 1
+              },
+              {
+                "id": "55c27380-5130-4c43-97da-155327e6bc93",
+                "version": "KqlParameterItem/1.0",
+                "name": "TypeInternal",
+                "type": 7,
+                "query": "{\"version\":\"1.0.0\",\"content\":\"{\\\"value\\\":\\\"{Type}\\\", \\\"selected\\\":true}\",\"transformers\":null}",
+                "typeSettings": {
+                  "additionalResourceOptions": [],
+                  "showDefault": false
+                },
+                "queryType": 8
+              },
+              {
+                "id": "104bb4aa-c4b1-4ff5-a53f-4cb22d20e009",
+                "version": "KqlParameterItem/1.0",
+                "name": "dbType",
+                "type": 1
+              },
+              {
+                "id": "d8bb41fb-46fc-4cd8-a8a6-cead75ba2a32",
+                "version": "KqlParameterItem/1.0",
+                "name": "MonitoredResources",
+                "type": 9,
+                "multiSelect": true,
+                "quote": "'",
+                "delimiter": ",",
+                "query": "InsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace == 'sqlserver_performance'\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| project dbName = tolower(strcat(extract(\"^([^\\\\.]+)\\\\.?\", 1, sql_instance), '/', database_name))\r\n| distinct dbName",
+                "crossComponentResources": [
+                  "{WsResourcesInternal}"
+                ],
+                "value": null,
+                "timeContext": {
+                  "durationMs": 0
+                },
+                "timeContextFromParameter": "Timerange",
+                "queryType": 0,
+                "resourceType": "microsoft.operationalinsights/workspaces"
+              },
+              {
+                "id": "3f3783df-3615-4c1d-a49d-236526c12704",
+                "version": "KqlParameterItem/1.0",
+                "name": "Resources_deadlocks",
+                "type": 9,
+                "multiSelect": true,
+                "quote": "",
+                "delimiter": ",",
+                "query": "where type contains '{Type}'\r\n| extend ResourceId = tolower(id)\r\n| extend name = tolower(strcat(extract(tolower('/{Type}/([^/]+)/'), 1, ResourceId), '/', name))\r\n| where name in ({MonitoredResources})\r\n| project strcat('{\"name\":\"',name, '\" , \"subscription\": \"', subscriptionId, '\", \"resourceGroup\": \"', resourceGroup, '\"}')",
+                "crossComponentResources": [
+                  "value::all"
+                ],
+                "value": null,
+                "timeContext": {
+                  "durationMs": 0
+                },
+                "timeContextFromParameter": "Timerange",
+                "queryType": 1,
+                "resourceType": "microsoft.resourcegraph/resources"
+              }
+            ],
+            "style": "pills",
+            "queryType": 1,
+            "resourceType": "microsoft.resourcegraph/resources"
+          },
+          "conditionalVisibility": {
+            "parameterName": "hide",
+            "comparison": "isNotEqualTo"
+          },
+          "name": "parameters - 0"
+        },
+        {
+          "type": 1,
+          "content": {
+            "json": "# Deadlocks"
+          },
+          "name": "text - 3"
+        },
+        {
+          "type": 1,
+          "content": {
+            "json": "Data is loading",
+            "style": "info"
+          },
+          "conditionalVisibility": {
+            "parameterName": "Resources_deadlocks",
+            "comparison": "isEqualTo"
+          },
+          "name": "text - 3"
+        },
+        {
+          "type": 12,
+          "content": {
+            "version": "NotebookGroup/1.0",
+            "groupType": "editable",
+            "items": [
+              {
+                "type": 1,
+                "content": {
+                  "json": "## Subscriptions"
+                },
+                "name": "text - 9"
+              },
+              {
+                "type": 3,
+                "content": {
+                  "version": "KqlItem/1.0",
+                  "query": "let resources = print dynamic([{Resources_deadlocks}])\r\n| mv-expand print_0\r\n| evaluate bag_unpack(print_0);\r\nInsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace == 'sqlserver_performance'\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| where counter == 'Number of Deadlocks/sec'\r\n| extend resourceName = tolower(strcat(extract(\"^([^\\\\.]+)\\\\.?\", 1, sql_instance), '/', database_name))\r\n| join kind=leftouter (resources| extend resourceName = name)on resourceName\r\n| order by resourceName, TimeGenerated asc\r\n| serialize\r\n| extend delta = case(prev(resourceName) == resourceName, Val - prev(Val), real(null))\r\n| summarize Deadlocks = sum(delta) by subscription\r\n| sort by Deadlocks desc",
+                  "size": 1,
+                  "timeContext": {
+                    "durationMs": 86400000
+                  },
+                  "timeContextFromParameter": "Timerange",
+                  "exportFieldName": "subscription",
+                  "exportParameterName": "SubscriptionId",
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "crossComponentResources": [
+                    "{WsResourcesInternal}"
+                  ],
+                  "gridSettings": {
+                    "formatters": [
+                      {
+                        "columnMatch": "subscription",
+                        "formatter": 15,
+                        "formatOptions": {
+                          "linkTarget": null,
+                          "showIcon": true
+                        }
+                      }
+                    ],
+                    "labelSettings": [
+                      {
+                        "columnId": "subscription",
+                        "label": "Subscription"
+                      },
+                      {
+                        "columnId": "Deadlocks",
+                        "label": ""
+                      }
+                    ]
+                  }
+                },
+                "customWidth": "40",
+                "name": "query - 4"
+              },
+              {
+                "type": 3,
+                "content": {
+                  "version": "KqlItem/1.0",
+                  "query": "let resources = print dynamic([{Resources_deadlocks}])\r\n| mv-expand print_0\r\n| evaluate bag_unpack(print_0);\r\nInsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace == 'sqlserver_performance'\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| where counter == 'Number of Deadlocks/sec'\r\n| extend resourceName = tolower(strcat(extract(\"^([^\\\\.]+)\\\\.?\", 1, sql_instance), '/', database_name))\r\n| join kind=leftouter (resources| extend resourceName = name)on resourceName\r\n| where tostring(subscription) contains '{SubscriptionId}'\r\n| order by resourceName, TimeGenerated asc\r\n| serialize\r\n| extend delta = case(prev(resourceName) == resourceName, case(Val>=prev(Val), Val - prev(Val), Val), real(null))\r\n| project tostring(subscription), deadlocks = delta, bin(TimeGenerated, {Timerange:grain})\r\n| summarize sum(deadlocks) by subscription, TimeGenerated",
+                  "size": 1,
+                  "showAnalytics": true,
+                  "timeContext": {
+                    "durationMs": 0
+                  },
+                  "timeContextFromParameter": "Timerange",
+                  "exportFieldName": "SubscriptionId",
+                  "exportParameterName": "SubscriptionId",
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "crossComponentResources": [
+                    "{WsResourcesInternal}"
+                  ],
+                  "visualization": "barchart",
+                  "gridSettings": {
+                    "formatters": [
+                      {
+                        "columnMatch": "SubscriptionId",
+                        "formatter": 15,
+                        "formatOptions": {
+                          "linkTarget": null,
+                          "customColumnWidthSetting": "24ch"
+                        }
+                      },
+                      {
+                        "columnMatch": "max_duration",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "14ch"
+                        },
+                        "numberFormat": {
+                          "unit": 24,
+                          "options": {
+                            "style": "decimal",
+                            "useGrouping": false
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "avg_duration",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "14ch"
+                        },
+                        "numberFormat": {
+                          "unit": 24,
+                          "options": {
+                            "style": "decimal",
+                            "useGrouping": false
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "avg_cpu",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "14ch"
+                        },
+                        "numberFormat": {
+                          "unit": 24,
+                          "options": {
+                            "style": "decimal"
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "executions_count",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "13ch"
+                        },
+                        "numberFormat": {
+                          "unit": 17,
+                          "options": {
+                            "style": "decimal"
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "ResourceIdPrefix",
+                        "formatter": 5
+                      }
+                    ],
+                    "labelSettings": [
+                      {
+                        "columnId": "SubscriptionId",
+                        "label": "Subscription"
+                      },
+                      {
+                        "columnId": "max_duration",
+                        "label": "Max"
+                      },
+                      {
+                        "columnId": "avg_duration",
+                        "label": "Avg"
+                      },
+                      {
+                        "columnId": "avg_cpu",
+                        "label": "CPU"
+                      },
+                      {
+                        "columnId": "executions_count",
+                        "label": "Execs"
+                      },
+                      {
+                        "columnId": "ResourceIdPrefix"
+                      }
+                    ]
+                  }
+                },
+                "customWidth": "60",
+                "name": "query - 4 - Copy"
+              },
+              {
+                "type": 1,
+                "content": {
+                  "json": "## {TypeInternal:label}s"
+                },
+                "name": "text - 10"
+              },
+              {
+                "type": 1,
+                "content": {
+                  "json": "SubscriptionID: {SubscriptionId}"
+                },
+                "conditionalVisibility": {
+                  "parameterName": "SubscriptionId",
+                  "comparison": "isNotEqualTo"
+                },
+                "name": "text - 11"
+              },
+              {
+                "type": 3,
+                "content": {
+                  "version": "KqlItem/1.0",
+                  "query": "let resources = print dynamic([{Resources_deadlocks}])\r\n| mv-expand print_0\r\n| evaluate bag_unpack(print_0);\r\nInsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace == 'sqlserver_performance'\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| where counter == 'Number of Deadlocks/sec'\r\n| extend resourceName = tolower(strcat(extract(\"^([^\\\\.]+)\\\\.?\", 1, sql_instance), '/', database_name))\r\n| join kind=leftouter (resources| extend resourceName = name)on resourceName\r\n| where tostring(subscription) contains '{SubscriptionId}'\r\n| order by resourceName, TimeGenerated asc\r\n| serialize\r\n| extend delta = case(prev(resourceName) == resourceName, Val - prev(Val), real(null))\r\n| summarize Deadlocks = sum(delta) by sql_instance\r\n| project Type = '{Type}', ['{TypeInternal:label}'] = sql_instance, Deadlocks, sql_instance\r\n| sort by Deadlocks desc",
+                  "size": 1,
+                  "timeContext": {
+                    "durationMs": 86400000
+                  },
+                  "timeContextFromParameter": "Timerange",
+                  "exportFieldName": "sql_instance",
+                  "exportParameterName": "ServerId",
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "crossComponentResources": [
+                    "{WsResourcesInternal}"
+                  ],
+                  "gridSettings": {
+                    "formatters": [
+                      {
+                        "columnMatch": "Type",
+                        "formatter": 16,
+                        "formatOptions": {
+                          "showIcon": true,
+                          "customColumnWidthSetting": "4ch"
+                        }
+                      },
+                      {
+                        "columnMatch": "SQL",
+                        "formatter": 1
+                      },
+                      {
+                        "columnMatch": "sql_instance",
+                        "formatter": 5
+                      }
+                    ],
+                    "labelSettings": [
+                      {
+                        "columnId": "Type",
+                        "label": " "
+                      },
+                      {
+                        "columnId": "SQL server"
+                      },
+                      {
+                        "columnId": "Deadlocks",
+                        "label": ""
+                      },
+                      {
+                        "columnId": "sql_instance"
+                      }
+                    ]
+                  }
+                },
+                "customWidth": "40",
+                "name": "query - 4 - Copy"
+              },
+              {
+                "type": 3,
+                "content": {
+                  "version": "KqlItem/1.0",
+                  "query": "let resources = print dynamic([{Resources_deadlocks}])\r\n| mv-expand print_0\r\n| evaluate bag_unpack(print_0);\r\nInsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace == 'sqlserver_performance'\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| where counter == 'Number of Deadlocks/sec'\r\n| extend resourceName = tolower(strcat(extract(\"^([^\\\\.]+)\\\\.?\", 1, sql_instance), '/', database_name))\r\n| join kind=leftouter (resources| extend resourceName = name)on resourceName\r\n| where tostring(subscription) contains '{SubscriptionId}'\r\n| where tostring(sql_instance) contains '{ServerId}'\r\n| order by resourceName, TimeGenerated asc\r\n| serialize\r\n| extend delta = case(prev(resourceName) == resourceName, case(Val>=prev(Val), Val - prev(Val), Val), real(null))\r\n| project sql_instance, deadlocks = delta, bin(TimeGenerated, {Timerange:grain})\r\n| summarize sum(deadlocks) by sql_instance, TimeGenerated",
+                  "size": 1,
+                  "showAnalytics": true,
+                  "timeContext": {
+                    "durationMs": 0
+                  },
+                  "timeContextFromParameter": "Timerange",
+                  "exportFieldName": "SubscriptionId",
+                  "exportParameterName": "SubscriptionId",
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "crossComponentResources": [
+                    "{WsResourcesInternal}"
+                  ],
+                  "visualization": "barchart",
+                  "gridSettings": {
+                    "formatters": [
+                      {
+                        "columnMatch": "SubscriptionId",
+                        "formatter": 15,
+                        "formatOptions": {
+                          "linkTarget": null,
+                          "customColumnWidthSetting": "24ch"
+                        }
+                      },
+                      {
+                        "columnMatch": "max_duration",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "14ch"
+                        },
+                        "numberFormat": {
+                          "unit": 24,
+                          "options": {
+                            "style": "decimal",
+                            "useGrouping": false
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "avg_duration",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "14ch"
+                        },
+                        "numberFormat": {
+                          "unit": 24,
+                          "options": {
+                            "style": "decimal",
+                            "useGrouping": false
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "avg_cpu",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "14ch"
+                        },
+                        "numberFormat": {
+                          "unit": 24,
+                          "options": {
+                            "style": "decimal"
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "executions_count",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "13ch"
+                        },
+                        "numberFormat": {
+                          "unit": 17,
+                          "options": {
+                            "style": "decimal"
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "ResourceIdPrefix",
+                        "formatter": 5
+                      }
+                    ],
+                    "labelSettings": [
+                      {
+                        "columnId": "SubscriptionId",
+                        "label": "Subscription"
+                      },
+                      {
+                        "columnId": "max_duration",
+                        "label": "Max"
+                      },
+                      {
+                        "columnId": "avg_duration",
+                        "label": "Avg"
+                      },
+                      {
+                        "columnId": "avg_cpu",
+                        "label": "CPU"
+                      },
+                      {
+                        "columnId": "executions_count",
+                        "label": "Execs"
+                      },
+                      {
+                        "columnId": "ResourceIdPrefix"
+                      }
+                    ]
+                  }
+                },
+                "customWidth": "60",
+                "name": "query - 4 - Copy - Copy"
+              },
+              {
+                "type": 1,
+                "content": {
+                  "json": "## Databases"
+                },
+                "name": "text - 12"
+              },
+              {
+                "type": 1,
+                "content": {
+                  "json": "Subscription ID: {SubscriptionId}"
+                },
+                "conditionalVisibility": {
+                  "parameterName": "SuubscriptionId",
+                  "comparison": "isNotEqualTo"
+                },
+                "name": "text - 13"
+              },
+              {
+                "type": 1,
+                "content": {
+                  "json": "Server: {ServerId:name}"
+                },
+                "conditionalVisibility": {
+                  "parameterName": "ServerId",
+                  "comparison": "isNotEqualTo"
+                },
+                "name": "text - 14"
+              },
+              {
+                "type": 3,
+                "content": {
+                  "version": "KqlItem/1.0",
+                  "query": "let resources = print dynamic([{Resources_deadlocks}])\r\n| mv-expand print_0\r\n| evaluate bag_unpack(print_0);\r\nInsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace == 'sqlserver_performance'\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| where counter == 'Number of Deadlocks/sec'\r\n| extend resourceName = tolower(strcat(extract(\"^([^\\\\.]+)\\\\.?\", 1, sql_instance), '/', database_name))\r\n| join kind=leftouter (resources| extend resourceName = name)on resourceName\r\n| where tostring(subscription) contains '{SubscriptionId}'\r\n| where tostring(sql_instance) contains '{ServerId}'\r\n| order by resourceName, TimeGenerated asc\r\n| serialize\r\n| extend delta = case(prev(resourceName) == resourceName, Val - prev(Val), real(null))\r\n| summarize Deadlocks = sum(delta) by resourceName\r\n| project Type = '{Type}/DATABASES', ResourceId = resourceName, Deadlocks,    \r\n    wbLink = '{DBWorkbook}'\r\n| sort by Deadlocks desc",
+                  "size": 1,
+                  "timeContext": {
+                    "durationMs": 86400000
+                  },
+                  "timeContextFromParameter": "Timerange",
+                  "exportedParameters": [
+                    {
+                      "fieldName": "ResourceId",
+                      "parameterName": "DbId"
+                    },
+                    {
+                      "fieldName": "ResourceId",
+                      "parameterName": "ResourceId",
+                      "parameterType": 1
+                    }
+                  ],
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "crossComponentResources": [
+                    "{WsResourcesInternal}"
+                  ],
+                  "gridSettings": {
+                    "formatters": [
+                      {
+                        "columnMatch": "Type",
+                        "formatter": 16,
+                        "formatOptions": {
+                          "showIcon": true,
+                          "customColumnWidthSetting": "4ch"
+                        }
+                      },
+                      {
+                        "columnMatch": "ResourceId",
+                        "formatter": 7,
+                        "formatOptions": {
+                          "linkColumn": "wbLink",
+                          "linkTarget": "WorkbookTemplate",
+                          "workbookContext": {
+                            "componentIdSource": "workbook",
+                            "resourceIdsSource": "workbook",
+                            "templateIdSource": "column",
+                            "templateId": "wbLink",
+                            "typeSource": "workbook",
+                            "gallerySource": "workbook",
+                            "locationSource": "default"
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "wbLink",
+                        "formatter": 5
+                      }
+                    ],
+                    "labelSettings": [
+                      {
+                        "columnId": "Type",
+                        "label": " "
+                      },
+                      {
+                        "columnId": "ResourceId",
+                        "label": "Database"
+                      },
+                      {
+                        "columnId": "Deadlocks",
+                        "label": ""
+                      },
+                      {
+                        "columnId": "wbLink"
+                      }
+                    ]
+                  },
+                  "sortBy": []
+                },
+                "customWidth": "40",
+                "name": "query - 4 - Copy - Copy"
+              },
+              {
+                "type": 3,
+                "content": {
+                  "version": "KqlItem/1.0",
+                  "query": "let resources = print dynamic([{Resources_deadlocks}])\r\n| mv-expand print_0\r\n| evaluate bag_unpack(print_0);\r\nInsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace == 'sqlserver_performance'\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| where counter == 'Number of Deadlocks/sec'\r\n| extend resourceName = tolower(strcat(extract(\"^([^\\\\.]+)\\\\.?\", 1, sql_instance), '/', database_name))\r\n| join kind=leftouter (resources| extend resourceName = name)on resourceName\r\n| where tostring(subscription) contains '{SubscriptionId}'\r\n| where tostring(sql_instance) contains '{ServerId}'\r\n| where tostring(resourceName) contains '{DbId}'\r\n| order by resourceName, TimeGenerated asc\r\n| serialize\r\n| extend delta = case(prev(resourceName) == resourceName, case(Val>=prev(Val), Val - prev(Val), Val), real(null))\r\n| project resourceName, deadlocks = delta, bin(TimeGenerated, {Timerange:grain})\r\n| summarize sum(deadlocks) by resourceName, TimeGenerated",
+                  "size": 1,
+                  "showAnalytics": true,
+                  "timeContext": {
+                    "durationMs": 0
+                  },
+                  "timeContextFromParameter": "Timerange",
+                  "exportFieldName": "SubscriptionId",
+                  "exportParameterName": "SubscriptionId",
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "crossComponentResources": [
+                    "{WsResourcesInternal}"
+                  ],
+                  "visualization": "barchart",
+                  "gridSettings": {
+                    "formatters": [
+                      {
+                        "columnMatch": "SubscriptionId",
+                        "formatter": 15,
+                        "formatOptions": {
+                          "linkTarget": null,
+                          "customColumnWidthSetting": "24ch"
+                        }
+                      },
+                      {
+                        "columnMatch": "max_duration",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "14ch"
+                        },
+                        "numberFormat": {
+                          "unit": 24,
+                          "options": {
+                            "style": "decimal",
+                            "useGrouping": false
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "avg_duration",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "14ch"
+                        },
+                        "numberFormat": {
+                          "unit": 24,
+                          "options": {
+                            "style": "decimal",
+                            "useGrouping": false
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "avg_cpu",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "14ch"
+                        },
+                        "numberFormat": {
+                          "unit": 24,
+                          "options": {
+                            "style": "decimal"
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "executions_count",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "13ch"
+                        },
+                        "numberFormat": {
+                          "unit": 17,
+                          "options": {
+                            "style": "decimal"
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "ResourceIdPrefix",
+                        "formatter": 5
+                      }
+                    ],
+                    "labelSettings": [
+                      {
+                        "columnId": "SubscriptionId",
+                        "label": "Subscription"
+                      },
+                      {
+                        "columnId": "max_duration",
+                        "label": "Max"
+                      },
+                      {
+                        "columnId": "avg_duration",
+                        "label": "Avg"
+                      },
+                      {
+                        "columnId": "avg_cpu",
+                        "label": "CPU"
+                      },
+                      {
+                        "columnId": "executions_count",
+                        "label": "Execs"
+                      },
+                      {
+                        "columnId": "ResourceIdPrefix"
+                      }
+                    ]
+                  }
+                },
+                "customWidth": "60",
+                "name": "query - 4 - Copy - Copy - Copy"
+              }
+            ]
+          },
+          "conditionalVisibility": {
+            "parameterName": "Resources_deadlocks",
+            "comparison": "isNotEqualTo"
+          },
+          "name": "group - 14"
+        }
+      ],
+      "fallbackResourceIds": [
+      ],
+      "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
+    },
+    "workbookDisplayName": "Deadlocks",
+    "workbookName": "[parameters('workbookNames').Deadlocks]"
+  },
+  "resources": [
+    {
+      "name": "[variables('workbookName')]",
+      "type": "microsoft.insights/workbooks",
+      "location": "[resourceGroup().location]",
+      "apiVersion": "2018-06-17-preview",
+      "kind": "shared",
+      "properties": {
+        "displayName": "[variables('workbookDisplayName')]",
+        "serializedData": "[string(variables('workbookMarkup'))]",
+        "version": "Notebook/1.0",
+        "sourceId": "[resourceGroup().id]",
+        "category": "workbook"
+      },
+      "tags": {
+        "hidden-title": "[variables('workbookDisplayName')]"
+      }
+    }
+  ]
+}

--- a/Workbooks/Workloads/QDS/Errors.json
+++ b/Workbooks/Workloads/QDS/Errors.json
@@ -1,0 +1,1004 @@
+{
+  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "workbookNames": {
+      "type": "object",
+      "defaultValue": {
+        "Errors": "[guid(resourceGroup().id, 'Errors')]",
+        "Database": "[guid(resourceGroup().id, 'Database')]",
+        "Query": "[guid(resourceGroup().id, 'Query')]"
+      }
+    }
+  },
+  "variables": {
+    "workbookMarkup": {
+      "version": "Notebook/1.0",
+      "items": [
+        {
+          "type": 9,
+          "content": {
+            "version": "KqlParameterItem/1.0",
+            "crossComponentResources": [
+              "{WsResourcesInternal}"
+            ],
+            "parameters": [
+              {
+                "id": "4ecc9f52-2e3f-4c8e-b9ea-f3e2f2583f5b",
+                "version": "KqlParameterItem/1.0",
+                "name": "WsResources",
+                "type": 1
+              },
+              {
+                "id": "f3e20cbc-b692-4b3d-8916-2fd0662ecfe6",
+                "version": "KqlParameterItem/1.0",
+                "name": "WsResourcesInternal",
+                "type": 5,
+                "multiSelect": true,
+                "quote": "'",
+                "delimiter": ",",
+                "query": "where id in~ ({WsResources})\r\n| project id, selected=1",
+                "crossComponentResources": [
+                  "value::all"
+                ],
+                "typeSettings": {
+                  "additionalResourceOptions": [],
+                  "showDefault": false
+                },
+                "queryType": 1,
+                "resourceType": "microsoft.resourcegraph/resources"
+              },
+              {
+                "id": "30b86356-1bba-4603-83d1-835b99171066",
+                "version": "KqlParameterItem/1.0",
+                "name": "Timerange",
+                "type": 4,
+                "value": {
+                  "durationMs": 86400000
+                },
+                "typeSettings": {
+                  "selectableValues": [
+                    {
+                      "durationMs": 300000
+                    },
+                    {
+                      "durationMs": 900000
+                    },
+                    {
+                      "durationMs": 1800000
+                    },
+                    {
+                      "durationMs": 3600000
+                    },
+                    {
+                      "durationMs": 14400000
+                    },
+                    {
+                      "durationMs": 43200000
+                    },
+                    {
+                      "durationMs": 86400000
+                    },
+                    {
+                      "durationMs": 172800000
+                    },
+                    {
+                      "durationMs": 259200000
+                    },
+                    {
+                      "durationMs": 604800000
+                    },
+                    {
+                      "durationMs": 1209600000
+                    },
+                    {
+                      "durationMs": 2419200000
+                    },
+                    {
+                      "durationMs": 2592000000
+                    },
+                    {
+                      "durationMs": 5184000000
+                    },
+                    {
+                      "durationMs": 7776000000
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "f2ae16b9-0bea-4ad0-b14e-93a51424fab9",
+                "version": "KqlParameterItem/1.0",
+                "name": "DBWorkbook",
+                "type": 1,
+                "value": "[resourceId('microsoft.insights/workbooks', parameters('workbookNames').Database)]"
+              },
+              {
+                "id": "58ec8e26-5dac-4c4c-9441-47daa7adf18f",
+                "version": "KqlParameterItem/1.0",
+                "name": "SubscriptionId",
+                "type": 1,
+                "value": ""
+              },
+              {
+                "id": "d2d2fa1b-070a-45d8-94ec-411c60379803",
+                "version": "KqlParameterItem/1.0",
+                "name": "ServerId",
+                "type": 1,
+                "value": ""
+              },
+              {
+                "id": "4adf7337-0c81-48ab-97a9-5917de6da6c0",
+                "version": "KqlParameterItem/1.0",
+                "name": "ResourceId",
+                "type": 1
+              },
+              {
+                "id": "1ad21b75-d765-4756-823e-3c37538374f4",
+                "version": "KqlParameterItem/1.0",
+                "name": "Type",
+                "type": 1
+              },
+              {
+                "id": "a61f2f01-00c7-4706-a0e0-7f187d4ac424",
+                "version": "KqlParameterItem/1.0",
+                "name": "TypeInternal",
+                "type": 7,
+                "query": "{\"version\":\"1.0.0\",\"content\":\"{\\\"value\\\":\\\"{Type}\\\", \\\"selected\\\":true}\",\"transformers\":null}",
+                "typeSettings": {
+                  "additionalResourceOptions": [],
+                  "showDefault": false
+                },
+                "queryType": 8
+              },
+              {
+                "id": "918e512b-2236-4a2e-94b5-a75a6347b06f",
+                "version": "KqlParameterItem/1.0",
+                "name": "dbType",
+                "type": 1
+              },
+              {
+                "id": "a1bcb07e-fe63-4a1a-ab39-b277b8cb7667",
+                "version": "KqlParameterItem/1.0",
+                "name": "MonitoredResources",
+                "type": 9,
+                "multiSelect": true,
+                "quote": "'",
+                "delimiter": ",",
+                "query": "InsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace matches regex 'sqlserver_azure.._querystore_runtime_stats'\r\n| distinct Tags\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| project dbName = tolower(strcat(extract(\"^([^\\\\.]+)\\\\.?\", 1, sql_instance), '/', database_name))\r\n| distinct dbName",
+                "crossComponentResources": [
+                  "{WsResourcesInternal}"
+                ],
+                "value": null,
+                "timeContext": {
+                  "durationMs": 86400000
+                },
+                "timeContextFromParameter": "Timerange",
+                "queryType": 0,
+                "resourceType": "microsoft.operationalinsights/workspaces"
+              },
+              {
+                "id": "4e1d227e-6470-42b1-8af0-39d017d52bd0",
+                "version": "KqlParameterItem/1.0",
+                "name": "Resources_errors",
+                "type": 9,
+                "multiSelect": true,
+                "quote": "",
+                "delimiter": ",",
+                "query": "where type contains '{Type}'\r\n| extend ResourceId = tolower(id)\r\n| extend name = tolower(strcat(extract(tolower('/{Type}/([^/]+)/'), 1, ResourceId), '/', name))\r\n| where name in ({MonitoredResources})\r\n| project strcat('{\"name\":\"',name, '\" , \"subscription\": \"', subscriptionId, '\", \"resourceGroup\": \"', resourceGroup, '\"}')",
+                "crossComponentResources": [
+                  "value::all"
+                ],
+                "timeContext": {
+                  "durationMs": 0
+                },
+                "timeContextFromParameter": "Timerange",
+                "queryType": 1,
+                "resourceType": "microsoft.resourcegraph/resources",
+                "value": null
+              },
+              {
+                "id": "93340513-ad4d-47fc-81d3-8dc11dd272c3",
+                "version": "KqlParameterItem/1.0",
+                "name": "QueryWorkbook",
+                "type": 1,
+                "value": "[resourceId('microsoft.insights/workbooks', parameters('workbookNames').Query)]",
+                "timeContext": {
+                  "durationMs": 0
+                },
+                "timeContextFromParameter": "Timerange"
+              }
+            ],
+            "style": "pills",
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          },
+          "conditionalVisibility": {
+            "parameterName": "hide",
+            "comparison": "isNotEqualTo"
+          },
+          "name": "parameters - 0"
+        },
+        {
+          "type": 1,
+          "content": {
+            "json": "# Query errors"
+          },
+          "name": "text - 3"
+        },
+        {
+          "type": 1,
+          "content": {
+            "json": "Data is loading",
+            "style": "info"
+          },
+          "conditionalVisibility": {
+            "parameterName": "Resources_errors",
+            "comparison": "isEqualTo"
+          },
+          "name": "text - 3"
+        },
+        {
+          "type": 12,
+          "content": {
+            "version": "NotebookGroup/1.0",
+            "groupType": "editable",
+            "items": [
+              {
+                "type": 1,
+                "content": {
+                  "json": "## Subscriptions"
+                },
+                "name": "text - 18"
+              },
+              {
+                "type": 3,
+                "content": {
+                  "version": "KqlItem/1.0",
+                  "query": "let resources = print dynamic([{Resources_errors}])\r\n| mv-expand print_0\r\n| evaluate bag_unpack(print_0);\r\nInsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace matches regex 'sqlserver_azure.._querystore_runtime_stats'\r\n| summarize make_bag( pack(Name, Val)) by Tags\r\n| evaluate bag_unpack(bag_)\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| extend resourceName = tolower(strcat(extract(\"^([^\\\\.]+)\\\\.?\", 1, sql_instance), '/', database_name))\r\n| join kind=leftouter (resources| extend resourceName = name)on resourceName\r\n| summarize Errors = sumif(count_executions,execution_type==4) by SubscriptionId = subscription\r\n| sort by Errors desc",
+                  "size": 1,
+                  "timeContext": {
+                    "durationMs": 0
+                  },
+                  "timeContextFromParameter": "Timerange",
+                  "exportFieldName": "SubscriptionId",
+                  "exportParameterName": "SubscriptionId",
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "crossComponentResources": [
+                    "{WsResourcesInternal}"
+                  ],
+                  "gridSettings": {
+                    "formatters": [
+                      {
+                        "columnMatch": "SubscriptionId",
+                        "formatter": 15,
+                        "formatOptions": {
+                          "linkTarget": null,
+                          "customColumnWidthSetting": "24ch"
+                        }
+                      },
+                      {
+                        "columnMatch": "max_duration",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "14ch"
+                        },
+                        "numberFormat": {
+                          "unit": 24,
+                          "options": {
+                            "style": "decimal",
+                            "useGrouping": false
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "avg_duration",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "14ch"
+                        },
+                        "numberFormat": {
+                          "unit": 24,
+                          "options": {
+                            "style": "decimal",
+                            "useGrouping": false
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "avg_cpu",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "14ch"
+                        },
+                        "numberFormat": {
+                          "unit": 24,
+                          "options": {
+                            "style": "decimal"
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "executions_count",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "13ch"
+                        },
+                        "numberFormat": {
+                          "unit": 17,
+                          "options": {
+                            "style": "decimal"
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "ResourceIdPrefix",
+                        "formatter": 5
+                      }
+                    ]
+                  }
+                },
+                "customWidth": "40",
+                "name": "query - 4"
+              },
+              {
+                "type": 3,
+                "content": {
+                  "version": "KqlItem/1.0",
+                  "query": "let resources = print dynamic([{Resources_errors}])\r\n| mv-expand print_0\r\n| evaluate bag_unpack(print_0);\r\nInsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace matches regex 'sqlserver_azure.._querystore_runtime_stats'\r\n| summarize make_bag( pack(Name, Val)) by Tags\r\n| evaluate bag_unpack(bag_)\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| extend resourceName = tolower(strcat(extract(\"^([^\\\\.]+)\\\\.?\", 1, sql_instance), '/', database_name))\r\n| join kind=leftouter (resources| extend resourceName = name)on resourceName\r\n| where tostring(subscription) contains '{SubscriptionId}'\r\n| where tostring(sql_instance) contains '{ServerId}'\r\n| where tostring(resourceName) contains '{ResourceId}'\r\n| project tostring(subscription), errors = case(execution_type==4, count_executions, 0.), bin(interval_start_time, {Timerange:grain})\r\n| summarize sum(errors) by subscription, interval_start_time",
+                  "size": 1,
+                  "showAnalytics": true,
+                  "timeContext": {
+                    "durationMs": 0
+                  },
+                  "timeContextFromParameter": "Timerange",
+                  "exportFieldName": "SubscriptionId",
+                  "exportParameterName": "SubscriptionId",
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "crossComponentResources": [
+                    "{WsResourcesInternal}"
+                  ],
+                  "visualization": "barchart",
+                  "gridSettings": {
+                    "formatters": [
+                      {
+                        "columnMatch": "SubscriptionId",
+                        "formatter": 15,
+                        "formatOptions": {
+                          "linkTarget": null,
+                          "customColumnWidthSetting": "24ch"
+                        }
+                      },
+                      {
+                        "columnMatch": "max_duration",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "14ch"
+                        },
+                        "numberFormat": {
+                          "unit": 24,
+                          "options": {
+                            "style": "decimal",
+                            "useGrouping": false
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "avg_duration",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "14ch"
+                        },
+                        "numberFormat": {
+                          "unit": 24,
+                          "options": {
+                            "style": "decimal",
+                            "useGrouping": false
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "avg_cpu",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "14ch"
+                        },
+                        "numberFormat": {
+                          "unit": 24,
+                          "options": {
+                            "style": "decimal"
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "executions_count",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "13ch"
+                        },
+                        "numberFormat": {
+                          "unit": 17,
+                          "options": {
+                            "style": "decimal"
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "ResourceIdPrefix",
+                        "formatter": 5
+                      }
+                    ],
+                    "labelSettings": [
+                      {
+                        "columnId": "SubscriptionId",
+                        "label": "Subscription"
+                      },
+                      {
+                        "columnId": "max_duration",
+                        "label": "Max"
+                      },
+                      {
+                        "columnId": "avg_duration",
+                        "label": "Avg"
+                      },
+                      {
+                        "columnId": "avg_cpu",
+                        "label": "CPU"
+                      },
+                      {
+                        "columnId": "executions_count",
+                        "label": "Execs"
+                      },
+                      {
+                        "columnId": "ResourceIdPrefix"
+                      }
+                    ]
+                  }
+                },
+                "customWidth": "60",
+                "name": "query - 4 - Copy"
+              },
+              {
+                "type": 1,
+                "content": {
+                  "json": "## {TypeInternal:label}s"
+                },
+                "name": "text - 9"
+              },
+              {
+                "type": 1,
+                "content": {
+                  "json": "Subscription ID: {SubscriptionId}"
+                },
+                "conditionalVisibility": {
+                  "parameterName": "SubscriptionId",
+                  "comparison": "isNotEqualTo"
+                },
+                "name": "text - 10"
+              },
+              {
+                "type": 3,
+                "content": {
+                  "version": "KqlItem/1.0",
+                  "query": "let resources = print dynamic([{Resources_errors}])\r\n| mv-expand print_0\r\n| evaluate bag_unpack(print_0);\r\nInsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace matches regex 'sqlserver_azure.._querystore_runtime_stats'\r\n| summarize make_bag( pack(Name, Val)) by Tags\r\n| evaluate bag_unpack(bag_)\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| extend resourceName = tolower(strcat(extract(\"^([^\\\\.]+)\\\\.?\", 1, sql_instance), '/', database_name))\r\n| join kind=leftouter (resources| extend resourceName = name)on resourceName\r\n| where tostring(subscription) contains '{SubscriptionId}'\r\n| summarize Errors = sumif(count_executions, execution_type==4) by ResourceId = sql_instance\r\n| project Type = '{Type}', ['{TypeInternal:label}'] = ResourceId, Errors, ResourceId\r\n| sort by Errors desc",
+                  "size": 1,
+                  "timeContext": {
+                    "durationMs": 86400000
+                  },
+                  "timeContextFromParameter": "Timerange",
+                  "exportedParameters": [
+                    {
+                      "fieldName": "ResourceId",
+                      "parameterName": "ServerId",
+                      "parameterType": 5
+                    }
+                  ],
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "crossComponentResources": [
+                    "{WsResourcesInternal}"
+                  ],
+                  "gridSettings": {
+                    "formatters": [
+                      {
+                        "columnMatch": "Type",
+                        "formatter": 16,
+                        "formatOptions": {
+                          "showIcon": true,
+                          "customColumnWidthSetting": "4ch"
+                        }
+                      },
+                      {
+                        "columnMatch": "ResourceId",
+                        "formatter": 5
+                      }
+                    ],
+                    "labelSettings": [
+                      {
+                        "columnId": "Type",
+                        "label": " "
+                      },
+                      {
+                        "columnId": "Errors"
+                      },
+                      {
+                        "columnId": "ResourceId"
+                      }
+                    ]
+                  }
+                },
+                "customWidth": "40",
+                "name": "query - 4 - Copy"
+              },
+              {
+                "type": 3,
+                "content": {
+                  "version": "KqlItem/1.0",
+                  "query": "let resources = print dynamic([{Resources_errors}])\r\n| mv-expand print_0\r\n| evaluate bag_unpack(print_0);\r\nInsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace matches regex 'sqlserver_azure.._querystore_runtime_stats'\r\n| summarize make_bag( pack(Name, Val)) by Tags\r\n| evaluate bag_unpack(bag_)\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| extend resourceName = tolower(strcat(sql_instance, '/', database_name))\r\n| join kind=leftouter (resources| extend resourceName = name)on resourceName\r\n| where tostring(subscription) contains '{SubscriptionId}'\r\n| where tostring(sql_instance) contains '{ServerId}'\r\n| where tostring(resourceName) contains '{ResourceId}'\r\n| project sql_instance, errors = iif(execution_type==4, count_executions, 0.), bin(interval_start_time, {Timerange:grain})\r\n| summarize sum(errors) by sql_instance, interval_start_time",
+                  "size": 1,
+                  "showAnalytics": true,
+                  "timeContext": {
+                    "durationMs": 0
+                  },
+                  "timeContextFromParameter": "Timerange",
+                  "exportFieldName": "SubscriptionId",
+                  "exportParameterName": "SubscriptionId",
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "crossComponentResources": [
+                    "{WsResourcesInternal}"
+                  ],
+                  "visualization": "barchart",
+                  "gridSettings": {
+                    "formatters": [
+                      {
+                        "columnMatch": "SubscriptionId",
+                        "formatter": 15,
+                        "formatOptions": {
+                          "linkTarget": null,
+                          "customColumnWidthSetting": "24ch"
+                        }
+                      },
+                      {
+                        "columnMatch": "max_duration",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "14ch"
+                        },
+                        "numberFormat": {
+                          "unit": 24,
+                          "options": {
+                            "style": "decimal",
+                            "useGrouping": false
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "avg_duration",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "14ch"
+                        },
+                        "numberFormat": {
+                          "unit": 24,
+                          "options": {
+                            "style": "decimal",
+                            "useGrouping": false
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "avg_cpu",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "14ch"
+                        },
+                        "numberFormat": {
+                          "unit": 24,
+                          "options": {
+                            "style": "decimal"
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "executions_count",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "13ch"
+                        },
+                        "numberFormat": {
+                          "unit": 17,
+                          "options": {
+                            "style": "decimal"
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "ResourceIdPrefix",
+                        "formatter": 5
+                      }
+                    ],
+                    "labelSettings": [
+                      {
+                        "columnId": "SubscriptionId",
+                        "label": "Subscription"
+                      },
+                      {
+                        "columnId": "max_duration",
+                        "label": "Max"
+                      },
+                      {
+                        "columnId": "avg_duration",
+                        "label": "Avg"
+                      },
+                      {
+                        "columnId": "avg_cpu",
+                        "label": "CPU"
+                      },
+                      {
+                        "columnId": "executions_count",
+                        "label": "Execs"
+                      },
+                      {
+                        "columnId": "ResourceIdPrefix"
+                      }
+                    ]
+                  }
+                },
+                "customWidth": "60",
+                "name": "query - 4 - Copy - Copy"
+              },
+              {
+                "type": 1,
+                "content": {
+                  "json": "## Databases"
+                },
+                "name": "text - 11"
+              },
+              {
+                "type": 1,
+                "content": {
+                  "json": "Subscription ID: {SubscriptionId}"
+                },
+                "conditionalVisibility": {
+                  "parameterName": "SubscriptionId",
+                  "comparison": "isNotEqualTo"
+                },
+                "name": "text - 12"
+              },
+              {
+                "type": 1,
+                "content": {
+                  "json": "Server: {ServerId:name}"
+                },
+                "conditionalVisibility": {
+                  "parameterName": "ServerId",
+                  "comparison": "isNotEqualTo"
+                },
+                "name": "text - 13"
+              },
+              {
+                "type": 3,
+                "content": {
+                  "version": "KqlItem/1.0",
+                  "query": "let resources = print dynamic([{Resources_errors}])\r\n| mv-expand print_0\r\n| evaluate bag_unpack(print_0);\r\nInsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace matches regex 'sqlserver_azure.._querystore_runtime_stats'\r\n| summarize make_bag( pack(Name, Val)) by Tags\r\n| evaluate bag_unpack(bag_)\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| extend resourceName = tolower(strcat(extract(\"^([^\\\\.]+)\\\\.?\", 1, sql_instance), '/', database_name))\r\n| join kind=leftouter (resources| extend resourceName = name)on resourceName\r\n| where tostring(subscription) contains '{SubscriptionId}'\r\n| where tostring(sql_instance) contains '{ServerId}'\r\n| summarize Errors = sumif(count_executions, execution_type==4) by ResourceId = tolower(strcat(sql_instance, '/', database_name))\r\n| project Type = '{Type}/DATABASES', ResourceId, Errors, wbLink = '{DBWorkbook}'\r\n| sort by Errors desc",
+                  "size": 1,
+                  "timeContext": {
+                    "durationMs": 86400000
+                  },
+                  "timeContextFromParameter": "Timerange",
+                  "exportFieldName": "ResourceId",
+                  "exportParameterName": "ResourceId",
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "crossComponentResources": [
+                    "{WsResourcesInternal}"
+                  ],
+                  "gridSettings": {
+                    "formatters": [
+                      {
+                        "columnMatch": "Type",
+                        "formatter": 16,
+                        "formatOptions": {
+                          "showIcon": true,
+                          "customColumnWidthSetting": "4ch"
+                        }
+                      },
+                      {
+                        "columnMatch": "ResourceId",
+                        "formatter": 7,
+                        "formatOptions": {
+                          "linkColumn": "wbLink",
+                          "linkTarget": "WorkbookTemplate",
+                          "workbookContext": {
+                            "componentIdSource": "workbook",
+                            "resourceIdsSource": "workbook",
+                            "templateIdSource": "column",
+                            "templateId": "wbLink",
+                            "typeSource": "workbook",
+                            "gallerySource": "workbook",
+                            "locationSource": "default"
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "wbLink",
+                        "formatter": 5
+                      }
+                    ],
+                    "labelSettings": [
+                      {
+                        "columnId": "Type",
+                        "label": " "
+                      },
+                      {
+                        "columnId": "ResourceId",
+                        "label": "Database"
+                      },
+                      {
+                        "columnId": "Errors"
+                      },
+                      {
+                        "columnId": "wbLink"
+                      }
+                    ]
+                  },
+                  "sortBy": []
+                },
+                "customWidth": "40",
+                "name": "query - 4 - Copy - Copy"
+              },
+              {
+                "type": 3,
+                "content": {
+                  "version": "KqlItem/1.0",
+                  "query": "let resources = print dynamic([{Resources_errors}])\r\n| mv-expand print_0\r\n| evaluate bag_unpack(print_0);\r\nInsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace matches regex 'sqlserver_azure.._querystore_runtime_stats'\r\n| summarize make_bag( pack(Name, Val)) by Tags\r\n| evaluate bag_unpack(bag_)\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| extend resourceName = tolower(strcat(extract(\"^([^\\\\.]+)\\\\.?\", 1, sql_instance), '/', database_name))\r\n| join kind=leftouter (resources| extend resourceName = name)on resourceName\r\n| where tostring(subscription) contains '{SubscriptionId}'\r\n| where tostring(sql_instance) contains '{ServerId}'\r\n| where tolower(strcat(sql_instance, '/', database_name)) contains '{ResourceId}'\r\n| project resourceName, errors = iif(execution_type==4, count_executions, 0.), bin(interval_start_time, {Timerange:grain})\r\n| summarize sum(errors) by resourceName, interval_start_time",
+                  "size": 1,
+                  "showAnalytics": true,
+                  "timeContext": {
+                    "durationMs": 0
+                  },
+                  "timeContextFromParameter": "Timerange",
+                  "exportFieldName": "SubscriptionId",
+                  "exportParameterName": "SubscriptionId",
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "crossComponentResources": [
+                    "{WsResourcesInternal}"
+                  ],
+                  "visualization": "barchart",
+                  "gridSettings": {
+                    "formatters": [
+                      {
+                        "columnMatch": "SubscriptionId",
+                        "formatter": 15,
+                        "formatOptions": {
+                          "linkTarget": null,
+                          "customColumnWidthSetting": "24ch"
+                        }
+                      },
+                      {
+                        "columnMatch": "max_duration",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "14ch"
+                        },
+                        "numberFormat": {
+                          "unit": 24,
+                          "options": {
+                            "style": "decimal",
+                            "useGrouping": false
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "avg_duration",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "14ch"
+                        },
+                        "numberFormat": {
+                          "unit": 24,
+                          "options": {
+                            "style": "decimal",
+                            "useGrouping": false
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "avg_cpu",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "14ch"
+                        },
+                        "numberFormat": {
+                          "unit": 24,
+                          "options": {
+                            "style": "decimal"
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "executions_count",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "13ch"
+                        },
+                        "numberFormat": {
+                          "unit": 17,
+                          "options": {
+                            "style": "decimal"
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "ResourceIdPrefix",
+                        "formatter": 5
+                      }
+                    ],
+                    "labelSettings": [
+                      {
+                        "columnId": "SubscriptionId",
+                        "label": "Subscription"
+                      },
+                      {
+                        "columnId": "max_duration",
+                        "label": "Max"
+                      },
+                      {
+                        "columnId": "avg_duration",
+                        "label": "Avg"
+                      },
+                      {
+                        "columnId": "avg_cpu",
+                        "label": "CPU"
+                      },
+                      {
+                        "columnId": "executions_count",
+                        "label": "Execs"
+                      },
+                      {
+                        "columnId": "ResourceIdPrefix"
+                      }
+                    ]
+                  }
+                },
+                "customWidth": "60",
+                "name": "query - 4 - Copy - Copy - Copy"
+              },
+              {
+                "type": 1,
+                "content": {
+                  "json": "## Failed Queries"
+                },
+                "name": "text - 14"
+              },
+              {
+                "type": 1,
+                "content": {
+                  "json": "Subscription ID: {SubscriptionId}"
+                },
+                "conditionalVisibility": {
+                  "parameterName": "SubscriptionId",
+                  "comparison": "isNotEqualTo"
+                },
+                "name": "text - 15"
+              },
+              {
+                "type": 1,
+                "content": {
+                  "json": "Server: {ServerId:name}"
+                },
+                "conditionalVisibility": {
+                  "parameterName": "ServerId",
+                  "comparison": "isNotEqualTo"
+                },
+                "name": "text - 15 - Copy"
+              },
+              {
+                "type": 1,
+                "content": {
+                  "json": "Database: {ResourceId:name}"
+                },
+                "conditionalVisibility": {
+                  "parameterName": "DbId",
+                  "comparison": "isNotEqualTo"
+                },
+                "name": "text - 15 - Copy - Copy"
+              },
+              {
+                "type": 3,
+                "content": {
+                  "version": "KqlItem/1.0",
+                  "query": "let resources = print dynamic([{Resources_errors}])\r\n| mv-expand print_0\r\n| evaluate bag_unpack(print_0);\r\nInsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace matches regex 'sqlserver_azure.._querystore_runtime_stats'\r\n| summarize make_bag( pack(Name, Val)) by Tags\r\n| evaluate bag_unpack(bag_)\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| extend resourceName = tolower(strcat(extract(\"^([^\\\\.]+)\\\\.?\", 1, sql_instance), '/', database_name))\r\n| join kind=leftouter (resources| extend resourceName = name)on resourceName\r\n| where tostring(subscription) contains '{SubscriptionId}'\r\n| where tolower(strcat(sql_instance, '/', database_name)) contains '{ResourceId}'\r\n| where execution_type==4\r\n| summarize Errors = sum(count_executions) by query_hash\r\n| extend wbLink = '{QueryWorkbook}'",
+                  "size": 1,
+                  "timeContext": {
+                    "durationMs": 0
+                  },
+                  "timeContextFromParameter": "Timerange",
+                  "exportFieldName": "query_hash",
+                  "exportParameterName": "QueryHash",
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "crossComponentResources": [
+                    "{WsResourcesInternal}"
+                  ],
+                  "gridSettings": {
+                    "formatters": [
+                      {
+                        "columnMatch": "query_hash",
+                        "formatter": 7,
+                        "formatOptions": {
+                          "linkTarget": "WorkbookTemplate",
+                          "workbookContext": {
+                            "componentIdSource": "workbook",
+                            "resourceIdsSource": "workbook",
+                            "templateIdSource": "column",
+                            "templateId": "wbLink",
+                            "typeSource": "workbook",
+                            "gallerySource": "workbook",
+                            "locationSource": "default"
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "wbLink",
+                        "formatter": 5
+                      }
+                    ],
+                    "labelSettings": [
+                      {
+                        "columnId": "query_hash",
+                        "label": "Query"
+                      },
+                      {
+                        "columnId": "Errors"
+                      },
+                      {
+                        "columnId": "wbLink"
+                      }
+                    ]
+                  },
+                  "sortBy": []
+                },
+                "customWidth": "60",
+                "name": "query - 4 - Copy - Copy - Copy"
+              }
+            ]
+          },
+          "conditionalVisibility": {
+            "parameterName": "Resources_errors",
+            "comparison": "isNotEqualTo"
+          },
+          "name": "group - 19"
+        }
+      ],
+      "fallbackResourceIds": [
+      ],
+      "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
+    },
+    "workbookDisplayName": "Errors",
+    "workbookName": "[parameters('workbookNames').Errors]"
+  },
+  "resources": [
+    {
+      "name": "[variables('workbookName')]",
+      "type": "microsoft.insights/workbooks",
+      "location": "[resourceGroup().location]",
+      "apiVersion": "2018-06-17-preview",
+      "kind": "shared",
+      "properties": {
+        "displayName": "[variables('workbookDisplayName')]",
+        "serializedData": "[string(variables('workbookMarkup'))]",
+        "version": "Notebook/1.0",
+        "sourceId": "[resourceGroup().id]",
+        "category": "workbook"
+      },
+      "tags": {
+        "hidden-title": "[variables('workbookDisplayName')]"
+      }
+    }
+  ]
+}

--- a/Workbooks/Workloads/QDS/LogAlertRule.json
+++ b/Workbooks/Workloads/QDS/LogAlertRule.json
@@ -1,0 +1,302 @@
+{
+  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "workbookNames": {
+      "type": "object",
+      "defaultValue": {
+        "LogAlertRule": "[guid(resourceGroup().id, 'Log Alert Rule')]"
+      }
+    }
+  },
+  "variables": {
+    "workbookMarkup": {
+      "version": "Notebook/1.0",
+      "items": [
+        {
+          "type": 9,
+          "content": {
+            "version": "KqlParameterItem/1.0",
+            "parameters": [
+              {
+                "id": "95013231-5597-4abc-a4a3-ff7b8424a831",
+                "version": "KqlParameterItem/1.0",
+                "name": "QueryText",
+                "type": 1,
+                "value": "InsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace == 'sqlserver_database_io'\r\n| summarize make_bag(pack(Name, Val)) by Tags, TimeGenerated\r\n| evaluate bag_unpack(bag_)\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == 'AzureSQLManagedInstance'\r\n| where sql_instance == 'kdvmigp.60da8ee02807.database.windows.net'\r\n| order by physical_filename, TimeGenerated asc\r\n| serialize \r\n| extend reads = case(physical_filename == prev(physical_filename), reads-prev(reads), real(null)),\r\nwrites = case(physical_filename == prev(physical_filename), writes-prev(writes), real(null))\r\n| summarize requests = max(reads+writes) by bin(TimeGenerated, 30m)",
+                "typeSettings": {
+                  "multiLineText": true,
+                  "editorLanguage": "kql"
+                },
+                "timeContext": {
+                  "durationMs": 86400000
+                }
+              },
+              {
+                "id": "41e93303-ad2d-46b0-8ad7-66da9e538b72",
+                "version": "KqlParameterItem/1.0",
+                "name": "wsExact",
+                "type": 1,
+                "timeContext": {
+                  "durationMs": 86400000
+                }
+              },
+              {
+                "id": "d355e5f6-12cd-4d30-aa21-c606645354d2",
+                "version": "KqlParameterItem/1.0",
+                "name": "wsExactInternal",
+                "type": 5,
+                "query": "{\"version\":\"1.0.0\",\"content\":\"{\\\"value\\\":\\\"{wsExact}\\\", \\\"selected\\\":true}\",\"transformers\":null}",
+                "typeSettings": {
+                  "additionalResourceOptions": [],
+                  "showDefault": false
+                },
+                "timeContext": {
+                  "durationMs": 86400000
+                },
+                "queryType": 8
+              },
+              {
+                "id": "639c989e-66a9-4842-b8ed-0ffcee6cf276",
+                "version": "KqlParameterItem/1.0",
+                "name": "resourceGroup",
+                "type": 1,
+                "query": "{\"version\":\"1.0.0\",\"content\":\"\\\"/subscriptions/{wsExactInternal:subscription}/resourceGroups/{wsExactInternal:resourceGroup}\\\"\",\"transformers\":null}",
+                "timeContext": {
+                  "durationMs": 86400000
+                },
+                "queryType": 8
+              },
+              {
+                "id": "b626d679-0808-4af0-afe9-d5087a8b07fd",
+                "version": "KqlParameterItem/1.0",
+                "name": "ParameterName",
+                "type": 1,
+                "value": "IO Requests",
+                "timeContext": {
+                  "durationMs": 86400000
+                }
+              },
+              {
+                "id": "8709281d-191d-4d8b-8c5a-1a979cb2b9fa",
+                "version": "KqlParameterItem/1.0",
+                "name": "IntervalMinutes",
+                "type": 1,
+                "value": "30",
+                "timeContext": {
+                  "durationMs": 86400000
+                }
+              }
+            ],
+            "style": "pills",
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          },
+          "conditionalVisibility": {
+            "parameterName": "hide",
+            "comparison": "isNotEqualTo"
+          },
+          "name": "parameters - 0"
+        },
+        {
+          "type": 1,
+          "content": {
+            "json": "Alert will fire when maximum of {ParameterName} over the last {IntervalMinutes} minutes breaches the threshold.  \r\nYou can adjust the query frequency, the time interval and the repeat count later."
+          },
+          "name": "text - 2"
+        },
+        {
+          "type": 9,
+          "content": {
+            "version": "KqlParameterItem/1.0",
+            "crossComponentResources": [
+              "value::selected"
+            ],
+            "parameters": [
+              {
+                "id": "dcc58ea4-4696-40ed-862e-7368d590b501",
+                "version": "KqlParameterItem/1.0",
+                "name": "Operator",
+                "type": 2,
+                "value": null,
+                "typeSettings": {
+                  "additionalResourceOptions": [],
+                  "showDefault": false
+                },
+                "jsonData": "[[\r\n    {\"value\":\"GreaterThan\", \"label\":\"Greater Than\"},\r\n    {\"value\":\"LessThan\", \"label\":\"Less Than\"},\r\n    {\"value\":\"Equal\", \"label\":\"Equal\"}\r\n]",
+                "timeContext": {
+                  "durationMs": 86400000
+                }
+              },
+              {
+                "id": "3d75d0f2-01f7-4e0f-9bfe-8f73bbdb666b",
+                "version": "KqlParameterItem/1.0",
+                "name": "Threshold",
+                "type": 1,
+                "value": "",
+                "typeSettings": {
+                  "paramValidationRules": [
+                    {
+                      "regExp": "^\\d+(\\.(\\d+))?$",
+                      "match": true,
+                      "message": "The value must be a number"
+                    }
+                  ]
+                },
+                "timeContext": {
+                  "durationMs": 86400000
+                }
+              },
+              {
+                "id": "eb1cb9c2-a6bd-4a5a-b5ef-ea7e917f29cc",
+                "version": "KqlParameterItem/1.0",
+                "name": "ActionGroup",
+                "label": "Action Group",
+                "type": 5,
+                "multiSelect": true,
+                "quote": "\"",
+                "delimiter": ",",
+                "query": "where subscriptionId == '{wsExactInternal:subscription}'\r\n| where type =~ 'microsoft.insights/actiongroups'\r\n| project id, selected = false",
+                "crossComponentResources": [
+                  "value::selected"
+                ],
+                "value": [],
+                "typeSettings": {
+                  "additionalResourceOptions": [],
+                  "showDefault": false
+                },
+                "queryType": 1,
+                "resourceType": "microsoft.resourcegraph/resources"
+              }
+            ],
+            "style": "above",
+            "queryType": 1,
+            "resourceType": "microsoft.resourcegraph/resources"
+          },
+          "name": "parameters - 1"
+        },
+        {
+          "type": 9,
+          "content": {
+            "version": "KqlParameterItem/1.0",
+            "parameters": [
+              {
+                "id": "c44eaad6-2e1f-4c0e-968b-cec052cafee2",
+                "version": "KqlParameterItem/1.0",
+                "name": "RuleName",
+                "label": "Alert Rule Name",
+                "type": 1,
+                "query": "{\"version\":\"1.0.0\",\"content\":\"\\\"{ParameterName} is {Operator:label} {Threshold}\\\"\",\"transformers\":null}",
+                "timeContext": {
+                  "durationMs": 86400000
+                },
+                "queryType": 8
+              }
+            ],
+            "style": "formVertical",
+            "queryType": 8
+          },
+          "name": "parameters - 4"
+        },
+        {
+          "type": 11,
+          "content": {
+            "version": "LinkItem/1.0",
+            "style": "list",
+            "links": [
+              {
+                "id": "46277bf3-2693-4209-b8fb-81d26c81192d",
+                "cellValue": "f",
+                "linkTarget": "ArmTemplate",
+                "linkLabel": "Create Alert Rule",
+                "preText": "",
+                "style": "primary",
+                "linkIsContextBlade": true,
+                "templateRunContext": {
+                  "componentIdSource": "parameter",
+                  "componentId": "resourceGroup",
+                  "templateUriSource": "static",
+                  "templateUri": "https://pmarmtemplates.blob.core.windows.net/templates/logAlert.json",
+                  "templateParameters": [
+                    {
+                      "name": "alertRuleName",
+                      "source": "parameter",
+                      "value": "RuleName",
+                      "kind": "stringValue"
+                    },
+                    {
+                      "name": "workspaceId",
+                      "source": "parameter",
+                      "value": "wsExact",
+                      "kind": "stringValue"
+                    },
+                    {
+                      "name": "queryText",
+                      "source": "parameter",
+                      "value": "QueryText",
+                      "kind": "stringValue"
+                    },
+                    {
+                      "name": "frequency",
+                      "source": "parameter",
+                      "value": "IntervalMinutes",
+                      "kind": "intValue"
+                    },
+                    {
+                      "name": "actionGroup",
+                      "source": "static",
+                      "value": "[[{ActionGroup}]",
+                      "kind": "arrayValue"
+                    },
+                    {
+                      "name": "operator",
+                      "source": "parameter",
+                      "value": "Operator",
+                      "kind": "stringValue"
+                    },
+                    {
+                      "name": "threshold",
+                      "source": "parameter",
+                      "value": "Threshold",
+                      "kind": "intValue"
+                    }
+                  ],
+                  "titleSource": "static",
+                  "title": "Alert Rule Deployment",
+                  "descriptionSource": "static",
+                  "runLabelSource": "static",
+                  "runLabel": "Deploy"
+                }
+              }
+            ]
+          },
+          "name": "links - 3"
+        }
+      ],
+      "fallbackResourceIds": [
+      ],
+      "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
+    },
+    "workbookDisplayName": "Log Alert Rule",
+    "workbookName": "[parameters('workbookNames').LogAlertRule]"
+  },
+  "resources": [
+    {
+      "name": "[variables('workbookName')]",
+      "type": "microsoft.insights/workbooks",
+      "location": "[resourceGroup().location]",
+      "apiVersion": "2018-06-17-preview",
+      "kind": "shared",
+      "properties": {
+        "displayName": "[variables('workbookDisplayName')]",
+        "serializedData": "[string(variables('workbookMarkup'))]",
+        "version": "Notebook/1.0",
+        "sourceId": "[resourceGroup().id]",
+        "category": "workbook"
+      },
+      "tags": {
+        "hidden-title": "[variables('workbookDisplayName')]"
+      }
+    }
+  ]
+}

--- a/Workbooks/Workloads/QDS/LogAlertRules.json
+++ b/Workbooks/Workloads/QDS/LogAlertRules.json
@@ -1,0 +1,155 @@
+{
+  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "workbookNames": {
+      "type": "object",
+      "defaultValue": {
+        "LogAlertRules": "[guid(resourceGroup().id, 'Log Alert Rules')]"
+      }
+    }
+  },
+  "variables": {
+    "workbookMarkup": {
+      "version": "Notebook/1.0",
+      "items": [
+        {
+          "type": 9,
+          "content": {
+            "version": "KqlParameterItem/1.0",
+            "parameters": [
+              {
+                "id": "14be21d4-ac66-412b-908a-fcb7a0d2be22",
+                "version": "KqlParameterItem/1.0",
+                "name": "Type",
+                "type": 1
+              },
+              {
+                "id": "bfaeb080-dacd-443c-85c0-648a42df1671",
+                "version": "KqlParameterItem/1.0",
+                "name": "ResourceName",
+                "type": 1
+              },
+              {
+                "id": "a83e5b41-4258-46d9-82f9-105867df9ed8",
+                "version": "KqlParameterItem/1.0",
+                "name": "ParameterName",
+                "type": 1
+              },
+              {
+                "id": "0b3fe5e9-1c7e-4540-8022-ce49abac5aff",
+                "version": "KqlParameterItem/1.0",
+                "name": "TypeInternal",
+                "type": 7,
+                "query": "{\"version\":\"1.0.0\",\"content\":\"{\\\"value\\\":\\\"{Type}\\\", \\\"selected\\\":true}\",\"transformers\":null}",
+                "typeSettings": {
+                  "additionalResourceOptions": [],
+                  "showDefault": false
+                },
+                "queryType": 8
+              },
+              {
+                "id": "508e0fd4-ccd5-442c-bce5-670d90743bac",
+                "version": "KqlParameterItem/1.0",
+                "name": "wsExact",
+                "type": 1
+              },
+              {
+                "id": "4be5ade6-d8cd-42a9-a031-f00c0df34619",
+                "version": "KqlParameterItem/1.0",
+                "name": "QueryText",
+                "type": 1,
+                "value": "InsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace == 'sqlserver_database_io'\r\n| summarize make_bag(pack(Name, Val)) by Tags, TimeGenerated\r\n| evaluate bag_unpack(bag_)\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == 'AzureSQLManagedInstance'\r\n| where sql_instance == 'kdvmigp.60da8ee02807.database.windows.net'\r\n| order by physical_filename, TimeGenerated asc\r\n| serialize \r\n| extend reads = case(physical_filename == prev(physical_filename), reads-prev(reads), real(null))\r\n| summarize AggregatedValue = max(reads+writes)",
+                "typeSettings": {
+                  "multiLineText": true,
+                  "editorLanguage": "kql"
+                }
+              }
+            ],
+            "style": "pills",
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          },
+          "conditionalVisibility": {
+            "parameterName": "hide",
+            "comparison": "isNotEqualTo"
+          },
+          "name": "parameters"
+        },
+        {
+          "type": 1,
+          "content": {
+            "json": "# Alert Rules\r\n## {TypeInternal:label}: {ResourceName}  \r\n## Parameter: {ParameterName}"
+          },
+          "name": "text - 1"
+        },
+        {
+          "type": 3,
+          "content": {
+            "version": "KqlItem/1.0",
+            "query": "where type =~ 'microsoft.insights/scheduledqueryrules'\r\n| where properties.source.dataSourceId =~ '{wsExact}'\r\n| where properties.source.query contains \"{QueryText:escapejson}\"\r\n| project Name = name, Parameter = '{ParameterName}', Operator = properties.action.trigger.thresholdOperator, Threshold = properties.action.trigger.threshold//, link = strcat(\"https://ms.portal.azure.com/#blade/Microsoft_Azure_Monitoring/UpdateVNextAlertRuleBlade/ruleInputs/\", replace(\"\\\\+\", \"%20\", url_encode(tostring(linkParams))))",
+            "size": 1,
+            "queryType": 1,
+            "resourceType": "microsoft.resourcegraph/resources",
+            "crossComponentResources": [
+              "value::all"
+            ],
+            "gridSettings": {
+              "formatters": [
+                {
+                  "columnMatch": "Operator",
+                  "formatter": 1
+                },
+                {
+                  "columnMatch": "Threshold",
+                  "formatter": 1
+                }
+              ]
+            }
+          },
+          "name": "query - 2"
+        },
+        {
+          "type": 11,
+          "content": {
+            "version": "LinkItem/1.0",
+            "style": "list",
+            "links": [
+              {
+                "id": "7ea93f9c-4793-4cdd-903c-e50a16528804",
+                "cellValue": "https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/resource{wsExact}/alerts",
+                "linkTarget": "Url",
+                "linkLabel": "Edit alert rules",
+                "style": "link"
+              }
+            ]
+          },
+          "name": "links - 3"
+        }
+      ],
+      "fallbackResourceIds": [],
+      "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
+    },
+    "workbookDisplayName": "Log Alert Rules",
+    "workbookName": "[parameters('workbookNames').LogAlertRules]"
+  },
+  "resources": [
+    {
+      "name": "[variables('workbookName')]",
+      "type": "microsoft.insights/workbooks",
+      "location": "[resourceGroup().location]",
+      "apiVersion": "2018-06-17-preview",
+      "kind": "shared",
+      "properties": {
+        "displayName": "[variables('workbookDisplayName')]",
+        "serializedData": "[string(variables('workbookMarkup'))]",
+        "version": "Notebook/1.0",
+        "sourceId": "[resourceGroup().id]",
+        "category": "workbook"
+      },
+      "tags": {
+        "hidden-title": "[variables('workbookDisplayName')]"
+      }
+    }
+  ]
+}

--- a/Workbooks/Workloads/QDS/ManagedInstance.json
+++ b/Workbooks/Workloads/QDS/ManagedInstance.json
@@ -1,0 +1,1268 @@
+{
+  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "workbookNames": {
+      "type": "object",
+      "defaultValue": {
+        "QueryWaits": "[guid(resourceGroup().id, 'Query Waits')]",
+        "ManagedInstance": "[guid(resourceGroup().id, 'Managed Instance')]",
+        "Query": "[guid(resourceGroup().id, 'Query')]",
+        "ManagedInstanceDatabase": "[guid(resourceGroup().id, 'Managed Instance Database')]",
+        "AlertRules": "[guid(resourceGroup().id, 'Alert Rules')]",
+        "LogAlertRule": "[guid(resourceGroup().id, 'Log Alert Rule')]",
+        "LogAlertRules": "[guid(resourceGroup().id, 'Log Alert Rules')]"
+      }
+    }
+  },
+  "variables": {
+    "workbookMarkup": {
+      "version": "Notebook/1.0",
+      "items": [
+        {
+          "type": 9,
+          "content": {
+            "version": "KqlParameterItem/1.0",
+            "parameters": [
+              {
+                "id": "7300e9ec-01ec-4c96-8d24-12b843750628",
+                "version": "KqlParameterItem/1.0",
+                "name": "ResourceId",
+                "type": 1,
+                "value": "fk-mibc.36c954d642c6.database.windows.net"
+              },
+              {
+                "id": "4ecc9f52-2e3f-4c8e-b9ea-f3e2f2583f5b",
+                "version": "KqlParameterItem/1.0",
+                "name": "WsResources",
+                "type": 1
+              },
+              {
+                "id": "f3e20cbc-b692-4b3d-8916-2fd0662ecfe6",
+                "version": "KqlParameterItem/1.0",
+                "name": "WsResourcesInternal",
+                "type": 5,
+                "multiSelect": true,
+                "quote": "'",
+                "delimiter": ",",
+                "query": "where id in~ ({WsResources})\r\n| project id, selected=1",
+                "crossComponentResources": [
+                  "value::all"
+                ],
+                "typeSettings": {
+                  "additionalResourceOptions": [],
+                  "showDefault": false
+                },
+                "queryType": 1,
+                "resourceType": "microsoft.resourcegraph/resources"
+              },
+              {
+                "id": "30b86356-1bba-4603-83d1-835b99171066",
+                "version": "KqlParameterItem/1.0",
+                "name": "Timerange",
+                "type": 4,
+                "value": {
+                  "durationMs": 86400000
+                },
+                "typeSettings": {
+                  "selectableValues": [
+                    {
+                      "durationMs": 300000
+                    },
+                    {
+                      "durationMs": 900000
+                    },
+                    {
+                      "durationMs": 1800000
+                    },
+                    {
+                      "durationMs": 3600000
+                    },
+                    {
+                      "durationMs": 14400000
+                    },
+                    {
+                      "durationMs": 43200000
+                    },
+                    {
+                      "durationMs": 86400000
+                    },
+                    {
+                      "durationMs": 172800000
+                    },
+                    {
+                      "durationMs": 259200000
+                    },
+                    {
+                      "durationMs": 604800000
+                    },
+                    {
+                      "durationMs": 1209600000
+                    },
+                    {
+                      "durationMs": 2419200000
+                    },
+                    {
+                      "durationMs": 2592000000
+                    },
+                    {
+                      "durationMs": 5184000000
+                    },
+                    {
+                      "durationMs": 7776000000
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "4e9f82e1-d302-466b-8f85-2c1966916cf1",
+                "version": "KqlParameterItem/1.0",
+                "name": "QueryWorkbook",
+                "type": 1,
+                "value": "[resourceId('microsoft.insights/workbooks', parameters('workbookNames').Query)]"
+              },
+              {
+                "id": "492550b7-78ea-4b5a-b26b-330cfb499f3e",
+                "version": "KqlParameterItem/1.0",
+                "name": "MIDBWorkbook",
+                "type": 1,
+                "value": "[resourceId('microsoft.insights/workbooks', parameters('workbookNames').ManagedInstanceDatabase)]"
+              },
+              {
+                "id": "a611e58c-0f45-4ef4-acd3-a43656cb4440",
+                "version": "KqlParameterItem/1.0",
+                "name": "Type",
+                "type": 1,
+                "value": "MICROSOFT.SQL/MANAGEDINSTANCES"
+              },
+              {
+                "id": "2f2432a8-bd82-4e71-8465-fac1a22179dd",
+                "version": "KqlParameterItem/1.0",
+                "name": "managedInstance",
+                "type": 5,
+                "query": "where type =~ '{Type}'\r\n| where '{ResourceId}' startswith name\r\n| project id, selected = 1",
+                "crossComponentResources": [
+                  "value::all"
+                ],
+                "typeSettings": {
+                  "additionalResourceOptions": [],
+                  "showDefault": false
+                },
+                "queryType": 1,
+                "resourceType": "microsoft.resourcegraph/resources"
+              },
+              {
+                "id": "1b593c45-5910-4b93-8eb7-b3dadaccf2e9",
+                "version": "KqlParameterItem/1.0",
+                "name": "dbType",
+                "type": 1,
+                "value": "AzureSQLManagedInstance"
+              },
+              {
+                "id": "55df770f-e991-47c5-a367-84d8bea544bd",
+                "version": "KqlParameterItem/1.0",
+                "name": "AlertRulesWorkbook",
+                "type": 1,
+                "value": "[resourceId('microsoft.insights/workbooks', parameters('workbookNames').AlertRules)]"
+              },
+              {
+                "id": "7115697c-a6c2-4dba-8441-6ce4ba5fec83",
+                "version": "KqlParameterItem/1.0",
+                "name": "LogAlertWorkbook",
+                "type": 1,
+                "value": "[resourceId('microsoft.insights/workbooks', parameters('workbookNames').LogAlertRule)]"
+              },
+              {
+                "id": "4e5e71ad-ec58-4c57-b489-2089cf05dd7d",
+                "version": "KqlParameterItem/1.0",
+                "name": "LogRulesWorkbook",
+                "type": 1,
+                "value": "[resourceId('microsoft.insights/workbooks', parameters('workbookNames').LogAlertRules)]"
+              },
+              {
+                "id": "5e1b8158-227e-4732-aedc-55f4c082e3f1",
+                "version": "KqlParameterItem/1.0",
+                "name": "wsQuery",
+                "type": 1,
+                "query": "let workspaces = dynamic([{WsResources}]);\r\nprint workspaces\r\n| mv-expand(workspaces)\r\n| project line = strcat(\"(workspace('\", Column1, \"').InsightsMetrics| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'| where Namespace == 'sqlserver_azure_db_resource_stats'| where Name == 'avg_cpu_percent'| extend data = todynamic(Tags)| evaluate bag_unpack(data)| where measurement_db_type == '{dbType}'| where sql_instance == '{ResourceId}'| limit 1 | summarize rowCount = count()| where rowCount>0 | project workspace = '\", Column1, \"')\")\r\n| summarize makelist(line)\r\n| project strcat_array(list_line, '\\r\\n| union\\r\\n')",
+                "crossComponentResources": [
+                  "{WsResourcesInternal}"
+                ],
+                "typeSettings": {
+                  "multiLineText": true,
+                  "editorLanguage": "kql"
+                },
+                "timeContext": {
+                  "durationMs": 86400000
+                },
+                "timeContextFromParameter": "Timerange",
+                "queryType": 0,
+                "resourceType": "microsoft.operationalinsights/workspaces"
+              },
+              {
+                "id": "1678d215-c21c-4acf-a7ea-69a54d421c7d",
+                "version": "KqlParameterItem/1.0",
+                "name": "wsExact",
+                "type": 1,
+                "query": "{wsQuery}\r\n| limit 1",
+                "crossComponentResources": [
+                  "{WsResourcesInternal}"
+                ],
+                "timeContext": {
+                  "durationMs": 0
+                },
+                "timeContextFromParameter": "Timerange",
+                "queryType": 0,
+                "resourceType": "microsoft.operationalinsights/workspaces"
+              },
+              {
+                "id": "2dbab4a1-4785-4011-aadd-278b974450a3",
+                "version": "KqlParameterItem/1.0",
+                "name": "IntervalMinutes",
+                "type": 1,
+                "query": "print {Timerange:grain}/1m",
+                "crossComponentResources": [
+                  "{WsResourcesInternal}"
+                ],
+                "queryType": 0,
+                "resourceType": "microsoft.operationalinsights/workspaces"
+              }
+            ],
+            "style": "pills",
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          },
+          "conditionalVisibility": {
+            "parameterName": "hide",
+            "comparison": "isNotEqualTo"
+          },
+          "name": "parameters - 0"
+        },
+        {
+          "type": 1,
+          "content": {
+            "json": "# Managed Instance\r\n{managedInstance:name}"
+          },
+          "name": "text - 1"
+        },
+        {
+          "type": 12,
+          "content": {
+            "version": "NotebookGroup/1.0",
+            "groupType": "editable",
+            "title": "MANAGED INSTANCE RESOURCE USAGE STATS",
+            "items": [
+              {
+                "type": 1,
+                "content": {
+                  "json": "### CPU utilization"
+                },
+                "customWidth": "50",
+                "name": "text - 4"
+              },
+              {
+                "type": 1,
+                "content": {
+                  "json": "### Storage used/reserved"
+                },
+                "customWidth": "50",
+                "name": "text - 4 - Copy"
+              },
+              {
+                "type": 11,
+                "content": {
+                  "version": "LinkItem/1.0",
+                  "style": "nav",
+                  "links": [
+                    {
+                      "id": "787e1b29-5289-4e7e-91a9-b0ea344949e8",
+                      "cellValue": "{managedInstance}",
+                      "linkTarget": "AlertCreation",
+                      "linkLabel": "New Alert Rule",
+                      "style": "link",
+                      "alertRuleContext": {
+                        "alertType": "Metric",
+                        "namespace": "microsoft.sql/managedinstances",
+                        "metricId": "microsoft.sql/managedinstances--avg_cpu_percent",
+                        "aggregation": 4
+                      }
+                    },
+                    {
+                      "id": "7d1b1f9e-8de4-4cd0-a4c4-9e6b8a5fe1ee",
+                      "cellValue": "{AlertRulesWorkbook}",
+                      "linkTarget": "WorkbookTemplate",
+                      "linkLabel": "Edit Alert Rules",
+                      "style": "link",
+                      "workbookContext": {
+                        "componentIdSource": "workbook",
+                        "resourceIdsSource": "workbook",
+                        "templateIdSource": "cell",
+                        "templateId": "wbLink",
+                        "typeSource": "workbook",
+                        "gallerySource": "workbook",
+                        "locationSource": "default",
+                        "passSpecificParams": true,
+                        "templateParameters": [
+                          {
+                            "name": "database",
+                            "source": "parameter",
+                            "value": "managedInstance"
+                          },
+                          {
+                            "name": "MetricNamespace",
+                            "source": "static",
+                            "value": "{Type}"
+                          },
+                          {
+                            "name": "MetricCategory",
+                            "source": "static",
+                            "value": ""
+                          },
+                          {
+                            "name": "MetricName",
+                            "source": "static",
+                            "value": "avg_cpu_percent"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                },
+                "customWidth": "50",
+                "name": "links - 8"
+              },
+              {
+                "type": 11,
+                "content": {
+                  "version": "LinkItem/1.0",
+                  "style": "nav",
+                  "links": [
+                    {
+                      "id": "8935647a-922b-451e-bb16-765b5397e4c9",
+                      "cellValue": "{managedInstance}",
+                      "linkTarget": "AlertCreation",
+                      "linkLabel": "New Alert Rule",
+                      "style": "link",
+                      "alertRuleContext": {
+                        "alertType": "Metric",
+                        "namespace": "microsoft.sql/managedinstances",
+                        "metricId": "microsoft.sql/managedinstances--storage_space_used_mb",
+                        "aggregation": 4
+                      }
+                    },
+                    {
+                      "id": "7d1b1f9e-8de4-4cd0-a4c4-9e6b8a5fe1ee",
+                      "cellValue": "{AlertRulesWorkbook}",
+                      "linkTarget": "WorkbookTemplate",
+                      "linkLabel": "Edit Alert Rules",
+                      "style": "link",
+                      "linkIsContextBlade": true,
+                      "workbookContext": {
+                        "componentIdSource": "workbook",
+                        "resourceIdsSource": "workbook",
+                        "templateIdSource": "cell",
+                        "templateId": "wbLink",
+                        "typeSource": "workbook",
+                        "gallerySource": "workbook",
+                        "locationSource": "default",
+                        "passSpecificParams": true,
+                        "templateParameters": [
+                          {
+                            "name": "database",
+                            "source": "parameter",
+                            "value": "managedInstance"
+                          },
+                          {
+                            "name": "MetricNamespace",
+                            "source": "static",
+                            "value": "{Type}"
+                          },
+                          {
+                            "name": "MetricCategory",
+                            "source": "static",
+                            "value": ""
+                          },
+                          {
+                            "name": "MetricName",
+                            "source": "static",
+                            "value": "storage_space_used_mb"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                },
+                "customWidth": "50",
+                "name": "links - 8 - Copy"
+              },
+              {
+                "type": 3,
+                "content": {
+                  "version": "KqlItem/1.0",
+                  "query": "set truncationmaxrecords=5000;\r\nInsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace == 'sqlserver_azure_db_resource_stats'\r\n| where Name == 'avg_cpu_percent'\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| where sql_instance == '{ResourceId}'\r\n| summarize cpu = max(todouble(Val)) by bin(TimeGenerated, {Timerange:grain})",
+                  "size": 0,
+                  "aggregation": 3,
+                  "showAnalytics": true,
+                  "title": "CPU utilization",
+                  "timeContext": {
+                    "durationMs": 86400000
+                  },
+                  "timeContextFromParameter": "Timerange",
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "crossComponentResources": [
+                    "{WsResourcesInternal}"
+                  ],
+                  "visualization": "linechart",
+                  "chartSettings": {
+                    "ySettings": {
+                      "numberFormatSettings": {
+                        "unit": 1,
+                        "options": {
+                          "style": "decimal",
+                          "useGrouping": true
+                        }
+                      },
+                      "min": 0,
+                      "max": 100
+                    }
+                  }
+                },
+                "customWidth": "50",
+                "name": "query - 11"
+              },
+              {
+                "type": 3,
+                "content": {
+                  "version": "KqlItem/1.0",
+                  "query": "set truncationmaxrecords=5000;\r\nInsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace == 'sqlserver_azure_db_resource_stats'\r\n| summarize make_bag(pack(Name, Val)) by Tags, TimeGenerated\r\n| evaluate bag_unpack(bag_)\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| where sql_instance == '{ResourceId}'\r\n| summarize storage_used = max(todouble(storage_space_used_mb)/1024), storage_reserved = max(todouble(reserved_storage_mb)/1024) by bin(TimeGenerated, {Timerange:grain})",
+                  "size": 0,
+                  "aggregation": 3,
+                  "showAnalytics": true,
+                  "title": "Storage used/reserved",
+                  "timeContext": {
+                    "durationMs": 86400000
+                  },
+                  "timeContextFromParameter": "Timerange",
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "crossComponentResources": [
+                    "{WsResourcesInternal}"
+                  ],
+                  "visualization": "linechart",
+                  "chartSettings": {
+                    "ySettings": {
+                      "numberFormatSettings": {
+                        "unit": 5,
+                        "options": {
+                          "style": "decimal",
+                          "useGrouping": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "customWidth": "50",
+                "name": "query - 11 - Copy"
+              },
+              {
+                "type": 1,
+                "content": {
+                  "json": "### IO requests"
+                },
+                "customWidth": "50",
+                "name": "text - 4 - Copy - Copy"
+              },
+              {
+                "type": 1,
+                "content": {
+                  "json": "### IO read/write"
+                },
+                "customWidth": "50",
+                "name": "text - 4 - Copy - Copy - Copy"
+              },
+              {
+                "type": 11,
+                "content": {
+                  "version": "LinkItem/1.0",
+                  "style": "nav",
+                  "links": [
+                    {
+                      "id": "7e97488e-fa5c-4500-8c62-8143140e8284",
+                      "cellValue": "{LogAlertWorkbook}",
+                      "linkTarget": "WorkbookTemplate",
+                      "linkLabel": "New Alert Rule",
+                      "style": "link",
+                      "linkIsContextBlade": true,
+                      "workbookContext": {
+                        "componentIdSource": "workbook",
+                        "resourceIdsSource": "workbook",
+                        "templateIdSource": "cell",
+                        "templateId": "wbLink",
+                        "typeSource": "workbook",
+                        "gallerySource": "workbook",
+                        "locationSource": "default",
+                        "passSpecificParams": true,
+                        "templateParameters": [
+                          {
+                            "name": "QueryText",
+                            "source": "static",
+                            "value": "InsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace == 'sqlserver_database_io'\r\n| summarize make_bag(pack(Name, Val)) by Tags, TimeGenerated\r\n| evaluate bag_unpack(bag_)\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| where sql_instance == '{ResourceId}'\r\n| order by physical_filename, TimeGenerated asc\r\n| serialize \r\n| extend reads = case(physical_filename == prev(physical_filename), reads-prev(reads), real(null)),\r\nwrites = case(physical_filename == prev(physical_filename), writes-prev(writes), real(null))\r\n| summarize AggregatedValue = max(reads+writes) by bin(TimeGenerated, {Timerange:grain})"
+                          },
+                          {
+                            "name": "wsExact",
+                            "source": "parameter",
+                            "value": "wsExact"
+                          },
+                          {
+                            "name": "ParameterName",
+                            "source": "static",
+                            "value": "IO Requests"
+                          },
+                          {
+                            "name": "IntervalMinutes",
+                            "source": "parameter",
+                            "value": "IntervalMinutes"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "id": "7d1b1f9e-8de4-4cd0-a4c4-9e6b8a5fe1ee",
+                      "cellValue": "{LogRulesWorkbook}",
+                      "linkTarget": "WorkbookTemplate",
+                      "linkLabel": "View Alert Rules",
+                      "style": "link",
+                      "linkIsContextBlade": true,
+                      "workbookContext": {
+                        "componentIdSource": "workbook",
+                        "resourceIdsSource": "workbook",
+                        "templateIdSource": "cell",
+                        "templateId": "wbLink",
+                        "typeSource": "workbook",
+                        "gallerySource": "workbook",
+                        "locationSource": "default",
+                        "passSpecificParams": true,
+                        "templateParameters": [
+                          {
+                            "name": "QueryText",
+                            "source": "static",
+                            "value": "InsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace == 'sqlserver_database_io'\r\n| summarize make_bag(pack(Name, Val)) by Tags, TimeGenerated\r\n| evaluate bag_unpack(bag_)\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| where sql_instance == '{ResourceId}'\r\n| order by physical_filename, TimeGenerated asc\r\n| serialize \r\n| extend reads = case(physical_filename == prev(physical_filename), reads-prev(reads), real(null)),\r\nwrites = case(physical_filename == prev(physical_filename), writes-prev(writes), real(null))\r\n| summarize AggregatedValue = max(reads+writes)"
+                          },
+                          {
+                            "name": "Type",
+                            "source": "parameter",
+                            "value": "Type"
+                          },
+                          {
+                            "name": "ResourceName",
+                            "source": "parameter",
+                            "value": "ResourceId"
+                          },
+                          {
+                            "name": "ParameterName",
+                            "source": "static",
+                            "value": "IO Requests"
+                          },
+                          {
+                            "name": "wsExact",
+                            "source": "parameter",
+                            "value": "wsExact"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                },
+                "customWidth": "50",
+                "name": "links - 8 - Copy - Copy"
+              },
+              {
+                "type": 11,
+                "content": {
+                  "version": "LinkItem/1.0",
+                  "style": "nav",
+                  "links": [
+                    {
+                      "id": "fcb12ce7-04af-438a-a775-8daf3d81b1ad",
+                      "cellValue": "{LogAlertWorkbook}",
+                      "linkTarget": "WorkbookTemplate",
+                      "linkLabel": "New Alert Rule (reads)",
+                      "style": "link",
+                      "linkIsContextBlade": true,
+                      "workbookContext": {
+                        "componentIdSource": "workbook",
+                        "resourceIdsSource": "workbook",
+                        "templateIdSource": "cell",
+                        "templateId": "wbLink",
+                        "typeSource": "workbook",
+                        "gallerySource": "workbook",
+                        "locationSource": "default",
+                        "passSpecificParams": true,
+                        "templateParameters": [
+                          {
+                            "name": "QueryText",
+                            "source": "static",
+                            "value": "InsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace == 'sqlserver_database_io'\r\n| summarize make_bag(pack(Name, Val)) by Tags, TimeGenerated\r\n| evaluate bag_unpack(bag_)\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| where sql_instance == '{ResourceId}'\r\n| order by physical_filename, TimeGenerated asc\r\n| serialize \r\n| extend io_bytes_read = case(physical_filename == prev(physical_filename), read_bytes-prev(read_bytes), real(null)),\r\nio_bytes_written = case(physical_filename == prev(physical_filename), write_bytes-prev(write_bytes), real(null))\r\n| summarize AggregatedValue = max(toint(io_bytes_read)) by bin(TimeGenerated, {Timerange:grain})"
+                          },
+                          {
+                            "name": "wsExact",
+                            "source": "parameter",
+                            "value": "wsExact"
+                          },
+                          {
+                            "name": "ParameterName",
+                            "source": "static",
+                            "value": "IO Reads"
+                          },
+                          {
+                            "name": "IntervalMinutes",
+                            "source": "parameter",
+                            "value": "IntervalMinutes"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "id": "2e70c162-5884-449a-b36d-10a3706ec19c",
+                      "cellValue": "{LogAlertWorkbook}",
+                      "linkTarget": "WorkbookTemplate",
+                      "linkLabel": "New Alert Rule (writes)",
+                      "style": "link",
+                      "linkIsContextBlade": true,
+                      "workbookContext": {
+                        "componentIdSource": "workbook",
+                        "resourceIdsSource": "workbook",
+                        "templateIdSource": "cell",
+                        "templateId": "wbLink",
+                        "typeSource": "workbook",
+                        "gallerySource": "workbook",
+                        "locationSource": "default",
+                        "passSpecificParams": true,
+                        "templateParameters": [
+                          {
+                            "name": "QueryText",
+                            "source": "static",
+                            "value": "InsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace == 'sqlserver_database_io'\r\n| summarize make_bag(pack(Name, Val)) by Tags, TimeGenerated\r\n| evaluate bag_unpack(bag_)\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| where sql_instance == '{ResourceId}'\r\n| order by physical_filename, TimeGenerated asc\r\n| serialize \r\n| extend io_bytes_read = case(physical_filename == prev(physical_filename), read_bytes-prev(read_bytes), real(null)),\r\nio_bytes_written = case(physical_filename == prev(physical_filename), write_bytes-prev(write_bytes), real(null))\r\n| summarize AggregatedValue = max(toint(io_bytes_written)) by bin(TimeGenerated, {Timerange:grain})"
+                          },
+                          {
+                            "name": "wsExact",
+                            "source": "parameter",
+                            "value": "wsExact"
+                          },
+                          {
+                            "name": "ParameterName",
+                            "source": "static",
+                            "value": "IO Writes"
+                          },
+                          {
+                            "name": "IntervalMinutes",
+                            "source": "parameter",
+                            "value": "IntervalMinutes"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "id": "7d1b1f9e-8de4-4cd0-a4c4-9e6b8a5fe1ee",
+                      "cellValue": "{LogRulesWorkbook}",
+                      "linkTarget": "WorkbookTemplate",
+                      "linkLabel": "View Alert Rules(reads)",
+                      "style": "link",
+                      "linkIsContextBlade": true,
+                      "workbookContext": {
+                        "componentIdSource": "workbook",
+                        "resourceIdsSource": "workbook",
+                        "templateIdSource": "cell",
+                        "templateId": "wbLink",
+                        "typeSource": "workbook",
+                        "gallerySource": "workbook",
+                        "locationSource": "default",
+                        "passSpecificParams": true,
+                        "templateParameters": [
+                          {
+                            "name": "QueryText",
+                            "source": "static",
+                            "value": "InsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace == 'sqlserver_database_io'\r\n| summarize make_bag(pack(Name, Val)) by Tags, TimeGenerated\r\n| evaluate bag_unpack(bag_)\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| where sql_instance == '{ResourceId}'\r\n| order by physical_filename, TimeGenerated asc\r\n| serialize \r\n| extend io_bytes_read = case(physical_filename == prev(physical_filename), read_bytes-prev(read_bytes), real(null)),\r\nio_bytes_written = case(physical_filename == prev(physical_filename), write_bytes-prev(write_bytes), real(null))\r\n| summarize AggregatedValue = max(toint(io_bytes_read))"
+                          },
+                          {
+                            "name": "Type",
+                            "source": "parameter",
+                            "value": "Type"
+                          },
+                          {
+                            "name": "ResourceName",
+                            "source": "parameter",
+                            "value": "ResourceId"
+                          },
+                          {
+                            "name": "ParameterName",
+                            "source": "static",
+                            "value": "IO Reads"
+                          },
+                          {
+                            "name": "wsExact",
+                            "source": "parameter",
+                            "value": "wsExact"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "id": "5d321650-c528-4739-8623-26a981dd659c",
+                      "cellValue": "{LogRulesWorkbook}",
+                      "linkTarget": "WorkbookTemplate",
+                      "linkLabel": "View Alert Rules(writes)",
+                      "style": "link",
+                      "linkIsContextBlade": true,
+                      "workbookContext": {
+                        "componentIdSource": "workbook",
+                        "resourceIdsSource": "workbook",
+                        "templateIdSource": "cell",
+                        "templateId": "wbLink",
+                        "typeSource": "workbook",
+                        "gallerySource": "workbook",
+                        "locationSource": "default",
+                        "passSpecificParams": true,
+                        "templateParameters": [
+                          {
+                            "name": "QueryText",
+                            "source": "static",
+                            "value": "InsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace == 'sqlserver_database_io'\r\n| summarize make_bag(pack(Name, Val)) by Tags, TimeGenerated\r\n| evaluate bag_unpack(bag_)\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| where sql_instance == '{ResourceId}'\r\n| order by physical_filename, TimeGenerated asc\r\n| serialize \r\n| extend io_bytes_read = case(physical_filename == prev(physical_filename), read_bytes-prev(read_bytes), real(null)),\r\nio_bytes_written = case(physical_filename == prev(physical_filename), write_bytes-prev(write_bytes), real(null))\r\n| summarize AggregatedValue = max(toint(io_bytes_written))"
+                          },
+                          {
+                            "name": "Type",
+                            "source": "parameter",
+                            "value": "Type"
+                          },
+                          {
+                            "name": "ResourceName",
+                            "source": "parameter",
+                            "value": "ResourceId"
+                          },
+                          {
+                            "name": "ParameterName",
+                            "source": "static",
+                            "value": "IO Writes"
+                          },
+                          {
+                            "name": "wsExact",
+                            "source": "parameter",
+                            "value": "wsExact"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                },
+                "customWidth": "50",
+                "name": "links - 8 - Copy - Copy - Copy"
+              },
+              {
+                "type": 3,
+                "content": {
+                  "version": "KqlItem/1.0",
+                  "query": "set truncationmaxrecords=5000;\r\nInsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace == 'sqlserver_database_io'\r\n| summarize make_bag(pack(Name, Val)) by Tags, TimeGenerated\r\n| evaluate bag_unpack(bag_)\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| where sql_instance == '{ResourceId}'\r\n| order by physical_filename, TimeGenerated asc\r\n| serialize \r\n| extend reads = case(physical_filename == prev(physical_filename), reads-prev(reads), real(null)),\r\nwrites = case(physical_filename == prev(physical_filename), writes-prev(writes), real(null))\r\n| summarize requests = max(reads+writes) by bin(TimeGenerated, {Timerange:grain})",
+                  "size": 0,
+                  "aggregation": 3,
+                  "showAnalytics": true,
+                  "title": "IO requests",
+                  "timeContext": {
+                    "durationMs": 86400000
+                  },
+                  "timeContextFromParameter": "Timerange",
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "crossComponentResources": [
+                    "{WsResourcesInternal}"
+                  ],
+                  "visualization": "linechart"
+                },
+                "customWidth": "50",
+                "name": "query - 11 - Copy - Copy"
+              },
+              {
+                "type": 3,
+                "content": {
+                  "version": "KqlItem/1.0",
+                  "query": "set truncationmaxrecords=5000;\r\nInsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace == 'sqlserver_database_io'\r\n| summarize make_bag(pack(Name, Val)) by Tags, TimeGenerated\r\n| evaluate bag_unpack(bag_)\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| where sql_instance == '{ResourceId}'\r\n| order by physical_filename, TimeGenerated asc\r\n| serialize \r\n| extend io_bytes_read = case(physical_filename == prev(physical_filename), read_bytes-prev(read_bytes), real(null)),\r\nio_bytes_written = case(physical_filename == prev(physical_filename), write_bytes-prev(write_bytes), real(null))\r\n| summarize read = max(toint(io_bytes_read)), write = max(toint(io_bytes_written)) by bin(TimeGenerated, {Timerange:grain})",
+                  "size": 0,
+                  "aggregation": 3,
+                  "showAnalytics": true,
+                  "title": "IO read/write",
+                  "timeContext": {
+                    "durationMs": 86400000
+                  },
+                  "timeContextFromParameter": "Timerange",
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "crossComponentResources": [
+                    "{WsResourcesInternal}"
+                  ],
+                  "visualization": "linechart",
+                  "chartSettings": {
+                    "ySettings": {
+                      "numberFormatSettings": {
+                        "unit": 2,
+                        "options": {
+                          "style": "decimal",
+                          "useGrouping": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "customWidth": "50",
+                "name": "query - 11 - Copy - Copy - Copy"
+              }
+            ]
+          },
+          "customWidth": "70",
+          "name": "group - 10"
+        },
+        {
+          "type": 3,
+          "content": {
+            "version": "KqlItem/1.0",
+            "query": "InsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| distinct database_name, sql_instance\r\n| where database_name != '' and database_name != 'master' and sql_instance != ''\r\n| where sql_instance == '{ResourceId}'\r\n| project Type='{Type}/DATABASES', ResourceId=strcat(sql_instance, '/', database_name)\r\n| extend wbLink = '{MIDBWorkbook}'",
+            "size": 2,
+            "title": "MANAGED INSTANCE DATABASES",
+            "timeContext": {
+              "durationMs": 86400000
+            },
+            "timeContextFromParameter": "Timerange",
+            "exportFieldName": "ResourceId",
+            "exportParameterName": "ResourceId",
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces",
+            "crossComponentResources": [
+              "{WsResourcesInternal}"
+            ],
+            "gridSettings": {
+              "formatters": [
+                {
+                  "columnMatch": "Type",
+                  "formatter": 16,
+                  "formatOptions": {
+                    "showIcon": true,
+                    "customColumnWidthSetting": "4ch"
+                  }
+                },
+                {
+                  "columnMatch": "ResourceId",
+                  "formatter": 13,
+                  "formatOptions": {
+                    "linkColumn": "wbLink",
+                    "linkTarget": "WorkbookTemplate",
+                    "showIcon": true,
+                    "customColumnWidthSetting": "100%"
+                  }
+                },
+                {
+                  "columnMatch": "wbLink",
+                  "formatter": 5
+                }
+              ],
+              "filter": true,
+              "labelSettings": [
+                {
+                  "columnId": "Type",
+                  "label": " "
+                },
+                {
+                  "columnId": "ResourceId",
+                  "label": "Database"
+                },
+                {
+                  "columnId": "wbLink"
+                }
+              ]
+            }
+          },
+          "customWidth": "30",
+          "name": "query - 10"
+        },
+        {
+          "type": 1,
+          "content": {
+            "json": "QUERIES"
+          },
+          "name": "text - 6"
+        },
+        {
+          "type": 9,
+          "content": {
+            "version": "KqlParameterItem/1.0",
+            "parameters": [
+              {
+                "id": "913bacd0-f883-483f-b286-75d61236e95e",
+                "version": "KqlParameterItem/1.0",
+                "name": "query_hash",
+                "type": 1,
+                "isHiddenWhenLocked": true,
+                "timeContext": {
+                  "durationMs": 86400000
+                }
+              }
+            ],
+            "style": "pills",
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          },
+          "name": "parameters - 17"
+        },
+        {
+          "type": 3,
+          "content": {
+            "version": "KqlItem/1.0",
+            "query": "set truncationmaxrecords=5000;\r\nInsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace matches regex 'sqlserver_azure.._querystore_runtime_stats'\r\n| summarize make_bag( pack(Name, Val)) by Tags, TimeGenerated\r\n| evaluate bag_unpack(bag_)\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| where sql_instance contains '{ResourceId}'\r\n| summarize max_duration = max(max_duration)/1000000,\r\navg_duration = sum(avg_duration*count_executions)/sum(count_executions)/1000000,\r\navg_cpu = sum(avg_cpu_time*count_executions)/sum(count_executions)/1000000,\r\nexecutions_count = sum(count_executions)\r\n    by query_hash\r\n| join kind=fullouter (\r\n    InsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace matches regex 'sqlserver_azure.._querystore_wait_stats'\r\n| summarize make_bag(pack(Name, Val)) by Tags, TimeGenerated\r\n| evaluate bag_unpack(bag_)\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| where strcat(sql_instance,'/',database_name) contains '{ResourceId}'\r\n    | summarize\r\n        avg_wait_duration = sum(total_query_wait_time_ms)/sum(count_executions) / 1000,\r\n        max_wait_duration = max(max_query_wait_time_ms)/1000\r\n        by wait_category, query_hash\r\n    | summarize arg_max(avg_wait_duration, max_wait_duration, wait_category)\r\n        by query_hash\r\n) on query_hash\r\n| project query_hash,\r\n    metric = \"Duration\",\r\n    max_duration,\r\n    avg_duration,\r\n    avg_cpu,\r\n    executions_count,\r\n    wait_category, max_wait_duration, avg_wait_duration,\r\n    wbLink = '{QueryWorkbook}'\r\n| extend resourceIdPrefix = \"{ResourceId}\"\r\n| sort by avg_duration desc",
+            "size": 2,
+            "showAnalytics": true,
+            "timeContext": {
+              "durationMs": 86400000
+            },
+            "timeContextFromParameter": "Timerange",
+            "exportedParameters": [
+              {
+                "fieldName": "query_hash",
+                "parameterName": "query_hash"
+              },
+              {
+                "fieldName": "query_hash",
+                "parameterName": "QueryHash",
+                "parameterType": 1
+              }
+            ],
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces",
+            "crossComponentResources": [
+              "{WsResourcesInternal}"
+            ],
+            "gridSettings": {
+              "formatters": [
+                {
+                  "columnMatch": "query_hash",
+                  "formatter": 7,
+                  "formatOptions": {
+                    "linkTarget": "WorkbookTemplate",
+                    "workbookContext": {
+                      "componentIdSource": "workbook",
+                      "resourceIdsSource": "workbook",
+                      "templateIdSource": "column",
+                      "templateId": "wbLink",
+                      "typeSource": "workbook",
+                      "gallerySource": "workbook",
+                      "locationSource": "default"
+                    }
+                  }
+                },
+                {
+                  "columnMatch": "max_duration",
+                  "formatter": 0,
+                  "formatOptions": {
+                    "customColumnWidthSetting": "15ch"
+                  },
+                  "numberFormat": {
+                    "unit": 24,
+                    "options": {
+                      "style": "decimal",
+                      "useGrouping": false
+                    }
+                  }
+                },
+                {
+                  "columnMatch": "avg_duration",
+                  "formatter": 0,
+                  "formatOptions": {
+                    "customColumnWidthSetting": "15ch"
+                  },
+                  "numberFormat": {
+                    "unit": 24,
+                    "options": {
+                      "style": "decimal"
+                    }
+                  }
+                },
+                {
+                  "columnMatch": "avg_cpu",
+                  "formatter": 0,
+                  "formatOptions": {
+                    "customColumnWidthSetting": "15ch"
+                  },
+                  "numberFormat": {
+                    "unit": 24,
+                    "options": {
+                      "style": "decimal"
+                    }
+                  }
+                },
+                {
+                  "columnMatch": "executions_count",
+                  "formatter": 0,
+                  "formatOptions": {
+                    "customColumnWidthSetting": "10ch"
+                  },
+                  "numberFormat": {
+                    "unit": 17,
+                    "options": {
+                      "style": "decimal"
+                    }
+                  }
+                },
+                {
+                  "columnMatch": "wait_category",
+                  "formatter": 0,
+                  "formatOptions": {
+                    "customColumnWidthSetting": "20ch"
+                  }
+                },
+                {
+                  "columnMatch": "max_wait_duration",
+                  "formatter": 0,
+                  "formatOptions": {
+                    "customColumnWidthSetting": "15ch"
+                  },
+                  "numberFormat": {
+                    "unit": 24,
+                    "options": {
+                      "style": "decimal"
+                    }
+                  }
+                },
+                {
+                  "columnMatch": "avg_wait_duration",
+                  "formatter": 0,
+                  "formatOptions": {
+                    "customColumnWidthSetting": "15ch"
+                  },
+                  "numberFormat": {
+                    "unit": 24,
+                    "options": {
+                      "style": "decimal"
+                    }
+                  }
+                },
+                {
+                  "columnMatch": "wbLink",
+                  "formatter": 5
+                },
+                {
+                  "columnMatch": "resourceIdPrefix",
+                  "formatter": 5
+                }
+              ],
+              "labelSettings": [
+                {
+                  "columnId": "query_hash",
+                  "label": "Query"
+                },
+                {
+                  "columnId": "metric",
+                  "label": "Metric"
+                },
+                {
+                  "columnId": "max_duration",
+                  "label": "Max"
+                },
+                {
+                  "columnId": "avg_duration",
+                  "label": "Avg"
+                },
+                {
+                  "columnId": "avg_cpu",
+                  "label": "CPU"
+                },
+                {
+                  "columnId": "executions_count",
+                  "label": "Execs"
+                },
+                {
+                  "columnId": "wait_category",
+                  "label": "Dominant Wait"
+                },
+                {
+                  "columnId": "max_wait_duration",
+                  "label": "Max"
+                },
+                {
+                  "columnId": "avg_wait_duration",
+                  "label": "Avg"
+                },
+                {
+                  "columnId": "wbLink"
+                },
+                {
+                  "columnId": "resourceIdPrefix"
+                }
+              ]
+            }
+          },
+          "customWidth": "60",
+          "name": "query - 7"
+        },
+        {
+          "type": 12,
+          "content": {
+            "version": "NotebookGroup/1.0",
+            "groupType": "editable",
+            "items": [
+              {
+                "type": 3,
+                "content": {
+                  "version": "KqlItem/1.0",
+                  "query": "InsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace matches regex 'sqlserver_azure.._querystore_runtime_stats'\r\n| summarize make_bag( pack(Name, Val)) by Tags, TimeGenerated\r\n| evaluate bag_unpack(bag_)\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| where tostring(sql_instance) contains '{ResourceId}'\r\n| where tostring(query_hash) contains '{query_hash}'\r\n| project interval_start_time, max_duration, cpu_time_d = avg_cpu_time*count_executions, duration_d = avg_duration*count_executions, count_executions_d = count_executions\r\n| summarize avg_duration = sum(duration_d)/sum(count_executions_d)/1000000,\r\navg_cpu = sum(cpu_time_d)/sum(count_executions_d)/1000000\r\n    by bin(interval_start_time, {Timerange:grain})",
+                  "size": 0,
+                  "title": "Query Duration",
+                  "timeContext": {
+                    "durationMs": 86400000
+                  },
+                  "timeContextFromParameter": "Timerange",
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "crossComponentResources": [
+                    "{WsResourcesInternal}"
+                  ],
+                  "visualization": "linechart"
+                },
+                "name": "query - 17"
+              },
+              {
+                "type": 3,
+                "content": {
+                  "version": "KqlItem/1.0",
+                  "query": "InsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace matches regex 'sqlserver_azure.._querystore_wait_stats'\r\n| summarize make_bag(pack(Name, Val)) by Tags, TimeGenerated\r\n| evaluate bag_unpack(bag_)\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| where tostring(sql_instance) contains '{ResourceId}'\r\n| where tostring(query_hash) contains '{query_hash}'\r\n| summarize total_wait_time = sum(total_query_wait_time_ms)/1000\r\n    by wait_category, bin(interval_start_time, {Timerange:grain})\r\n| top 1000 by total_wait_time desc\r\n| evaluate pivot(wait_category, sum(total_wait_time))\r\n",
+                  "size": 0,
+                  "title": "Query Waits",
+                  "timeContext": {
+                    "durationMs": 86400000
+                  },
+                  "timeContextFromParameter": "Timerange",
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "crossComponentResources": [
+                    "{WsResourcesInternal}"
+                  ],
+                  "visualization": "barchart"
+                },
+                "name": "query - 17 - Copy"
+              }
+            ]
+          },
+          "customWidth": "40",
+          "name": "group - 19"
+        },
+        {
+          "type": 1,
+          "content": {
+            "json": "FAILED QUERIES"
+          },
+          "name": "text - 11"
+        },
+        {
+          "type": 3,
+          "content": {
+            "version": "KqlItem/1.0",
+            "query": "InsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace matches regex 'sqlserver_azure.._querystore_runtime_stats'\r\n| summarize make_bag( pack(Name, Val)) by Tags, TimeGenerated\r\n| evaluate bag_unpack(bag_)\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| where tostring(sql_instance) contains '{ResourceId}'\r\n| where execution_type==4\r\n| summarize Errors = sum(count_executions) by query_hash\r\n| extend wbLink = '{QueryWorkbook}'",
+            "size": 0,
+            "showAnalytics": true,
+            "timeContext": {
+              "durationMs": 86400000
+            },
+            "timeContextFromParameter": "Timerange",
+            "exportFieldName": "query_hash",
+            "exportParameterName": "QueryHash",
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces",
+            "crossComponentResources": [
+              "{WsResourcesInternal}"
+            ],
+            "gridSettings": {
+              "formatters": [
+                {
+                  "columnMatch": "query_hash",
+                  "formatter": 7,
+                  "formatOptions": {
+                    "linkTarget": "WorkbookTemplate",
+                    "workbookContext": {
+                      "componentIdSource": "workbook",
+                      "resourceIdsSource": "workbook",
+                      "templateIdSource": "column",
+                      "templateId": "wbLink",
+                      "typeSource": "workbook",
+                      "gallerySource": "workbook",
+                      "locationSource": "default"
+                    }
+                  }
+                },
+                {
+                  "columnMatch": "wbLink",
+                  "formatter": 5
+                }
+              ],
+              "labelSettings": [
+                {
+                  "columnId": "query_hash",
+                  "label": "Query"
+                },
+                {
+                  "columnId": "Errors"
+                },
+                {
+                  "columnId": "wbLink",
+                  "label": "Details"
+                }
+              ]
+            }
+          },
+          "customWidth": "60",
+          "name": "query - 2 - Copy - Copy - Copy"
+        },
+        {
+          "type": 3,
+          "content": {
+            "version": "KqlItem/1.0",
+            "query": "InsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace matches regex 'sqlserver_azure.._querystore_runtime_stats'\r\n| summarize make_bag( pack(Name, Val)) by Tags, TimeGenerated\r\n| evaluate bag_unpack(bag_)\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| extend resourceName = tolower(strcat(sql_instance, '/', database_name))\r\n| where tostring(resourceName) contains '{ResourceId}'\r\n| summarize errors = sumif(count_executions, execution_type==4) by TimeGenerated = bin(interval_start_time, {Timerange:grain})",
+            "size": 0,
+            "showAnalytics": true,
+            "timeContext": {
+              "durationMs": 86400000
+            },
+            "timeContextFromParameter": "Timerange",
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces",
+            "crossComponentResources": [
+              "{WsResourcesInternal}"
+            ],
+            "visualization": "barchart"
+          },
+          "customWidth": "40",
+          "name": "query - 2 - Copy - Copy"
+        }
+      ],
+      "fallbackResourceIds": [
+      ],
+      "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
+    },
+    "workbookDisplayName": "Managed Instance",
+    "workbookName": "[parameters('workbookNames').ManagedInstance]"
+  },
+  "resources": [
+    {
+      "name": "[variables('workbookName')]",
+      "type": "microsoft.insights/workbooks",
+      "location": "[resourceGroup().location]",
+      "apiVersion": "2018-06-17-preview",
+      "kind": "shared",
+      "properties": {
+        "displayName": "[variables('workbookDisplayName')]",
+        "serializedData": "[string(variables('workbookMarkup'))]",
+        "version": "Notebook/1.0",
+        "sourceId": "[resourceGroup().id]",
+        "category": "workbook"
+      },
+      "tags": {
+        "hidden-title": "[variables('workbookDisplayName')]"
+      }
+    }
+  ]
+}

--- a/Workbooks/Workloads/QDS/ManagedInstanceDatabase.json
+++ b/Workbooks/Workloads/QDS/ManagedInstanceDatabase.json
@@ -1,0 +1,579 @@
+﻿{
+  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "workbookNames": {
+      "type": "object",
+      "defaultValue": {
+        "ManagedInstanceDatabase": "[guid(resourceGroup().id, 'Managed Instance Database')]",
+        "Query": "[guid(resourceGroup().id, 'Query')]"
+      }
+    }
+  },
+  "variables": {
+    "workbookMarkup": {
+      "version": "Notebook/1.0",
+      "items": [
+        {
+          "type": 9,
+          "content": {
+            "version": "KqlParameterItem/1.0",
+            "parameters": [
+              {
+                "id": "7300e9ec-01ec-4c96-8d24-12b843750628",
+                "version": "KqlParameterItem/1.0",
+                "name": "ResourceId",
+                "type": 1
+              },
+              {
+                "id": "2f2432a8-bd82-4e71-8465-fac1a22179dd",
+                "version": "KqlParameterItem/1.0",
+                "name": "database",
+                "type": 5,
+                "query": "{\"version\":\"1.0.0\",\"content\":\"{\\\"value\\\":\\\"{ResourceId}\\\", \\\"selected\\\":true}\",\"transformers\":null}",
+                "typeSettings": {
+                  "additionalResourceOptions": [],
+                  "showDefault": false
+                },
+                "queryType": 8
+              },
+              {
+                "id": "4ecc9f52-2e3f-4c8e-b9ea-f3e2f2583f5b",
+                "version": "KqlParameterItem/1.0",
+                "name": "WsResources",
+                "type": 1
+              },
+              {
+                "id": "f3e20cbc-b692-4b3d-8916-2fd0662ecfe6",
+                "version": "KqlParameterItem/1.0",
+                "name": "WsResourcesInternal",
+                "type": 5,
+                "multiSelect": true,
+                "quote": "'",
+                "delimiter": ",",
+                "query": "where id in~ ({WsResources})\r\n| project id, selected=1",
+                "crossComponentResources": [
+                  "value::all"
+                ],
+                "typeSettings": {
+                  "additionalResourceOptions": [],
+                  "showDefault": false
+                },
+                "queryType": 1,
+                "resourceType": "microsoft.resourcegraph/resources"
+              },
+              {
+                "id": "30b86356-1bba-4603-83d1-835b99171066",
+                "version": "KqlParameterItem/1.0",
+                "name": "Timerange",
+                "type": 4,
+                "value": {
+                  "durationMs": 86400000
+                },
+                "typeSettings": {
+                  "selectableValues": [
+                    {
+                      "durationMs": 300000
+                    },
+                    {
+                      "durationMs": 900000
+                    },
+                    {
+                      "durationMs": 1800000
+                    },
+                    {
+                      "durationMs": 3600000
+                    },
+                    {
+                      "durationMs": 14400000
+                    },
+                    {
+                      "durationMs": 43200000
+                    },
+                    {
+                      "durationMs": 86400000
+                    },
+                    {
+                      "durationMs": 172800000
+                    },
+                    {
+                      "durationMs": 259200000
+                    },
+                    {
+                      "durationMs": 604800000
+                    },
+                    {
+                      "durationMs": 1209600000
+                    },
+                    {
+                      "durationMs": 2419200000
+                    },
+                    {
+                      "durationMs": 2592000000
+                    },
+                    {
+                      "durationMs": 5184000000
+                    },
+                    {
+                      "durationMs": 7776000000
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "4e9f82e1-d302-466b-8f85-2c1966916cf1",
+                "version": "KqlParameterItem/1.0",
+                "name": "QueryWorkbook",
+                "type": 1,
+                "value": "[resourceId('microsoft.insights/workbooks', parameters('workbookNames').Query)]"
+              },
+              {
+                "id": "8396d2e2-ab56-4660-b77f-7d7f98d6f966",
+                "version": "KqlParameterItem/1.0",
+                "name": "Type",
+                "type": 1
+              },
+              {
+                "id": "ae44d91e-1536-44cd-91f2-a549ef88f5e2",
+                "version": "KqlParameterItem/1.0",
+                "name": "dbType",
+                "type": 1
+              }
+            ],
+            "style": "pills",
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          },
+          "conditionalVisibility": {
+            "parameterName": "hide",
+            "comparison": "isNotEqualTo"
+          },
+          "name": "parameters - 0"
+        },
+        {
+          "type": 1,
+          "content": {
+            "json": "# Database\r\n{database:name}"
+          },
+          "name": "text - 1"
+        },
+        {
+          "type": 1,
+          "content": {
+            "json": "QUERIES"
+          },
+          "name": "text - 6"
+        },
+        {
+          "type": 9,
+          "content": {
+            "version": "KqlParameterItem/1.0",
+            "parameters": [
+              {
+                "id": "913bacd0-f883-483f-b286-75d61236e95e",
+                "version": "KqlParameterItem/1.0",
+                "name": "query_hash",
+                "type": 1,
+                "isHiddenWhenLocked": true,
+                "timeContext": {
+                  "durationMs": 86400000
+                }
+              }
+            ],
+            "style": "pills",
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          },
+          "name": "parameters - 17"
+        },
+        {
+          "type": 3,
+          "content": {
+            "version": "KqlItem/1.0",
+            "query": "set truncationmaxrecords=5000;\r\nInsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace matches regex 'sqlserver_azure.._querystore_runtime_stats'\r\n| summarize make_bag( pack(Name, Val)) by Tags, TimeGenerated\r\n| evaluate bag_unpack(bag_)\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| where strcat(sql_instance,'/',database_name) contains '{ResourceId}'\r\n| summarize max_duration = max(max_duration)/1000000,\r\navg_duration = sum(avg_duration*count_executions)/sum(count_executions)/1000000,\r\navg_cpu = sum(avg_cpu_time*count_executions)/sum(count_executions)/1000000,\r\nexecutions_count = sum(count_executions)\r\n    by query_hash\r\n| join kind=fullouter (\r\n    InsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace == 'sqlserver_azuremi_querystore_wait_stats'\r\n| summarize make_bag(pack(Name, Val)) by Tags, TimeGenerated\r\n| evaluate bag_unpack(bag_)\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where strcat(sql_instance,'/',database_name) contains '{ResourceId}'\r\n    | summarize\r\n        avg_wait_duration = sum(total_query_wait_time_ms)/sum(count_executions) / 1000,\r\n        max_wait_duration = max(max_query_wait_time_ms)/1000\r\n        by wait_category, query_hash\r\n    | summarize arg_max(avg_wait_duration, max_wait_duration, wait_category)\r\n        by query_hash\r\n) on query_hash\r\n| project query_hash,\r\n    metric = \"Duration\",\r\n    max_duration,\r\n    avg_duration,\r\n    avg_cpu,\r\n    executions_count,\r\n    wait_category, max_wait_duration, avg_wait_duration,\r\n    wbLink = '{QueryWorkbook}'\r\n| sort by avg_duration desc",
+            "size": 2,
+            "showAnalytics": true,
+            "timeContext": {
+              "durationMs": 86400000
+            },
+            "timeContextFromParameter": "Timerange",
+            "exportedParameters": [
+              {
+                "fieldName": "query_hash",
+                "parameterName": "QueryHash"
+              },
+              {
+                "fieldName": "query_hash",
+                "parameterName": "query_hash",
+                "parameterType": 1
+              }
+            ],
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces",
+            "crossComponentResources": [
+              "{WsResourcesInternal}"
+            ],
+            "gridSettings": {
+              "formatters": [
+                {
+                  "columnMatch": "query_hash",
+                  "formatter": 7,
+                  "formatOptions": {
+                    "linkTarget": "WorkbookTemplate",
+                    "workbookContext": {
+                      "componentIdSource": "workbook",
+                      "resourceIdsSource": "workbook",
+                      "templateIdSource": "column",
+                      "templateId": "wbLink",
+                      "typeSource": "workbook",
+                      "gallerySource": "workbook",
+                      "locationSource": "default"
+                    }
+                  }
+                },
+                {
+                  "columnMatch": "max_duration",
+                  "formatter": 0,
+                  "formatOptions": {
+                    "customColumnWidthSetting": "15ch"
+                  },
+                  "numberFormat": {
+                    "unit": 24,
+                    "options": {
+                      "style": "decimal",
+                      "useGrouping": false
+                    }
+                  }
+                },
+                {
+                  "columnMatch": "avg_duration",
+                  "formatter": 0,
+                  "formatOptions": {
+                    "customColumnWidthSetting": "15ch"
+                  },
+                  "numberFormat": {
+                    "unit": 24,
+                    "options": {
+                      "style": "decimal"
+                    }
+                  }
+                },
+                {
+                  "columnMatch": "avg_cpu",
+                  "formatter": 0,
+                  "formatOptions": {
+                    "customColumnWidthSetting": "15ch"
+                  },
+                  "numberFormat": {
+                    "unit": 24,
+                    "options": {
+                      "style": "decimal"
+                    }
+                  }
+                },
+                {
+                  "columnMatch": "executions_count",
+                  "formatter": 0,
+                  "formatOptions": {
+                    "customColumnWidthSetting": "10ch"
+                  },
+                  "numberFormat": {
+                    "unit": 17,
+                    "options": {
+                      "style": "decimal"
+                    }
+                  }
+                },
+                {
+                  "columnMatch": "wait_category",
+                  "formatter": 0,
+                  "formatOptions": {
+                    "customColumnWidthSetting": "20ch"
+                  }
+                },
+                {
+                  "columnMatch": "max_wait_duration",
+                  "formatter": 0,
+                  "formatOptions": {
+                    "customColumnWidthSetting": "15ch"
+                  },
+                  "numberFormat": {
+                    "unit": 24,
+                    "options": {
+                      "style": "decimal"
+                    }
+                  }
+                },
+                {
+                  "columnMatch": "avg_wait_duration",
+                  "formatter": 0,
+                  "formatOptions": {
+                    "customColumnWidthSetting": "15ch"
+                  },
+                  "numberFormat": {
+                    "unit": 24,
+                    "options": {
+                      "style": "decimal"
+                    }
+                  }
+                },
+                {
+                  "columnMatch": "wbLink",
+                  "formatter": 5
+                },
+                {
+                  "columnMatch": "resourceIdPrefix",
+                  "formatter": 5
+                }
+              ],
+              "labelSettings": [
+                {
+                  "columnId": "query_hash",
+                  "label": "Query"
+                },
+                {
+                  "columnId": "metric",
+                  "label": "Metric"
+                },
+                {
+                  "columnId": "max_duration",
+                  "label": "Max"
+                },
+                {
+                  "columnId": "avg_duration",
+                  "label": "Avg"
+                },
+                {
+                  "columnId": "avg_cpu",
+                  "label": "CPU"
+                },
+                {
+                  "columnId": "executions_count",
+                  "label": "Execs"
+                },
+                {
+                  "columnId": "wait_category",
+                  "label": "Dominant Wait"
+                },
+                {
+                  "columnId": "max_wait_duration",
+                  "label": "Max"
+                },
+                {
+                  "columnId": "avg_wait_duration",
+                  "label": "Avg"
+                },
+                {
+                  "columnId": "wbLink"
+                }
+              ]
+            }
+          },
+          "customWidth": "60",
+          "name": "query - 7"
+        },
+        {
+          "type": 12,
+          "content": {
+            "version": "NotebookGroup/1.0",
+            "groupType": "editable",
+            "items": [
+              {
+                "type": 3,
+                "content": {
+                  "version": "KqlItem/1.0",
+                  "query": "InsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace matches regex 'sqlserver_azure.._querystore_runtime_stats'\r\n| summarize make_bag( pack(Name, Val)) by Tags, TimeGenerated\r\n| evaluate bag_unpack(bag_)\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| where strcat(sql_instance,'/',database_name) contains '{ResourceId}'\r\n| where tostring(query_hash) contains '{query_hash}'\r\n| project interval_start_time, max_duration, cpu_time_d = avg_cpu_time*count_executions, duration_d = avg_duration*count_executions, count_executions_d = count_executions\r\n| summarize avg_duration = sum(duration_d)/sum(count_executions_d)/1000000,\r\navg_cpu = sum(cpu_time_d)/sum(count_executions_d)/1000000\r\n    by bin(interval_start_time, {Timerange:grain})",
+                  "size": 0,
+                  "aggregation": 3,
+                  "showAnalytics": true,
+                  "title": "Query Duration",
+                  "timeContext": {
+                    "durationMs": 86400000
+                  },
+                  "timeContextFromParameter": "Timerange",
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "crossComponentResources": [
+                    "{WsResourcesInternal}"
+                  ],
+                  "visualization": "linechart",
+                  "chartSettings": {
+                    "ySettings": {
+                      "numberFormatSettings": {
+                        "unit": 24,
+                        "options": {
+                          "style": "decimal",
+                          "useGrouping": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "name": "query - 2 - Copy"
+              },
+              {
+                "type": 3,
+                "content": {
+                  "version": "KqlItem/1.0",
+                  "query": "InsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace matches regex 'sqlserver_azure.._querystore_wait_stats'\r\n| summarize make_bag(pack(Name, Val)) by Tags, TimeGenerated\r\n| evaluate bag_unpack(bag_)\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| where strcat(sql_instance,'/',database_name) contains '{ResourceId}'\r\n| where tostring(query_hash) contains '{query_hash}'\r\n| summarize total_wait_time = sum(total_query_wait_time_ms)/1000\r\n    by wait_category, bin(interval_start_time, {Timerange:grain})\r\n| top 1000 by total_wait_time desc\r\n| evaluate pivot(wait_category, sum(total_wait_time))\r\n",
+                  "size": 0,
+                  "showAnalytics": true,
+                  "title": "Query Waits",
+                  "timeContext": {
+                    "durationMs": 86400000
+                  },
+                  "timeContextFromParameter": "Timerange",
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "crossComponentResources": [
+                    "{WsResourcesInternal}"
+                  ],
+                  "visualization": "barchart"
+                },
+                "name": "query - 2 - Copy - Copy"
+              }
+            ]
+          },
+          "customWidth": "40",
+          "name": "group - 7"
+        },
+        {
+          "type": 1,
+          "content": {
+            "json": "QUERY EXECUTIONS"
+          },
+          "name": "text - 11"
+        },
+        {
+          "type": 3,
+          "content": {
+            "version": "KqlItem/1.0",
+            "query": "InsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace matches regex 'sqlserver_azure.._querystore_runtime_stats'\r\n| summarize make_bag( pack(Name, Val)) by Tags, TimeGenerated\r\n| evaluate bag_unpack(bag_)\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| extend resourceName = tolower(strcat(sql_instance, '/', database_name))\r\n| where tostring(resourceName) contains '{ResourceId}'\r\n| summarize regular = sumif(count_executions, execution_type==0), errors = sumif(count_executions, execution_type==4), aborted = sumif(count_executions, execution_type==3) by query_hash\r\n| extend wbLink = '{QueryWorkbook}'\r\n| order by errors desc, query_hash",
+            "size": 0,
+            "showAnalytics": true,
+            "timeContext": {
+              "durationMs": 86400000
+            },
+            "timeContextFromParameter": "Timerange",
+            "exportFieldName": "query_hash",
+            "exportParameterName": "QueryHash",
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces",
+            "crossComponentResources": [
+              "{WsResourcesInternal}"
+            ],
+            "gridSettings": {
+              "formatters": [
+                {
+                  "columnMatch": "query_hash",
+                  "formatter": 7,
+                  "formatOptions": {
+                    "linkTarget": "WorkbookTemplate",
+                    "workbookContext": {
+                      "componentIdSource": "workbook",
+                      "resourceIdsSource": "workbook",
+                      "templateIdSource": "column",
+                      "templateId": "wbLink",
+                      "typeSource": "workbook",
+                      "gallerySource": "workbook",
+                      "locationSource": "default"
+                    }
+                  }
+                },
+                {
+                  "columnMatch": "wbLink",
+                  "formatter": 5
+                }
+              ],
+              "labelSettings": [
+                {
+                  "columnId": "query_hash",
+                  "label": "Query"
+                },
+                {
+                  "columnId": "regular",
+                  "label": "Regular"
+                },
+                {
+                  "columnId": "errors",
+                  "label": "Aborted by Exception"
+                },
+                {
+                  "columnId": "aborted",
+                  "label": "Aborted by Client"
+                },
+                {
+                  "columnId": "wbLink",
+                  "label": "Details"
+                }
+              ]
+            }
+          },
+          "customWidth": "60",
+          "name": "query - 2 - Copy - Copy - Copy"
+        },
+        {
+          "type": 3,
+          "content": {
+            "version": "KqlItem/1.0",
+            "query": "InsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace matches regex 'sqlserver_azure.._querystore_runtime_stats'\r\n| summarize make_bag( pack(Name, Val)) by Tags, TimeGenerated\r\n| evaluate bag_unpack(bag_)\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| extend resourceName = tolower(strcat(sql_instance, '/', database_name))\r\n| where tostring(resourceName) contains '{ResourceId}'\r\n| summarize regular = sumif(count_executions, execution_type==0), aborted = sumif(count_executions, execution_type==3), errors = sumif(count_executions, execution_type==4) by TimeGenerated = bin(interval_start_time, {Timerange:grain})",
+            "size": 0,
+            "showAnalytics": true,
+            "timeContext": {
+              "durationMs": 86400000
+            },
+            "timeContextFromParameter": "Timerange",
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces",
+            "crossComponentResources": [
+              "{WsResourcesInternal}"
+            ],
+            "visualization": "unstackedbar",
+            "chartSettings": {
+              "seriesLabelSettings": [
+                {
+                  "seriesName": "regular",
+                  "label": "Regular"
+                },
+                {
+                  "seriesName": "aborted",
+                  "label": "Aborted by Client"
+                },
+                {
+                  "seriesName": "errors",
+                  "label": "Aborted by Exception"
+                }
+              ]
+            }
+          },
+          "customWidth": "40",
+          "name": "query - 2 - Copy - Copy"
+        }
+      ],
+      "fallbackResourceIds": [
+      ],
+      "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
+    },
+    "workbookDisplayName": "Managed Instance Database",
+    "workbookName": "[parameters('workbookNames').ManagedInstanceDatabase]"
+  },
+  "resources": [
+    {
+      "name": "[variables('workbookName')]",
+      "type": "microsoft.insights/workbooks",
+      "location": "[resourceGroup().location]",
+      "apiVersion": "2018-06-17-preview",
+      "kind": "shared",
+      "properties": {
+        "displayName": "[variables('workbookDisplayName')]",
+        "serializedData": "[string(variables('workbookMarkup'))]",
+        "version": "Notebook/1.0",
+        "sourceId": "[resourceGroup().id]",
+        "category": "workbook"
+      },
+      "tags": {
+        "hidden-title": "[variables('workbookDisplayName')]"
+      }
+    }
+  ]
+}

--- a/Workbooks/Workloads/QDS/Metrics.json
+++ b/Workbooks/Workloads/QDS/Metrics.json
@@ -1,0 +1,520 @@
+{
+  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "workbookNames": {
+      "type": "object",
+      "defaultValue": {
+        "Metrics": "[guid(resourceGroup().id, 'Metrics')]",
+        "Database": "[guid(resourceGroup().id, 'Database')]"
+      }
+    }
+  },
+  "variables": {
+    "workbookMarkup": {
+      "version": "Notebook/1.0",
+      "items": [
+        {
+          "type": 9,
+          "content": {
+            "version": "KqlParameterItem/1.0",
+            "crossComponentResources": [
+              "{WsResourcesInternal}"
+            ],
+            "parameters": [
+              {
+                "id": "4ecc9f52-2e3f-4c8e-b9ea-f3e2f2583f5b",
+                "version": "KqlParameterItem/1.0",
+                "name": "WsResources",
+                "type": 1
+              },
+              {
+                "id": "f3e20cbc-b692-4b3d-8916-2fd0662ecfe6",
+                "version": "KqlParameterItem/1.0",
+                "name": "WsResourcesInternal",
+                "type": 5,
+                "multiSelect": true,
+                "quote": "'",
+                "delimiter": ",",
+                "query": "where id in~ ({WsResources})\r\n| project id, selected=1",
+                "crossComponentResources": [
+                  "value::all"
+                ],
+                "typeSettings": {
+                  "additionalResourceOptions": [],
+                  "showDefault": false
+                },
+                "queryType": 1,
+                "resourceType": "microsoft.resourcegraph/resources"
+              },
+              {
+                "id": "30b86356-1bba-4603-83d1-835b99171066",
+                "version": "KqlParameterItem/1.0",
+                "name": "Timerange",
+                "type": 4,
+                "value": {
+                  "durationMs": 86400000
+                },
+                "typeSettings": {
+                  "selectableValues": [
+                    {
+                      "durationMs": 300000
+                    },
+                    {
+                      "durationMs": 900000
+                    },
+                    {
+                      "durationMs": 1800000
+                    },
+                    {
+                      "durationMs": 3600000
+                    },
+                    {
+                      "durationMs": 14400000
+                    },
+                    {
+                      "durationMs": 43200000
+                    },
+                    {
+                      "durationMs": 86400000
+                    },
+                    {
+                      "durationMs": 172800000
+                    },
+                    {
+                      "durationMs": 259200000
+                    },
+                    {
+                      "durationMs": 604800000
+                    },
+                    {
+                      "durationMs": 1209600000
+                    },
+                    {
+                      "durationMs": 2419200000
+                    },
+                    {
+                      "durationMs": 2592000000
+                    },
+                    {
+                      "durationMs": 5184000000
+                    },
+                    {
+                      "durationMs": 7776000000
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "f2ae16b9-0bea-4ad0-b14e-93a51424fab9",
+                "version": "KqlParameterItem/1.0",
+                "name": "DBWorkbook",
+                "type": 1,
+                "value": "[resourceId('microsoft.insights/workbooks', parameters('workbookNames').Database)]"
+              },
+              {
+                "id": "58ec8e26-5dac-4c4c-9441-47daa7adf18f",
+                "version": "KqlParameterItem/1.0",
+                "name": "SubscriptionId",
+                "type": 1,
+                "value": ""
+              },
+              {
+                "id": "d2d2fa1b-070a-45d8-94ec-411c60379803",
+                "version": "KqlParameterItem/1.0",
+                "name": "ServerId",
+                "type": 1,
+                "value": ""
+              },
+              {
+                "id": "c3be0e03-709b-4778-8642-d4c0920c0b66",
+                "version": "KqlParameterItem/1.0",
+                "name": "Type",
+                "type": 1,
+                "value": "MICROSOFT.SQL/SERVERS"
+              },
+              {
+                "id": "f57defd5-1efd-445e-9a91-f3e22c2b703d",
+                "version": "KqlParameterItem/1.0",
+                "name": "MonitoredResources",
+                "type": 9,
+                "multiSelect": true,
+                "quote": "'",
+                "delimiter": ",",
+                "query": "InsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace == 'sqlserver_azure_db_resource_stats'\r\n| distinct Tags\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == 'AzureSQLDB'\r\n| project dbName = tolower(strcat(sql_instance, '/', database_name))\r\n| distinct dbName",
+                "crossComponentResources": [
+                  "{WsResourcesInternal}"
+                ],
+                "timeContext": {
+                  "durationMs": 0
+                },
+                "timeContextFromParameter": "Timerange",
+                "queryType": 0,
+                "resourceType": "microsoft.operationalinsights/workspaces"
+              },
+              {
+                "id": "a968655c-53a1-4bf8-81dc-9d4af49eb223",
+                "version": "KqlParameterItem/1.0",
+                "name": "Resources_metrics",
+                "type": 9,
+                "multiSelect": true,
+                "quote": "",
+                "delimiter": ",",
+                "query": "where type contains '{Type}'\r\n| extend ResourceId = tolower(id)\r\n| extend name = tolower(strcat(extract('/servers/([^/]+)/', 1, ResourceId), '/', name))\r\n| where name in ({MonitoredResources})\r\n| project strcat('{\"name\":\"',name, '\" , \"subscription\": \"', subscriptionId, '\", \"resourceGroup\": \"', resourceGroup, '\"}')",
+                "crossComponentResources": [
+                  "value::all"
+                ],
+                "timeContext": {
+                  "durationMs": 86400000
+                },
+                "timeContextFromParameter": "Timerange",
+                "queryType": 1,
+                "resourceType": "microsoft.resourcegraph/resources"
+              }
+            ],
+            "style": "pills",
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          },
+          "conditionalVisibility": {
+            "parameterName": "hide",
+            "comparison": "isNotEqualTo"
+          },
+          "name": "parameters - 0"
+        },
+        {
+          "type": 1,
+          "content": {
+            "json": "# Metrics"
+          },
+          "name": "text - 3"
+        },
+        {
+          "type": 1,
+          "content": {
+            "json": "Data is loading",
+            "style": "info"
+          },
+          "conditionalVisibility": {
+            "parameterName": "Resources_metrics",
+            "comparison": "isEqualTo"
+          },
+          "name": "text - 3"
+        },
+        {
+          "type": 12,
+          "content": {
+            "version": "NotebookGroup/1.0",
+            "groupType": "editable",
+            "items": [
+              {
+                "type": 3,
+                "content": {
+                  "version": "KqlItem/1.0",
+                  "query": "set truncationmaxrecords=5000;\r\nlet resources = print dynamic([{Resources_metrics}])\r\n| mv-expand print_0\r\n| evaluate bag_unpack(print_0);\r\nInsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace == 'sqlserver_azure_db_resource_stats'\r\n| where Name in ('avg_cpu_percent', 'avg_data_io_percent', 'avg_log_write_percent')\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == 'AzureSQLDB'\r\n| extend resourceName = tolower(strcat(sql_instance, '/', database_name))\r\n| join kind=leftouter (resources | extend resourceName = name) on resourceName\r\n| summarize Val = percentile(Val, 80) by Name, subscription, resourceName, bin(TimeGenerated, {Timerange:grain})\r\n| summarize max_val = max(Val) by subscription, resourceName\r\n| extend category = case(max_val < 20, \"low\", max_val < 80, \"medium\", \"high\")\r\n| summarize high = countif(category == \"high\"), medium = countif(category == \"medium\"), low = countif(category == \"low\") by subscription\r\n| extend Resource = subscription\r\n| project Resource, high, medium, low, subscription \r\n| sort by high, medium, low desc",
+                  "size": 1,
+                  "title": "Subscriptions",
+                  "timeContext": {
+                    "durationMs": 86400000
+                  },
+                  "timeContextFromParameter": "Timerange",
+                  "exportFieldName": "subscription",
+                  "exportParameterName": "SubscriptionId",
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "crossComponentResources": [
+                    "{WsResourcesInternal}"
+                  ],
+                  "gridSettings": {
+                    "formatters": [
+                      {
+                        "columnMatch": "Resource",
+                        "formatter": 15,
+                        "formatOptions": {
+                          "linkTarget": null,
+                          "showIcon": true
+                        }
+                      },
+                      {
+                        "columnMatch": "subscription",
+                        "formatter": 5
+                      }
+                    ],
+                    "labelSettings": [
+                      {
+                        "columnId": "Resource",
+                        "label": "Subscription"
+                      },
+                      {
+                        "columnId": "high"
+                      },
+                      {
+                        "columnId": "medium"
+                      },
+                      {
+                        "columnId": "low"
+                      }
+                    ]
+                  }
+                },
+                "customWidth": "33",
+                "name": "query - 4"
+              },
+              {
+                "type": 1,
+                "content": {
+                  "json": ""
+                },
+                "customWidth": "67",
+                "name": "text - 7"
+              },
+              {
+                "type": 3,
+                "content": {
+                  "version": "KqlItem/1.0",
+                  "query": "set truncationmaxrecords=5000;\r\nlet resources = print dynamic([{Resources_metrics}])\r\n| mv-expand print_0\r\n| evaluate bag_unpack(print_0);\r\nInsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace == 'sqlserver_azure_db_resource_stats'\r\n| where Name in ('avg_cpu_percent', 'avg_data_io_percent', 'avg_log_write_percent')\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == 'AzureSQLDB'\r\n| extend resourceName = tolower(strcat(sql_instance, '/', database_name))\r\n| join kind=leftouter (resources | extend resourceName = name) on resourceName\r\n| where tostring(subscription) contains '{SubscriptionId}'\r\n| summarize Val = percentile(Val, 80) by Name, subscription, sql_instance, resourceGroup, database_name, bin(TimeGenerated, {Timerange:grain})\r\n| summarize max_val = max(Val) by subscription, sql_instance, resourceGroup, database_name\r\n| extend category = case(max_val < 20, \"low\", max_val < 80, \"medium\", \"high\")\r\n| summarize high = countif(category == \"high\"), medium = countif(category == \"medium\"), low = countif(category == \"low\") by sql_instance\r\n| project Type = '{Type}', ResourceIdPrefix = sql_instance , high, medium, low, sql_instance\r\n| sort by high, medium, low desc",
+                  "size": 1,
+                  "title": "Servers",
+                  "timeContext": {
+                    "durationMs": 86400000
+                  },
+                  "timeContextFromParameter": "Timerange",
+                  "exportFieldName": "sql_instance",
+                  "exportParameterName": "ServerId",
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "crossComponentResources": [
+                    "{WsResourcesInternal}"
+                  ],
+                  "gridSettings": {
+                    "formatters": [
+                      {
+                        "columnMatch": "Type",
+                        "formatter": 16,
+                        "formatOptions": {
+                          "showIcon": true,
+                          "customColumnWidthSetting": "4ch"
+                        }
+                      },
+                      {
+                        "columnMatch": "ResourceIdPrefix",
+                        "formatter": 1
+                      },
+                      {
+                        "columnMatch": "sql_instance",
+                        "formatter": 5
+                      }
+                    ],
+                    "labelSettings": [
+                      {
+                        "columnId": "Type",
+                        "label": " "
+                      },
+                      {
+                        "columnId": "ResourceIdPrefix",
+                        "label": "Server"
+                      },
+                      {
+                        "columnId": "high"
+                      },
+                      {
+                        "columnId": "medium"
+                      },
+                      {
+                        "columnId": "low"
+                      },
+                      {
+                        "columnId": "sql_instance"
+                      }
+                    ]
+                  }
+                },
+                "customWidth": "33",
+                "name": "query - 4 - Copy"
+              },
+              {
+                "type": 1,
+                "content": {
+                  "json": ""
+                },
+                "customWidth": "67",
+                "name": "text - 8"
+              },
+              {
+                "type": 3,
+                "content": {
+                  "version": "KqlItem/1.0",
+                  "query": "set truncationmaxrecords=5000;\r\nlet resources = print dynamic([{Resources_metrics}])\r\n| mv-expand print_0\r\n| evaluate bag_unpack(print_0);\r\nlet metrics = InsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace == 'sqlserver_azure_db_resource_stats'\r\n| where Name in ('avg_cpu_percent', 'avg_data_io_percent', 'avg_log_write_percent')\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == 'AzureSQLDB'\r\n| extend resourceName = tolower(strcat(sql_instance, '/', database_name))\r\n| join kind=leftouter (resources| extend resourceName = name)on resourceName\r\n| where tostring(subscription) contains '{SubscriptionId}'\r\n| where tostring(sql_instance) contains '{ServerId}';\r\nmetrics\r\n| where Val > 0 \r\n| summarize metric_value = percentile(min_of(Val, 100.0), 80) by bin(TimeGenerated, {Timerange:grain}), resourceName, subscription, resourceGroup, sql_instance, database_name, Name\r\n| summarize arg_max(metric_value, Name) by resourceName, subscription, resourceGroup, sql_instance, database_name\r\n| project ResourceId = resourceName, MetricName=Name, metric_value\r\n| union ( metrics \r\n| summarize max(Val) by resourceName, subscription, resourceGroup, sql_instance, database_name \r\n| where max_Val == 0 \r\n| project ResourceId = resourceName, MetricName = \"none\", metric_value = 0.0)\r\n| project Type = '{Type}', ResourceId, MetricName, metric_value, wbLink='{DBWorkbook}'\r\n| sort by metric_value desc",
+                  "size": 1,
+                  "title": "Databases",
+                  "timeContext": {
+                    "durationMs": 86400000
+                  },
+                  "timeContextFromParameter": "Timerange",
+                  "exportFieldName": "resourceName",
+                  "exportParameterName": "ResourceId",
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "crossComponentResources": [
+                    "{WsResourcesInternal}"
+                  ],
+                  "gridSettings": {
+                    "formatters": [
+                      {
+                        "columnMatch": "Type",
+                        "formatter": 16,
+                        "formatOptions": {
+                          "showIcon": true,
+                          "customColumnWidthSetting": "4ch"
+                        }
+                      },
+                      {
+                        "columnMatch": "ResourceId",
+                        "formatter": 7,
+                        "formatOptions": {
+                          "linkColumn": "wbLink",
+                          "linkTarget": "WorkbookTemplate",
+                          "workbookContext": {
+                            "componentIdSource": "workbook",
+                            "resourceIdsSource": "workbook",
+                            "templateIdSource": "column",
+                            "templateId": "wbLink",
+                            "typeSource": "workbook",
+                            "gallerySource": "workbook",
+                            "locationSource": "default"
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "MetricName",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "15ch"
+                        }
+                      },
+                      {
+                        "columnMatch": "metric_value",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "15ch"
+                        },
+                        "numberFormat": {
+                          "unit": 1,
+                          "options": {
+                            "style": "decimal"
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "wbLink",
+                        "formatter": 5
+                      },
+                      {
+                        "columnMatch": "resourceName",
+                        "formatter": 5
+                      }
+                    ],
+                    "labelSettings": [
+                      {
+                        "columnId": "Type",
+                        "label": " "
+                      },
+                      {
+                        "columnId": "ResourceId",
+                        "label": "Database"
+                      },
+                      {
+                        "columnId": "MetricName",
+                        "label": "Metric"
+                      },
+                      {
+                        "columnId": "metric_value",
+                        "label": "Value"
+                      },
+                      {
+                        "columnId": "wbLink"
+                      }
+                    ]
+                  }
+                },
+                "customWidth": "33",
+                "name": "query - 4 - Copy - Copy"
+              },
+              {
+                "type": 3,
+                "content": {
+                  "version": "KqlItem/1.0",
+                  "query": "set truncationmaxrecords=5000;\r\nlet resources = print dynamic([{Resources_metrics}])\r\n| mv-expand print_0\r\n| evaluate bag_unpack(print_0);\r\nlet metrics = InsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace == 'sqlserver_azure_db_resource_stats'\r\n| where Name in ('avg_cpu_percent', 'avg_data_io_percent', 'avg_log_write_percent')\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == 'AzureSQLDB'\r\n| extend resourceName = tolower(strcat(sql_instance, '/', database_name))\r\n| join kind=leftouter (resources| extend resourceName = name)on resourceName\r\n| where tostring(subscription) contains '{SubscriptionId}'\r\n| where tostring(sql_instance) contains '{ServerId}';\r\nmetrics\r\n| summarize Val = percentile(Val, 80) by Name, sql_instance, database_name, bin(TimeGenerated, {Timerange:grain})\r\n| summarize max_val = max(Val) by sql_instance, database_name, bin(TimeGenerated, {Timerange:grain})\r\n| extend category = case(max_val < 20, \"low\", max_val < 80, \"medium\", \"high\")\r\n| summarize high = countif(category == \"high\"), medium = countif(category == \"medium\"), low = countif(category == \"low\") by TimeGenerated\r\n",
+                  "size": 0,
+                  "aggregation": 3,
+                  "showAnalytics": true,
+                  "title": "Usage",
+                  "timeContext": {
+                    "durationMs": 86400000
+                  },
+                  "timeContextFromParameter": "Timerange",
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "crossComponentResources": [
+                    "{WsResourcesInternal}"
+                  ],
+                  "visualization": "barchart",
+                  "chartSettings": {
+                    "seriesLabelSettings": [
+                      {
+                        "seriesName": "high",
+                        "color": "orange"
+                      },
+                      {
+                        "seriesName": "medium",
+                        "color": "green"
+                      },
+                      {
+                        "seriesName": "low",
+                        "color": "blue"
+                      }
+                    ]
+                  }
+                },
+                "customWidth": "67",
+                "name": "query - 2",
+                "styleSettings": {
+                  "margin": "-550px 0px 0px 0px"
+                }
+              }
+            ]
+          },
+          "conditionalVisibility": {
+            "parameterName": "Resources_metrics",
+            "comparison": "isNotEqualTo"
+          },
+          "name": "group - 8"
+        }
+      ],
+      "fallbackResourceIds": [
+      ],
+      "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
+    },
+    "workbookDisplayName": "Metrics",
+    "workbookName": "[parameters('workbookNames').Metrics]"
+  },
+  "resources": [
+    {
+      "name": "[variables('workbookName')]",
+      "type": "microsoft.insights/workbooks",
+      "location": "[resourceGroup().location]",
+      "apiVersion": "2018-06-17-preview",
+      "kind": "shared",
+      "properties": {
+        "displayName": "[variables('workbookDisplayName')]",
+        "serializedData": "[string(variables('workbookMarkup'))]",
+        "version": "Notebook/1.0",
+        "sourceId": "[resourceGroup().id]",
+        "category": "workbook"
+      },
+      "tags": {
+        "hidden-title": "[variables('workbookDisplayName')]"
+      }
+    }
+  ]
+}

--- a/Workbooks/Workloads/QDS/Queries.json
+++ b/Workbooks/Workloads/QDS/Queries.json
@@ -1,0 +1,836 @@
+{
+  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "workbookNames": {
+      "type": "object",
+      "defaultValue": {
+        "Queries": "[guid(resourceGroup().id, 'Queries')]",
+        "Database": "[guid(resourceGroup().id, 'Database')]",
+        "Query": "[guid(resourceGroup().id, 'Query')]"
+      }
+    }
+  },
+  "variables": {
+    "workbookMarkup": {
+      "version": "Notebook/1.0",
+      "items": [
+        {
+          "type": 9,
+          "content": {
+            "version": "KqlParameterItem/1.0",
+            "crossComponentResources": [
+              "{WsResourcesInternal}"
+            ],
+            "parameters": [
+              {
+                "id": "4ecc9f52-2e3f-4c8e-b9ea-f3e2f2583f5b",
+                "version": "KqlParameterItem/1.0",
+                "name": "WsResources",
+                "type": 1,
+                "isHiddenWhenLocked": true
+              },
+              {
+                "id": "f3e20cbc-b692-4b3d-8916-2fd0662ecfe6",
+                "version": "KqlParameterItem/1.0",
+                "name": "WsResourcesInternal",
+                "type": 5,
+                "multiSelect": true,
+                "quote": "'",
+                "delimiter": ",",
+                "query": "where id in~ ({WsResources})\r\n| project id, selected=1",
+                "crossComponentResources": [
+                  "value::all"
+                ],
+                "isHiddenWhenLocked": true,
+                "typeSettings": {
+                  "additionalResourceOptions": [],
+                  "showDefault": false
+                },
+                "queryType": 1,
+                "resourceType": "microsoft.resourcegraph/resources"
+              },
+              {
+                "id": "30b86356-1bba-4603-83d1-835b99171066",
+                "version": "KqlParameterItem/1.0",
+                "name": "Timerange",
+                "type": 4,
+                "isHiddenWhenLocked": true,
+                "typeSettings": {
+                  "selectableValues": [
+                    {
+                      "durationMs": 300000
+                    },
+                    {
+                      "durationMs": 900000
+                    },
+                    {
+                      "durationMs": 1800000
+                    },
+                    {
+                      "durationMs": 3600000
+                    },
+                    {
+                      "durationMs": 14400000
+                    },
+                    {
+                      "durationMs": 43200000
+                    },
+                    {
+                      "durationMs": 86400000
+                    },
+                    {
+                      "durationMs": 172800000
+                    },
+                    {
+                      "durationMs": 259200000
+                    },
+                    {
+                      "durationMs": 604800000
+                    },
+                    {
+                      "durationMs": 1209600000
+                    },
+                    {
+                      "durationMs": 2419200000
+                    },
+                    {
+                      "durationMs": 2592000000
+                    },
+                    {
+                      "durationMs": 5184000000
+                    },
+                    {
+                      "durationMs": 7776000000
+                    }
+                  ]
+                },
+                "value": {
+                  "durationMs": 86400000
+                }
+              },
+              {
+                "id": "f2ae16b9-0bea-4ad0-b14e-93a51424fab9",
+                "version": "KqlParameterItem/1.0",
+                "name": "DBWorkbook",
+                "type": 1,
+                "isHiddenWhenLocked": true,
+                "value": "[resourceId('microsoft.insights/workbooks', parameters('workbookNames').Database)]"
+              },
+              {
+                "id": "58ec8e26-5dac-4c4c-9441-47daa7adf18f",
+                "version": "KqlParameterItem/1.0",
+                "name": "SubscriptionId",
+                "type": 1,
+                "isHiddenWhenLocked": true
+              },
+              {
+                "id": "d2d2fa1b-070a-45d8-94ec-411c60379803",
+                "version": "KqlParameterItem/1.0",
+                "name": "ServerId",
+                "type": 1,
+                "isHiddenWhenLocked": true
+              },
+              {
+                "id": "be50e0a3-ec3a-4b7d-bd17-006135b6e356",
+                "version": "KqlParameterItem/1.0",
+                "name": "QueryWorkbook",
+                "type": 1,
+                "isHiddenWhenLocked": true,
+                "value": "[resourceId('microsoft.insights/workbooks', parameters('workbookNames').Query)]"
+              },
+              {
+                "id": "492c11ca-b5a5-45f2-85e5-1ab9a857072a",
+                "version": "KqlParameterItem/1.0",
+                "name": "ResourceId",
+                "type": 1,
+                "isHiddenWhenLocked": true
+              },
+              {
+                "id": "28218b60-2905-4ce8-94d1-564fea2d0e57",
+                "version": "KqlParameterItem/1.0",
+                "name": "Type",
+                "type": 1
+              },
+              {
+                "id": "1a5530ae-1627-49e2-b15e-1f2c2e82775b",
+                "version": "KqlParameterItem/1.0",
+                "name": "TypeInternal",
+                "type": 7,
+                "query": "{\"version\":\"1.0.0\",\"content\":\"{\\\"value\\\":\\\"{Type}\\\", \\\"selected\\\":true}\",\"transformers\":null}",
+                "typeSettings": {
+                  "additionalResourceOptions": [],
+                  "showDefault": false
+                },
+                "queryType": 8
+              },
+              {
+                "id": "6603192f-19cd-496f-b209-1fe9e397e6e7",
+                "version": "KqlParameterItem/1.0",
+                "name": "dbType",
+                "type": 1,
+                "value": "AzureSQLDB"
+              },
+              {
+                "id": "d3b7aaba-0f9b-4e58-954a-d01522f664cf",
+                "version": "KqlParameterItem/1.0",
+                "name": "MonitoredResources",
+                "type": 9,
+                "multiSelect": true,
+                "quote": "'",
+                "delimiter": ",",
+                "query": "InsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace matches regex 'sqlserver_azure.._querystore_runtime_stats'\r\n| distinct Tags\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| project dbName = tolower(strcat(extract(\"^([^\\\\.]+)\\\\.?\", 1, sql_instance), '/', database_name))\r\n| distinct dbName",
+                "crossComponentResources": [
+                  "{WsResourcesInternal}"
+                ],
+                "timeContext": {
+                  "durationMs": 86400000
+                },
+                "timeContextFromParameter": "Timerange",
+                "queryType": 0,
+                "resourceType": "microsoft.operationalinsights/workspaces"
+              },
+              {
+                "id": "253c067c-1f8f-479e-9d33-ce63f87416f2",
+                "version": "KqlParameterItem/1.0",
+                "name": "Resources_queries",
+                "type": 9,
+                "multiSelect": true,
+                "quote": "",
+                "delimiter": ",",
+                "query": "where type contains '{Type}'\r\n| extend ResourceId = tolower(id)\r\n| extend name = tolower(strcat(extract(tolower('/{Type}/([^/]+)/'), 1, ResourceId), '/', name))\r\n| where name in ({MonitoredResources})\r\n| project strcat('{\"name\":\"',name, '\" , \"subscription\": \"', subscriptionId, '\", \"resourceGroup\": \"', resourceGroup, '\"}')",
+                "crossComponentResources": [
+                  "value::all"
+                ],
+                "timeContext": {
+                  "durationMs": 0
+                },
+                "timeContextFromParameter": "Timerange",
+                "queryType": 1,
+                "resourceType": "microsoft.resourcegraph/resources"
+              }
+            ],
+            "style": "pills",
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          },
+          "conditionalVisibility": {
+            "parameterName": "hide",
+            "comparison": "isNotEqualTo"
+          },
+          "name": "parameters - 0"
+        },
+        {
+          "type": 1,
+          "content": {
+            "json": "# Queries"
+          },
+          "name": "text - 3"
+        },
+        {
+          "type": 1,
+          "content": {
+            "json": "Data is loading",
+            "style": "info"
+          },
+          "conditionalVisibility": {
+            "parameterName": "Resources_queries",
+            "comparison": "isEqualTo"
+          },
+          "name": "text - 3"
+        },
+        {
+          "type": 12,
+          "content": {
+            "version": "NotebookGroup/1.0",
+            "groupType": "editable",
+            "items": [
+              {
+                "type": 3,
+                "content": {
+                  "version": "KqlItem/1.0",
+                  "query": "let resources = print dynamic([{Resources_queries}])\r\n| mv-expand print_0\r\n| evaluate bag_unpack(print_0);\r\nInsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace matches regex 'sqlserver_azure.._querystore_runtime_stats'\r\n| summarize make_bag( pack(Name, Val)) by Tags, TimeGenerated\r\n| evaluate bag_unpack(bag_)\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| extend resourceName = tolower(strcat(extract(\"^([^\\\\.]+)\\\\.?\", 1, sql_instance), '/', database_name))\r\n| join kind=leftouter (resources| extend resourceName = name)on resourceName\r\n| summarize max_duration = max(max_duration)/1000000,\r\navg_duration = sum(avg_duration*count_executions)/sum(count_executions)/1000000,\r\navg_cpu = sum(avg_cpu_time*count_executions)/sum(count_executions)/1000000,\r\nexecutions_count = sum(count_executions)\r\n    by subscription\r\n| extend ResourceIdPrefix = strcat(\"/SUBSCRIPTIONS/\", subscription, \"/\")\r\n| project SubscriptionId = subscription, max_duration,\r\n    avg_duration,\r\n    avg_cpu,\r\n    executions_count, ResourceIdPrefix\r\n| sort by avg_duration desc",
+                  "size": 1,
+                  "title": "Subscriptions",
+                  "timeContext": {
+                    "durationMs": 86400000
+                  },
+                  "timeContextFromParameter": "Timerange",
+                  "exportFieldName": "SubscriptionId",
+                  "exportParameterName": "SubscriptionId",
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "crossComponentResources": [
+                    "{WsResourcesInternal}"
+                  ],
+                  "gridSettings": {
+                    "formatters": [
+                      {
+                        "columnMatch": "SubscriptionId",
+                        "formatter": 15,
+                        "formatOptions": {
+                          "linkTarget": null,
+                          "customColumnWidthSetting": "24ch"
+                        }
+                      },
+                      {
+                        "columnMatch": "max_duration",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "14ch"
+                        },
+                        "numberFormat": {
+                          "unit": 24,
+                          "options": {
+                            "style": "decimal",
+                            "useGrouping": false
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "avg_duration",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "14ch"
+                        },
+                        "numberFormat": {
+                          "unit": 24,
+                          "options": {
+                            "style": "decimal",
+                            "useGrouping": false
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "avg_cpu",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "14ch"
+                        },
+                        "numberFormat": {
+                          "unit": 24,
+                          "options": {
+                            "style": "decimal"
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "executions_count",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "13ch"
+                        },
+                        "numberFormat": {
+                          "unit": 17,
+                          "options": {
+                            "style": "decimal"
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "ResourceIdPrefix",
+                        "formatter": 5
+                      }
+                    ],
+                    "labelSettings": [
+                      {
+                        "columnId": "SubscriptionId",
+                        "label": "Subscription"
+                      },
+                      {
+                        "columnId": "max_duration",
+                        "label": "Max"
+                      },
+                      {
+                        "columnId": "avg_duration",
+                        "label": "Avg"
+                      },
+                      {
+                        "columnId": "avg_cpu",
+                        "label": "CPU"
+                      },
+                      {
+                        "columnId": "executions_count",
+                        "label": "Execs"
+                      },
+                      {
+                        "columnId": "ResourceIdPrefix"
+                      }
+                    ]
+                  }
+                },
+                "customWidth": "33",
+                "name": "query - 4"
+              },
+              {
+                "type": 1,
+                "content": {
+                  "json": ""
+                },
+                "customWidth": "67",
+                "name": "text - 7"
+              },
+              {
+                "type": 3,
+                "content": {
+                  "version": "KqlItem/1.0",
+                  "query": "let resources = print dynamic([{Resources_queries}])\r\n| mv-expand print_0\r\n| evaluate bag_unpack(print_0);\r\nInsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace matches regex 'sqlserver_azure.._querystore_runtime_stats'\r\n| summarize make_bag( pack(Name, Val)) by Tags, TimeGenerated\r\n| evaluate bag_unpack(bag_)\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| extend resourceName = tolower(strcat(extract(\"^([^\\\\.]+)\\\\.?\", 1, sql_instance), '/', database_name))\r\n| join kind=leftouter (resources| extend resourceName = name)on resourceName\r\n| where tostring(subscription) contains '{SubscriptionId}'\r\n| summarize max_duration = max(max_duration)/1000000,\r\navg_duration = sum(avg_duration*count_executions)/sum(count_executions)/1000000,\r\navg_cpu = sum(avg_cpu_time*count_executions)/sum(count_executions)/1000000,\r\nexecutions_count = sum(count_executions)\r\n    by subscription, resourceGroup, sql_instance\r\n| extend ResourceIdPrefix = strcat(\"/SUBSCRIPTIONS/\", subscription, \"/RESOURCEGROUPS/\", resourceGroup, \"/PROVIDERS/{Type}/\", sql_instance)\r\n| project ['{TypeInternal:label}'] = ResourceIdPrefix,\r\n    ResourceIdPrefix,\r\n    max_duration,\r\n    avg_duration,\r\n    avg_cpu,\r\n    executions_count,\r\n    sql_instance\r\n| sort by avg_duration desc",
+                  "size": 1,
+                  "title": "{TypeInternal:label}s",
+                  "timeContext": {
+                    "durationMs": 86400000
+                  },
+                  "timeContextFromParameter": "Timerange",
+                  "exportFieldName": "sql_instance",
+                  "exportParameterName": "ServerId",
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "crossComponentResources": [
+                    "{WsResourcesInternal}"
+                  ],
+                  "gridSettings": {
+                    "formatters": [
+                      {
+                        "columnMatch": "SQL",
+                        "formatter": 13,
+                        "formatOptions": {
+                          "linkTarget": null,
+                          "showIcon": true,
+                          "customColumnWidthSetting": "26ch"
+                        }
+                      },
+                      {
+                        "columnMatch": "ResourceIdPrefix",
+                        "formatter": 5
+                      },
+                      {
+                        "columnMatch": "max_duration",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "14ch"
+                        },
+                        "numberFormat": {
+                          "unit": 24,
+                          "options": {
+                            "style": "decimal",
+                            "useGrouping": false
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "avg_duration",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "14ch"
+                        },
+                        "numberFormat": {
+                          "unit": 24,
+                          "options": {
+                            "style": "decimal"
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "avg_cpu",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "14ch"
+                        },
+                        "numberFormat": {
+                          "unit": 24,
+                          "options": {
+                            "style": "decimal"
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "executions_count",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "13ch"
+                        },
+                        "numberFormat": {
+                          "unit": 17,
+                          "options": {
+                            "style": "decimal",
+                            "useGrouping": false
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "sql_instance",
+                        "formatter": 5
+                      }
+                    ],
+                    "labelSettings": [
+                      {
+                        "columnId": "ResourceIdPrefix",
+                        "label": "Server"
+                      },
+                      {
+                        "columnId": "max_duration",
+                        "label": "Max"
+                      },
+                      {
+                        "columnId": "avg_duration",
+                        "label": "Avg"
+                      },
+                      {
+                        "columnId": "avg_cpu",
+                        "label": "CPU"
+                      },
+                      {
+                        "columnId": "executions_count",
+                        "label": "Execs"
+                      }
+                    ]
+                  }
+                },
+                "customWidth": "33",
+                "name": "query - 4 - Copy"
+              },
+              {
+                "type": 1,
+                "content": {
+                  "json": ""
+                },
+                "customWidth": "67",
+                "name": "text - 8"
+              },
+              {
+                "type": 3,
+                "content": {
+                  "version": "KqlItem/1.0",
+                  "query": "let resources = print dynamic([{Resources_queries}])\r\n| mv-expand print_0\r\n| evaluate bag_unpack(print_0);\r\nInsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace matches regex 'sqlserver_azure.._querystore_runtime_stats'\r\n| summarize make_bag( pack(Name, Val)) by Tags, TimeGenerated\r\n| evaluate bag_unpack(bag_)\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| extend resourceName = tolower(strcat(extract(\"^([^\\\\.]+)\\\\.?\", 1, sql_instance), '/', database_name))\r\n| join kind=leftouter (resources| extend resourceName = name)on resourceName\r\n| where tostring(subscription) contains '{SubscriptionId}'\r\n| where tostring(sql_instance) contains '{ServerId}'\r\n| summarize max_duration = max(max_duration)/1000000,\r\navg_duration = sum(avg_duration*count_executions)/sum(count_executions)/1000000,\r\navg_cpu = sum(avg_cpu_time*count_executions)/sum(count_executions)/1000000,\r\nexecutions_count = sum(count_executions)\r\n    by resourceName, subscription, resourceGroup, sql_instance, database_name\r\n| project\r\n    ResourceId = strcat(\"/SUBSCRIPTIONS/\", subscription, \"/RESOURCEGROUPS/\", resourceGroup, \"/PROVIDERS/{Type}/\", sql_instance, \"/DATABASES/\", database_name),\r\n    max_duration,\r\n    avg_duration,\r\n    avg_cpu,\r\n    executions_count,\r\n    resourceName,\r\n    wbLink = '{DBWorkbook}'\r\n| sort by avg_duration desc",
+                  "size": 1,
+                  "title": "Databases",
+                  "timeContext": {
+                    "durationMs": 86400000
+                  },
+                  "timeContextFromParameter": "Timerange",
+                  "exportFieldName": "resourceName",
+                  "exportParameterName": "ResourceId",
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "crossComponentResources": [
+                    "{WsResourcesInternal}"
+                  ],
+                  "gridSettings": {
+                    "formatters": [
+                      {
+                        "columnMatch": "ResourceId",
+                        "formatter": 13,
+                        "formatOptions": {
+                          "linkColumn": "wbLink",
+                          "linkTarget": "WorkbookTemplate",
+                          "showIcon": true,
+                          "customColumnWidthSetting": "24ch"
+                        }
+                      },
+                      {
+                        "columnMatch": "max_duration",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "14ch"
+                        },
+                        "numberFormat": {
+                          "unit": 24,
+                          "options": {
+                            "style": "decimal",
+                            "useGrouping": false
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "avg_duration",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "14ch"
+                        },
+                        "numberFormat": {
+                          "unit": 24,
+                          "options": {
+                            "style": "decimal"
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "avg_cpu",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "14ch"
+                        },
+                        "numberFormat": {
+                          "unit": 24,
+                          "options": {
+                            "style": "decimal"
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "executions_count",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "13ch"
+                        },
+                        "numberFormat": {
+                          "unit": 17,
+                          "options": {
+                            "style": "decimal"
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "resourceName",
+                        "formatter": 5
+                      },
+                      {
+                        "columnMatch": "wbLink",
+                        "formatter": 5
+                      }
+                    ],
+                    "sortBy": [
+                      {
+                        "itemKey": "$gen_number_avg_duration_2",
+                        "sortOrder": 1
+                      }
+                    ],
+                    "labelSettings": [
+                      {
+                        "columnId": "ResourceId"
+                      },
+                      {
+                        "columnId": "max_duration",
+                        "label": "Max"
+                      },
+                      {
+                        "columnId": "avg_duration",
+                        "label": "Avg"
+                      },
+                      {
+                        "columnId": "avg_cpu",
+                        "label": "CPU"
+                      },
+                      {
+                        "columnId": "executions_count",
+                        "label": "Exec"
+                      },
+                      {
+                        "columnId": "wbLink"
+                      }
+                    ]
+                  },
+                  "sortBy": [
+                    {
+                      "itemKey": "$gen_number_avg_duration_2",
+                      "sortOrder": 1
+                    }
+                  ]
+                },
+                "customWidth": "33",
+                "name": "query - 4 - Copy - Copy"
+              },
+              {
+                "type": 3,
+                "content": {
+                  "version": "KqlItem/1.0",
+                  "query": "let resources = print dynamic([{Resources_queries}])\r\n| mv-expand print_0\r\n| evaluate bag_unpack(print_0);\r\nInsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace matches regex 'sqlserver_azure.._querystore_runtime_stats'\r\n| summarize make_bag( pack(Name, Val)) by Tags, TimeGenerated\r\n| evaluate bag_unpack(bag_)\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| extend resourceName = tolower(strcat(extract(\"^([^\\\\.]+)\\\\.?\", 1, sql_instance), '/', database_name))\r\n| join kind=leftouter (resources| extend resourceName = name)on resourceName\r\n| where tostring(subscription) contains '{SubscriptionId}'\r\n| where tostring(sql_instance) contains '{ServerId}'\r\n| where tostring(resourceName) contains '{ResourceId}'\r\n| project interval_start_time, max_duration, cpu_time_d = avg_cpu_time*count_executions, duration_d = avg_duration*count_executions, count_executions_d = count_executions\r\n| summarize avg_duration = sum(duration_d)/sum(count_executions_d)/1000000,\r\navg_cpu = sum(cpu_time_d)/sum(count_executions_d)/1000000\r\n    by bin(interval_start_time, {Timerange:grain})",
+                  "size": 0,
+                  "aggregation": 3,
+                  "showAnalytics": true,
+                  "title": "Query duration",
+                  "timeContext": {
+                    "durationMs": 86400000
+                  },
+                  "timeContextFromParameter": "Timerange",
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "crossComponentResources": [
+                    "{WsResourcesInternal}"
+                  ],
+                  "visualization": "linechart",
+                  "chartSettings": {
+                    "ySettings": {
+                      "numberFormatSettings": {
+                        "unit": 23,
+                        "options": {
+                          "style": "decimal",
+                          "useGrouping": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "customWidth": "67",
+                "name": "query - 2",
+                "styleSettings": {
+                  "margin": "-550px 0px 0px 0px"
+                }
+              },
+              {
+                "type": 3,
+                "content": {
+                  "version": "KqlItem/1.0",
+                  "query": "let resources = print dynamic([{Resources_queries}])\r\n| mv-expand print_0\r\n| evaluate bag_unpack(print_0);\r\nInsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace matches regex 'sqlserver_azure.._querystore_runtime_stats'\r\n| summarize make_bag( pack(Name, Val)) by Tags, TimeGenerated\r\n| evaluate bag_unpack(bag_)\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| extend resourceName = tolower(strcat(extract(\"^([^\\\\.]+)\\\\.?\", 1, sql_instance), '/', database_name))\r\n| join kind=leftouter (resources| extend resourceName = name)on resourceName\r\n| where tostring(subscription) contains '{SubscriptionId}'\r\n| where tostring(sql_instance) contains '{ServerId}'\r\n| where tostring(resourceName) contains '{ResourceId}'\r\n| summarize max_duration = max(max_duration)/1000000,\r\navg_duration = sum(avg_duration*count_executions)/sum(count_executions)/1000000,\r\navg_cpu = sum(avg_cpu_time*count_executions)/sum(count_executions)/1000000,\r\nexecutions_count = sum(count_executions)\r\n    by query_hash\r\n| project query_hash,\r\n    max_duration,\r\n    avg_duration,\r\n    avg_cpu,\r\n    executions_count,\r\n    wbLink = '{QueryWorkbook}'\r\n| sort by avg_duration desc",
+                  "size": 1,
+                  "title": "Queries",
+                  "timeContext": {
+                    "durationMs": 86400000
+                  },
+                  "timeContextFromParameter": "Timerange",
+                  "exportFieldName": "query_hash",
+                  "exportParameterName": "QueryHash",
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "crossComponentResources": [
+                    "{WsResourcesInternal}"
+                  ],
+                  "gridSettings": {
+                    "formatters": [
+                      {
+                        "columnMatch": "query_hash",
+                        "formatter": 1,
+                        "formatOptions": {
+                          "linkColumn": "wbLink",
+                          "linkTarget": "WorkbookTemplate",
+                          "linkIsContextBlade": false
+                        }
+                      },
+                      {
+                        "columnMatch": "max_duration",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "14ch"
+                        },
+                        "numberFormat": {
+                          "unit": 24,
+                          "options": {
+                            "style": "decimal",
+                            "useGrouping": false
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "avg_duration",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "14ch"
+                        },
+                        "numberFormat": {
+                          "unit": 24,
+                          "options": {
+                            "style": "decimal",
+                            "useGrouping": false
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "avg_cpu",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "14ch"
+                        },
+                        "numberFormat": {
+                          "unit": 24,
+                          "options": {
+                            "style": "decimal"
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "executions_count",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "13ch"
+                        },
+                        "numberFormat": {
+                          "unit": 17,
+                          "options": {
+                            "style": "decimal"
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "wbLink",
+                        "formatter": 5
+                      },
+                      {
+                        "columnMatch": "ResourceId",
+                        "formatter": 5
+                      }
+                    ],
+                    "sortBy": [
+                      {
+                        "itemKey": "$gen_number_avg_duration_2",
+                        "sortOrder": 2
+                      }
+                    ],
+                    "labelSettings": [
+                      {
+                        "columnId": "query_hash",
+                        "label": "Query"
+                      },
+                      {
+                        "columnId": "max_duration",
+                        "label": "Max"
+                      },
+                      {
+                        "columnId": "avg_duration",
+                        "label": "Avg"
+                      },
+                      {
+                        "columnId": "avg_cpu",
+                        "label": "CPU"
+                      },
+                      {
+                        "columnId": "executions_count",
+                        "label": "Exec"
+                      }
+                    ]
+                  },
+                  "sortBy": [
+                    {
+                      "itemKey": "$gen_number_avg_duration_2",
+                      "sortOrder": 2
+                    }
+                  ]
+                },
+                "customWidth": "33",
+                "name": "query - 4 - Copy - Copy - Copy"
+              }
+            ]
+          },
+          "conditionalVisibility": {
+            "parameterName": "Resources_queries",
+            "comparison": "isNotEqualTo"
+          },
+          "name": "group - 9"
+        }
+      ],
+      "fallbackResourceIds": [
+      ],
+      "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
+    },
+    "workbookDisplayName": "Queries",
+    "workbookName": "[parameters('workbookNames').Queries]"
+  },
+  "resources": [
+    {
+      "name": "[variables('workbookName')]",
+      "type": "microsoft.insights/workbooks",
+      "location": "[resourceGroup().location]",
+      "apiVersion": "2018-06-17-preview",
+      "kind": "shared",
+      "properties": {
+        "displayName": "[variables('workbookDisplayName')]",
+        "serializedData": "[string(variables('workbookMarkup'))]",
+        "version": "Notebook/1.0",
+        "sourceId": "[resourceGroup().id]",
+        "category": "workbook"
+      },
+      "tags": {
+        "hidden-title": "[variables('workbookDisplayName')]"
+      }
+    }
+  ]
+}

--- a/Workbooks/Workloads/QDS/Query.json
+++ b/Workbooks/Workloads/QDS/Query.json
@@ -1,0 +1,1253 @@
+{
+  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "workbookNames": {
+      "type": "object",
+      "defaultValue": {
+        "Query": "[guid(resourceGroup().id, 'Query')]",
+        "Database": "[guid(resourceGroup().id, 'Database')]"
+      }
+    }
+  },
+  "variables": {
+    "workbookMarkup": {
+      "version": "Notebook/1.0",
+      "items": [
+        {
+          "type": 9,
+          "content": {
+            "version": "KqlParameterItem/1.0",
+            "crossComponentResources": [
+              "{WsResourcesInternal}"
+            ],
+            "parameters": [
+              {
+                "id": "4ecc9f52-2e3f-4c8e-b9ea-f3e2f2583f5b",
+                "version": "KqlParameterItem/1.0",
+                "name": "WsResources",
+                "type": 1
+              },
+              {
+                "id": "f3e20cbc-b692-4b3d-8916-2fd0662ecfe6",
+                "version": "KqlParameterItem/1.0",
+                "name": "WsResourcesInternal",
+                "type": 5,
+                "query": "where id in~ ({WsResources})\r\n| project id, selected=1",
+                "crossComponentResources": [
+                  "value::all"
+                ],
+                "typeSettings": {
+                  "additionalResourceOptions": [],
+                  "showDefault": false
+                },
+                "queryType": 1,
+                "resourceType": "microsoft.resourcegraph/resources"
+              },
+              {
+                "id": "30b86356-1bba-4603-83d1-835b99171066",
+                "version": "KqlParameterItem/1.0",
+                "name": "Timerange",
+                "type": 4,
+                "value": {
+                  "durationMs": 86400000
+                },
+                "typeSettings": {
+                  "selectableValues": [
+                    {
+                      "durationMs": 300000
+                    },
+                    {
+                      "durationMs": 900000
+                    },
+                    {
+                      "durationMs": 1800000
+                    },
+                    {
+                      "durationMs": 3600000
+                    },
+                    {
+                      "durationMs": 14400000
+                    },
+                    {
+                      "durationMs": 43200000
+                    },
+                    {
+                      "durationMs": 86400000
+                    },
+                    {
+                      "durationMs": 172800000
+                    },
+                    {
+                      "durationMs": 259200000
+                    },
+                    {
+                      "durationMs": 604800000
+                    },
+                    {
+                      "durationMs": 1209600000
+                    },
+                    {
+                      "durationMs": 2419200000
+                    },
+                    {
+                      "durationMs": 2592000000
+                    },
+                    {
+                      "durationMs": 5184000000
+                    },
+                    {
+                      "durationMs": 7776000000
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "f2ae16b9-0bea-4ad0-b14e-93a51424fab9",
+                "version": "KqlParameterItem/1.0",
+                "name": "DBWorkbook",
+                "type": 1,
+                "value": "[resourceId('microsoft.insights/workbooks', parameters('workbookNames').Database)]"
+              },
+              {
+                "id": "2f3b41da-04b0-4390-b630-66f6409add65",
+                "version": "KqlParameterItem/1.0",
+                "name": "QueryHash",
+                "type": 1
+              },
+              {
+                "id": "2c2f0c8e-d2d5-43a2-81e5-f6a24a708726",
+                "version": "KqlParameterItem/1.0",
+                "name": "ResourceName",
+                "type": 1,
+                "value": ""
+              },
+              {
+                "id": "6ac48c43-56f4-4ecc-b012-6842b8951514",
+                "version": "KqlParameterItem/1.0",
+                "name": "Type",
+                "type": 1
+              },
+              {
+                "id": "0409d1db-76c6-4b5a-9157-52906527c27d",
+                "version": "KqlParameterItem/1.0",
+                "name": "dbType",
+                "type": 1
+              },
+              {
+                "id": "423aa443-3d9f-4598-8928-681e3532f554",
+                "version": "KqlParameterItem/1.0",
+                "name": "MonitoredResources",
+                "type": 9,
+                "multiSelect": true,
+                "quote": "'",
+                "delimiter": ",",
+                "query": "InsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace matches regex 'sqlserver_azure.._querystore_runtime_stats'\r\n| distinct Tags\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| project dbName = tolower(strcat(extract(\"^([^\\\\.]+)\\\\.?\", 1, sql_instance), '/', database_name))\r\n| distinct dbName",
+                "crossComponentResources": [
+                  "{WsResourcesInternal}"
+                ],
+                "value": null,
+                "queryType": 0,
+                "resourceType": "microsoft.operationalinsights/workspaces"
+              },
+              {
+                "id": "36e0f6ea-0edb-451d-b932-9bb615413d9a",
+                "version": "KqlParameterItem/1.0",
+                "name": "Resources_query",
+                "type": 9,
+                "multiSelect": true,
+                "quote": "",
+                "delimiter": ",",
+                "query": "where type contains '{Type}'\r\n| extend ResourceId = tolower(id)\r\n| extend name = tolower(strcat(extract(tolower('/{Type}/([^/]+)/'), 1, ResourceId), '/', name))\r\n| where name in ({MonitoredResources})\r\n| project strcat('{\"name\":\"',name, '\" , \"subscription\": \"', subscriptionId, '\", \"resourceGroup\": \"', resourceGroup, '\"}')",
+                "crossComponentResources": [
+                  "value::all"
+                ],
+                "queryType": 1,
+                "resourceType": "microsoft.resourcegraph/resources",
+                "value": null
+              },
+              {
+                "id": "54b3cdbc-aa4b-478d-a936-59bd75bc8ec7",
+                "version": "KqlParameterItem/1.0",
+                "name": "queryText",
+                "type": 1,
+                "query": "InsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace == 'sqlserver_requests'\r\n| summarize make_bag(pack(Name, Val)) by Tags, TimeGenerated\r\n| evaluate bag_unpack(bag_)\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| where query_hash == '{QueryHash}'\r\n| top 1 by TimeGenerated desc\r\n| project statement_text",
+                "crossComponentResources": [
+                  "{WsResourcesInternal}"
+                ],
+                "typeSettings": {
+                  "multiLineText": true,
+                  "editorLanguage": "sql"
+                },
+                "timeContext": {
+                  "durationMs": 0
+                },
+                "timeContextFromParameter": "Timerange",
+                "queryType": 0,
+                "resourceType": "microsoft.operationalinsights/workspaces"
+              }
+            ],
+            "style": "pills",
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          },
+          "conditionalVisibility": {
+            "parameterName": "hide",
+            "comparison": "isNotEqualTo"
+          },
+          "name": "parameters - 0"
+        },
+        {
+          "type": 1,
+          "content": {
+            "json": "# Query\r\nQuery hash: {QueryHash}"
+          },
+          "name": "text - 3"
+        },
+        {
+          "type": 1,
+          "content": {
+            "json": "-- Get query text by connecting to database and executing the query below\r\n\r\nSELECT qt.query_sql_text query_text, q.query_hash\r\nFROM sys.query_store_query q \r\n    JOIN sys.query_store_query_text qt\r\n    ON q.query_text_id = qt.query_text_id \r\nWHERE q.query_hash = {QueryHash}",
+            "style": "info"
+          },
+          "conditionalVisibility": {
+            "parameterName": "queryText",
+            "comparison": "isEqualTo"
+          },
+          "name": "text - 14"
+        },
+        {
+          "type": 12,
+          "content": {
+            "version": "NotebookGroup/1.0",
+            "groupType": "editable",
+            "loadType": "explicit",
+            "loadButtonText": "View Text",
+            "items": [
+              {
+                "type": 1,
+                "content": {
+                  "json": "```sql\r\n{queryText}\r\n```"
+                },
+                "name": "text - 9"
+              }
+            ]
+          },
+          "conditionalVisibility": {
+            "parameterName": "queryText",
+            "comparison": "isNotEqualTo"
+          },
+          "name": "group - 10"
+        },
+        {
+          "type": 12,
+          "content": {
+            "version": "NotebookGroup/1.0",
+            "groupType": "editable",
+            "title": "Duration",
+            "items": [
+              {
+                "type": 3,
+                "content": {
+                  "version": "KqlItem/1.0",
+                  "query": "set truncationmaxrecords=5000;\r\nInsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace matches regex 'sqlserver_azure.._querystore_runtime_stats'\r\n| summarize make_bag( pack(Name, Val)) by Tags, TimeGenerated\r\n| evaluate bag_unpack(bag_)\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| extend resourceName = tolower(strcat(sql_instance, '/', database_name))\r\n| where query_hash == \"{QueryHash}\" \r\n| summarize max_duration = max(max_duration)/1000000,\r\navg_duration = sum(avg_duration*count_executions)/sum(count_executions)/1000000,\r\navg_cpu = sum(avg_cpu_time*count_executions)/sum(count_executions)/1000000,\r\nexecutions_count = sum(count_executions)\r\n    by resourceName\r\n| project Type = '{Type}/DATABASES', ResourceId = resourceName,\r\n    max_duration,\r\n    avg_duration,\r\n    avg_cpu,\r\n    executions_count,resourceName,\r\n    wbLink='{DBWorkbook}'\r\n| sort by avg_duration desc",
+                  "size": 0,
+                  "showAnalytics": true,
+                  "timeContext": {
+                    "durationMs": 86400000
+                  },
+                  "timeContextFromParameter": "Timerange",
+                  "exportFieldName": "resourceName",
+                  "exportParameterName": "ResourceName",
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "crossComponentResources": [
+                    "{WsResourcesInternal}"
+                  ],
+                  "gridSettings": {
+                    "formatters": [
+                      {
+                        "columnMatch": "Type",
+                        "formatter": 16,
+                        "formatOptions": {
+                          "showIcon": true,
+                          "customColumnWidthSetting": "4ch"
+                        }
+                      },
+                      {
+                        "columnMatch": "ResourceId",
+                        "formatter": 7,
+                        "formatOptions": {
+                          "linkColumn": "wbLink",
+                          "linkTarget": "WorkbookTemplate",
+                          "workbookContext": {
+                            "componentIdSource": "workbook",
+                            "resourceIdsSource": "workbook",
+                            "templateIdSource": "column",
+                            "templateId": "wbLink",
+                            "typeSource": "workbook",
+                            "gallerySource": "workbook",
+                            "locationSource": "default"
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "max_duration",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "11ch"
+                        },
+                        "numberFormat": {
+                          "unit": 24,
+                          "options": {
+                            "style": "decimal",
+                            "useGrouping": false
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "avg_duration",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "11ch"
+                        },
+                        "numberFormat": {
+                          "unit": 24,
+                          "options": {
+                            "style": "decimal"
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "avg_cpu",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "11ch"
+                        },
+                        "numberFormat": {
+                          "unit": 24,
+                          "options": {
+                            "style": "decimal",
+                            "useGrouping": false
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "executions_count",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "10ch"
+                        },
+                        "numberFormat": {
+                          "unit": 17,
+                          "options": {
+                            "style": "decimal"
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "resourceName",
+                        "formatter": 5
+                      },
+                      {
+                        "columnMatch": "wbLink",
+                        "formatter": 5
+                      }
+                    ],
+                    "labelSettings": [
+                      {
+                        "columnId": "Type",
+                        "label": " "
+                      },
+                      {
+                        "columnId": "ResourceId",
+                        "label": "Database"
+                      },
+                      {
+                        "columnId": "max_duration",
+                        "label": "Max"
+                      },
+                      {
+                        "columnId": "avg_duration",
+                        "label": "Avg"
+                      },
+                      {
+                        "columnId": "avg_cpu",
+                        "label": "CPU"
+                      },
+                      {
+                        "columnId": "executions_count",
+                        "label": "Execs"
+                      },
+                      {
+                        "columnId": "resourceName"
+                      },
+                      {
+                        "columnId": "wbLink"
+                      }
+                    ]
+                  }
+                },
+                "customWidth": "40",
+                "name": "query - 3"
+              },
+              {
+                "type": 3,
+                "content": {
+                  "version": "KqlItem/1.0",
+                  "query": "set truncationmaxrecords=5000;\r\nInsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace matches regex 'sqlserver_azure.._querystore_runtime_stats'\r\n| summarize make_bag( pack(Name, Val)) by Tags, TimeGenerated\r\n| evaluate bag_unpack(bag_)\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| extend resourceName = tolower(strcat(sql_instance, '/', database_name))\r\n| where resourceName contains '{ResourceName}'\r\n| where query_hash == \"{QueryHash}\" \r\n| summarize avg_duration = sum(avg_duration*count_executions)/sum(count_executions)/1000000,\r\navg_cpu = sum(avg_cpu_time*count_executions)/sum(count_executions)/1000000\r\n    by bin(interval_start_time, {Timerange:grain})",
+                  "size": 0,
+                  "aggregation": 3,
+                  "showAnalytics": true,
+                  "timeContext": {
+                    "durationMs": 86400000
+                  },
+                  "timeContextFromParameter": "Timerange",
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "crossComponentResources": [
+                    "{WsResourcesInternal}"
+                  ],
+                  "visualization": "linechart",
+                  "chartSettings": {
+                    "ySettings": {
+                      "numberFormatSettings": {
+                        "unit": 24,
+                        "options": {
+                          "style": "decimal",
+                          "useGrouping": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "customWidth": "60",
+                "name": "query - 2"
+              }
+            ]
+          },
+          "name": "group - 15"
+        },
+        {
+          "type": 12,
+          "content": {
+            "version": "NotebookGroup/1.0",
+            "groupType": "editable",
+            "title": "Waits Duration",
+            "items": [
+              {
+                "type": 3,
+                "content": {
+                  "version": "KqlItem/1.0",
+                  "query": "InsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace matches regex 'sqlserver_azure.._querystore_wait_stats'\r\n| summarize make_bag( pack(Name, Val)) by Tags, TimeGenerated\r\n| evaluate bag_unpack(bag_)\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| extend resourceName = tolower(strcat(sql_instance, '/', database_name))\r\n| where query_hash == \"{QueryHash}\" \r\n| summarize avg_wait_time = sum(total_query_wait_time_ms)/sum(count_executions) / 1000\r\n    by resourceName, wait_category = wait_category\r\n| project Type = '{Type}/DATABASES', ResourceId = resourceName,\r\n resourceName ,\r\nwait_category, avg_wait_time, \r\n    wbLink='{DBWorkbook}'\r\n| sort by avg_wait_time desc",
+                  "size": 0,
+                  "showAnalytics": true,
+                  "timeContext": {
+                    "durationMs": 86400000
+                  },
+                  "timeContextFromParameter": "Timerange",
+                  "exportFieldName": "resourceName",
+                  "exportParameterName": "ResourceName",
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "crossComponentResources": [
+                    "{WsResourcesInternal}"
+                  ],
+                  "gridSettings": {
+                    "formatters": [
+                      {
+                        "columnMatch": "Type",
+                        "formatter": 16,
+                        "formatOptions": {
+                          "showIcon": true,
+                          "customColumnWidthSetting": "4ch"
+                        }
+                      },
+                      {
+                        "columnMatch": "ResourceId",
+                        "formatter": 7,
+                        "formatOptions": {
+                          "linkColumn": "wbLink",
+                          "linkTarget": "WorkbookTemplate",
+                          "workbookContext": {
+                            "componentIdSource": "workbook",
+                            "resourceIdsSource": "workbook",
+                            "templateIdSource": "column",
+                            "templateId": "wbLink",
+                            "typeSource": "workbook",
+                            "gallerySource": "workbook",
+                            "locationSource": "default"
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "resourceName",
+                        "formatter": 5
+                      },
+                      {
+                        "columnMatch": "wait_category",
+                        "formatter": 0,
+                        "numberFormat": {
+                          "unit": 24,
+                          "options": {
+                            "style": "decimal"
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "avg_wait_time",
+                        "formatter": 0,
+                        "numberFormat": {
+                          "unit": 24,
+                          "options": {
+                            "style": "decimal",
+                            "useGrouping": false
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "wbLink",
+                        "formatter": 5
+                      }
+                    ],
+                    "labelSettings": [
+                      {
+                        "columnId": "Type",
+                        "label": " "
+                      },
+                      {
+                        "columnId": "ResourceId",
+                        "label": "Database"
+                      },
+                      {
+                        "columnId": "resourceName"
+                      },
+                      {
+                        "columnId": "wait_category",
+                        "label": "Wait Category"
+                      },
+                      {
+                        "columnId": "avg_wait_time",
+                        "label": "Avg"
+                      },
+                      {
+                        "columnId": "wbLink"
+                      }
+                    ]
+                  }
+                },
+                "customWidth": "40",
+                "name": "query - 3 - Copy"
+              },
+              {
+                "type": 3,
+                "content": {
+                  "version": "KqlItem/1.0",
+                  "query": "InsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace matches regex 'sqlserver_azure.._querystore_wait_stats'\r\n| summarize make_bag(pack(Name, Val)) by Tags, TimeGenerated\r\n| evaluate bag_unpack(bag_)\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| extend resourceName = tolower(strcat(sql_instance, '/', database_name))\r\n| where resourceName contains '{ResourceName}'\r\n| where query_hash == \"{QueryHash}\" \r\n| summarize total = sum(total_query_wait_time_ms)/1000\r\n    by bin(interval_start_time, {Timerange:grain})",
+                  "size": 0,
+                  "aggregation": 3,
+                  "showAnalytics": true,
+                  "timeContext": {
+                    "durationMs": 86400000
+                  },
+                  "timeContextFromParameter": "Timerange",
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "crossComponentResources": [
+                    "{WsResourcesInternal}"
+                  ],
+                  "visualization": "linechart",
+                  "chartSettings": {
+                    "ySettings": {
+                      "numberFormatSettings": {
+                        "unit": 24,
+                        "options": {
+                          "style": "decimal",
+                          "useGrouping": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "customWidth": "60",
+                "name": "query - 2 - Copy"
+              }
+            ]
+          },
+          "name": "group - 14"
+        },
+        {
+          "type": 12,
+          "content": {
+            "version": "NotebookGroup/1.0",
+            "groupType": "editable",
+            "title": "CPU",
+            "items": [
+              {
+                "type": 3,
+                "content": {
+                  "version": "KqlItem/1.0",
+                  "query": "set truncationmaxrecords=5000;\r\nInsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace matches regex 'sqlserver_azure.._querystore_runtime_stats'\r\n| summarize make_bag( pack(Name, Val)) by Tags, TimeGenerated\r\n| evaluate bag_unpack(bag_)\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| extend resourceName = tolower(strcat(sql_instance, '/', database_name))\r\n| where query_hash == \"{QueryHash}\" \r\n| summarize max = max(max_cpu_time)/1000000, \r\navg = sum(avg_cpu_time*count_executions)/sum(count_executions)/1000000, execs = sum(count_executions) by resourceName\r\n| project Type = '{Type}/DATABASES', ResourceId = resourceName,\r\nmax, avg, execs, \r\n    wbLink='{DBWorkbook}', resourceName\r\n| sort by max desc",
+                  "size": 0,
+                  "showAnalytics": true,
+                  "timeContext": {
+                    "durationMs": 86400000
+                  },
+                  "timeContextFromParameter": "Timerange",
+                  "exportFieldName": "resourceName",
+                  "exportParameterName": "ResourceName",
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "crossComponentResources": [
+                    "{WsResourcesInternal}"
+                  ],
+                  "gridSettings": {
+                    "formatters": [
+                      {
+                        "columnMatch": "Type",
+                        "formatter": 16,
+                        "formatOptions": {
+                          "showIcon": true,
+                          "customColumnWidthSetting": "4ch"
+                        }
+                      },
+                      {
+                        "columnMatch": "ResourceId",
+                        "formatter": 7,
+                        "formatOptions": {
+                          "linkColumn": "wbLink",
+                          "linkTarget": "WorkbookTemplate",
+                          "workbookContext": {
+                            "componentIdSource": "workbook",
+                            "resourceIdsSource": "workbook",
+                            "templateIdSource": "column",
+                            "templateId": "wbLink",
+                            "typeSource": "workbook",
+                            "gallerySource": "workbook",
+                            "locationSource": "default"
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "max",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "11ch"
+                        },
+                        "numberFormat": {
+                          "unit": 24,
+                          "options": {
+                            "style": "decimal",
+                            "useGrouping": false
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "avg",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "11ch"
+                        },
+                        "numberFormat": {
+                          "unit": 24,
+                          "options": {
+                            "style": "decimal"
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "execs",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "11ch"
+                        },
+                        "numberFormat": {
+                          "unit": 17,
+                          "options": {
+                            "style": "decimal"
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "wbLink",
+                        "formatter": 5
+                      },
+                      {
+                        "columnMatch": "resourceName",
+                        "formatter": 5
+                      }
+                    ],
+                    "labelSettings": [
+                      {
+                        "columnId": "Type",
+                        "label": " "
+                      },
+                      {
+                        "columnId": "ResourceId",
+                        "label": "Database"
+                      },
+                      {
+                        "columnId": "max",
+                        "label": "Max"
+                      },
+                      {
+                        "columnId": "avg",
+                        "label": "Avg"
+                      },
+                      {
+                        "columnId": "execs",
+                        "label": "Execs"
+                      },
+                      {
+                        "columnId": "wbLink"
+                      },
+                      {
+                        "columnId": "resourceName"
+                      }
+                    ]
+                  }
+                },
+                "customWidth": "40",
+                "name": "query - 3 - Copy - Copy"
+              },
+              {
+                "type": 3,
+                "content": {
+                  "version": "KqlItem/1.0",
+                  "query": "set truncationmaxrecords=5000;\r\nInsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace matches regex 'sqlserver_azure.._querystore_runtime_stats'\r\n| summarize make_bag( pack(Name, Val)) by Tags, TimeGenerated\r\n| evaluate bag_unpack(bag_)\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| extend resourceName = tolower(strcat(sql_instance, '/', database_name))\r\n| where resourceName contains '{ResourceName}'\r\n| where query_hash == \"{QueryHash}\" \r\n| summarize max = max(max_cpu_time)/1000000, \r\navg = sum(avg_cpu_time*count_executions)/sum(count_executions)/1000000\r\n    by bin(interval_start_time, {Timerange:grain})",
+                  "size": 0,
+                  "aggregation": 3,
+                  "showAnalytics": true,
+                  "timeContext": {
+                    "durationMs": 86400000
+                  },
+                  "timeContextFromParameter": "Timerange",
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "crossComponentResources": [
+                    "{WsResourcesInternal}"
+                  ],
+                  "visualization": "linechart",
+                  "chartSettings": {
+                    "ySettings": {
+                      "numberFormatSettings": {
+                        "unit": 24,
+                        "options": {
+                          "style": "decimal",
+                          "useGrouping": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "customWidth": "60",
+                "name": "query - 2 - Copy - Copy"
+              }
+            ]
+          },
+          "name": "group - 13"
+        },
+        {
+          "type": 12,
+          "content": {
+            "version": "NotebookGroup/1.0",
+            "groupType": "editable",
+            "title": "Data IO",
+            "items": [
+              {
+                "type": 3,
+                "content": {
+                  "version": "KqlItem/1.0",
+                  "query": "set truncationmaxrecords=5000;\r\nInsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace matches regex 'sqlserver_azure.._querystore_runtime_stats'\r\n| summarize make_bag( pack(Name, Val)) by Tags, TimeGenerated\r\n| evaluate bag_unpack(bag_)\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n|where measurement_db_type == '{dbType}'\r\n| extend resourceName = tolower(strcat(sql_instance, '/', database_name))\r\n| where query_hash == \"{QueryHash}\"\r\n| summarize max = max(max_physical_io_reads), \r\navg = sum(avg_physical_io_reads*count_executions)/sum(count_executions), execs = sum(count_executions) by resourceName\r\n| project Type = '{Type}/DATABASES', ResourceId = resourceName,\r\nmax, avg, execs,  \r\n    wbLink='{DBWorkbook}', resourceName\r\n| sort by max desc ",
+                  "size": 0,
+                  "showAnalytics": true,
+                  "timeContext": {
+                    "durationMs": 86400000
+                  },
+                  "timeContextFromParameter": "Timerange",
+                  "exportFieldName": "resourceName",
+                  "exportParameterName": "ResourceName",
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "crossComponentResources": [
+                    "{WsResourcesInternal}"
+                  ],
+                  "gridSettings": {
+                    "formatters": [
+                      {
+                        "columnMatch": "Type",
+                        "formatter": 16,
+                        "formatOptions": {
+                          "showIcon": true,
+                          "customColumnWidthSetting": "4ch"
+                        }
+                      },
+                      {
+                        "columnMatch": "ResourceId",
+                        "formatter": 7,
+                        "formatOptions": {
+                          "linkColumn": "wbLink",
+                          "linkTarget": "WorkbookTemplate",
+                          "workbookContext": {
+                            "componentIdSource": "workbook",
+                            "resourceIdsSource": "workbook",
+                            "templateIdSource": "column",
+                            "templateId": "wbLink",
+                            "typeSource": "workbook",
+                            "gallerySource": "workbook",
+                            "locationSource": "default"
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "max",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "11ch"
+                        },
+                        "numberFormat": {
+                          "unit": 17,
+                          "options": {
+                            "style": "decimal",
+                            "useGrouping": false
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "avg",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "11ch"
+                        },
+                        "numberFormat": {
+                          "unit": 17,
+                          "options": {
+                            "style": "decimal"
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "execs",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "11ch"
+                        },
+                        "numberFormat": {
+                          "unit": 17,
+                          "options": {
+                            "style": "decimal"
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "wbLink",
+                        "formatter": 5
+                      },
+                      {
+                        "columnMatch": "resourceName",
+                        "formatter": 5
+                      }
+                    ],
+                    "labelSettings": [
+                      {
+                        "columnId": "Type",
+                        "label": " "
+                      },
+                      {
+                        "columnId": "ResourceId",
+                        "label": "Database"
+                      },
+                      {
+                        "columnId": "max",
+                        "label": "Max"
+                      },
+                      {
+                        "columnId": "avg",
+                        "label": "Avg"
+                      },
+                      {
+                        "columnId": "execs",
+                        "label": "Execs"
+                      },
+                      {
+                        "columnId": "wbLink"
+                      },
+                      {
+                        "columnId": "resourceName"
+                      }
+                    ]
+                  }
+                },
+                "customWidth": "40",
+                "name": "query - 3 - Copy - Copy - Copy"
+              },
+              {
+                "type": 3,
+                "content": {
+                  "version": "KqlItem/1.0",
+                  "query": "set truncationmaxrecords=5000;\r\nInsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace matches regex 'sqlserver_azure.._querystore_runtime_stats'\r\n| summarize make_bag( pack(Name, Val)) by Tags, TimeGenerated\r\n| evaluate bag_unpack(bag_)\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| extend resourceName = tolower(strcat(sql_instance, '/', database_name))\r\n| where resourceName contains '{ResourceName}'\r\n| where query_hash == \"{QueryHash}\"\r\n| summarize max = max(max_physical_io_reads), \r\navg = sum(avg_physical_io_reads*count_executions)/sum(count_executions)\r\n    by bin(interval_start_time, {Timerange:grain})",
+                  "size": 0,
+                  "aggregation": 3,
+                  "showAnalytics": true,
+                  "timeContext": {
+                    "durationMs": 86400000
+                  },
+                  "timeContextFromParameter": "Timerange",
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "crossComponentResources": [
+                    "{WsResourcesInternal}"
+                  ],
+                  "visualization": "linechart",
+                  "chartSettings": {
+                    "ySettings": {
+                      "numberFormatSettings": {
+                        "unit": 17,
+                        "options": {
+                          "style": "decimal",
+                          "useGrouping": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "customWidth": "60",
+                "name": "query - 2 - Copy - Copy - Copy"
+              }
+            ]
+          },
+          "name": "group - 12"
+        },
+        {
+          "type": 12,
+          "content": {
+            "version": "NotebookGroup/1.0",
+            "groupType": "editable",
+            "title": "LOG IO",
+            "items": [
+              {
+                "type": 3,
+                "content": {
+                  "version": "KqlItem/1.0",
+                  "query": "set truncationmaxrecords=5000;\r\nInsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace matches regex 'sqlserver_azure.._querystore_runtime_stats'\r\n| summarize make_bag( pack(Name, Val)) by Tags, TimeGenerated\r\n| evaluate bag_unpack(bag_)\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| extend resourceName = tolower(strcat(sql_instance, '/', database_name))\r\n| where query_hash == \"{QueryHash}\"\r\n| summarize max = max(max_logical_io_reads), \r\navg = sum(avg_logical_io_reads*count_executions)/sum(count_executions), execs = sum(count_executions) by resourceName\r\n| project Type = '{Type}/DATABASES', ResourceId = resourceName,\r\nmax, avg, execs, \r\n    wbLink='{DBWorkbook}',resourceName\r\n| sort by max desc ",
+                  "size": 0,
+                  "showAnalytics": true,
+                  "timeContext": {
+                    "durationMs": 86400000
+                  },
+                  "timeContextFromParameter": "Timerange",
+                  "exportFieldName": "resourceName",
+                  "exportParameterName": "ResourceName",
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "crossComponentResources": [
+                    "{WsResourcesInternal}"
+                  ],
+                  "gridSettings": {
+                    "formatters": [
+                      {
+                        "columnMatch": "Type",
+                        "formatter": 16,
+                        "formatOptions": {
+                          "showIcon": true,
+                          "customColumnWidthSetting": "4ch"
+                        }
+                      },
+                      {
+                        "columnMatch": "ResourceId",
+                        "formatter": 7,
+                        "formatOptions": {
+                          "linkColumn": "wbLink",
+                          "linkTarget": "WorkbookTemplate",
+                          "workbookContext": {
+                            "componentIdSource": "workbook",
+                            "resourceIdsSource": "workbook",
+                            "templateIdSource": "column",
+                            "templateId": "wbLink",
+                            "typeSource": "workbook",
+                            "gallerySource": "workbook",
+                            "locationSource": "default"
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "max",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "11ch"
+                        },
+                        "numberFormat": {
+                          "unit": 17,
+                          "options": {
+                            "style": "decimal",
+                            "useGrouping": false
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "avg",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "11ch"
+                        },
+                        "numberFormat": {
+                          "unit": 17,
+                          "options": {
+                            "style": "decimal"
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "execs",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "11ch"
+                        },
+                        "numberFormat": {
+                          "unit": 17,
+                          "options": {
+                            "style": "decimal"
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "wbLink",
+                        "formatter": 5
+                      },
+                      {
+                        "columnMatch": "resourceName",
+                        "formatter": 5
+                      }
+                    ],
+                    "labelSettings": [
+                      {
+                        "columnId": "Type",
+                        "label": " "
+                      },
+                      {
+                        "columnId": "ResourceId",
+                        "label": "Database"
+                      },
+                      {
+                        "columnId": "max",
+                        "label": "Max"
+                      },
+                      {
+                        "columnId": "avg",
+                        "label": "Avg"
+                      },
+                      {
+                        "columnId": "execs",
+                        "label": "Execs"
+                      },
+                      {
+                        "columnId": "wbLink"
+                      },
+                      {
+                        "columnId": "resourceName"
+                      }
+                    ]
+                  }
+                },
+                "customWidth": "40",
+                "name": "query - 3 - Copy - Copy - Copy - Copy"
+              },
+              {
+                "type": 3,
+                "content": {
+                  "version": "KqlItem/1.0",
+                  "query": "set truncationmaxrecords=5000;\r\nInsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace matches regex 'sqlserver_azure.._querystore_runtime_stats'\r\n| summarize make_bag( pack(Name, Val)) by Tags, TimeGenerated\r\n| evaluate bag_unpack(bag_)\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| extend resourceName = tolower(strcat(sql_instance, '/', database_name))\r\n| where resourceName contains '{ResourceName}'\r\n| where query_hash == \"{QueryHash}\"\r\n| summarize max = max(max_logical_io_reads), \r\navg = sum(avg_logical_io_reads*count_executions)/sum(count_executions)\r\n    by bin(interval_start_time, {Timerange:grain})",
+                  "size": 0,
+                  "aggregation": 3,
+                  "showAnalytics": true,
+                  "timeContext": {
+                    "durationMs": 86400000
+                  },
+                  "timeContextFromParameter": "Timerange",
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "crossComponentResources": [
+                    "{WsResourcesInternal}"
+                  ],
+                  "visualization": "linechart",
+                  "chartSettings": {
+                    "ySettings": {
+                      "numberFormatSettings": {
+                        "unit": 17,
+                        "options": {
+                          "style": "decimal",
+                          "useGrouping": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "customWidth": "60",
+                "name": "query - 2 - Copy - Copy - Copy - Copy"
+              }
+            ]
+          },
+          "name": "group - 10"
+        },
+        {
+          "type": 12,
+          "content": {
+            "version": "NotebookGroup/1.0",
+            "groupType": "editable",
+            "title": "Executions",
+            "items": [
+              {
+                "type": 3,
+                "content": {
+                  "version": "KqlItem/1.0",
+                  "query": "set truncationmaxrecords=5000;\r\nInsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace matches regex 'sqlserver_azure.._querystore_runtime_stats'\r\n| summarize make_bag( pack(Name, Val)) by Tags, TimeGenerated\r\n| evaluate bag_unpack(bag_)\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| extend resourceName = tolower(strcat(sql_instance, '/', database_name))\r\n| where query_hash == \"{QueryHash}\" \r\n| summarize execs = sum(count_executions) by resourceName\r\n| project Type = '{Type}/DATABASES', ResourceId = resourceName,\r\nexecs, \r\n    wbLink='{DBWorkbook}', resourceName\r\n| sort by execs desc",
+                  "size": 0,
+                  "showAnalytics": true,
+                  "timeContext": {
+                    "durationMs": 86400000
+                  },
+                  "timeContextFromParameter": "Timerange",
+                  "exportFieldName": "resourceName",
+                  "exportParameterName": "ResourceName",
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "crossComponentResources": [
+                    "{WsResourcesInternal}"
+                  ],
+                  "gridSettings": {
+                    "formatters": [
+                      {
+                        "columnMatch": "Type",
+                        "formatter": 16,
+                        "formatOptions": {
+                          "showIcon": true,
+                          "customColumnWidthSetting": "4ch"
+                        }
+                      },
+                      {
+                        "columnMatch": "ResourceId",
+                        "formatter": 7,
+                        "formatOptions": {
+                          "linkColumn": "wbLink",
+                          "linkTarget": "WorkbookTemplate",
+                          "workbookContext": {
+                            "componentIdSource": "workbook",
+                            "resourceIdsSource": "workbook",
+                            "templateIdSource": "column",
+                            "templateId": "wbLink",
+                            "typeSource": "workbook",
+                            "gallerySource": "workbook",
+                            "locationSource": "default"
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "execs",
+                        "formatter": 0,
+                        "numberFormat": {
+                          "unit": 17,
+                          "options": {
+                            "style": "decimal",
+                            "useGrouping": false
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "wbLink",
+                        "formatter": 5
+                      },
+                      {
+                        "columnMatch": "resourceName",
+                        "formatter": 5
+                      }
+                    ],
+                    "labelSettings": [
+                      {
+                        "columnId": "Type",
+                        "label": " "
+                      },
+                      {
+                        "columnId": "ResourceId",
+                        "label": "Database"
+                      },
+                      {
+                        "columnId": "execs",
+                        "label": "Execs"
+                      },
+                      {
+                        "columnId": "wbLink"
+                      },
+                      {
+                        "columnId": "resourceName"
+                      }
+                    ]
+                  }
+                },
+                "customWidth": "40",
+                "name": "query - 3 - Copy - Copy"
+              },
+              {
+                "type": 3,
+                "content": {
+                  "version": "KqlItem/1.0",
+                  "query": "set truncationmaxrecords=5000;\r\nInsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace matches regex 'sqlserver_azure.._querystore_runtime_stats'\r\n| summarize make_bag( pack(Name, Val)) by Tags, TimeGenerated\r\n| evaluate bag_unpack(bag_)\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| extend resourceName = tolower(strcat(sql_instance, '/', database_name))\r\n| where resourceName contains '{ResourceName}'\r\n| where query_hash == \"{QueryHash}\" \r\n| summarize execs = sum(count_executions)\r\n    by bin(interval_start_time, {Timerange:grain})",
+                  "size": 0,
+                  "aggregation": 3,
+                  "showAnalytics": true,
+                  "timeContext": {
+                    "durationMs": 86400000
+                  },
+                  "timeContextFromParameter": "Timerange",
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "crossComponentResources": [
+                    "{WsResourcesInternal}"
+                  ],
+                  "visualization": "linechart",
+                  "chartSettings": {
+                    "ySettings": {
+                      "numberFormatSettings": {
+                        "unit": 17,
+                        "options": {
+                          "style": "decimal",
+                          "useGrouping": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "customWidth": "60",
+                "name": "query - 2 - Copy - Copy"
+              }
+            ]
+          },
+          "name": "group - 11"
+        }
+      ],
+      "fallbackResourceIds": [
+      ],
+      "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
+    },
+    "workbookDisplayName": "Query",
+    "workbookName": "[parameters('workbookNames').Query]"
+  },
+  "resources": [
+    {
+      "name": "[variables('workbookName')]",
+      "type": "microsoft.insights/workbooks",
+      "location": "[resourceGroup().location]",
+      "apiVersion": "2018-06-17-preview",
+      "kind": "shared",
+      "properties": {
+        "displayName": "[variables('workbookDisplayName')]",
+        "serializedData": "[string(variables('workbookMarkup'))]",
+        "version": "Notebook/1.0",
+        "sourceId": "[resourceGroup().id]",
+        "category": "workbook"
+      },
+      "tags": {
+        "hidden-title": "[variables('workbookDisplayName')]"
+      }
+    }
+  ]
+}

--- a/Workbooks/Workloads/QDS/QueryWaits.json
+++ b/Workbooks/Workloads/QDS/QueryWaits.json
@@ -1,0 +1,732 @@
+{
+  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "workbookNames": {
+      "type": "object",
+      "defaultValue": {
+        "QueryWaits": "[guid(resourceGroup().id, 'Query Waits')]",
+        "Database": "[guid(resourceGroup().id, 'Database')]",
+        "Query": "[guid(resourceGroup().id, 'Query')]"
+      }
+    }
+  },
+  "variables": {
+    "workbookMarkup": {
+      "version": "Notebook/1.0",
+      "items": [
+        {
+          "type": 9,
+          "content": {
+            "version": "KqlParameterItem/1.0",
+            "crossComponentResources": [
+              "{WsResourcesInternal}"
+            ],
+            "parameters": [
+              {
+                "id": "4ecc9f52-2e3f-4c8e-b9ea-f3e2f2583f5b",
+                "version": "KqlParameterItem/1.0",
+                "name": "WsResources",
+                "type": 1
+              },
+              {
+                "id": "f3e20cbc-b692-4b3d-8916-2fd0662ecfe6",
+                "version": "KqlParameterItem/1.0",
+                "name": "WsResourcesInternal",
+                "type": 5,
+                "multiSelect": true,
+                "quote": "'",
+                "delimiter": ",",
+                "query": "where id in~ ({WsResources})\r\n| project id, selected=1",
+                "crossComponentResources": [
+                  "value::all"
+                ],
+                "typeSettings": {
+                  "additionalResourceOptions": [],
+                  "showDefault": false
+                },
+                "queryType": 1,
+                "resourceType": "microsoft.resourcegraph/resources"
+              },
+              {
+                "id": "30b86356-1bba-4603-83d1-835b99171066",
+                "version": "KqlParameterItem/1.0",
+                "name": "Timerange",
+                "type": 4,
+                "value": {
+                  "durationMs": 86400000
+                },
+                "typeSettings": {
+                  "selectableValues": [
+                    {
+                      "durationMs": 300000
+                    },
+                    {
+                      "durationMs": 900000
+                    },
+                    {
+                      "durationMs": 1800000
+                    },
+                    {
+                      "durationMs": 3600000
+                    },
+                    {
+                      "durationMs": 14400000
+                    },
+                    {
+                      "durationMs": 43200000
+                    },
+                    {
+                      "durationMs": 86400000
+                    },
+                    {
+                      "durationMs": 172800000
+                    },
+                    {
+                      "durationMs": 259200000
+                    },
+                    {
+                      "durationMs": 604800000
+                    },
+                    {
+                      "durationMs": 1209600000
+                    },
+                    {
+                      "durationMs": 2419200000
+                    },
+                    {
+                      "durationMs": 2592000000
+                    },
+                    {
+                      "durationMs": 5184000000
+                    },
+                    {
+                      "durationMs": 7776000000
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "f2ae16b9-0bea-4ad0-b14e-93a51424fab9",
+                "version": "KqlParameterItem/1.0",
+                "name": "DBWorkbook",
+                "type": 1,
+                "value": "[resourceId('microsoft.insights/workbooks', parameters('workbookNames').Database)]"
+              },
+              {
+                "id": "58ec8e26-5dac-4c4c-9441-47daa7adf18f",
+                "version": "KqlParameterItem/1.0",
+                "name": "SubscriptionId",
+                "type": 1,
+                "value": ""
+              },
+              {
+                "id": "d2d2fa1b-070a-45d8-94ec-411c60379803",
+                "version": "KqlParameterItem/1.0",
+                "name": "ServerId",
+                "type": 1,
+                "value": ""
+              },
+              {
+                "id": "be50e0a3-ec3a-4b7d-bd17-006135b6e356",
+                "version": "KqlParameterItem/1.0",
+                "name": "QueryWorkbook",
+                "type": 1,
+                "value": "[resourceId('microsoft.insights/workbooks', parameters('workbookNames').Query)]"
+              },
+              {
+                "id": "492c11ca-b5a5-45f2-85e5-1ab9a857072a",
+                "version": "KqlParameterItem/1.0",
+                "name": "ResourceId",
+                "type": 1,
+                "value": ""
+              },
+              {
+                "id": "1ad21b75-d765-4756-823e-3c37538374f4",
+                "version": "KqlParameterItem/1.0",
+                "name": "Type",
+                "type": 1,
+                "value": "MICROSOFT.SQL/SERVERS"
+              },
+              {
+                "id": "a61f2f01-00c7-4706-a0e0-7f187d4ac424",
+                "version": "KqlParameterItem/1.0",
+                "name": "TypeInternal",
+                "type": 7,
+                "query": "{\"version\":\"1.0.0\",\"content\":\"{\\\"value\\\":\\\"{Type}\\\", \\\"selected\\\":true}\",\"transformers\":null}",
+                "typeSettings": {
+                  "additionalResourceOptions": [],
+                  "showDefault": false
+                },
+                "queryType": 8
+              },
+              {
+                "id": "0d150d0f-1253-4fd4-b7db-9d64abfe4b84",
+                "version": "KqlParameterItem/1.0",
+                "name": "dbType",
+                "type": 1,
+                "value": "AzureSQLDB"
+              },
+              {
+                "id": "e0be3faa-c16f-478d-8c28-a57d91e68407",
+                "version": "KqlParameterItem/1.0",
+                "name": "MonitoredResources",
+                "type": 9,
+                "multiSelect": true,
+                "quote": "'",
+                "delimiter": ",",
+                "query": "InsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace matches regex 'sqlserver_azure.._querystore_runtime_stats'\r\n| distinct Tags\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| project dbName = tolower(strcat(extract(\"^([^\\\\.]+)\\\\.?\", 1, sql_instance), '/', database_name))\r\n| distinct dbName",
+                "crossComponentResources": [
+                  "{WsResourcesInternal}"
+                ],
+                "value": null,
+                "queryType": 0,
+                "resourceType": "microsoft.operationalinsights/workspaces"
+              },
+              {
+                "id": "89358b96-036c-40a7-bd58-bd3ff0361e34",
+                "version": "KqlParameterItem/1.0",
+                "name": "Resources_Query_waits",
+                "type": 9,
+                "multiSelect": true,
+                "quote": "",
+                "delimiter": ",",
+                "query": "where type contains '{Type}'\r\n| extend ResourceId = tolower(id)\r\n| extend name = tolower(strcat(extract(tolower('/{Type}/([^/]+)/'), 1, ResourceId), '/', name))\r\n| where name in ({MonitoredResources})\r\n| project strcat('{\"name\":\"',name, '\" , \"subscription\": \"', subscriptionId, '\", \"resourceGroup\": \"', resourceGroup, '\"}')",
+                "crossComponentResources": [
+                  "value::all"
+                ],
+                "queryType": 1,
+                "resourceType": "microsoft.resourcegraph/resources",
+                "value": null
+              }
+            ],
+            "style": "pills",
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          },
+          "conditionalVisibility": {
+            "parameterName": "hide",
+            "comparison": "isNotEqualTo"
+          },
+          "name": "parameters - 0"
+        },
+        {
+          "type": 1,
+          "content": {
+            "json": "# Query waits"
+          },
+          "name": "text - 3"
+        },
+        {
+          "type": 1,
+          "content": {
+            "json": "Data is loading",
+            "style": "info"
+          },
+          "conditionalVisibility": {
+            "parameterName": "Resources_Query_waits",
+            "comparison": "isEqualTo"
+          },
+          "name": "text - 3"
+        },
+        {
+          "type": 12,
+          "content": {
+            "version": "NotebookGroup/1.0",
+            "groupType": "editable",
+            "items": [
+              {
+                "type": 3,
+                "content": {
+                  "version": "KqlItem/1.0",
+                  "query": "let resources = print dynamic([{Resources_Query_waits}])\r\n| mv-expand print_0\r\n| evaluate bag_unpack(print_0);\r\nInsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace matches regex 'sqlserver_azure.._querystore_wait_stats'\r\n| summarize make_bag(pack(Name, Val)) by Tags\r\n| evaluate bag_unpack(bag_)\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| extend resourceName = tolower(strcat(extract(\"^([^\\\\.]+)\\\\.?\", 1, sql_instance), '/', database_name))\r\n| join kind=leftouter (resources\r\n| extend resourceName = name)\r\non resourceName\r\n| summarize avg_wait_time = sum(total_query_wait_time_ms)/sum(count_executions) / 1000, executions_count = sum(count_executions)\r\nby subscription\r\n| extend ResourceIdPrefix = strcat(\"/SUBSCRIPTIONS/\", subscription, \"/\")\r\n| project SubscriptionId = subscription, avg_wait_time, executions_count, ResourceIdPrefix\r\n| sort by avg_wait_time desc",
+                  "size": 1,
+                  "title": "Subscriptions",
+                  "timeContext": {
+                    "durationMs": 0
+                  },
+                  "timeContextFromParameter": "Timerange",
+                  "exportFieldName": "SubscriptionId",
+                  "exportParameterName": "SubscriptionId",
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "crossComponentResources": [
+                    "{WsResourcesInternal}"
+                  ],
+                  "gridSettings": {
+                    "formatters": [
+                      {
+                        "columnMatch": "SubscriptionId",
+                        "formatter": 15,
+                        "formatOptions": {
+                          "linkTarget": null,
+                          "showIcon": true,
+                          "customColumnWidthSetting": "24ch"
+                        }
+                      },
+                      {
+                        "columnMatch": "avg_wait_time",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "14ch"
+                        },
+                        "numberFormat": {
+                          "unit": 24,
+                          "options": {
+                            "style": "decimal"
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "executions_count",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "13ch"
+                        },
+                        "numberFormat": {
+                          "unit": 17,
+                          "options": {
+                            "style": "decimal"
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "ResourceIdPrefix",
+                        "formatter": 5
+                      }
+                    ],
+                    "labelSettings": [
+                      {
+                        "columnId": "SubscriptionId",
+                        "label": "Subscription"
+                      },
+                      {
+                        "columnId": "avg_wait_time",
+                        "label": "Avg"
+                      },
+                      {
+                        "columnId": "executions_count",
+                        "label": "Execs"
+                      },
+                      {
+                        "columnId": "ResourceIdPrefix"
+                      }
+                    ]
+                  }
+                },
+                "customWidth": "33",
+                "name": "query - 4"
+              },
+              {
+                "type": 1,
+                "content": {
+                  "json": ""
+                },
+                "customWidth": "67",
+                "name": "text - 7"
+              },
+              {
+                "type": 3,
+                "content": {
+                  "version": "KqlItem/1.0",
+                  "query": "let resources = print dynamic([{Resources_Query_waits}])\r\n| mv-expand print_0\r\n| evaluate bag_unpack(print_0);\r\nInsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace matches regex 'sqlserver_azure.._querystore_wait_stats'\r\n| summarize make_bag(pack(Name, Val)) by Tags\r\n| evaluate bag_unpack(bag_)\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| extend resourceName = tolower(strcat(extract(\"^([^\\\\.]+)\\\\.?\", 1, sql_instance), '/', database_name))\r\n| join kind=leftouter (resources\r\n| extend resourceName = name)\r\non resourceName\r\n| where tostring(subscription) contains '{SubscriptionId}'\r\n| summarize avg_wait_time = sum(total_query_wait_time_ms)/sum(count_executions) / 1000, executions_count = sum(count_executions)\r\nby subscription, resourceGroup, sql_instance\r\n| project Type = '{Type}', ['{TypeInternal:label}'] = sql_instance, sql_instance, avg_wait_time, executions_count \r\n| sort by avg_wait_time desc",
+                  "size": 1,
+                  "title": "{TypeInternal:label}s",
+                  "timeContext": {
+                    "durationMs": 0
+                  },
+                  "timeContextFromParameter": "Timerange",
+                  "exportFieldName": "sql_instance",
+                  "exportParameterName": "ServerId",
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "crossComponentResources": [
+                    "{WsResourcesInternal}"
+                  ],
+                  "gridSettings": {
+                    "formatters": [
+                      {
+                        "columnMatch": "Type",
+                        "formatter": 16,
+                        "formatOptions": {
+                          "showIcon": true,
+                          "customColumnWidthSetting": "4ch"
+                        }
+                      },
+                      {
+                        "columnMatch": "SQL",
+                        "formatter": 1
+                      },
+                      {
+                        "columnMatch": "sql_instance",
+                        "formatter": 5
+                      },
+                      {
+                        "columnMatch": "avg_wait_time",
+                        "formatter": 0,
+                        "numberFormat": {
+                          "unit": 24,
+                          "options": {
+                            "style": "decimal",
+                            "useGrouping": false
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "executions_count",
+                        "formatter": 0,
+                        "numberFormat": {
+                          "unit": 17,
+                          "options": {
+                            "style": "decimal"
+                          }
+                        }
+                      }
+                    ],
+                    "labelSettings": [
+                      {
+                        "columnId": "Type",
+                        "label": " "
+                      },
+                      {
+                        "columnId": "sql_instance"
+                      },
+                      {
+                        "columnId": "avg_wait_time",
+                        "label": "Avg"
+                      },
+                      {
+                        "columnId": "executions_count",
+                        "label": "Execs"
+                      }
+                    ]
+                  }
+                },
+                "customWidth": "33",
+                "name": "query - 4 - Copy"
+              },
+              {
+                "type": 1,
+                "content": {
+                  "json": ""
+                },
+                "customWidth": "67",
+                "name": "text - 8"
+              },
+              {
+                "type": 3,
+                "content": {
+                  "version": "KqlItem/1.0",
+                  "query": "let resources = print dynamic([{Resources_Query_waits}])\r\n| mv-expand print_0\r\n| evaluate bag_unpack(print_0);\r\nInsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace matches regex 'sqlserver_azure.._querystore_wait_stats'\r\n| summarize make_bag(pack(Name, Val)) by Tags\r\n| evaluate bag_unpack(bag_)\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| extend resourceName = tolower(strcat(extract(\"^([^\\\\.]+)\\\\.?\", 1, sql_instance), '/', database_name))\r\n| join kind=leftouter (resources\r\n| extend resourceName = name)\r\non resourceName\r\n| where tostring(subscription) contains '{SubscriptionId}'\r\n| where tostring(sql_instance) contains '{ServerId}'\r\n| summarize avg_wait_time = sum(total_query_wait_time_ms)/sum(count_executions) / 1000, executions_count = sum(count_executions)\r\nby subscription, resourceGroup, sql_instance, database_name, resourceName\r\n| project Type = '{Type}/DATABASES', ResourceId = resourceName, resourceName, avg_wait_time, executions_count, \r\n    wbLink = '{DBWorkbook}'\r\n| sort by avg_wait_time desc\r\n",
+                  "size": 1,
+                  "title": "Databases",
+                  "timeContext": {
+                    "durationMs": 0
+                  },
+                  "timeContextFromParameter": "Timerange",
+                  "exportFieldName": "resourceName",
+                  "exportParameterName": "ResourceId",
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "crossComponentResources": [
+                    "{WsResourcesInternal}"
+                  ],
+                  "gridSettings": {
+                    "formatters": [
+                      {
+                        "columnMatch": "Type",
+                        "formatter": 16,
+                        "formatOptions": {
+                          "showIcon": true,
+                          "customColumnWidthSetting": "4ch"
+                        }
+                      },
+                      {
+                        "columnMatch": "ResourceId",
+                        "formatter": 7,
+                        "formatOptions": {
+                          "linkColumn": "wbLink",
+                          "linkTarget": "WorkbookTemplate",
+                          "workbookContext": {
+                            "componentIdSource": "workbook",
+                            "resourceIdsSource": "workbook",
+                            "templateIdSource": "column",
+                            "templateId": "wbLink",
+                            "typeSource": "workbook",
+                            "gallerySource": "workbook",
+                            "locationSource": "default"
+                          },
+                          "customColumnWidthSetting": "24ch"
+                        }
+                      },
+                      {
+                        "columnMatch": "resourceName",
+                        "formatter": 5
+                      },
+                      {
+                        "columnMatch": "avg_wait_time",
+                        "formatter": 0,
+                        "numberFormat": {
+                          "unit": 24,
+                          "options": {
+                            "style": "decimal"
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "executions_count",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "13ch"
+                        },
+                        "numberFormat": {
+                          "unit": 17,
+                          "options": {
+                            "style": "decimal"
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "wbLink",
+                        "formatter": 5
+                      }
+                    ],
+                    "labelSettings": [
+                      {
+                        "columnId": "Type",
+                        "label": " "
+                      },
+                      {
+                        "columnId": "ResourceId",
+                        "label": "Database"
+                      },
+                      {
+                        "columnId": "resourceName"
+                      },
+                      {
+                        "columnId": "avg_wait_time",
+                        "label": "Avg"
+                      },
+                      {
+                        "columnId": "executions_count",
+                        "label": "Exec"
+                      },
+                      {
+                        "columnId": "wbLink"
+                      }
+                    ]
+                  },
+                  "sortBy": []
+                },
+                "customWidth": "33",
+                "name": "query - 4 - Copy - Copy"
+              },
+              {
+                "type": 3,
+                "content": {
+                  "version": "KqlItem/1.0",
+                  "query": "let resources = print dynamic([{Resources_Query_waits}])\r\n| mv-expand print_0\r\n| evaluate bag_unpack(print_0);\r\nInsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace matches regex 'sqlserver_azure.._querystore_wait_stats'\r\n| summarize make_bag(pack(Name, Val)) by Tags, TimeGenerated\r\n| evaluate bag_unpack(bag_)\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| extend resourceName = tolower(strcat(extract(\"^([^\\\\.]+)\\\\.?\", 1, sql_instance), '/', database_name))\r\n| join kind=leftouter (resources\r\n| extend resourceName = name)\r\non resourceName\r\n| where tostring(subscription) contains '{SubscriptionId}'\r\n| where tostring(sql_instance) contains '{ServerId}'\r\n| where tostring(resourceName) contains '{ResourceId}'\r\n| summarize total_wait_time = sum(total_query_wait_time_ms)/1000\r\n    by wait_category, bin(interval_start_time, {Timerange:grain})\r\n| top 1000 by total_wait_time desc\r\n| evaluate pivot(wait_category, sum(total_wait_time))\r\n",
+                  "size": 0,
+                  "aggregation": 3,
+                  "showAnalytics": true,
+                  "title": "Query waits",
+                  "timeContext": {
+                    "durationMs": 0
+                  },
+                  "timeContextFromParameter": "Timerange",
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "crossComponentResources": [
+                    "{WsResourcesInternal}"
+                  ],
+                  "visualization": "barchart",
+                  "chartSettings": {
+                    "ySettings": {
+                      "numberFormatSettings": {
+                        "unit": 24,
+                        "options": {
+                          "style": "decimal",
+                          "useGrouping": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "customWidth": "67",
+                "name": "query - 2",
+                "styleSettings": {
+                  "margin": "-550px 0px 0px 0px"
+                }
+              },
+              {
+                "type": 3,
+                "content": {
+                  "version": "KqlItem/1.0",
+                  "query": "let resources = print dynamic([{Resources_Query_waits}])\r\n| mv-expand print_0\r\n| evaluate bag_unpack(print_0);\r\nInsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace matches regex 'sqlserver_azure.._querystore_wait_stats'\r\n| summarize make_bag(pack(Name, Val)) by Tags\r\n| evaluate bag_unpack(bag_)\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| extend resourceName = tolower(strcat(extract(\"^([^\\\\.]+)\\\\.?\", 1, sql_instance), '/', database_name))\r\n| join kind=leftouter (resources\r\n| extend resourceName = name)\r\non resourceName\r\n| where tostring(subscription) contains '{SubscriptionId}'\r\n| where tostring(sql_instance) contains '{ServerId}'\r\n| where tostring(resourceName) contains '{ResourceId}'\r\n| summarize avg_wait_time = sum(total_query_wait_time_ms)/sum(count_executions) / 1000, executions_count = sum(count_executions)\r\nby query_hash\r\n| project query_hash, avg_wait_time, executions_count,\r\n    wbLink = '{QueryWorkbook}'\r\n| sort by avg_wait_time desc",
+                  "size": 1,
+                  "title": "Queries",
+                  "timeContext": {
+                    "durationMs": 0
+                  },
+                  "timeContextFromParameter": "Timerange",
+                  "exportedParameters": [
+                    {
+                      "fieldName": "query_hash",
+                      "parameterName": "QueryHash"
+                    },
+                    {
+                      "fieldName": "ResourceId",
+                      "parameterName": "ResourceId",
+                      "parameterType": 1
+                    }
+                  ],
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "crossComponentResources": [
+                    "{WsResourcesInternal}"
+                  ],
+                  "gridSettings": {
+                    "formatters": [
+                      {
+                        "columnMatch": "query_hash",
+                        "formatter": 1,
+                        "formatOptions": {
+                          "linkColumn": "wbLink",
+                          "linkTarget": "WorkbookTemplate",
+                          "linkIsContextBlade": false
+                        }
+                      },
+                      {
+                        "columnMatch": "avg_wait_time",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "14ch"
+                        },
+                        "numberFormat": {
+                          "unit": 24,
+                          "options": {
+                            "style": "decimal"
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "executions_count",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "13ch"
+                        },
+                        "numberFormat": {
+                          "unit": 17,
+                          "options": {
+                            "style": "decimal"
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "wbLink",
+                        "formatter": 5
+                      },
+                      {
+                        "columnMatch": "max_duration",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "14ch"
+                        },
+                        "numberFormat": {
+                          "unit": 24,
+                          "options": {
+                            "style": "decimal",
+                            "useGrouping": false
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "avg_duration",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "14ch"
+                        },
+                        "numberFormat": {
+                          "unit": 24,
+                          "options": {
+                            "style": "decimal",
+                            "useGrouping": false
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "avg_cpu",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "14ch"
+                        },
+                        "numberFormat": {
+                          "unit": 24,
+                          "options": {
+                            "style": "decimal"
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "ResourceId",
+                        "formatter": 5
+                      }
+                    ],
+                    "labelSettings": [
+                      {
+                        "columnId": "query_hash",
+                        "label": "Query"
+                      },
+                      {
+                        "columnId": "avg_wait_time",
+                        "label": "Avg"
+                      },
+                      {
+                        "columnId": "executions_count",
+                        "label": "Exec"
+                      },
+                      {
+                        "columnId": "wbLink"
+                      }
+                    ]
+                  },
+                  "sortBy": []
+                },
+                "customWidth": "33",
+                "name": "query - 4 - Copy - Copy - Copy"
+              }
+            ]
+          },
+          "conditionalVisibility": {
+            "parameterName": "Resources_Query_waits",
+            "comparison": "isNotEqualTo"
+          },
+          "name": "group - 9"
+        }
+      ],
+      "fallbackResourceIds": [],
+      "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
+    },
+    "workbookDisplayName": "Query Waits",
+    "workbookName": "[parameters('workbookNames').QueryWaits]"
+  },
+  "resources": [
+    {
+      "name": "[variables('workbookName')]",
+      "type": "microsoft.insights/workbooks",
+      "location": "[resourceGroup().location]",
+      "apiVersion": "2018-06-17-preview",
+      "kind": "shared",
+      "properties": {
+        "displayName": "[variables('workbookDisplayName')]",
+        "serializedData": "[string(variables('workbookMarkup'))]",
+        "version": "Notebook/1.0",
+        "sourceId": "[resourceGroup().id]",
+        "category": "workbook"
+      },
+      "tags": {
+        "hidden-title": "[variables('workbookDisplayName')]"
+      }
+    }
+  ]
+}

--- a/Workbooks/Workloads/QDS/SQLAnalytics.json
+++ b/Workbooks/Workloads/QDS/SQLAnalytics.json
@@ -1,0 +1,1197 @@
+{
+  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "workbookNames": {
+      "type": "object",
+      "defaultValue": {
+        "SQLAnalytics": "[guid(resourceGroup().id, 'SQL Analytics')]",
+        "Database": "[guid(resourceGroup().id, 'Database')]",
+        "ManagedInstance": "[guid(resourceGroup().id, 'Managed Instance')]",
+        "ManagedInstanceDatabase": "[guid(resourceGroup().id, 'Managed Instance Database')]",
+        "Errors": "[guid(resourceGroup().id, 'Errors')]",
+        "Queries": "[guid(resourceGroup().id, 'Queries')]",
+        "QueryWaits": "[guid(resourceGroup().id, 'Query Waits')]",
+        "Metrics": "[guid(resourceGroup().id, 'Metrics')]",
+        "Deadlocks": "[guid(resourceGroup().id, 'Deadlocks')]",
+        "Timeouts": "[guid(resourceGroup().id, 'Timeouts')]",
+        "DatabaseWaits": "[guid(resourceGroup().id, 'DatabaseWaits')]",
+        "Blockings": "[guid(resourceGroup().id, 'Blockings')]"
+      }
+    }
+  },
+  "variables": {
+    "workbookMarkup": {
+      "version": "Notebook/1.0",
+      "items": [
+        {
+          "type": 9,
+          "content": {
+            "version": "KqlParameterItem/1.0",
+            "parameters": [
+              {
+                "id": "1f74ed9a-e3ed-498d-bd5b-f68f3836a117",
+                "version": "KqlParameterItem/1.0",
+                "name": "Subscription",
+                "label": "Subscriptions",
+                "type": 6,
+                "isRequired": true,
+                "multiSelect": true,
+                "quote": "'",
+                "delimiter": ",",
+                "query": "Resources\r\n| where type =~ 'Microsoft.OperationalInsights/workspaces'\r\n| project value = subscriptionId, label = subscriptionId\r\n| distinct value, label",
+                "crossComponentResources": [
+                  "value::selected"
+                ],
+                "typeSettings": {
+                  "additionalResourceOptions": [],
+                  "showDefault": false
+                },
+                "queryType": 1,
+                "resourceType": "microsoft.resourcegraph/resources"
+              },
+              {
+                "id": "619bf90b-5093-47cc-83a3-bf009257bc7d",
+                "version": "KqlParameterItem/1.0",
+                "name": "Workspaces",
+                "type": 5,
+                "isRequired": true,
+                "multiSelect": true,
+                "quote": "\"",
+                "delimiter": ",",
+                "query": "where type =~ 'Microsoft.OperationalInsights/workspaces'\n| project id, name",
+                "crossComponentResources": [
+                  "{Subscription}"
+                ],
+                "typeSettings": {
+                  "additionalResourceOptions": [],
+                  "showDefault": false
+                },
+                "queryType": 1,
+                "resourceType": "microsoft.resourcegraph/resources"
+              },
+              {
+                "id": "4908b8cf-7658-4356-9aa5-5dc5aca7a1aa",
+                "version": "KqlParameterItem/1.0",
+                "name": "Timerange",
+                "label": "Time range",
+                "type": 4,
+                "value": {
+                  "durationMs": 86400000
+                },
+                "typeSettings": {
+                  "selectableValues": [
+                    {
+                      "durationMs": 1800000
+                    },
+                    {
+                      "durationMs": 3600000
+                    },
+                    {
+                      "durationMs": 14400000
+                    },
+                    {
+                      "durationMs": 43200000
+                    },
+                    {
+                      "durationMs": 86400000
+                    },
+                    {
+                      "durationMs": 172800000
+                    },
+                    {
+                      "durationMs": 259200000
+                    },
+                    {
+                      "durationMs": 604800000
+                    },
+                    {
+                      "durationMs": 1209600000
+                    },
+                    {
+                      "durationMs": 2592000000
+                    }
+                  ],
+                  "allowCustom": true
+                }
+              },
+              {
+                "id": "ae6ec2d5-88f9-4924-87f8-8c8e6f7b00b9",
+                "version": "KqlParameterItem/1.0",
+                "name": "AzureDBWorkbook",
+                "type": 1,
+                "isHiddenWhenLocked": true,
+                "value": "[resourceId('microsoft.insights/workbooks', parameters('workbookNames').Database)]"
+              },
+              {
+                "id": "8af872ad-a262-41bb-859d-3f0a714f7784",
+                "version": "KqlParameterItem/1.0",
+                "name": "WsResources",
+                "type": 1,
+                "query": "{\"version\":\"1.0.0\",\"content\":\"\\\"{Workspaces:value}\\\"\",\"transformers\":null}",
+                "isHiddenWhenLocked": true,
+                "queryType": 8
+              },
+              {
+                "id": "423384c4-c43a-447a-b040-36ab00176694",
+                "version": "KqlParameterItem/1.0",
+                "name": "MIWorkbook",
+                "type": 1,
+                "value": "[resourceId('microsoft.insights/workbooks', parameters('workbookNames').ManagedInstance)]",
+                "isHiddenWhenLocked": true
+              },
+              {
+                "id": "4f72c27e-b347-47e9-aa8a-a7f1e31e95a5",
+                "version": "KqlParameterItem/1.0",
+                "name": "MIDBWorkbook",
+                "type": 1,
+                "value": "[resourceId('microsoft.insights/workbooks', parameters('workbookNames').ManagedInstanceDatabase)]",
+                "isHiddenWhenLocked": true
+              }
+            ],
+            "style": "above",
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          },
+          "name": "Parameter block",
+          "styleSettings": {
+            "margin": "10px 0 15px 0"
+          }
+        },
+        {
+          "type": 11,
+          "content": {
+            "version": "LinkItem/1.0",
+            "style": "tabs",
+            "links": [
+              {
+                "id": "fe8477cd-168a-4c71-b332-038a3f2893da",
+                "cellValue": "dbType",
+                "linkTarget": "parameter",
+                "linkLabel": "Azure SQL",
+                "subTarget": "AzureSQLDB",
+                "preText": "",
+                "style": "link"
+              },
+              {
+                "id": "8928aa2a-10a3-42a5-98a8-0f817878dbf4",
+                "cellValue": "dbType",
+                "linkTarget": "parameter",
+                "linkLabel": "Managed Instance",
+                "subTarget": "AzureSQLManagedInstance",
+                "style": "link"
+              }
+            ]
+          },
+          "name": "links - 8"
+        },
+        {
+          "type": 3,
+          "content": {
+            "version": "KqlItem/1.0",
+            "query": "let data = \r\nInsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| project data = todynamic(Tags)\r\n| project dbType = tostring(data.measurement_db_type), dbName = tostring(data.database_name), serverName = tostring(data.sql_instance)\r\n| distinct dbName, serverName, dbType\r\n| where dbName != '' and serverName != '';\r\ndata\r\n| where ['dbType'] == 'AzureSQLDB'\r\n| summarize DBcount=count() by dbType\r\n| project DisplayType = 'MICROSOFT.SQL/SERVERS/DATABASES', DBcount",
+            "size": 4,
+            "timeContext": {
+              "durationMs": 86400000
+            },
+            "timeContextFromParameter": "Timerange",
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces",
+            "crossComponentResources": [
+              "{Workspaces}"
+            ],
+            "visualization": "tiles",
+            "tileSettings": {
+              "titleContent": {
+                "columnMatch": "DisplayType",
+                "formatter": 16,
+                "formatOptions": {
+                  "showIcon": true
+                }
+              },
+              "leftContent": {
+                "columnMatch": "DBcount",
+                "formatter": 12,
+                "formatOptions": {
+                  "palette": "auto"
+                },
+                "numberFormat": {
+                  "unit": 17,
+                  "options": {
+                    "style": "decimal",
+                    "useGrouping": false,
+                    "maximumFractionDigits": 2,
+                    "maximumSignificantDigits": 3
+                  }
+                }
+              },
+              "showBorder": false
+            }
+          },
+          "conditionalVisibility": {
+            "parameterName": "dbType",
+            "comparison": "isEqualTo",
+            "value": "AzureSQLDB"
+          },
+          "name": "query - 9"
+        },
+        {
+          "type": 3,
+          "content": {
+            "version": "KqlItem/1.0",
+            "query": "let data = \r\nInsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| project data = todynamic(Tags) \r\n| project dbType = tostring(data.measurement_db_type), dbName = tostring(data.database_name), serverName = tostring(data.sql_instance)\r\n| distinct dbName, serverName, dbType\r\n| where dbName != '' and serverName != '';\r\ndata\r\n| where ['dbType'] == 'AzureSQLManagedInstance'\r\n| distinct serverName, dbType\r\n| summarize DBcount = count() by dbType\r\n| project DisplayType = 'MICROSOFT.SQL/MANAGEDINSTANCES', DBcount, Order = 1\r\n| union (data\r\n| where ['dbType'] == 'AzureSQLManagedInstance'\r\n| summarize DBcount = count() by dbType\r\n| project DisplayType = 'MICROSOFT.SQL/MANAGEDINSTANCES/DATABASES', DBcount, Order = 2)\r\n| order by Order asc",
+            "size": 4,
+            "timeContext": {
+              "durationMs": 86400000
+            },
+            "timeContextFromParameter": "Timerange",
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces",
+            "crossComponentResources": [
+              "{Workspaces}"
+            ],
+            "visualization": "tiles",
+            "tileSettings": {
+              "titleContent": {
+                "columnMatch": "DisplayType",
+                "formatter": 16,
+                "formatOptions": {
+                  "showIcon": true
+                }
+              },
+              "leftContent": {
+                "columnMatch": "DBcount",
+                "formatter": 12,
+                "formatOptions": {
+                  "palette": "auto"
+                },
+                "numberFormat": {
+                  "unit": 17,
+                  "options": {
+                    "style": "decimal",
+                    "useGrouping": false,
+                    "maximumFractionDigits": 2,
+                    "maximumSignificantDigits": 3
+                  }
+                }
+              },
+              "showBorder": false
+            }
+          },
+          "conditionalVisibility": {
+            "parameterName": "dbType",
+            "comparison": "isEqualTo",
+            "value": "AzureSQLManagedInstance"
+          },
+          "name": "query - 9 - Copy"
+        },
+        {
+          "type": 9,
+          "content": {
+            "version": "KqlParameterItem/1.0",
+            "parameters": [
+              {
+                "id": "95348338-b964-43e1-889a-0e8825057a48",
+                "version": "KqlParameterItem/1.0",
+                "name": "Type",
+                "type": 1,
+                "criteriaData": [
+                  {
+                    "criteriaContext": {
+                      "leftOperand": "dbType",
+                      "operator": "==",
+                      "rightValType": "static",
+                      "rightVal": "AzureSQLManagedInstance",
+                      "resultValType": "static",
+                      "resultVal": "MICROSOFT.SQL/MANAGEDINSTANCES"
+                    }
+                  },
+                  {
+                    "criteriaContext": {
+                      "operator": "Default",
+                      "rightValType": "param",
+                      "resultValType": "static",
+                      "resultVal": "MICROSOFT.SQL/SERVERS"
+                    }
+                  }
+                ],
+                "timeContext": {
+                  "durationMs": 86400000
+                },
+                "value": "MICROSOFT.SQL/SERVERS"
+              },
+              {
+                "id": "21b7a0a9-eeb5-4ee4-9c2d-a1492d67d49c",
+                "version": "KqlParameterItem/1.0",
+                "name": "Mode",
+                "type": 1,
+                "criteriaData": [
+                  {
+                    "criteriaContext": {
+                      "leftOperand": "Type",
+                      "operator": "contains",
+                      "rightValType": "static",
+                      "rightVal": "MANAGEDINSTANCES",
+                      "resultValType": "static",
+                      "resultVal": "Managed Instance"
+                    }
+                  },
+                  {
+                    "criteriaContext": {
+                      "operator": "Default",
+                      "rightValType": "param",
+                      "resultValType": "static",
+                      "resultVal": "Azure SQL"
+                    }
+                  }
+                ],
+                "timeContext": {
+                  "durationMs": 86400000
+                },
+                "value": "Azure SQL"
+              },
+              {
+                "id": "2cf540be-bacf-4393-a51f-cc76bc2f032c",
+                "version": "KqlParameterItem/1.0",
+                "name": "DBWorkbook",
+                "type": 1,
+                "criteriaData": [
+                  {
+                    "criteriaContext": {
+                      "leftOperand": "Mode",
+                      "operator": "==",
+                      "rightValType": "static",
+                      "rightVal": "Managed Instance",
+                      "resultValType": "param",
+                      "resultVal": "MIDBWorkbook"
+                    }
+                  },
+                  {
+                    "criteriaContext": {
+                      "operator": "Default",
+                      "rightValType": "param",
+                      "resultValType": "param",
+                      "resultVal": "AzureDBWorkbook"
+                    }
+                  }
+                ]
+              }
+            ],
+            "style": "pills",
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          },
+          "conditionalVisibility": {
+            "parameterName": "hide",
+            "comparison": "isNotEqualTo"
+          },
+          "name": "parameters - 5"
+        },
+        {
+          "type": 3,
+          "content": {
+            "version": "KqlItem/1.0",
+            "query": "InsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| project data = todynamic(Tags) \r\n| project dbType = tostring(data.measurement_db_type), dbName = tostring(data.database_name), serverName = tostring(data.sql_instance)\r\n| where ['dbType'] == 'AzureSQLManagedInstance'\r\n| distinct dbName, serverName\r\n| where serverName != '' and dbName != 'master'\r\n| project Type = case(dbName=='', 'MICROSOFT.SQL/MANAGEDINSTANCES', 'MICROSOFT.SQL/MANAGEDINSTANCES/DATABASES'), Resource = case(dbName=='', serverName, strcat(serverName, \"/\", dbName)), wbLink = case(dbName=='', '{MIWorkbook}', '{MIDBWorkbook}')\r\n| extend TypeName = Type\r\n| order by Type asc",
+            "size": 0,
+            "title": "MANAGED INSTANCE RESOURCES",
+            "timeContext": {
+              "durationMs": 86400000
+            },
+            "timeContextFromParameter": "Timerange",
+            "exportFieldName": "Resource",
+            "exportParameterName": "ResourceId",
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces",
+            "crossComponentResources": [
+              "{Workspaces}"
+            ],
+            "gridSettings": {
+              "formatters": [
+                {
+                  "columnMatch": "Type",
+                  "formatter": 16,
+                  "formatOptions": {
+                    "showIcon": true,
+                    "customColumnWidthSetting": "4ch"
+                  }
+                },
+                {
+                  "columnMatch": "Resource",
+                  "formatter": 7,
+                  "formatOptions": {
+                    "linkTarget": "WorkbookTemplate",
+                    "workbookContext": {
+                      "componentIdSource": "workbook",
+                      "resourceIdsSource": "workbook",
+                      "templateIdSource": "column",
+                      "templateId": "wbLink",
+                      "typeSource": "workbook",
+                      "gallerySource": "workbook",
+                      "locationSource": "default"
+                    }
+                  }
+                },
+                {
+                  "columnMatch": "wbLink",
+                  "formatter": 5
+                },
+                {
+                  "columnMatch": "TypeName",
+                  "formatter": 16,
+                  "formatOptions": {
+                    "showIcon": false,
+                    "customColumnWidthSetting": "25ch"
+                  }
+                }
+              ],
+              "filter": true,
+              "labelSettings": [
+                {
+                  "columnId": "Type",
+                  "label": " "
+                },
+                {
+                  "columnId": "Resource"
+                },
+                {
+                  "columnId": "wbLink"
+                },
+                {
+                  "columnId": "TypeName",
+                  "label": "Type"
+                }
+              ]
+            }
+          },
+          "conditionalVisibility": {
+            "parameterName": "Mode",
+            "comparison": "isEqualTo",
+            "value": "Managed Instance"
+          },
+          "customWidth": "35",
+          "name": "query - 4"
+        },
+        {
+          "type": 3,
+          "content": {
+            "version": "KqlItem/1.0",
+            "query": "set truncationmaxrecords=5000;\r\nInsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace == 'sqlserver_azure_db_resource_stats'\r\n| where Name == 'avg_cpu_percent'\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| summarize max_cpu = max(todouble(Val)) by sql_instance, bin(TimeGenerated, {Timerange:grain})",
+            "size": 0,
+            "aggregation": 3,
+            "showAnalytics": true,
+            "title": "Managed instances CPU utilization",
+            "timeContext": {
+              "durationMs": 86400000
+            },
+            "timeContextFromParameter": "Timerange",
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces",
+            "crossComponentResources": [
+              "{Workspaces}"
+            ],
+            "visualization": "linechart",
+            "chartSettings": {
+              "ySettings": {
+                "numberFormatSettings": {
+                  "unit": 1,
+                  "options": {
+                    "style": "decimal",
+                    "useGrouping": true
+                  }
+                },
+                "min": 0,
+                "max": 100
+              }
+            }
+          },
+          "conditionalVisibility": {
+            "parameterName": "Mode",
+            "comparison": "isEqualTo",
+            "value": "Managed Instance"
+          },
+          "customWidth": "65",
+          "name": "query - 6"
+        },
+        {
+          "type": 12,
+          "content": {
+            "version": "NotebookGroup/1.0",
+            "groupType": "editable",
+            "title": "DATABASE FLEET OVERVIEW",
+            "items": [
+              {
+                "type": 11,
+                "content": {
+                  "version": "LinkItem/1.0",
+                  "style": "list",
+                  "links": [
+                    {
+                      "id": "b1a725ae-faef-4b34-999b-88eaf6e6cdd1",
+                      "cellValue": "[resourceId('microsoft.insights/workbooks', parameters('workbookNames').Errors)]",
+                      "linkTarget": "WorkbookTemplate",
+                      "linkLabel": "Number of query errors",
+                      "style": "link"
+                    }
+                  ]
+                },
+                "customWidth": "50",
+                "name": "links - 8 - Copy"
+              },
+              {
+                "type": 11,
+                "content": {
+                  "version": "LinkItem/1.0",
+                  "style": "list",
+                  "links": [
+                    {
+                      "id": "833dae53-0c82-4d16-ab37-e456831752ab",
+                      "cellValue": "[resourceId('microsoft.insights/workbooks', parameters('workbookNames').Queries)]",
+                      "linkTarget": "WorkbookTemplate",
+                      "linkLabel": "Query duration in seconds",
+                      "style": "link"
+                    }
+                  ]
+                },
+                "customWidth": "50",
+                "name": "links - 8 - Copy"
+              },
+              {
+                "type": 3,
+                "content": {
+                  "version": "KqlItem/1.0",
+                  "query": "InsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace matches regex 'sqlserver_azure.._querystore_runtime_stats'\r\n| summarize make_bag( pack(Name, Val)) by Tags\r\n| evaluate bag_unpack(bag_)\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| summarize errors = sumif(count_executions, execution_type==4) by TimeGenerated = bin(interval_start_time, {Timerange:grain})\r\n| sort by TimeGenerated desc",
+                  "size": 0,
+                  "timeContext": {
+                    "durationMs": 86400000
+                  },
+                  "timeContextFromParameter": "Timerange",
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "crossComponentResources": [
+                    "{Workspaces}"
+                  ],
+                  "visualization": "barchart"
+                },
+                "customWidth": "50",
+                "name": "query - 7 - Copy"
+              },
+              {
+                "type": 3,
+                "content": {
+                  "version": "KqlItem/1.0",
+                  "query": "InsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace matches regex 'sqlserver_azure.._querystore_runtime_stats'\r\n| summarize make_bag( pack(Name, Val)) by Tags, TimeGenerated\r\n| evaluate bag_unpack(bag_)\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| extend duration_d = avg_duration*count_executions, cpu_time_d = avg_cpu_time*count_executions, count_executions_d = count_executions\r\n| summarize avg_duration = sum(duration_d)/sum(count_executions_d)/1000000,\r\navg_cpu = sum(cpu_time_d)/sum(count_executions_d)/1000000\r\n    by bin(interval_start_time, {Timerange:grain})",
+                  "size": 0,
+                  "aggregation": 3,
+                  "timeContext": {
+                    "durationMs": 0
+                  },
+                  "timeContextFromParameter": "Timerange",
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "crossComponentResources": [
+                    "{Workspaces}"
+                  ],
+                  "visualization": "linechart",
+                  "chartSettings": {
+                    "ySettings": {
+                      "numberFormatSettings": {
+                        "unit": 24,
+                        "options": {
+                          "style": "decimal",
+                          "useGrouping": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "customWidth": "50",
+                "name": "query - 7 - Copy - Copy"
+              },
+              {
+                "type": 11,
+                "content": {
+                  "version": "LinkItem/1.0",
+                  "style": "list",
+                  "links": [
+                    {
+                      "id": "b5c423dd-18b8-4d54-bec1-9223028707d2",
+                      "cellValue": "[resourceId('microsoft.insights/workbooks', parameters('workbookNames').QueryWaits)]",
+                      "linkTarget": "WorkbookTemplate",
+                      "linkLabel": "Total time queries spent waiting per type",
+                      "style": "link"
+                    }
+                  ]
+                },
+                "customWidth": "50",
+                "name": "links - 8 - Copy - Copy"
+              },
+              {
+                "type": 1,
+                "content": {
+                  "json": ""
+                },
+                "customWidth": "50",
+                "name": "text - 6"
+              },
+              {
+                "type": 3,
+                "content": {
+                  "version": "KqlItem/1.0",
+                  "query": "InsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace matches regex 'sqlserver_azure.._querystore_wait_stats'\r\n| summarize make_bag(pack(Name, Val)) by Tags, TimeGenerated\r\n| evaluate bag_unpack(bag_)\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| summarize total_wait_time = sum(total_query_wait_time_ms)/1000\r\n    by wait_category, bin(interval_start_time, {Timerange:grain})\r\n| top 1000 by total_wait_time desc\r\n| evaluate pivot(wait_category, sum(total_wait_time))",
+                  "size": 0,
+                  "aggregation": 3,
+                  "timeContext": {
+                    "durationMs": 0
+                  },
+                  "timeContextFromParameter": "Timerange",
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "crossComponentResources": [
+                    "{Workspaces}"
+                  ],
+                  "visualization": "barchart",
+                  "chartSettings": {
+                    "ySettings": {
+                      "numberFormatSettings": {
+                        "unit": 24,
+                        "options": {
+                          "style": "decimal",
+                          "useGrouping": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "customWidth": "50",
+                "name": "query - 7 - Copy - Copy - Copy"
+              }
+            ]
+          },
+          "conditionalVisibility": {
+            "parameterName": "Mode",
+            "comparison": "isEqualTo",
+            "value": "Managed Instance"
+          },
+          "name": "group - 15"
+        },
+        {
+          "type": 3,
+          "content": {
+            "version": "KqlItem/1.0",
+            "query": "set truncationmaxrecords=5000;\r\nlet metrics = InsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace == 'sqlserver_azure_db_resource_stats'\r\n| where Name in ('avg_cpu_percent', 'avg_data_io_percent', 'avg_log_write_percent')\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data);\r\nmetrics\r\n| where measurement_db_type == 'AzureSQLDB'\r\n| where Val > 0 \r\n| summarize metric_value = percentile(min_of(Val, 100.0), 80)by bin(TimeGenerated, {Timerange:grain}), sql_instance, database_name, Name\r\n| summarize arg_max(metric_value, Name) by sql_instance, database_name \r\n| project Resource = strcat(sql_instance, \"/\", database_name).tolower(), MetricName=Name, metric_value\r\n| union ( metrics \r\n| summarize max(Val) by sql_instance, database_name \r\n| where max_Val == 0 \r\n| project Resource = strcat(sql_instance, \"/\", database_name).tolower(), MetricName = \"none\", metric_value = 0.0)\r\n| project Type = 'microsoft.sql/servers/databases', Resource, MetricName, metric_value, wbLink='{DBWorkbook}'\r\n| sort by metric_value desc",
+            "size": 0,
+            "title": "TOP METRIC UTILIZATION PER DATABASE",
+            "timeContext": {
+              "durationMs": 86400000
+            },
+            "timeContextFromParameter": "Timerange",
+            "exportFieldName": "Resource",
+            "exportParameterName": "ResourceId",
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces",
+            "crossComponentResources": [
+              "{Workspaces}"
+            ],
+            "gridSettings": {
+              "formatters": [
+                {
+                  "columnMatch": "Type",
+                  "formatter": 16,
+                  "formatOptions": {
+                    "showIcon": true,
+                    "customColumnWidthSetting": "4ch"
+                  }
+                },
+                {
+                  "columnMatch": "Resource",
+                  "formatter": 7,
+                  "formatOptions": {
+                    "linkTarget": "WorkbookTemplate",
+                    "workbookContext": {
+                      "componentIdSource": "workbook",
+                      "resourceIdsSource": "workbook",
+                      "templateIdSource": "column",
+                      "templateId": "wbLink",
+                      "typeSource": "workbook",
+                      "gallerySource": "workbook",
+                      "locationSource": "default"
+                    }
+                  }
+                },
+                {
+                  "columnMatch": "MetricName",
+                  "formatter": 0,
+                  "formatOptions": {
+                    "customColumnWidthSetting": "20ch"
+                  }
+                },
+                {
+                  "columnMatch": "metric_value",
+                  "formatter": 0,
+                  "formatOptions": {
+                    "customColumnWidthSetting": "11ch"
+                  },
+                  "numberFormat": {
+                    "unit": 1,
+                    "options": {
+                      "style": "decimal",
+                      "useGrouping": false
+                    }
+                  }
+                },
+                {
+                  "columnMatch": "wbLink",
+                  "formatter": 5
+                }
+              ],
+              "filter": true,
+              "labelSettings": [
+                {
+                  "columnId": "Type",
+                  "label": " "
+                },
+                {
+                  "columnId": "Resource"
+                },
+                {
+                  "columnId": "MetricName",
+                  "label": "Metric"
+                },
+                {
+                  "columnId": "metric_value",
+                  "label": "80th Percentile"
+                },
+                {
+                  "columnId": "wbLink"
+                }
+              ]
+            },
+            "sortBy": []
+          },
+          "conditionalVisibility": {
+            "parameterName": "Mode",
+            "comparison": "isEqualTo",
+            "value": "Azure SQL"
+          },
+          "customWidth": "30",
+          "name": "query - 15"
+        },
+        {
+          "type": 12,
+          "content": {
+            "version": "NotebookGroup/1.0",
+            "groupType": "editable",
+            "title": "DATABASE FLEET OVERVIEW",
+            "items": [
+              {
+                "type": 11,
+                "content": {
+                  "version": "LinkItem/1.0",
+                  "style": "nav",
+                  "links": [
+                    {
+                      "id": "298d3e49-deeb-4e8b-9799-6c383c3139f5",
+                      "cellValue": "[resourceId('microsoft.insights/workbooks', parameters('workbookNames').Metrics)]",
+                      "linkTarget": "WorkbookTemplate",
+                      "linkLabel": "Resources per utilization bucket",
+                      "style": "link"
+                    }
+                  ]
+                },
+                "customWidth": "33",
+                "name": "links - 11"
+              },
+              {
+                "type": 11,
+                "content": {
+                  "version": "LinkItem/1.0",
+                  "style": "nav",
+                  "links": [
+                    {
+                      "id": "4f7a50df-8010-413c-b85d-043c126024d3",
+                      "cellValue": "[resourceId('microsoft.insights/workbooks', parameters('workbookNames').Queries)]",
+                      "linkTarget": "WorkbookTemplate",
+                      "linkLabel": "Query duration in seconds",
+                      "style": "link"
+                    }
+                  ]
+                },
+                "customWidth": "33",
+                "name": "links - 11 - Copy"
+              },
+              {
+                "type": 11,
+                "content": {
+                  "version": "LinkItem/1.0",
+                  "style": "nav",
+                  "links": [
+                    {
+                      "id": "9558bd60-44ee-4ff7-89e4-c4d8a6e94a21",
+                      "cellValue": "[resourceId('microsoft.insights/workbooks', parameters('workbookNames').Errors)]",
+                      "linkTarget": "WorkbookTemplate",
+                      "linkLabel": "Number of query errors",
+                      "style": "link"
+                    }
+                  ]
+                },
+                "customWidth": "33",
+                "name": "links - 11 - Copy"
+              },
+              {
+                "type": 3,
+                "content": {
+                  "version": "KqlItem/1.0",
+                  "query": "set truncationmaxrecords=5000;\r\nlet metrics = InsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace == 'sqlserver_azure_db_resource_stats'\r\n| where Name in ('avg_cpu_percent', 'avg_data_io_percent', 'avg_log_write_percent')\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == 'AzureSQLDB';\r\nmetrics\r\n| summarize Val = percentile(Val, 80) by Name, sql_instance, database_name, bin(TimeGenerated, {Timerange:grain})\r\n| summarize max_val = max(Val) by sql_instance, database_name, TimeGenerated\r\n| extend category = case(max_val < 20, \"low\", max_val < 80, \"medium\", \"high\")\r\n| summarize high = countif(category == \"high\"), medium = countif(category == \"medium\"), low = countif(category == \"low\") by TimeGenerated\r\n",
+                  "size": 1,
+                  "aggregation": 5,
+                  "timeContext": {
+                    "durationMs": 86400000
+                  },
+                  "timeContextFromParameter": "Timerange",
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "crossComponentResources": [
+                    "{Workspaces}"
+                  ],
+                  "visualization": "barchart",
+                  "chartSettings": {
+                    "seriesLabelSettings": [
+                      {
+                        "seriesName": "high",
+                        "color": "orange"
+                      },
+                      {
+                        "seriesName": "medium",
+                        "color": "green"
+                      },
+                      {
+                        "seriesName": "low",
+                        "color": "blue"
+                      }
+                    ],
+                    "ySettings": {
+                      "numberFormatSettings": {
+                        "unit": 17,
+                        "options": {
+                          "style": "decimal",
+                          "useGrouping": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "customWidth": "33",
+                "name": "query - 17"
+              },
+              {
+                "type": 3,
+                "content": {
+                  "version": "KqlItem/1.0",
+                  "query": "InsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace == 'sqlserver_azuredb_querystore_runtime_stats'\r\n| summarize make_bag(pack(Name, Val)) by Tags, TimeGenerated\r\n| evaluate bag_unpack(bag_)\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == 'AzureSQLDB'\r\n| extend duration_d = avg_duration * count_executions, cpu_time_d = avg_cpu_time * count_executions, count_executions_d = count_executions\r\n| summarize avg_duration = sum(duration_d)/sum(count_executions_d)/1000000,\r\navg_cpu = sum(cpu_time_d)/sum(count_executions_d)/1000000\r\n    by bin(interval_start_time, {Timerange:grain})",
+                  "size": 1,
+                  "aggregation": 3,
+                  "timeContext": {
+                    "durationMs": 86400000
+                  },
+                  "timeContextFromParameter": "Timerange",
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "crossComponentResources": [
+                    "{Workspaces}"
+                  ],
+                  "visualization": "linechart",
+                  "chartSettings": {
+                    "ySettings": {
+                      "numberFormatSettings": {
+                        "unit": 24,
+                        "options": {
+                          "style": "decimal",
+                          "useGrouping": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "customWidth": "33",
+                "name": "query - 1"
+              },
+              {
+                "type": 3,
+                "content": {
+                  "version": "KqlItem/1.0",
+                  "query": "InsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace == 'sqlserver_azuredb_querystore_runtime_stats'\r\n| summarize make_bag(pack(Name, Val)) by Tags, TimeGenerated\r\n| evaluate bag_unpack(bag_)\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == 'AzureSQLDB'\r\n| summarize errors = sumif(count_executions, execution_type==4) by TimeGenerated = bin(interval_start_time, {Timerange:grain})\r\n| sort by TimeGenerated desc",
+                  "size": 1,
+                  "timeContext": {
+                    "durationMs": 86400000
+                  },
+                  "timeContextFromParameter": "Timerange",
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "crossComponentResources": [
+                    "{Workspaces}"
+                  ],
+                  "visualization": "barchart"
+                },
+                "customWidth": "33",
+                "name": "query - 2"
+              },
+              {
+                "type": 11,
+                "content": {
+                  "version": "LinkItem/1.0",
+                  "style": "nav",
+                  "links": [
+                    {
+                      "id": "ede5179f-ffc9-45ec-b03b-7aa21473350a",
+                      "cellValue": "[resourceId('microsoft.insights/workbooks', parameters('workbookNames').Deadlocks)]",
+                      "linkTarget": "WorkbookTemplate",
+                      "linkLabel": "Number of deadlock events",
+                      "style": "link"
+                    }
+                  ]
+                },
+                "customWidth": "33",
+                "name": "links - 11 - Copy - Copy"
+              },
+              {
+                "type": 11,
+                "content": {
+                  "version": "LinkItem/1.0",
+                  "style": "nav",
+                  "links": [
+                    {
+                      "id": "ecde842c-59a0-442f-aee8-1bea16e6d44f",
+                      "cellValue": "[resourceId('microsoft.insights/workbooks', parameters('workbookNames').QueryWaits)]",
+                      "linkTarget": "WorkbookTemplate",
+                      "linkLabel": "Total time queries spent waiting per type",
+                      "style": "link"
+                    }
+                  ]
+                },
+                "customWidth": "33",
+                "name": "links - 11 - Copy - Copy - Copy - Copy"
+              },
+              {
+                "type": 11,
+                "content": {
+                  "version": "LinkItem/1.0",
+                  "style": "nav",
+                  "links": [
+                    {
+                      "id": "1ed210a3-2a14-448d-9a5c-8af5f5366a2a",
+                      "cellValue": "[resourceId('microsoft.insights/workbooks', parameters('workbookNames').Timeouts)]",
+                      "linkTarget": "WorkbookTemplate",
+                      "linkLabel": "Number of timeouts",
+                      "style": "link"
+                    }
+                  ]
+                },
+                "customWidth": "33",
+                "name": "links - 11 - Copy - Copy - Copy - Copy - Copy"
+              },
+              {
+                "type": 3,
+                "content": {
+                  "version": "KqlItem/1.0",
+                  "query": "InsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace == 'sqlserver_performance'\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == 'AzureSQLDB'\r\n| extend resourceName = tolower(strcat(extract(\"^([^\\\\.]+)\\\\.?\", 1, sql_instance), '/', database_name))\r\n| where counter == 'Number of Deadlocks/sec'\r\n| order by resourceName, TimeGenerated asc\r\n| serialize\r\n| extend delta = case(prev(resourceName) == resourceName, case(Val>=prev(Val), Val - prev(Val), Val), real(null))\r\n| summarize deadlocks = sum(delta) by bin(TimeGenerated, {Timerange:grain})",
+                  "size": 1,
+                  "timeContext": {
+                    "durationMs": 86400000
+                  },
+                  "timeContextFromParameter": "Timerange",
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "crossComponentResources": [
+                    "{Workspaces}"
+                  ],
+                  "visualization": "barchart"
+                },
+                "customWidth": "33",
+                "name": "query - 2 - Copy"
+              },
+              {
+                "type": 3,
+                "content": {
+                  "version": "KqlItem/1.0",
+                  "query": "InsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace == 'sqlserver_azuredb_querystore_wait_stats'\r\n| summarize make_bag(pack(Name, Val)) by Tags, TimeGenerated\r\n| evaluate bag_unpack(bag_)\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == 'AzureSQLDB'\r\n| summarize total_wait_time = sum(total_query_wait_time_ms)/1000\r\n    by wait_category, bin(interval_start_time, {Timerange:grain})\r\n| top 1000 by total_wait_time desc\r\n| evaluate pivot(wait_category, sum(total_wait_time))",
+                  "size": 1,
+                  "aggregation": 3,
+                  "timeContext": {
+                    "durationMs": 86400000
+                  },
+                  "timeContextFromParameter": "Timerange",
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "crossComponentResources": [
+                    "{Workspaces}"
+                  ],
+                  "visualization": "barchart",
+                  "chartSettings": {
+                    "ySettings": {
+                      "numberFormatSettings": {
+                        "unit": 24,
+                        "options": {
+                          "style": "decimal",
+                          "useGrouping": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "customWidth": "33",
+                "name": "query - 2 - Copy - Copy"
+              },
+              {
+                "type": 3,
+                "content": {
+                  "version": "KqlItem/1.0",
+                  "query": "InsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace == 'sqlserver_performance'\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == 'AzureSQLDB'\r\n| extend resourceName = tolower(strcat(extract(\"^([^\\\\.]+)\\\\.?\", 1, sql_instance), '/', database_name))\r\n| where counter == 'Lock Timeouts (timeout > 0)/sec'\r\n| order by resourceName, TimeGenerated asc\r\n| serialize\r\n| extend delta = case(prev(resourceName) == resourceName, case(Val>=prev(Val), Val - prev(Val), Val), real(null))\r\n| summarize timeouts = max(delta) by bin(TimeGenerated, {Timerange:grain})\r\n| sort by TimeGenerated desc",
+                  "size": 1,
+                  "timeContext": {
+                    "durationMs": 86400000
+                  },
+                  "timeContextFromParameter": "Timerange",
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "crossComponentResources": [
+                    "{Workspaces}"
+                  ],
+                  "visualization": "barchart"
+                },
+                "customWidth": "32",
+                "name": "query - 2 - Copy - Copy - Copy"
+              },
+              {
+                "type": 11,
+                "content": {
+                  "version": "LinkItem/1.0",
+                  "style": "nav",
+                  "links": [
+                    {
+                      "id": "123ba7a3-dac4-4764-a1e2-43bfc32e7a70",
+                      "cellValue": "[resourceId('microsoft.insights/workbooks', parameters('workbookNames').DatabaseWaits)]",
+                      "linkTarget": "WorkbookTemplate",
+                      "linkLabel": "Total time DBs spent waiting per type",
+                      "style": "link"
+                    }
+                  ]
+                },
+                "customWidth": "33",
+                "name": "links - 11 - Copy - Copy - Copy - Copy - Copy - Copy - Copy - Copy"
+              },
+              {
+                "type": 11,
+                "content": {
+                  "version": "LinkItem/1.0",
+                  "style": "nav",
+                  "links": [
+                    {
+                      "id": "35ef9aac-4af4-42ee-8fd8-f552d8d56236",
+                      "cellValue": "[resourceId('microsoft.insights/workbooks', parameters('workbookNames').Blockings)]",
+                      "linkTarget": "WorkbookTemplate",
+                      "linkLabel": "Number of blocking events",
+                      "style": "link"
+                    }
+                  ]
+                },
+                "customWidth": "33",
+                "name": "links - 11 - Copy - Copy - Copy - Copy - Copy - Copy - Copy - Copy - Copy"
+              },
+              {
+                "type": 1,
+                "content": {
+                  "json": ""
+                },
+                "customWidth": "33",
+                "name": "text - 22"
+              },
+              {
+                "type": 3,
+                "content": {
+                  "version": "KqlItem/1.0",
+                  "query": "set truncationmaxrecords=5000;\r\nInsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace == 'sqlserver_azuredb_waitstats'\r\n| summarize make_bag(pack(Name, Val)) by Tags, TimeGenerated\r\n| evaluate bag_unpack(bag_)\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == 'AzureSQLDB'\r\n| where database_name!=''\r\n| extend resourceName = tolower(strcat(extract(\"^([^\\\\.]+)\\\\.?\", 1, sql_instance), '/', database_name))\r\n| order by resourceName, wait_type, TimeGenerated asc\r\n| serialize \r\n| project TimeGenerated, wait_time_ms = case(prev(resourceName) == resourceName and prev(wait_type) == wait_type, wait_time_ms - prev(wait_time_ms), real(null)), wait_type\r\n| summarize total_wait_time_in_ms = sum(wait_time_ms)/1000\r\n    by wait_type, bin(TimeGenerated, {Timerange:grain})\r\n| top 1000 by total_wait_time_in_ms desc\r\n| evaluate pivot(wait_type, sum(total_wait_time_in_ms))",
+                  "size": 1,
+                  "aggregation": 3,
+                  "timeContext": {
+                    "durationMs": 86400000
+                  },
+                  "timeContextFromParameter": "Timerange",
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "crossComponentResources": [
+                    "{Workspaces}"
+                  ],
+                  "visualization": "barchart",
+                  "chartSettings": {
+                    "ySettings": {
+                      "numberFormatSettings": {
+                        "unit": 24,
+                        "options": {
+                          "style": "decimal",
+                          "useGrouping": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "customWidth": "33",
+                "name": "query - 2 - Copy - Copy"
+              },
+              {
+                "type": 3,
+                "content": {
+                  "version": "KqlItem/1.0",
+                  "query": "InsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace == 'sqlserver_performance'\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == 'AzureSQLDB'\r\n| extend resourceName = tolower(strcat(extract(\"^([^\\\\.]+)\\\\.?\", 1, sql_instance), '/', database_name))\r\n| where counter == 'Lock Waits/sec'\r\n| order by resourceName, TimeGenerated asc\r\n| serialize\r\n| extend delta = case(prev(resourceName) == resourceName, case(Val>=prev(Val), Val - prev(Val), Val), real(null))\r\n| summarize blockings = max(delta) by bin(TimeGenerated, {Timerange:grain})\r\n| sort by TimeGenerated desc",
+                  "size": 1,
+                  "timeContext": {
+                    "durationMs": 86400000
+                  },
+                  "timeContextFromParameter": "Timerange",
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "crossComponentResources": [
+                    "{Workspaces}"
+                  ],
+                  "visualization": "barchart"
+                },
+                "customWidth": "33",
+                "name": "query - 2 - Copy - Copy - Copy"
+              }
+            ]
+          },
+          "conditionalVisibility": {
+            "parameterName": "Mode",
+            "comparison": "isEqualTo",
+            "value": "Azure SQL"
+          },
+          "customWidth": "70",
+          "name": "group - 16"
+        }
+      ],
+      "fallbackResourceIds": [
+      ],
+      "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
+    },
+    "workbookDisplayName": "SQL Analytics",
+    "workbookName": "[parameters('workbookNames').SQLAnalytics]"
+  },
+  "resources": [
+    {
+      "name": "[variables('workbookName')]",
+      "type": "microsoft.insights/workbooks",
+      "location": "[resourceGroup().location]",
+      "apiVersion": "2018-06-17-preview",
+      "kind": "shared",
+      "properties": {
+        "displayName": "[variables('workbookDisplayName')]",
+        "serializedData": "[string(variables('workbookMarkup'))]",
+        "version": "Notebook/1.0",
+        "sourceId": "[resourceGroup().id]",
+        "category": "workbook"
+      },
+      "tags": {
+        "hidden-title": "[variables('workbookDisplayName')]"
+      }
+    }
+  ]
+}

--- a/Workbooks/Workloads/QDS/Timeouts.json
+++ b/Workbooks/Workloads/QDS/Timeouts.json
@@ -1,0 +1,859 @@
+{
+  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "workbookNames": {
+      "type": "object",
+      "defaultValue": {
+        "Timeouts": "[guid(resourceGroup().id, 'Timeouts')]",
+        "Database": "[guid(resourceGroup().id, 'Database')]"
+      }
+    }
+  },
+  "variables": {
+    "workbookMarkup": {
+      "version": "Notebook/1.0",
+      "items": [
+        {
+          "type": 9,
+          "content": {
+            "version": "KqlParameterItem/1.0",
+            "crossComponentResources": [
+              "{WsResourcesInternal}"
+            ],
+            "parameters": [
+              {
+                "id": "4ecc9f52-2e3f-4c8e-b9ea-f3e2f2583f5b",
+                "version": "KqlParameterItem/1.0",
+                "name": "WsResources",
+                "type": 1
+              },
+              {
+                "id": "f3e20cbc-b692-4b3d-8916-2fd0662ecfe6",
+                "version": "KqlParameterItem/1.0",
+                "name": "WsResourcesInternal",
+                "type": 5,
+                "multiSelect": true,
+                "quote": "'",
+                "delimiter": ",",
+                "query": "where id in~ ({WsResources})\r\n| project id, selected=1",
+                "crossComponentResources": [
+                  "value::all"
+                ],
+                "typeSettings": {
+                  "additionalResourceOptions": [],
+                  "showDefault": false
+                },
+                "queryType": 1,
+                "resourceType": "microsoft.resourcegraph/resources"
+              },
+              {
+                "id": "30b86356-1bba-4603-83d1-835b99171066",
+                "version": "KqlParameterItem/1.0",
+                "name": "Timerange",
+                "type": 4,
+                "value": {
+                  "durationMs": 86400000
+                },
+                "typeSettings": {
+                  "selectableValues": [
+                    {
+                      "durationMs": 300000
+                    },
+                    {
+                      "durationMs": 900000
+                    },
+                    {
+                      "durationMs": 1800000
+                    },
+                    {
+                      "durationMs": 3600000
+                    },
+                    {
+                      "durationMs": 14400000
+                    },
+                    {
+                      "durationMs": 43200000
+                    },
+                    {
+                      "durationMs": 86400000
+                    },
+                    {
+                      "durationMs": 172800000
+                    },
+                    {
+                      "durationMs": 259200000
+                    },
+                    {
+                      "durationMs": 604800000
+                    },
+                    {
+                      "durationMs": 1209600000
+                    },
+                    {
+                      "durationMs": 2419200000
+                    },
+                    {
+                      "durationMs": 2592000000
+                    },
+                    {
+                      "durationMs": 5184000000
+                    },
+                    {
+                      "durationMs": 7776000000
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "f2ae16b9-0bea-4ad0-b14e-93a51424fab9",
+                "version": "KqlParameterItem/1.0",
+                "name": "DBWorkbook",
+                "type": 1,
+                "value": "[resourceId('microsoft.insights/workbooks', parameters('workbookNames').Database)]"
+              },
+              {
+                "id": "58ec8e26-5dac-4c4c-9441-47daa7adf18f",
+                "version": "KqlParameterItem/1.0",
+                "name": "SubscriptionId",
+                "type": 1,
+                "value": ""
+              },
+              {
+                "id": "d2d2fa1b-070a-45d8-94ec-411c60379803",
+                "version": "KqlParameterItem/1.0",
+                "name": "ServerId",
+                "type": 1,
+                "value": ""
+              },
+              {
+                "id": "4adf7337-0c81-48ab-97a9-5917de6da6c0",
+                "version": "KqlParameterItem/1.0",
+                "name": "DbId",
+                "type": 1
+              },
+              {
+                "id": "4feafee7-0cd9-435e-a42e-11f31984c024",
+                "version": "KqlParameterItem/1.0",
+                "name": "Type",
+                "type": 1
+              },
+              {
+                "id": "55c27380-5130-4c43-97da-155327e6bc93",
+                "version": "KqlParameterItem/1.0",
+                "name": "TypeInternal",
+                "type": 7,
+                "query": "{\"version\":\"1.0.0\",\"content\":\"{\\\"value\\\":\\\"{Type}\\\", \\\"selected\\\":true}\",\"transformers\":null}",
+                "typeSettings": {
+                  "additionalResourceOptions": [],
+                  "showDefault": false
+                },
+                "queryType": 8
+              },
+              {
+                "id": "104bb4aa-c4b1-4ff5-a53f-4cb22d20e009",
+                "version": "KqlParameterItem/1.0",
+                "name": "dbType",
+                "type": 1
+              },
+              {
+                "id": "d8bb41fb-46fc-4cd8-a8a6-cead75ba2a32",
+                "version": "KqlParameterItem/1.0",
+                "name": "MonitoredResources",
+                "type": 9,
+                "multiSelect": true,
+                "quote": "'",
+                "delimiter": ",",
+                "query": "InsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace == 'sqlserver_performance'\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| project dbName = tolower(strcat(extract(\"^([^\\\\.]+)\\\\.?\", 1, sql_instance), '/', database_name))\r\n| distinct dbName",
+                "crossComponentResources": [
+                  "{WsResourcesInternal}"
+                ],
+                "value": null,
+                "timeContext": {
+                  "durationMs": 0
+                },
+                "timeContextFromParameter": "Timerange",
+                "queryType": 0,
+                "resourceType": "microsoft.operationalinsights/workspaces"
+              },
+              {
+                "id": "3f3783df-3615-4c1d-a49d-236526c12704",
+                "version": "KqlParameterItem/1.0",
+                "name": "Resources_timeouts",
+                "type": 9,
+                "multiSelect": true,
+                "quote": "",
+                "delimiter": ",",
+                "query": "where type contains '{Type}'\r\n| extend ResourceId = tolower(id)\r\n| extend name = tolower(strcat(extract(tolower('/{Type}/([^/]+)/'), 1, ResourceId), '/', name))\r\n| where name in ({MonitoredResources})\r\n| project strcat('{\"name\":\"',name, '\" , \"subscription\": \"', subscriptionId, '\", \"resourceGroup\": \"', resourceGroup, '\"}')",
+                "crossComponentResources": [
+                  "value::all"
+                ],
+                "value": null,
+                "timeContext": {
+                  "durationMs": 0
+                },
+                "timeContextFromParameter": "Timerange",
+                "queryType": 1,
+                "resourceType": "microsoft.resourcegraph/resources"
+              }
+            ],
+            "style": "pills",
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          },
+          "conditionalVisibility": {
+            "parameterName": "hide",
+            "comparison": "isNotEqualTo"
+          },
+          "name": "parameters - 0"
+        },
+        {
+          "type": 1,
+          "content": {
+            "json": "# Timeouts"
+          },
+          "name": "text - 3"
+        },
+        {
+          "type": 1,
+          "content": {
+            "json": "Data is loading",
+            "style": "info"
+          },
+          "conditionalVisibility": {
+            "parameterName": "Resources_timeouts",
+            "comparison": "isEqualTo"
+          },
+          "name": "text - 3"
+        },
+        {
+          "type": 12,
+          "content": {
+            "version": "NotebookGroup/1.0",
+            "groupType": "editable",
+            "items": [
+              {
+                "type": 1,
+                "content": {
+                  "json": "## Subscriptions"
+                },
+                "name": "text - 9"
+              },
+              {
+                "type": 3,
+                "content": {
+                  "version": "KqlItem/1.0",
+                  "query": "let resources = print dynamic([{Resources_timeouts}])\r\n| mv-expand print_0\r\n| evaluate bag_unpack(print_0);\r\nInsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace == 'sqlserver_performance'\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| where counter == 'Lock Timeouts (timeout > 0)/sec'\r\n| extend resourceName = tolower(strcat(extract(\"^([^\\\\.]+)\\\\.?\", 1, sql_instance), '/', database_name))\r\n| join kind=leftouter (resources| extend resourceName = name)on resourceName\r\n| order by resourceName, TimeGenerated asc\r\n| serialize\r\n| extend delta = case(prev(resourceName) == resourceName, Val - prev(Val), real(null))\r\n| summarize Timeouts = sum(delta) by subscription\r\n| sort by Timeouts desc",
+                  "size": 1,
+                  "timeContext": {
+                    "durationMs": 86400000
+                  },
+                  "timeContextFromParameter": "Timerange",
+                  "exportFieldName": "subscription",
+                  "exportParameterName": "SubscriptionId",
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "crossComponentResources": [
+                    "{WsResourcesInternal}"
+                  ],
+                  "gridSettings": {
+                    "formatters": [
+                      {
+                        "columnMatch": "subscription",
+                        "formatter": 15,
+                        "formatOptions": {
+                          "linkTarget": null,
+                          "showIcon": true
+                        }
+                      }
+                    ],
+                    "labelSettings": [
+                      {
+                        "columnId": "subscription",
+                        "label": "Subscription"
+                      },
+                      {
+                        "columnId": "Timeouts",
+                        "label": ""
+                      }
+                    ]
+                  }
+                },
+                "customWidth": "40",
+                "name": "query - 4"
+              },
+              {
+                "type": 3,
+                "content": {
+                  "version": "KqlItem/1.0",
+                  "query": "let resources = print dynamic([{Resources_timeouts}])\r\n| mv-expand print_0\r\n| evaluate bag_unpack(print_0);\r\nInsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace == 'sqlserver_performance'\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| where counter == 'Lock Timeouts (timeout > 0)/sec'\r\n| extend resourceName = tolower(strcat(extract(\"^([^\\\\.]+)\\\\.?\", 1, sql_instance), '/', database_name))\r\n| join kind=leftouter (resources| extend resourceName = name)on resourceName\r\n| where tostring(subscription) contains '{SubscriptionId}'\r\n| order by resourceName, TimeGenerated asc\r\n| serialize\r\n| extend delta = case(prev(resourceName) == resourceName, case(Val>=prev(Val), Val - prev(Val), Val), real(null))\r\n| project tostring(subscription), timeouts = delta, bin(TimeGenerated, {Timerange:grain})\r\n| summarize sum(timeouts) by subscription, TimeGenerated",
+                  "size": 1,
+                  "showAnalytics": true,
+                  "timeContext": {
+                    "durationMs": 0
+                  },
+                  "timeContextFromParameter": "Timerange",
+                  "exportFieldName": "SubscriptionId",
+                  "exportParameterName": "SubscriptionId",
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "crossComponentResources": [
+                    "{WsResourcesInternal}"
+                  ],
+                  "visualization": "barchart",
+                  "gridSettings": {
+                    "formatters": [
+                      {
+                        "columnMatch": "SubscriptionId",
+                        "formatter": 15,
+                        "formatOptions": {
+                          "linkTarget": null,
+                          "customColumnWidthSetting": "24ch"
+                        }
+                      },
+                      {
+                        "columnMatch": "max_duration",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "14ch"
+                        },
+                        "numberFormat": {
+                          "unit": 24,
+                          "options": {
+                            "style": "decimal",
+                            "useGrouping": false
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "avg_duration",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "14ch"
+                        },
+                        "numberFormat": {
+                          "unit": 24,
+                          "options": {
+                            "style": "decimal",
+                            "useGrouping": false
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "avg_cpu",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "14ch"
+                        },
+                        "numberFormat": {
+                          "unit": 24,
+                          "options": {
+                            "style": "decimal"
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "executions_count",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "13ch"
+                        },
+                        "numberFormat": {
+                          "unit": 17,
+                          "options": {
+                            "style": "decimal"
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "ResourceIdPrefix",
+                        "formatter": 5
+                      }
+                    ],
+                    "labelSettings": [
+                      {
+                        "columnId": "SubscriptionId",
+                        "label": "Subscription"
+                      },
+                      {
+                        "columnId": "max_duration",
+                        "label": "Max"
+                      },
+                      {
+                        "columnId": "avg_duration",
+                        "label": "Avg"
+                      },
+                      {
+                        "columnId": "avg_cpu",
+                        "label": "CPU"
+                      },
+                      {
+                        "columnId": "executions_count",
+                        "label": "Execs"
+                      },
+                      {
+                        "columnId": "ResourceIdPrefix"
+                      }
+                    ]
+                  }
+                },
+                "customWidth": "60",
+                "name": "query - 4 - Copy"
+              },
+              {
+                "type": 1,
+                "content": {
+                  "json": "## {TypeInternal:label}s"
+                },
+                "name": "text - 10"
+              },
+              {
+                "type": 1,
+                "content": {
+                  "json": "SubscriptionID: {SubscriptionId}"
+                },
+                "conditionalVisibility": {
+                  "parameterName": "SubscriptionId",
+                  "comparison": "isNotEqualTo"
+                },
+                "name": "text - 11"
+              },
+              {
+                "type": 3,
+                "content": {
+                  "version": "KqlItem/1.0",
+                  "query": "let resources = print dynamic([{Resources_timeouts}])\r\n| mv-expand print_0\r\n| evaluate bag_unpack(print_0);\r\nInsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace == 'sqlserver_performance'\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| where counter == 'Lock Timeouts (timeout > 0)/sec'\r\n| extend resourceName = tolower(strcat(extract(\"^([^\\\\.]+)\\\\.?\", 1, sql_instance), '/', database_name))\r\n| join kind=leftouter (resources| extend resourceName = name)on resourceName\r\n| where tostring(subscription) contains '{SubscriptionId}'\r\n| order by resourceName, TimeGenerated asc\r\n| serialize\r\n| extend delta = case(prev(resourceName) == resourceName, Val - prev(Val), real(null))\r\n| summarize Timeouts = sum(delta) by sql_instance\r\n| project Type = '{Type}', ['{TypeInternal:label}'] = sql_instance, Timeouts, sql_instance\r\n| sort by Timeouts desc",
+                  "size": 1,
+                  "timeContext": {
+                    "durationMs": 86400000
+                  },
+                  "timeContextFromParameter": "Timerange",
+                  "exportFieldName": "sql_instance",
+                  "exportParameterName": "ServerId",
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "crossComponentResources": [
+                    "{WsResourcesInternal}"
+                  ],
+                  "gridSettings": {
+                    "formatters": [
+                      {
+                        "columnMatch": "Type",
+                        "formatter": 16,
+                        "formatOptions": {
+                          "showIcon": true,
+                          "customColumnWidthSetting": "4ch"
+                        }
+                      },
+                      {
+                        "columnMatch": "SQL",
+                        "formatter": 1
+                      },
+                      {
+                        "columnMatch": "sql_instance",
+                        "formatter": 5
+                      }
+                    ],
+                    "labelSettings": [
+                      {
+                        "columnId": "Type",
+                        "label": " "
+                      },
+                      {
+                        "columnId": "SQL server"
+                      },
+                      {
+                        "columnId": "Timeouts",
+                        "label": ""
+                      },
+                      {
+                        "columnId": "sql_instance"
+                      }
+                    ]
+                  }
+                },
+                "customWidth": "40",
+                "name": "query - 4 - Copy"
+              },
+              {
+                "type": 3,
+                "content": {
+                  "version": "KqlItem/1.0",
+                  "query": "let resources = print dynamic([{Resources_timeouts}])\r\n| mv-expand print_0\r\n| evaluate bag_unpack(print_0);\r\nInsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace == 'sqlserver_performance'\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| where counter == 'Lock Timeouts (timeout > 0)/sec'\r\n| extend resourceName = tolower(strcat(extract(\"^([^\\\\.]+)\\\\.?\", 1, sql_instance), '/', database_name))\r\n| join kind=leftouter (resources| extend resourceName = name)on resourceName\r\n| where tostring(subscription) contains '{SubscriptionId}'\r\n| where tostring(sql_instance) contains '{ServerId}'\r\n| order by resourceName, TimeGenerated asc\r\n| serialize\r\n| extend delta = case(prev(resourceName) == resourceName, case(Val>=prev(Val), Val - prev(Val), Val), real(null))\r\n| project sql_instance, timeouts = delta, bin(TimeGenerated, {Timerange:grain})\r\n| summarize sum(timeouts) by sql_instance, TimeGenerated",
+                  "size": 1,
+                  "showAnalytics": true,
+                  "timeContext": {
+                    "durationMs": 0
+                  },
+                  "timeContextFromParameter": "Timerange",
+                  "exportFieldName": "SubscriptionId",
+                  "exportParameterName": "SubscriptionId",
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "crossComponentResources": [
+                    "{WsResourcesInternal}"
+                  ],
+                  "visualization": "barchart",
+                  "gridSettings": {
+                    "formatters": [
+                      {
+                        "columnMatch": "SubscriptionId",
+                        "formatter": 15,
+                        "formatOptions": {
+                          "linkTarget": null,
+                          "customColumnWidthSetting": "24ch"
+                        }
+                      },
+                      {
+                        "columnMatch": "max_duration",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "14ch"
+                        },
+                        "numberFormat": {
+                          "unit": 24,
+                          "options": {
+                            "style": "decimal",
+                            "useGrouping": false
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "avg_duration",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "14ch"
+                        },
+                        "numberFormat": {
+                          "unit": 24,
+                          "options": {
+                            "style": "decimal",
+                            "useGrouping": false
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "avg_cpu",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "14ch"
+                        },
+                        "numberFormat": {
+                          "unit": 24,
+                          "options": {
+                            "style": "decimal"
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "executions_count",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "13ch"
+                        },
+                        "numberFormat": {
+                          "unit": 17,
+                          "options": {
+                            "style": "decimal"
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "ResourceIdPrefix",
+                        "formatter": 5
+                      }
+                    ],
+                    "labelSettings": [
+                      {
+                        "columnId": "SubscriptionId",
+                        "label": "Subscription"
+                      },
+                      {
+                        "columnId": "max_duration",
+                        "label": "Max"
+                      },
+                      {
+                        "columnId": "avg_duration",
+                        "label": "Avg"
+                      },
+                      {
+                        "columnId": "avg_cpu",
+                        "label": "CPU"
+                      },
+                      {
+                        "columnId": "executions_count",
+                        "label": "Execs"
+                      },
+                      {
+                        "columnId": "ResourceIdPrefix"
+                      }
+                    ]
+                  }
+                },
+                "customWidth": "60",
+                "name": "query - 4 - Copy - Copy"
+              },
+              {
+                "type": 1,
+                "content": {
+                  "json": "## Databases"
+                },
+                "name": "text - 12"
+              },
+              {
+                "type": 1,
+                "content": {
+                  "json": "Subscription ID: {SubscriptionId}"
+                },
+                "conditionalVisibility": {
+                  "parameterName": "SuubscriptionId",
+                  "comparison": "isNotEqualTo"
+                },
+                "name": "text - 13"
+              },
+              {
+                "type": 1,
+                "content": {
+                  "json": "Server: {ServerId:name}"
+                },
+                "conditionalVisibility": {
+                  "parameterName": "ServerId",
+                  "comparison": "isNotEqualTo"
+                },
+                "name": "text - 14"
+              },
+              {
+                "type": 3,
+                "content": {
+                  "version": "KqlItem/1.0",
+                  "query": "let resources = print dynamic([{Resources_timeouts}])\r\n| mv-expand print_0\r\n| evaluate bag_unpack(print_0);\r\nInsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace == 'sqlserver_performance'\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| where counter == 'Lock Timeouts (timeout > 0)/sec'\r\n| extend resourceName = tolower(strcat(extract(\"^([^\\\\.]+)\\\\.?\", 1, sql_instance), '/', database_name))\r\n| join kind=leftouter (resources| extend resourceName = name)on resourceName\r\n| where tostring(subscription) contains '{SubscriptionId}'\r\n| where tostring(sql_instance) contains '{ServerId}'\r\n| order by resourceName, TimeGenerated asc\r\n| serialize\r\n| extend delta = case(prev(resourceName) == resourceName, Val - prev(Val), real(null))\r\n| summarize Timeouts = sum(delta) by resourceName\r\n| project Type = '{Type}/DATABASES', ResourceId = resourceName, Timeouts,    \r\n    wbLink = '{DBWorkbook}'\r\n| sort by Timeouts desc",
+                  "size": 1,
+                  "timeContext": {
+                    "durationMs": 86400000
+                  },
+                  "timeContextFromParameter": "Timerange",
+                  "exportedParameters": [
+                    {
+                      "fieldName": "ResourceId",
+                      "parameterName": "DbId"
+                    },
+                    {
+                      "fieldName": "ResourceId",
+                      "parameterName": "ResourceId",
+                      "parameterType": 1
+                    }
+                  ],
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "crossComponentResources": [
+                    "{WsResourcesInternal}"
+                  ],
+                  "gridSettings": {
+                    "formatters": [
+                      {
+                        "columnMatch": "Type",
+                        "formatter": 16,
+                        "formatOptions": {
+                          "showIcon": true,
+                          "customColumnWidthSetting": "4ch"
+                        }
+                      },
+                      {
+                        "columnMatch": "ResourceId",
+                        "formatter": 7,
+                        "formatOptions": {
+                          "linkColumn": "wbLink",
+                          "linkTarget": "WorkbookTemplate",
+                          "workbookContext": {
+                            "componentIdSource": "workbook",
+                            "resourceIdsSource": "workbook",
+                            "templateIdSource": "column",
+                            "templateId": "wbLink",
+                            "typeSource": "workbook",
+                            "gallerySource": "workbook",
+                            "locationSource": "default"
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "wbLink",
+                        "formatter": 5
+                      }
+                    ],
+                    "labelSettings": [
+                      {
+                        "columnId": "Type",
+                        "label": " "
+                      },
+                      {
+                        "columnId": "ResourceId",
+                        "label": "Database"
+                      },
+                      {
+                        "columnId": "Timeouts",
+                        "label": ""
+                      },
+                      {
+                        "columnId": "wbLink"
+                      }
+                    ]
+                  },
+                  "sortBy": []
+                },
+                "customWidth": "40",
+                "name": "query - 4 - Copy - Copy"
+              },
+              {
+                "type": 3,
+                "content": {
+                  "version": "KqlItem/1.0",
+                  "query": "let resources = print dynamic([{Resources_timeouts}])\r\n| mv-expand print_0\r\n| evaluate bag_unpack(print_0);\r\nInsightsMetrics\r\n| where Origin == 'solutions.azm.ms/telegraf/SqlInsights'\r\n| where Namespace == 'sqlserver_performance'\r\n| extend data = todynamic(Tags)\r\n| evaluate bag_unpack(data)\r\n| where measurement_db_type == '{dbType}'\r\n| where counter == 'Lock Timeouts (timeout > 0)/sec'\r\n| extend resourceName = tolower(strcat(extract(\"^([^\\\\.]+)\\\\.?\", 1, sql_instance), '/', database_name))\r\n| join kind=leftouter (resources| extend resourceName = name)on resourceName\r\n| where tostring(subscription) contains '{SubscriptionId}'\r\n| where tostring(sql_instance) contains '{ServerId}'\r\n| where tostring(resourceName) contains '{DbId}'\r\n| order by resourceName, TimeGenerated asc\r\n| serialize\r\n| extend delta = case(prev(resourceName) == resourceName, case(Val>=prev(Val), Val - prev(Val), Val), real(null))\r\n| project resourceName, timeouts = delta, bin(TimeGenerated, {Timerange:grain})\r\n| summarize sum(timeouts) by resourceName, TimeGenerated",
+                  "size": 1,
+                  "showAnalytics": true,
+                  "timeContext": {
+                    "durationMs": 0
+                  },
+                  "timeContextFromParameter": "Timerange",
+                  "exportFieldName": "SubscriptionId",
+                  "exportParameterName": "SubscriptionId",
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "crossComponentResources": [
+                    "{WsResourcesInternal}"
+                  ],
+                  "visualization": "barchart",
+                  "gridSettings": {
+                    "formatters": [
+                      {
+                        "columnMatch": "SubscriptionId",
+                        "formatter": 15,
+                        "formatOptions": {
+                          "linkTarget": null,
+                          "customColumnWidthSetting": "24ch"
+                        }
+                      },
+                      {
+                        "columnMatch": "max_duration",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "14ch"
+                        },
+                        "numberFormat": {
+                          "unit": 24,
+                          "options": {
+                            "style": "decimal",
+                            "useGrouping": false
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "avg_duration",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "14ch"
+                        },
+                        "numberFormat": {
+                          "unit": 24,
+                          "options": {
+                            "style": "decimal",
+                            "useGrouping": false
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "avg_cpu",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "14ch"
+                        },
+                        "numberFormat": {
+                          "unit": 24,
+                          "options": {
+                            "style": "decimal"
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "executions_count",
+                        "formatter": 0,
+                        "formatOptions": {
+                          "customColumnWidthSetting": "13ch"
+                        },
+                        "numberFormat": {
+                          "unit": 17,
+                          "options": {
+                            "style": "decimal"
+                          }
+                        }
+                      },
+                      {
+                        "columnMatch": "ResourceIdPrefix",
+                        "formatter": 5
+                      }
+                    ],
+                    "labelSettings": [
+                      {
+                        "columnId": "SubscriptionId",
+                        "label": "Subscription"
+                      },
+                      {
+                        "columnId": "max_duration",
+                        "label": "Max"
+                      },
+                      {
+                        "columnId": "avg_duration",
+                        "label": "Avg"
+                      },
+                      {
+                        "columnId": "avg_cpu",
+                        "label": "CPU"
+                      },
+                      {
+                        "columnId": "executions_count",
+                        "label": "Execs"
+                      },
+                      {
+                        "columnId": "ResourceIdPrefix"
+                      }
+                    ]
+                  }
+                },
+                "customWidth": "60",
+                "name": "query - 4 - Copy - Copy - Copy"
+              }
+            ]
+          },
+          "conditionalVisibility": {
+            "parameterName": "Resources_timeouts",
+            "comparison": "isNotEqualTo"
+          },
+          "name": "group - 14"
+        }
+      ],
+      "fallbackResourceIds": [
+      ],
+      "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
+    },
+    "workbookDisplayName": "Timeouts",
+    "workbookName": "[parameters('workbookNames').Timeouts]"
+  },
+  "resources": [
+    {
+      "name": "[variables('workbookName')]",
+      "type": "microsoft.insights/workbooks",
+      "location": "[resourceGroup().location]",
+      "apiVersion": "2018-06-17-preview",
+      "kind": "shared",
+      "properties": {
+        "displayName": "[variables('workbookDisplayName')]",
+        "serializedData": "[string(variables('workbookMarkup'))]",
+        "version": "Notebook/1.0",
+        "sourceId": "[resourceGroup().id]",
+        "category": "workbook"
+      },
+      "tags": {
+        "hidden-title": "[variables('workbookDisplayName')]"
+      }
+    }
+  ]
+}

--- a/Workbooks/Workloads/QDS/deploy.json
+++ b/Workbooks/Workloads/QDS/deploy.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "storageLink": {
+      "type": "string"
+    }
+  },
+  "variables": {
+    "workbooks": [
+      "QueryWaits",
+      "LogAlertRule",
+      "LogAlertRules",
+      "Database",
+      "ManagedInstance",
+      "Blocking",
+      "Metrics",
+      "Queries",
+      "Errors",
+      "Timeouts",
+      "Blockings",
+      "DatabaseWaits",
+      "AlertRule",
+      "Deadlocks",
+      "Query",
+      "SQLAnalytics",
+      "ManagedInstanceDatabase"
+    ],
+    "workbookNames": {
+      "QueryWaits": "[guid(resourceGroup().id, 'Query Waits')]",
+      "LogAlertRule": "[guid(resourceGroup().id, 'Log Alert Rule')]",
+      "LogAlertRules": "[guid(resourceGroup().id, 'Log Alert Rules')]",
+      "Database": "[guid(resourceGroup().id, 'Database')]",
+      "Query": "[guid(resourceGroup().id, 'Query')]",
+      "AlertRules": "[guid(resourceGroup().id, 'Alert Rules')]",
+      "ManagedInstance": "[guid(resourceGroup().id, 'Managed Instance')]",
+      "ManagedInstanceDatabase": "[guid(resourceGroup().id, 'Managed Instance Database')]",
+      "Blocking": "[guid(resourceGroup().id, 'Blocking')]",
+      "Metrics": "[guid(resourceGroup().id, 'Metrics')]",
+      "Queries": "[guid(resourceGroup().id, 'Queries')]",
+      "Errors": "[guid(resourceGroup().id, 'Errors')]",
+      "Timeouts": "[guid(resourceGroup().id, 'Timeouts')]",
+      "Blockings": "[guid(resourceGroup().id, 'Blockings')]",
+      "DatabaseWaits": "[guid(resourceGroup().id, 'Database Waits')]",
+      "AlertRule": "[guid(resourceGroup().id, 'Alert Rule')]",
+      "Deadlocks": "[guid(resourceGroup().id, 'Deadlocks')]",
+      "SQLAnalytics": "[guid(resourceGroup().id, 'SQL Analytics')]"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2020-06-01",
+      "name": "[variables('workbooks')[copyIndex()]]",
+      "properties": {
+        "templateLink": {
+          "uri": "[concat(parameters('storageLink'), '/', variables('workbooks')[copyIndex()], '.json')]"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "workbookNames": { "value": "[variables('workbookNames')]" }
+        }
+      },
+      "copy": {
+        "count": "[length(variables('workbooks'))]",
+        "name": "wbLoop"
+      }
+    }
+  ]
+}

--- a/Workbooks/Workloads/QDS/deploy.ps1
+++ b/Workbooks/Workloads/QDS/deploy.ps1
@@ -1,0 +1,22 @@
+﻿param(
+[Parameter(Mandatory=$true)]
+[string]$storageRG,
+[Parameter(Mandatory=$true)]
+[string]$storageName,
+[Parameter(Mandatory=$true)]
+[string]$storageContainer,
+[Parameter(Mandatory=$true)]
+[string]$deploymentRG,
+[string]$templatesLocation = (Get-Location)
+)
+
+Set-Location $templatesLocation
+
+$sa = Get-AzStorageAccount -ResourceGroupName $storageRG -Name $storageName
+Get-ChildItem -Filter "*.json" | Set-AzStorageBlobContent -Container $storageContainer -Context ($sa.Context) -Force
+$mainTemplateLink = (Get-AzStorageBlob -Context $sa.Context -Container $storageContainer -Blob 'deploy.json').ICloudBlob.uri.AbsoluteUri
+
+#-ApiVersion '2020-06-01' `
+New-AzResourceGroupDeployment -ResourceGroupName $deploymentRG `
+    -TemplateUri $mainTemplateLink `
+    -storageLink (Get-AzStorageContainer -Name $storageContainer -Context $sa.Context).CloudBlobContainer.StorageUri.PrimaryUri.AbsoluteUri


### PR DESCRIPTION
The PR contains a set of workbooks for visualizing data related to SQL Server **Query Store**. Currently supported Sql Server types are **Azure SQL DB** and **Azure SQL Managed Instance**.
In order to deploy the workbooks execute powershell script deploy.ps1. The script accepts the following parameters:

- **storageName** - name of a storage account used for temporary storage of workbook files during deployment
- **storageContainer** - name of the container used for temporary storage of workbook files during deployment
- **storageRG** - name of Resource Group which contains Storage Account storageName
- **deploymentRG** - target Resource Group name where the workbooks should be deployed
- **templatesLocation** - path to a folder on a local disk where workbook files are located
