### PR TITLE
Change aggregation types for RedisCache metrics

### DIFF
--- a/Workbooks/RedisCache/AtResource/ResourceInsights.workbook
+++ b/Workbooks/RedisCache/AtResource/ResourceInsights.workbook
@@ -150,37 +150,41 @@
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--serverLoad",
-                  "aggregation": 3
+                  "aggregation": 3,
+                  "columnName": "Server Load (Max)"
                 },
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--percentProcessorTime",
-                  "aggregation": 3
+                  "aggregation": 3,
+                  "columnName": "CPU (Max)"
                 },
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--usedmemory",
-                  "aggregation": 3
+                  "aggregation": 3,
+                  "columnName": "Used Memory (Max)"
                 },
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--connectedclients",
-                  "aggregation": 3
+                  "aggregation": 3,
+                  "columnName": "Connected Clients (Max)"
                 },
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--errors",
-                  "aggregation": 4
+                  "aggregation": 1
                 },
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--expiredkeys",
-                  "aggregation": 3
+                  "aggregation": 1
                 },
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--evictedkeys",
-                  "aggregation": 3
+                  "aggregation": 1
                 }
               ],
               "gridFormatType": 1,
@@ -233,8 +237,9 @@
               "resourceIds": [
                 "{Resource}"
               ],
+              "timeContextFromParameter": "TimeRange",
               "timeContext": {
-                "durationMs": 14400000
+                "durationMs": 0
               },
               "metrics": [
                 {
@@ -267,8 +272,9 @@
               "resourceIds": [
                 "{Resource}"
               ],
+              "timeContextFromParameter": "TimeRange",
               "timeContext": {
-                "durationMs": 14400000
+                "durationMs": 0
               },
               "metrics": [
                 {
@@ -346,8 +352,9 @@
               "resourceIds": [
                 "{Resource}"
               ],
+              "timeContextFromParameter": "TimeRange",
               "timeContext": {
-                "durationMs": 14400000
+                "durationMs": 0
               },
               "metrics": [
                 {
@@ -433,7 +440,7 @@
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--connectedclients",
-                  "aggregation": 1,
+                  "aggregation": 3,
                   "splitBy": null
                 }
               ],
@@ -582,7 +589,7 @@
               ],
               "timeContextFromParameter": "TimeRange",
               "timeContext": {
-                "durationMs": 14400000
+                "durationMs": 0
               },
               "metrics": [
                 {
@@ -598,12 +605,14 @@
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--cacheWrite",
-                  "aggregation": 1
+                  "aggregation": 3,
+                  "columnName": "Cache Write (Max)"
                 },
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--cacheRead",
-                  "aggregation": 7
+                  "aggregation": 3,
+                  "columnName": "Cache Read (Max)"
                 },
                 {
                   "namespace": "microsoft.cache/redis",
@@ -663,20 +672,21 @@
               "resourceIds": [
                 "{Resource}"
               ],
+              "timeContextFromParameter": "TimeRange",
               "timeContext": {
-                "durationMs": 14400000
+                "durationMs": 0
               },
               "metrics": [
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--cacheRead",
-                  "aggregation": 1,
+                  "aggregation": 3,
                   "splitBy": null
                 },
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--cacheWrite",
-                  "aggregation": 1
+                  "aggregation": 3
                 }
               ],
               "title": "Cache Read and Write",
@@ -702,8 +712,9 @@
               "resourceIds": [
                 "{Resource}"
               ],
+              "timeContextFromParameter": "TimeRange",
               "timeContext": {
-                "durationMs": 14400000
+                "durationMs": 0
               },
               "metrics": [
                 {
@@ -743,7 +754,7 @@
               ],
               "timeContextFromParameter": "TimeRange",
               "timeContext": {
-                "durationMs": 14400000
+                "durationMs": 0
               },
               "metrics": [
                 {
@@ -823,7 +834,7 @@
               ],
               "timeContextFromParameter": "TimeRange",
               "timeContext": {
-                "durationMs": 14400000
+                "durationMs": 0
               },
               "metrics": [
                 {
@@ -903,44 +914,44 @@
               ],
               "timeContextFromParameter": "TimeRange",
               "timeContext": {
-                "durationMs": 14400000
+                "durationMs": 0
               },
               "metrics": [
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--cacheRead0",
-                  "aggregation": 1,
+                  "aggregation": 3,
                   "splitBy": null
                 },
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--cacheRead1",
-                  "aggregation": 1
+                  "aggregation": 3
                 },
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--cacheRead2",
-                  "aggregation": 1
+                  "aggregation": 3
                 },
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--cacheRead3",
-                  "aggregation": 1
+                  "aggregation": 3
                 },
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--cacheRead4",
-                  "aggregation": 1
+                  "aggregation": 3
                 },
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--cacheRead5",
-                  "aggregation": 1
+                  "aggregation": 3
                 },
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--cacheRead6",
-                  "aggregation": 1
+                  "aggregation": 3
                 },
                 {
                   "namespace": "microsoft.cache/redis",
@@ -950,12 +961,12 @@
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--cacheRead8",
-                  "aggregation": 1
+                  "aggregation": 3
                 },
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--cacheRead9",
-                  "aggregation": 1
+                  "aggregation": 3
                 }
               ],
               "title": "Cache Reads",
