### PR TITLE
Change aggregation type to max for used memory

### DIFF
--- a/Workbooks/RedisCache/AtResource/ResourceInsights.workbook
+++ b/Workbooks/RedisCache/AtResource/ResourceInsights.workbook
@@ -353,53 +353,53 @@
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--usedmemory0",
-                  "aggregation": 1,
+                  "aggregation": 3,
                   "splitBy": null
                 },
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--usedmemory1",
-                  "aggregation": 1
+                  "aggregation": 3
                 },
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--usedmemory2",
-                  "aggregation": 1
+                  "aggregation": 3
                 },
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--usedmemory3",
-                  "aggregation": 1
+                  "aggregation": 3
                 },
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--usedmemory4",
-                  "aggregation": 1
+                  "aggregation": 3
                 },
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--usedmemory5",
-                  "aggregation": 1
+                  "aggregation": 3
                 },
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--usedmemory6",
-                  "aggregation": 1
+                  "aggregation": 3
                 },
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--usedmemory7",
-                  "aggregation": 1
+                  "aggregation": 3
                 },
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--usedmemory8",
-                  "aggregation": 1
+                  "aggregation": 3
                 },
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--usedmemory9",
-                  "aggregation": 1
+                  "aggregation": 3
                 }
               ],
               "title": "Used Memory",

--- a/Workbooks/Resource Insights/RedisCache/ResourceInsights.workbook
+++ b/Workbooks/Resource Insights/RedisCache/ResourceInsights.workbook
@@ -353,53 +353,53 @@
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--usedmemory0",
-                  "aggregation": 1,
+                  "aggregation": 3,
                   "splitBy": null
                 },
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--usedmemory1",
-                  "aggregation": 1
+                  "aggregation": 3
                 },
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--usedmemory2",
-                  "aggregation": 1
+                  "aggregation": 3
                 },
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--usedmemory3",
-                  "aggregation": 1
+                  "aggregation": 3
                 },
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--usedmemory4",
-                  "aggregation": 1
+                  "aggregation": 3
                 },
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--usedmemory5",
-                  "aggregation": 1
+                  "aggregation": 3
                 },
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--usedmemory6",
-                  "aggregation": 1
+                  "aggregation": 3
                 },
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--usedmemory7",
-                  "aggregation": 1
+                  "aggregation": 3
                 },
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--usedmemory8",
-                  "aggregation": 1
+                  "aggregation": 3
                 },
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--usedmemory9",
-                  "aggregation": 1
+                  "aggregation": 3
                 }
               ],
               "title": "Used Memory",


### PR DESCRIPTION
Because the Azure Cache for Redis used memory metrics track single
values over time, aggregating by sum resulted in graphs that showed
higher than expected values for time granularities larger than 1 minute.
For example, if the used memory for a cache was constant at 100 MB, the
graph showed a value of 200 MB when set to a time granularity of 1
minute and 1 GB when set to a time granularity of 5 minutes.

To solve this issue, change the aggregation type from sum to max. This
results in graphs that show the expected values for all time
granularities. It also aligns the workbook with the at-scale workbook
and the Overview section of Azure Cache for Redis resources in the Azure
portal, which both already aggregate used memory by max.

At the moment, some places in the Azure portal still link to the
workbook via the old Workbooks/Resource Insights path, so apply the
change under both the old path and the new path.

## PR Checklist

* [x] Explain your changes, so people looking at the PR know *what* and *why*, the code changes are the *how*.

### If adding or updating templates:
* [x] post a screenshot of templates and/or gallery changes
  | Before | After |
  | :------: | :-----: |
  | ![image](https://user-images.githubusercontent.com/4934473/126566034-69e415dc-34c0-4017-82a5-ccc32274a4c8.png) | ![image](https://user-images.githubusercontent.com/4934473/126566147-5ce51644-f764-4108-b50e-4e3cab2aed9a.png) |
* [x] ensure your template has a corresponding gallery entry in the gallery folder
  * N/A, no changes
* [x] If you are adding a new template, add your team and template/gallery file(s) to the CODEOWNERS file. CODEOWNERS entries should be teams, not individuals
  * N/A, no changes
* [x] ensure all steps have meaningful names
  * N/A, no changes
* [x] ensure all parameters and grid columns have display names set so they can be localized
  * N/A, no changes
* [x] ensure that parameters id values are unique __or they will fail PR validation__ (parameter ids are used for localization)
  * N/A, no changes
* [x] ensure that steps names are unique __or they will fail PR validation__ (step names are used for localization)
  * N/A, no changes
* [x] grep `/subscription/` and ensure that your parameters don't have any hardcoded resourceIds __or they will fail PR validation__
  * N/A, no changes
* [x] remove `fallbackResourceIds` and `fromTemplateId` fields from your template workbook __or they will fail PR validation__
  * N/A, no changes