### PR TITLE
try to get github to detect workbook and cohort files as json

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
-*.workbook linguist-detectable
+*.workbook linguist-detectable=true
 *.workbook linguist-language=JSON
-*.cohort linguist-detectable
+*.cohort linguist-detectable=true
 *.cohort linguist-language=JSON


### PR DESCRIPTION
try to get github to detect workbook and cohort files as json.

i see they had `linquist-detectable` but not `=true` ?

maybe that's why this isn't working?