### PR TITLE
Add active connection metric to chart in MySQL Overview Workbook

### DIFF
--- a/Workbooks/MySQL Flexible Server/Overview/Overview.workbook
+++ b/Workbooks/MySQL Flexible Server/Overview/Overview.workbook
@@ -334,7 +334,7 @@
           },
           {
             "namespace": "microsoft.dbformysql/flexibleservers",
-            "metric": "microsoft.dbformysql/flexibleservers-Traffic-total_connections",
+            "metric": "microsoft.dbformysql/flexibleservers-Traffic-active_connections",
             "aggregation": 1
           }
         ],


### PR DESCRIPTION
 Both the metrics were Total connection ... We needed to make one for active connections instead
![image](https://user-images.githubusercontent.com/69922333/140792804-54818f83-2162-4259-a589-085298b6e707.png)
