### PR TITLE
fix sourceId, so recovered workbooks are linked to same resource as original

### DIFF
--- a/Documentation/LegacyAI/PrivateWorkbookConversion.workbook
+++ b/Documentation/LegacyAI/PrivateWorkbookConversion.workbook
@@ -58,7 +58,6 @@
             "defaultValue": "workbook"
           }
         ],
-        "style": "pills",
         "queryType": 1,
         "resourceType": "microsoft.resourcegraph/resources"
       },
@@ -75,7 +74,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "{\"version\":\"ARMEndpoint/1.0\",\"data\":null,\"headers\":[],\"method\":\"GETARRAY\",\"path\":\"/{Subscription}/resourceGroups/{ResourceGroup}/providers/microsoft.insights/myworkbooks\",\"urlParams\":[{\"key\":\"api-version\",\"value\":\"2020-10-20\"},{\"key\":\"category\",\"value\":\"{Category}\"}],\"batchDisabled\":false,\"transformers\":[{\"type\":\"jsonpath\",\"settings\":{\"tablePath\":\"$..[?(@.kind == \\\"user\\\")]\",\"columns\":[{\"path\":\"$.properties.displayName\",\"columnid\":\"name\"},{\"path\":\"$.name\",\"columnid\":\"id\"},{\"path\":\"$.kind\",\"columnid\":\"type\",\"columnType\":\"string\"},{\"path\":\"$.properties.timeModified\",\"columnid\":\"modified\",\"columnType\":\"datetime\"},{\"path\":\"$.id\",\"columnid\":\"resource\",\"columnType\":\"string\"}]}}]}",
+        "query": "{\"version\":\"ARMEndpoint/1.0\",\"data\":null,\"headers\":[],\"method\":\"GETARRAY\",\"path\":\"/{Subscription}/resourceGroups/{ResourceGroup}/providers/microsoft.insights/myworkbooks\",\"urlParams\":[{\"key\":\"api-version\",\"value\":\"2020-10-20\"},{\"key\":\"category\",\"value\":\"{Category}\"}],\"batchDisabled\":false,\"transformers\":[{\"type\":\"jsonpath\",\"settings\":{\"tablePath\":\"$..[?(@.kind == \\\"user\\\")]\",\"columns\":[{\"path\":\"$.properties.displayName\",\"columnid\":\"name\"},{\"path\":\"$.name\",\"columnid\":\"id\"},{\"path\":\"$.kind\",\"columnid\":\"type\",\"columnType\":\"string\"},{\"path\":\"$.properties.timeModified\",\"columnid\":\"modified\",\"columnType\":\"datetime\"},{\"path\":\"$.properties.sourceId\",\"columnid\":\"resource\",\"columnType\":\"string\"}]}}]}",
         "size": 1,
         "title": "Private Workbooks",
         "noDataMessage": "No private workbooks found",
@@ -101,24 +100,23 @@
           "formatters": [
             {
               "columnMatch": "resource",
-              "formatter": 5
+              "formatter": 13,
+              "formatOptions": {
+                "linkTarget": null,
+                "showIcon": true
+              }
             }
           ],
           "rowLimit": 1000,
           "filter": true,
-          "sortBy": [
+          "labelSettings": [
             {
-              "itemKey": "modified",
-              "sortOrder": 1
+              "columnId": "resource",
+              "label": "Linked To"
             }
           ]
         },
-        "sortBy": [
-          {
-            "itemKey": "modified",
-            "sortOrder": 1
-          }
-        ]
+        "sortBy": []
       },
       "name": "list private workbooks"
     },


### PR DESCRIPTION
Previous version was returning the workbook resource id of the private workbook being recovered, which by default then made a new workbook *linked to the old workbook* instead of linked to "Azure Monitor" or the resource the previous private workbook was linked to