### PR TITLE
Localization locked strings script fix

### DIFF
--- a/scripts/extractStrings.js
+++ b/scripts/extractStrings.js
@@ -272,7 +272,7 @@ function findAndGenerateLockedStringComment(jsonKey, stringToLoc, outputMap) {
 
   if (params || columns) {
     const commentKey = "_" + jsonKey + ".comment";
-    const commentEntry = "{Locked=" + (params || []).join(",") + (params && columns ? "," : "") + (columns || []).join(",") + "}";
+    const commentEntry = "{Locked=\"" + (params || []).join(",") + (params && columns ? "," : "") + (columns || []).join(",") + "\"}";
     outputMap[commentKey] = commentEntry;
   }
 }

--- a/scripts/extractStrings.js
+++ b/scripts/extractStrings.js
@@ -272,7 +272,7 @@ function findAndGenerateLockedStringComment(jsonKey, stringToLoc, outputMap) {
 
   if (params || columns) {
     const commentKey = "_" + jsonKey + ".comment";
-    const commentEntry = "{Locked=\"" + (params || []).join(",") + (params && columns ? "," : "") + (columns || []).join(",") + "\"}";
+    const commentEntry = "{Locked=" + (params|| []).map(p => "\""  + p + "\"").join(",") + (params && columns ? "," : "") + (columns || []).map(c =>  "\""  + c + "\"").join(",") + "}";
     outputMap[commentKey] = commentEntry;
   }
 }


### PR DESCRIPTION
Fix locked strings in script, missing quotes around the locked string
Eg. Currently locked strings are reported as "{Locked={newIssuesCnt}}"
Correction: "{Locked="{newIssuesCnt}"}"