@@ -983,44 +994,44 @@
               ],
               "timeContextFromParameter": "TimeRange",
               "timeContext": {
-                "durationMs": 14400000
+                "durationMs": 0
               },
               "metrics": [
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--cacheWrite0",
-                  "aggregation": 1,
+                  "aggregation": 3,
                   "splitBy": null
                 },
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--cacheWrite1",
-                  "aggregation": 1
+                  "aggregation": 3
                 },
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--cacheWrite2",
-                  "aggregation": 1
+                  "aggregation": 3
                 },
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--cacheWrite3",
-                  "aggregation": 1
+                  "aggregation": 3
                 },
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--cacheWrite4",
-                  "aggregation": 1
+                  "aggregation": 3
                 },
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--cacheWrite5",
-                  "aggregation": 1
+                  "aggregation": 3
                 },
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--cacheWrite6",
-                  "aggregation": 1
+                  "aggregation": 3
                 },
                 {
                   "namespace": "microsoft.cache/redis",
@@ -1030,12 +1041,12 @@
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--cacheWrite8",
-                  "aggregation": 1
+                  "aggregation": 3
                 },
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--cacheWrite9",
-                  "aggregation": 1
+                  "aggregation": 3
                 }
               ],
               "title": "Cache Writes",
@@ -1078,7 +1089,7 @@
               ],
               "timeContextFromParameter": "TimeRange",
               "timeContext": {
-                "durationMs": 14400000
+                "durationMs": 0
               },
               "metrics": [
                 {
@@ -1089,7 +1100,8 @@
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--operationsPerSecond",
-                  "aggregation": 1
+                  "aggregation": 3,
+                  "columnName": "Ops Per Second (Max)"
                 },
                 {
                   "namespace": "microsoft.cache/redis",
@@ -1154,7 +1166,7 @@
               ],
               "timeContextFromParameter": "TimeRange",
               "timeContext": {
-                "durationMs": 14400000
+                "durationMs": 0
               },
               "metrics": [
                 {
@@ -1234,59 +1246,59 @@
               ],
               "timeContextFromParameter": "TimeRange",
               "timeContext": {
-                "durationMs": 14400000
+                "durationMs": 0
               },
               "metrics": [
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--operationsPerSecond0",
-                  "aggregation": 1,
+                  "aggregation": 3,
                   "splitBy": null
                 },
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--operationsPerSecond1",
-                  "aggregation": 1
+                  "aggregation": 3
                 },
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--operationsPerSecond2",
-                  "aggregation": 1
+                  "aggregation": 3
                 },
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--operationsPerSecond3",
-                  "aggregation": 1
+                  "aggregation": 3
                 },
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--operationsPerSecond4",
-                  "aggregation": 1
+                  "aggregation": 3
                 },
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--operationsPerSecond5",
-                  "aggregation": 1
+                  "aggregation": 3
                 },
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--operationsPerSecond6",
-                  "aggregation": 1
+                  "aggregation": 3
                 },
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--operationsPerSecond7",
-                  "aggregation": 1
+                  "aggregation": 3
                 },
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--operationsPerSecond8",
-                  "aggregation": 1
+                  "aggregation": 3
                 },
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--operationsPerSecond9",
-                  "aggregation": 1
+                  "aggregation": 3
                 }
               ],
               "title": "Operation Rate",
