### PR TITLE
Enabling creating monitoring profile in all regions DCR is supported in.

### DIFF
--- a/Workbooks/Workloads/SQL/Create new profile/Create new profile.workbook
+++ b/Workbooks/Workloads/SQL/Create new profile/Create new profile.workbook
@@ -105,20 +105,6 @@
             }
           },
           {
-            "id": "77c2a6cf-83ad-48ea-87a0-37a59bbb1fd0",
-            "version": "KqlParameterItem/1.0",
-            "name": "ProfileLocation",
-            "label": "Profile Location",
-            "type": 8,
-            "isRequired": true,
-            "value": null,
-            "typeSettings": {
-              "additionalResourceOptions": [],
-              "showDefault": false
-            },
-            "jsonData": "[\r\n\"australiacentral\",\r\n\"australiasoutheast\",\r\n\"canadacentral\",\r\n\"centralindia\",\r\n\"centralus\",\r\n\"eastasia\",\r\n\"eastus\",\r\n\"eastus2\",\r\n\"francecentral\",\r\n\"germanywestcentral\",\r\n\"japaneast\",\r\n\"koreacentral\",\r\n\"northcentralus\",\r\n\"northeurope\",\r\n\"southafricanorth\",\r\n\"southcentralus\",\r\n\"southeastasia\",\r\n\"switzerlandnorth\",\r\n\"uksouth\",\r\n\"ukwest\",\r\n\"westcentralus\",\r\n\"westeurope\",\r\n\"westus\",\r\n\"westus2\",\r\n\"australiaeast\"\r\n]"
-          },
-          {
             "id": "350cc656-5650-4941-b6c4-455e37f6355c",
             "version": "KqlParameterItem/1.0",
             "name": "InsightTag",
@@ -155,6 +141,14 @@
       },
       "customWidth": "60",
       "name": "Profile parameters"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "Profile will be created in the same location where the Log Analytics workspace is.",
+        "style": "info"
+      },
+      "name": "text - 14"
     },
     {
       "type": 1,
@@ -202,7 +196,7 @@
             "type": 5,
             "description": "Set the workspace to send SQL monitoring data to. This list is limited to the workspaces in the location of the SQL monitoring profile",
             "isRequired": true,
-            "query": "Resources\n| where type =~ 'microsoft.operationalinsights/workspaces' and location == '{ProfileLocation}'\n| order by resourceGroup asc, name asc\n| project value = id, label = id, selected = false, group = resourceGroup",
+            "query": "Resources\n| where type =~ 'microsoft.operationalinsights/workspaces' \n| order by resourceGroup asc, name asc\n| project value = id, label = id, selected = false, group = resourceGroup",
             "crossComponentResources": [
               "{WorkspaceSubscription}"
             ],
@@ -218,8 +212,25 @@
               "durationMs": 86400000
             },
             "queryType": 1,
-            "resourceType": "microsoft.resourcegraph/resources",
-            "id": "cb72ee5a-3d03-4b18-80ac-6e9bc8859816"
+            "resourceType": "microsoft.resourcegraph/resources"
+          },
+          {
+            "id": "222c2f05-a2c7-4798-b95b-aa7fe1faf835",
+            "version": "KqlParameterItem/1.0",
+            "name": "ProfileLocation",
+            "label": "Profile Location",
+            "type": 1,
+            "isRequired": true,
+            "query": "Resources\r\n| where type =~ 'microsoft.operationalinsights/workspaces' and id == '{Workspace}'\r\n| project location",
+            "crossComponentResources": [
+              "{WorkspaceSubscription}"
+            ],
+            "isHiddenWhenLocked": true,
+            "timeContext": {
+              "durationMs": 86400000
+            },
+            "queryType": 1,
+            "resourceType": "microsoft.resourcegraph/resources"
           }
         ],
         "style": "formVertical",


### PR DESCRIPTION
## PR Checklist

The current region list for monitoring profile is static. DCR has become available in some regions that are not in the list. This PR ensures that DCR can be deployed to all the regions that it's supported in by doing the following:

1. Instead of asking users where the profile should be deployed to, we ask users to pick the LA workspace first.
2. With the LA workspace information we could fetch its location with ARM query and populate the profile location to be the same.
3. This doesn't change the existing behavior since customers can only pick LA workspace in the same profile location they've picked. Users can still pick a different LA workspace later with "Edit Profile"
4. DCR is supported in all regions LA workspace is supported in according to this - https://docs.microsoft.com/en-us/azure/azure-monitor/agents/data-collection-rule-overview

UI Changes:
1. Made profile location hidden
2. Added text to inform users that monitoring profile will be deployed to the same region where LA workspace is.
3. LA workspace list will show all the workspaces under the subscription as we don't filter on the location provided by users anymore.

* [x] Explain your changes, so people looking at the PR know *what* and *why*, the code changes are the *how*.

### If adding or updating templates:
* [x] post a screenshot of templates and/or gallery changes
* [x] ensure your template has a corresponding gallery entry in the gallery folder
* [ ] If you are adding a new template, add your team and template/gallery file(s) to the CODEOWNERS file. CODEOWNERS entries should be teams, not individuals
* [x] ensure all steps have meaningful names
* [x] ensure all parameters and grid columns have display names set so they can be localized
* [x] ensure that parameters id values are unique __or they will fail PR validation__ (parameter ids are used for localization)
* [x] ensure that steps names are unique __or they will fail PR validation__ (step names are used for localization)
* [x] grep `/subscription/` and ensure that your parameters don't have any hardcoded resourceIds __or they will fail PR validation__
* [x] remove `fallbackResourceIds` and `fromTemplateId` fields from your template workbook __or they will fail PR validation__
![image](https://user-images.githubusercontent.com/72472578/129784826-2287cbc9-9d3d-4276-8b92-c1517363e46a.png)
