### PR TITLE
Fixed queries in drill down sql server workbooks to use the time range parameter

### DIFF
--- a/Workbooks/Workloads/SQL/SQL Server/SQL Server.workbook
+++ b/Workbooks/Workloads/SQL/SQL Server/SQL Server.workbook
@@ -253,6 +253,7 @@
               "timeContext": {
                 "durationMs": 86400000
               },
+              "timeContextFromParameter": "TimeRange",
               "queryType": 0,
               "resourceType": "microsoft.operationalinsights/workspaces",
               "crossComponentResources": [
@@ -617,6 +618,7 @@
               "timeContext": {
                 "durationMs": 86400000
               },
+              "timeContextFromParameter": "TimeRange",
               "showExportToExcel": true,
               "queryType": 0,
               "resourceType": "microsoft.operationalinsights/workspaces",
@@ -654,6 +656,7 @@
               "timeContext": {
                 "durationMs": 86400000
               },
+              "timeContextFromParameter": "TimeRange",
               "showExportToExcel": true,
               "queryType": 0,
               "resourceType": "microsoft.operationalinsights/workspaces",
@@ -678,6 +681,7 @@
               "timeContext": {
                 "durationMs": 86400000
               },
+              "timeContextFromParameter": "TimeRange",
               "showExportToExcel": true,
               "queryType": 0,
               "resourceType": "microsoft.operationalinsights/workspaces",
@@ -714,6 +718,7 @@
               "timeContext": {
                 "durationMs": 86400000
               },
+              "timeContextFromParameter": "TimeRange",
               "showExportToExcel": true,
               "queryType": 0,
               "resourceType": "microsoft.operationalinsights/workspaces",
@@ -750,6 +755,7 @@
               "timeContext": {
                 "durationMs": 86400000
               },
+              "timeContextFromParameter": "TimeRange",
               "showExportToExcel": true,
               "queryType": 0,
               "resourceType": "microsoft.operationalinsights/workspaces",
@@ -786,6 +792,7 @@
               "timeContext": {
                 "durationMs": 86400000
               },
+              "timeContextFromParameter": "TimeRange",
               "showExportToExcel": true,
               "queryType": 0,
               "resourceType": "microsoft.operationalinsights/workspaces",
@@ -821,6 +828,7 @@
               "timeContext": {
                 "durationMs": 86400000
               },
+              "timeContextFromParameter": "TimeRange",
               "showExportToExcel": true,
               "queryType": 0,
               "resourceType": "microsoft.operationalinsights/workspaces",
@@ -2313,6 +2321,7 @@
               "timeContext": {
                 "durationMs": 86400000
               },
+              "timeContextFromParameter": "TimeRange",
               "showExportToExcel": true,
               "queryType": 0,
               "resourceType": "microsoft.operationalinsights/workspaces",


### PR DESCRIPTION
## PR Checklist

* [x] Explain your changes, so people looking at the PR know *what* and *why*, the code changes are the *how*.
Some queries in sql server workbook have fix time range regardless of what users select in the time range parameter. This PR fixes those queries to use the time range of users' selection.

### If adding or updating templates:
* [x] post a screenshot of templates and/or gallery changes
Before: the query only returns 1 day worth of data even though the time range is 3 days
![image](https://user-images.githubusercontent.com/72472578/135675375-0d773954-0fe0-42ae-bfb9-34aadbaa82a5.png)
After: the query now returns 3 days worth of data
![image](https://user-images.githubusercontent.com/72472578/135675472-d755203d-62ed-44a1-91a4-e189a004de33.png)

link to gallery: https://ms.portal.azure.com/?feature.includePreviewTemplates=true&feature.localtemplates=true&feature.workloadinsights=true&feature.workbookGalleryRedirect=https%3A%2F%2Freadablesecondaries.blob.core.windows.net%2Fazure-monitor-workbook-templates%2Fpackage#blade/Microsoft_Azure_Monitoring/AzureMonitoringBrowseBlade/sqlWorkloadInsights