@@ -1314,7 +1326,7 @@
               ],
               "timeContextFromParameter": "TimeRange",
               "timeContext": {
-                "durationMs": 14400000
+                "durationMs": 0
               },
               "metrics": [
                 {
@@ -1394,7 +1406,7 @@
               ],
               "timeContextFromParameter": "TimeRange",
               "timeContext": {
-                "durationMs": 14400000
+                "durationMs": 0
               },
               "metrics": [
                 {

--- a/Workbooks/Resource Insights/RedisCache/ResourceInsights.workbook
+++ b/Workbooks/Resource Insights/RedisCache/ResourceInsights.workbook
@@ -150,37 +150,41 @@
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--serverLoad",
-                  "aggregation": 3
+                  "aggregation": 3,
+                  "columnName": "Server Load (Max)"
                 },
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--percentProcessorTime",
-                  "aggregation": 3
+                  "aggregation": 3,
+                  "columnName": "CPU (Max)"
                 },
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--usedmemory",
-                  "aggregation": 3
+                  "aggregation": 3,
+                  "columnName": "Used Memory (Max)"
                 },
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--connectedclients",
-                  "aggregation": 3
+                  "aggregation": 3,
+                  "columnName": "Connected Clients (Max)"
                 },
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--errors",
-                  "aggregation": 4
+                  "aggregation": 1
                 },
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--expiredkeys",
-                  "aggregation": 3
+                  "aggregation": 1
                 },
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--evictedkeys",
-                  "aggregation": 3
+                  "aggregation": 1
                 }
               ],
               "gridFormatType": 1,
@@ -233,8 +237,9 @@
               "resourceIds": [
                 "{Resource}"
               ],
+              "timeContextFromParameter": "TimeRange",
               "timeContext": {
-                "durationMs": 14400000
+                "durationMs": 0
               },
               "metrics": [
                 {
@@ -267,8 +272,9 @@
               "resourceIds": [
                 "{Resource}"
               ],
+              "timeContextFromParameter": "TimeRange",
               "timeContext": {
-                "durationMs": 14400000
+                "durationMs": 0
               },
               "metrics": [
                 {
@@ -346,8 +352,9 @@
               "resourceIds": [
                 "{Resource}"
               ],
+              "timeContextFromParameter": "TimeRange",
               "timeContext": {
-                "durationMs": 14400000
+                "durationMs": 0
               },
               "metrics": [
                 {
@@ -433,7 +440,7 @@
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--connectedclients",
-                  "aggregation": 1,
+                  "aggregation": 3,
                   "splitBy": null
                 }
               ],
@@ -582,7 +589,7 @@
               ],
               "timeContextFromParameter": "TimeRange",
               "timeContext": {
-                "durationMs": 14400000
+                "durationMs": 0
               },
               "metrics": [
                 {
@@ -598,12 +605,14 @@
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--cacheWrite",
-                  "aggregation": 1
+                  "aggregation": 3,
+                  "columnName": "Cache Write (Max)"
                 },
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--cacheRead",
-                  "aggregation": 7
+                  "aggregation": 3,
+                  "columnName": "Cache Read (Max)"
                 },
                 {
                   "namespace": "microsoft.cache/redis",
@@ -663,20 +672,21 @@
               "resourceIds": [
                 "{Resource}"
               ],
+              "timeContextFromParameter": "TimeRange",
               "timeContext": {
-                "durationMs": 14400000
+                "durationMs": 0
               },
               "metrics": [
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--cacheRead",
-                  "aggregation": 1,
+                  "aggregation": 3,
                   "splitBy": null
                 },
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--cacheWrite",
-                  "aggregation": 1
+                  "aggregation": 3
                 }
               ],
               "title": "Cache Read and Write",
@@ -702,8 +712,9 @@
               "resourceIds": [
                 "{Resource}"
               ],
+              "timeContextFromParameter": "TimeRange",
               "timeContext": {
-                "durationMs": 14400000
+                "durationMs": 0
               },
               "metrics": [
                 {
@@ -743,7 +754,7 @@
               ],
               "timeContextFromParameter": "TimeRange",
               "timeContext": {
-                "durationMs": 14400000
+                "durationMs": 0
               },
               "metrics": [
                 {
@@ -823,7 +834,7 @@
               ],
               "timeContextFromParameter": "TimeRange",
               "timeContext": {
-                "durationMs": 14400000
+                "durationMs": 0
               },
               "metrics": [
                 {
@@ -903,44 +914,44 @@
               ],
               "timeContextFromParameter": "TimeRange",
               "timeContext": {
-                "durationMs": 14400000
+                "durationMs": 0
               },
               "metrics": [
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--cacheRead0",
-                  "aggregation": 1,
+                  "aggregation": 3,
                   "splitBy": null
                 },
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--cacheRead1",
-                  "aggregation": 1
+                  "aggregation": 3
                 },
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--cacheRead2",
-                  "aggregation": 1
+                  "aggregation": 3
                 },
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--cacheRead3",
-                  "aggregation": 1
+                  "aggregation": 3
                 },
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--cacheRead4",
-                  "aggregation": 1
+                  "aggregation": 3
                 },
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--cacheRead5",
-                  "aggregation": 1
+                  "aggregation": 3
                 },
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--cacheRead6",
-                  "aggregation": 1
+                  "aggregation": 3
                 },
                 {
                   "namespace": "microsoft.cache/redis",
@@ -950,12 +961,12 @@
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--cacheRead8",
-                  "aggregation": 1
+                  "aggregation": 3
                 },
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--cacheRead9",
-                  "aggregation": 1
+                  "aggregation": 3
                 }
               ],
               "title": "Cache Reads",
