### PR TITLE
Enforcing usage of Key Vaults in Add/Update monitoring virtual machine workbooks.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -81,7 +81,7 @@
 
 /Workbooks/Azure*SQL*VM/** @microsoft/azuresqlvm-workbook
 
-/Workbooks/Workloads/SQL** @microsoft/sqlexternalmonitoring
+/Workbooks/Workloads/SQL/** @microsoft/sqlexternalmonitoring
 
 # Section for gallery files
 /gallery/workbook/WaaSUpdateInsights.json @microsoft/update-compliance-workbooks

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -81,6 +81,8 @@
 
 /Workbooks/Azure*SQL*VM/** @microsoft/azuresqlvm-workbook
 
+/Workbooks/Communication*Services/** @microsoft/acs-data
+
 /Workbooks/Workloads/SQL/** @microsoft/sqlexternalmonitoring
 
 # Section for gallery files
@@ -102,6 +104,8 @@
 /gallery/adxcluster-insights/microsoft.kusto-clusters.json @microsoft/kusto-workbooks
 /gallery/workbook/microsoft.dbformysql-flexibleservers.json @microsoft/azuremysql
 /gallery/laws-insights/Azure*Monitor.json @microsoft/loganalytics
+/gallery/communicationservices-insights/** @microsoft/acs-data
+/gallery/workbook/Microsoft.Communication-CommunicationServices.json @microsoft/acs-data
 
 # leave this at the bottom!
 # EVERYTHING ending with resjson* is for loc, and is owned by the workbooks team and the loc team

--- a/Workbooks/Workloads/SQL/Add monitoring virtual machine/Add monitoring virtual machine.workbook
+++ b/Workbooks/Workloads/SQL/Add monitoring virtual machine/Add monitoring virtual machine.workbook
@@ -502,7 +502,7 @@
           {
             "type": 1,
             "content": {
-              "json": "#### Enable access to Azure Key Vaults (Optional)\nIf your connection strings reference secrets from Key Vaults, you need to provide access to it from the virtual machine via a Managed Service Identity."
+              "json": "#### Enable access to Azure Key Vaults\nPlease provide access to the virtual machine from the Key Vaults referenced in the connection strings via Managed Service Identity."
             },
             "name": "Key vault access label"
           },
@@ -705,12 +705,52 @@
                 }
               ]
             },
-            "conditionalVisibility": {
-              "parameterName": "isFormValid",
-              "comparison": "isEqualTo",
-              "value": "true"
-            },
+            "conditionalVisibilities": [
+              {
+                "parameterName": "isFormValid",
+                "comparison": "isEqualTo",
+                "value": "true"
+              },
+              {
+                "parameterName": "KeyVaultSubscriptions",
+                "comparison": "isNotEqualTo"
+              },
+              {
+                "parameterName": "KeyVaults",
+                "comparison": "isNotEqualTo"
+              }
+            ],
             "name": "links - 5"
+          },
+          {
+            "type": 1,
+            "content": {
+              "json": "Please provide access to the Key Vaults",
+              "style": "error"
+            },
+            "conditionalVisibility": {
+              "parameterName": "KeyVaultSubscriptions",
+              "comparison": "isEqualTo"
+            },
+            "name": "text - 7"
+          },
+          {
+            "type": 1,
+            "content": {
+              "json": "Please provide access to the Key Vaults",
+              "style": "error"
+            },
+            "conditionalVisibilities": [
+              {
+                "parameterName": "KeyVaultSubscriptions",
+                "comparison": "isNotEqualTo"
+              },
+              {
+                "parameterName": "KeyVaults",
+                "comparison": "isEqualTo"
+              }
+            ],
+            "name": "text - 8"
           }
         ]
       },

--- a/Workbooks/Workloads/SQL/Add monitoring virtual machine/Add monitoring virtual machine.workbook
+++ b/Workbooks/Workloads/SQL/Add monitoring virtual machine/Add monitoring virtual machine.workbook
@@ -319,7 +319,7 @@
     {
       "type": 1,
       "content": {
-        "json": "Please configure using the template below.",
+        "json": "Please configure using the template below and reference passwords from Key Vaults.",
         "style": "info"
       },
       "conditionalVisibility": {

--- a/Workbooks/Workloads/SQL/Add monitoring virtual machine/Add monitoring virtual machine.workbook
+++ b/Workbooks/Workloads/SQL/Add monitoring virtual machine/Add monitoring virtual machine.workbook
@@ -331,7 +331,7 @@
     {
       "type": 1,
       "content": {
-        "json": "Please reference passwords from Key Vaults.",
+        "json": "Please reference passwords stored as Key Vault secrets.",
         "style": "info"
       },
       "name": "text - 11"
@@ -510,7 +510,7 @@
           {
             "type": 1,
             "content": {
-              "json": "#### Enable access to Azure Key Vaults\nPlease provide access to the virtual machine from the Key Vaults referenced in the connection strings via Managed Service Identity."
+              "json": "#### Enable access to Azure Key Vault\nUse Key Vault access policy to provide the Get Secret permission for all key vaults referenced in configuration. Permission must be provided to the Managed Service Identity of the monitoring virtual machine."
             },
             "name": "Key vault access label"
           },
@@ -733,7 +733,7 @@
           {
             "type": 1,
             "content": {
-              "json": "Please provide access to the Key Vaults",
+              "json": "Please provide access to Key Vault.",
               "style": "error"
             },
             "conditionalVisibility": {
@@ -745,7 +745,7 @@
           {
             "type": 1,
             "content": {
-              "json": "Please provide access to the Key Vaults",
+              "json": "Please provide access to Key Vault.",
               "style": "error"
             },
             "conditionalVisibilities": [

--- a/Workbooks/Workloads/SQL/Add monitoring virtual machine/Add monitoring virtual machine.workbook
+++ b/Workbooks/Workloads/SQL/Add monitoring virtual machine/Add monitoring virtual machine.workbook
@@ -319,7 +319,7 @@
     {
       "type": 1,
       "content": {
-        "json": "Please configure using the template below and reference passwords from Key Vaults.",
+        "json": "Please configure using the template below.",
         "style": "info"
       },
       "conditionalVisibility": {
@@ -327,6 +327,14 @@
         "comparison": "isEqualTo"
       },
       "name": "Saved config not found message"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "Please reference passwords from Key Vaults.",
+        "style": "info"
+      },
+      "name": "text - 11"
     },
     {
       "type": 9,

--- a/Workbooks/Workloads/Update monitoring vm config/Update monitoring vm config.workbook
+++ b/Workbooks/Workloads/Update monitoring vm config/Update monitoring vm config.workbook
@@ -280,7 +280,7 @@
     {
       "type": 1,
       "content": {
-        "json": "#### Enable access to Azure Key Vaults (Optional)\nIf your connection strings reference secrets from Key Vaults, you need to provide access to it from the virtual machine via a Managed Service Identity."
+        "json": "#### Enable access to Azure Key Vaults\nPlease provide access to the virtual machine from the Key Vaults referenced in the connection strings via Managed Service Identity."
       },
       "name": "Key vault access label"
     },
@@ -493,12 +493,52 @@
           }
         ]
       },
-      "conditionalVisibility": {
-        "parameterName": "isValidJson",
-        "comparison": "isEqualTo",
-        "value": "true"
-      },
+      "conditionalVisibilities": [
+        {
+          "parameterName": "isValidJson",
+          "comparison": "isEqualTo",
+          "value": "true"
+        },
+        {
+          "parameterName": "KeyVaultSubscriptions",
+          "comparison": "isNotEqualTo"
+        },
+        {
+          "parameterName": "KeyVaults",
+          "comparison": "isNotEqualTo"
+        }
+      ],
       "name": "Valid Form"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "Please provide access to the Key Vaults",
+        "style": "error"
+      },
+      "conditionalVisibility": {
+        "parameterName": "KeyVaultSubscriptions",
+        "comparison": "isEqualTo"
+      },
+      "name": "text - 14"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "Please provide access to the Key Vaults",
+        "style": "error"
+      },
+      "conditionalVisibilities": [
+        {
+          "parameterName": "KeyVaultSubscriptions",
+          "comparison": "isNotEqualTo"
+        },
+        {
+          "parameterName": "KeyVaults",
+          "comparison": "isEqualTo"
+        }
+      ],
+      "name": "text - 15"
     }
   ],
   "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"

--- a/Workbooks/Workloads/Update monitoring vm config/Update monitoring vm config.workbook
+++ b/Workbooks/Workloads/Update monitoring vm config/Update monitoring vm config.workbook
@@ -151,6 +151,14 @@
       "name": "Saved config not found message"
     },
     {
+      "type": 1,
+      "content": {
+        "json": "Please reference passwords from Key Vaults.",
+        "style": "info"
+      },
+      "name": "text - 16"
+    },
+    {
       "type": 9,
       "content": {
         "version": "KqlParameterItem/1.0",

--- a/Workbooks/Workloads/Update monitoring vm config/Update monitoring vm config.workbook
+++ b/Workbooks/Workloads/Update monitoring vm config/Update monitoring vm config.workbook
@@ -153,7 +153,7 @@
     {
       "type": 1,
       "content": {
-        "json": "Please reference passwords from Key Vaults.",
+        "json": "Please reference passwords stored as Key Vault secrets.",
         "style": "info"
       },
       "name": "text - 16"
@@ -288,7 +288,7 @@
     {
       "type": 1,
       "content": {
-        "json": "#### Enable access to Azure Key Vaults\nPlease provide access to the virtual machine from the Key Vaults referenced in the connection strings via Managed Service Identity."
+        "json": "#### Enable access to Azure Key Vault\nUse Key Vault access policy to provide the Get Secret permission for all key vaults referenced in configuration. Permission must be provided to the Managed Service Identity of the monitoring virtual machine."
       },
       "name": "Key vault access label"
     },
@@ -521,7 +521,7 @@
     {
       "type": 1,
       "content": {
-        "json": "Please provide access to the Key Vaults",
+        "json": "Please provide access to Key Vault.",
         "style": "error"
       },
       "conditionalVisibility": {
@@ -533,7 +533,7 @@
     {
       "type": 1,
       "content": {
-        "json": "Please provide access to the Key Vaults",
+        "json": "Please provide access to Key Vault.",
         "style": "error"
       },
       "conditionalVisibilities": [


### PR DESCRIPTION
## PR Checklist
Enforcing usage of Key Vaults in monitoring vm config related workbooks due to security concerns. With this update, users cannot add/update monitoring vm config without giving access to Key Vaults. Added an informational banner asking user to reference passwords from Key Vaults and two error banners when access is not provided.
* [x] Explain your changes, so people looking at the PR know *what* and *why*, the code changes are the *how*.

### If adding or updating templates:
* [x] post a screenshot of templates and/or gallery changes
* [x] ensure your template has a corresponding gallery entry in the gallery folder
* [x] grep `/subscription/` and ensure that your parameters don't have any hardcoded resourceIds __or they will fail PR validation__
* [x] remove `fallbackResourceIds` and `fromTemplateId` fields from your template workbook __or they will fail PR validation__
![image](https://user-images.githubusercontent.com/72472578/140404708-778a6db5-c242-470e-9495-1fae660fba9c.png)
![image](https://user-images.githubusercontent.com/72472578/140404818-a0cb6f24-12c7-4db5-a642-e1452692f1e4.png)
link to workbooks: https://ms.portal.azure.com/?feature.includePreviewTemplates=true&feature.localtemplates=true&feature.workloadinsights=true&feature.workbookGalleryRedirect=https%3A%2F%2Freadablesecondaries.blob.core.windows.net%2Fazure-monitor-workbook-templates%2Fpackage#blade/Microsoft_Azure_Monitoring/AzureMonitoringBrowseBlade/sqlWorkloadInsights
