### PR TITLE
fix query returning old data 

### DIFF
--- a/Workbooks/SapMonitor/PrometheusOS/PrometheusOS.workbook
+++ b/Workbooks/SapMonitor/PrometheusOS/PrometheusOS.workbook
@@ -98,7 +98,7 @@
                         "name": "instance",
                         "type": 1,
                         "description": "Contains the Ip:port for the selected hostname",
-                        "query": "Prometheus_OSExporter_CL\r\n|where name_s == \"node_uname_info\"\r\n|extend hostname = parse_json(labels_s).nodename\r\n|where hostname == '{hostname}'\r\n|order by TimeGenerated desc\r\n|distinct instance_s",
+                        "query": "Prometheus_OSExporter_CL\r\n|where name_s == \"node_uname_info\"\r\n|extend hostname = parse_json(labels_s).nodename\r\n|where hostname == '{hostname}'\r\n|order by TimeGenerated desc\r\n| summarize arg_max(TimeGenerated,instance_s)\r\n| project instance_s",
                         "isHiddenWhenLocked": true,
                         "queryType": 0,
                         "resourceType": "microsoft.operationalinsights/workspaces"


### PR DESCRIPTION
## PR Checklist

* [ * ] Explain your changes, so people looking at the PR know *what* and *why*, the code changes are the *how*.
This change was required because of the change in the instance_s field.  It used to be (incorrectly) the IP address of the node, but is now the name of the provider instance.  Unfortunately this caused a problem with existing log analytics instances, that there would be old data as well as new data.  This change simply refines the query to take the newest data.  There should be no visible change to the workbook.

### If adding or updating templates:
* [ ] post a screenshot of templates and/or gallery changes
* [ ] ensure your template has a corresponding gallery entry in the gallery folder
* [ ] If you are adding a new template, add your team and template/gallery file(s) to the CODEOWNERS file. CODEOWNERS entries should be teams, not individuals
* [ ] ensure all steps have meaningful names
* [ ] ensure all parameters and grid columns have display names set so they can be localized
* [ ] ensure that parameters id values are unique __or they will fail PR validation__ (parameter ids are used for localization)
* [ ] ensure that steps names are unique __or they will fail PR validation__ (step names are used for localization)
* [ ] grep `/subscription/` and ensure that your parameters don't have any hardcoded resourceIds __or they will fail PR validation__
* [ ] remove `fallbackResourceIds` and `fromTemplateId` fields from your template workbook __or they will fail PR validation__