@@ -983,44 +994,44 @@
               ],
               "timeContextFromParameter": "TimeRange",
               "timeContext": {
-                "durationMs": 14400000
+                "durationMs": 0
               },
               "metrics": [
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--cacheWrite0",
-                  "aggregation": 1,
+                  "aggregation": 3,
                   "splitBy": null
                 },
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--cacheWrite1",
-                  "aggregation": 1
+                  "aggregation": 3
                 },
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--cacheWrite2",
-                  "aggregation": 1
+                  "aggregation": 3
                 },
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--cacheWrite3",
-                  "aggregation": 1
+                  "aggregation": 3
                 },
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--cacheWrite4",
-                  "aggregation": 1
+                  "aggregation": 3
                 },
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--cacheWrite5",
-                  "aggregation": 1
+                  "aggregation": 3
                 },
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--cacheWrite6",
-                  "aggregation": 1
+                  "aggregation": 3
                 },
                 {
                   "namespace": "microsoft.cache/redis",
@@ -1030,12 +1041,12 @@
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--cacheWrite8",
-                  "aggregation": 1
+                  "aggregation": 3
                 },
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--cacheWrite9",
-                  "aggregation": 1
+                  "aggregation": 3
                 }
               ],
               "title": "Cache Writes",
@@ -1078,7 +1089,7 @@
               ],
               "timeContextFromParameter": "TimeRange",
               "timeContext": {
-                "durationMs": 14400000
+                "durationMs": 0
               },
               "metrics": [
                 {
@@ -1089,7 +1100,8 @@
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--operationsPerSecond",
-                  "aggregation": 1
+                  "aggregation": 3,
+                  "columnName": "Ops Per Second (Max)"
                 },
                 {
                   "namespace": "microsoft.cache/redis",
@@ -1154,7 +1166,7 @@
               ],
               "timeContextFromParameter": "TimeRange",
               "timeContext": {
-                "durationMs": 14400000
+                "durationMs": 0
               },
               "metrics": [
                 {
@@ -1234,59 +1246,59 @@
               ],
               "timeContextFromParameter": "TimeRange",
               "timeContext": {
-                "durationMs": 14400000
+                "durationMs": 0
               },
               "metrics": [
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--operationsPerSecond0",
-                  "aggregation": 1,
+                  "aggregation": 3,
                   "splitBy": null
                 },
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--operationsPerSecond1",
-                  "aggregation": 1
+                  "aggregation": 3
                 },
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--operationsPerSecond2",
-                  "aggregation": 1
+                  "aggregation": 3
                 },
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--operationsPerSecond3",
-                  "aggregation": 1
+                  "aggregation": 3
                 },
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--operationsPerSecond4",
-                  "aggregation": 1
+                  "aggregation": 3
                 },
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--operationsPerSecond5",
-                  "aggregation": 1
+                  "aggregation": 3
                 },
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--operationsPerSecond6",
-                  "aggregation": 1
+                  "aggregation": 3
                 },
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--operationsPerSecond7",
-                  "aggregation": 1
+                  "aggregation": 3
                 },
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--operationsPerSecond8",
-                  "aggregation": 1
+                  "aggregation": 3
                 },
                 {
                   "namespace": "microsoft.cache/redis",
                   "metric": "microsoft.cache/redis--operationsPerSecond9",
-                  "aggregation": 1
+                  "aggregation": 3
                 }
               ],
               "title": "Operation Rate",
