### PR TITLE
fix a bug where trend tab is displayed first. Need to display results tab

### DIFF
--- a/Workbooks/Azure SQL VM/SQL Assessment/SQL Assessment.workbook
+++ b/Workbooks/Azure SQL VM/SQL Assessment/SQL Assessment.workbook
@@ -144,7 +144,7 @@
                         },
                         "queryType": 0,
                         "resourceType": "microsoft.operationalinsights/workspaces",
-                        "value": "3395d0c2-9657-4552-b0d6-fe7dc8e07987"
+                        "value": ""
                       },
                       {
                         "id": "0f3a2317-ef9d-4fe4-a163-db56ba444d69",


### PR DESCRIPTION
fix a bug where trend tab is displayed first. Need to display results tab

## PR Checklist

* [X] Explain your changes, so people looking at the PR know *what* and *why*, the code changes are the *how*.
* fix a bug where trend tab is displayed first. Need to display results tab

### If adding or updating templates:
* [X] post a screenshot of templates and/or gallery changes
![image](https://user-images.githubusercontent.com/53497183/137369706-9efa2f82-6569-43cb-9f78-caea706ecd7e.png)

* [X] ensure your template has a corresponding gallery entry in the gallery folder
* [X] grep `/subscription/` and ensure that your parameters don't have any hardcoded resourceIds __or they will fail PR validation__
* [X] remove `fallbackResourceIds` and `fromTemplateId` fields from your template workbook __or they will fail PR validation__