### PR TITLE
Removed static region filters in query for monitoring vms

### DIFF
--- a/Workbooks/Workloads/SQL/Add monitoring virtual machine/Add monitoring virtual machine.workbook
+++ b/Workbooks/Workloads/SQL/Add monitoring virtual machine/Add monitoring virtual machine.workbook
@@ -86,7 +86,7 @@
             "label": "Virtual machine",
             "type": 5,
             "isRequired": true,
-            "query": "Resources\r\n| where type =~ 'microsoft.compute/virtualmachines' and location in (dynamic([ \"australiacentral\", \"australiaeast\", \"australiasoutheast\", \"canadacentral\", \"centralindia\", \"centralus\", \"eastasia\", \"eastus\", \"eastus2\", \"eastus2euap\", \"francecentral\", \"germanywestcentral\", \"japaneast\", \"koreacentral\", \"northcentralus\", \"northeurope\", \"southafricanorth\", \"southcentralus\", \"southeastasia\", \"switzerlandnorth\", \"uksouth\", \"ukwest\", \"westcentralus\", \"westeurope\", \"westus\", \"westus2\", \"australiaeast\"]))\r\n| where properties.storageProfile.osDisk.osType =~ 'Linux'\r\n| order by resourceGroup asc, name asc\r\n| project id\r\n",
+            "query": "Resources\r\n| where properties.storageProfile.osDisk.osType =~ 'Linux'\r\n| order by resourceGroup asc, name asc\r\n| project id\r\n",
             "crossComponentResources": [
               "{Subscription}"
             ],


### PR DESCRIPTION
## PR Checklist

* [x] Explain your changes, so people looking at the PR know *what* and *why*, the code changes are the *how*.
Remove the static region filter in the monitoring vm query in the "Add monitoring virtual machine workbook", so customers can choose monitoring vms from a broader list.

Gallery link: https://ms.portal.azure.com/?feature.includePreviewTemplates=true&feature.localtemplates=true&feature.workloadinsights=true&feature.workbookGalleryRedirect=https%3A%2F%2Freadablesecondaries.blob.core.windows.net%2Fazure-monitor-workbook-templates%2Fpackage#blade/Microsoft_Azure_Monitoring/AzureMonitoringBrowseBlade/sqlWorkloadInsights

### If adding or updating templates:
* [x] post a screenshot of templates and/or gallery changes
Monitoring vms in Brazil South and other regions are now available in the list.
![image](https://user-images.githubusercontent.com/72472578/135536525-af733d7c-ec6e-41ab-a6f8-beab72ba58fc.png)
* [x] ensure all steps have meaningful names
* [x] ensure all parameters and grid columns have display names set so they can be localized
* [x] ensure that parameters id values are unique __or they will fail PR validation__ (parameter ids are used for localization)
* [x] ensure that steps names are unique __or they will fail PR validation__ (step names are used for localization)
* [x] grep `/subscription/` and ensure that your parameters don't have any hardcoded resourceIds __or they will fail PR validation__
* [x] remove `fallbackResourceIds` and `fromTemplateId` fields from your template workbook __or they will fail PR validation__