@@ -1314,7 +1326,7 @@
               ],
               "timeContextFromParameter": "TimeRange",
               "timeContext": {
-                "durationMs": 14400000
+                "durationMs": 0
               },
               "metrics": [
                 {
@@ -1394,7 +1406,7 @@
               ],
               "timeContextFromParameter": "TimeRange",
               "timeContext": {
-                "durationMs": 14400000
+                "durationMs": 0
               },
               "metrics": [
                 {


### PR DESCRIPTION
* Add display names for the server load, CPU, used memory, and connected
  clients tiles to indicate that they show max values.
* Change the tiles for errors, expired keys, and evicted keys to
  aggregate by sum to match the larger graphs for those metrics.
* Change the connected clients graph to aggregate by max instead of sum.
  Each connected clients data point records the total number of
  connected clients, not the change in number of connected clients, so
  aggregating by max or by average is typically the most useful option.
  Aggregating by max helps reveal temporary spikes of high activity.
* Change the graphs for cache read, cache write, and operations per
  second to aggregate by max instead of sum. Each of these metrics
  records values in units per second. Although it's tempting to
  aggregate by sum to try to get total numbers over larger time
  intervals, that doesn't quite work because the metrics are updated
  more often than once per second. Instead, aggregate by max to help
  reveal temporary spikes, like for connected clients.
* Change the tiles for the cache read, cache write, operations per
  second metrics to aggregate by max as well, and update the
  corresponding display names.
* Standardize all of the graphs to use the `TimeRange` parameter for the
  time context so that setting the parameter will update all of the
  graphs.

Like in commit f7bde430, apply the changes under both the old and new
path for the workbook.

## PR Checklist

* [x] Explain your changes, so people looking at the PR know *what* and *why*, the code changes are the *how*.

### If adding or updating templates:
* [x] post a screenshot of templates and/or gallery changes
  
  **Overview**
  | Before | After |
  | :------: | :-----: |
  | ![overview-before](https://user-images.githubusercontent.com/4934473/126734237-c36d6ab5-c5f5-483f-80a4-b33059389b3e.png) | ![overview-after](https://user-images.githubusercontent.com/4934473/126734283-55208e2f-206c-4aca-b224-3fcba9784106.png) |

  **Performance**
  | Before | After |
  | :------: | :-----: |
  | ![performance-before](https://user-images.githubusercontent.com/4934473/126734342-5bc71801-c2be-4cd1-9709-16982df57072.png) | ![performance-after](https://user-images.githubusercontent.com/4934473/126734336-9c2fabc5-83b6-4643-8709-29dbde4b7b68.png) |

  **Operations**
  | Before | After |
  | :------: | :-----: |
  | ![operations-before](https://user-images.githubusercontent.com/4934473/126734353-ab0f8949-7264-41a3-bae2-e93b394f7a9e.png) | ![operations-after](https://user-images.githubusercontent.com/4934473/126734257-b22ee5a2-2387-463a-846a-c44cd26aa4b5.png) |

* [x] ensure your template has a corresponding gallery entry in the gallery folder
  * N/A, no changes
* [x] If you are adding a new template, add your team and template/gallery file(s) to the CODEOWNERS file. CODEOWNERS entries should be teams, not individuals
  * N/A, no changes
* [x] ensure all steps have meaningful names
  * N/A, no changes
* [x] ensure all parameters and grid columns have display names set so they can be localized
  * This PR makes a few small adjustments to add the aggregation type "(Max)" in the display name of some of the tile grid columns.
* [x] ensure that parameters id values are unique __or they will fail PR validation__ (parameter ids are used for localization)
  * N/A, no changes
* [x] ensure that steps names are unique __or they will fail PR validation__ (step names are used for localization)
  * N/A, no changes
* [x] grep `/subscription/` and ensure that your parameters don't have any hardcoded resourceIds __or they will fail PR validation__
  * N/A, no changes
* [x] remove `fallbackResourceIds` and `fromTemplateId` fields from your template workbook __or they will fail PR validation__
  * N/A, no changes