### PR TITLE
ACS Insights tab v2

### DIFF
--- a/Workbooks/Communication Services/Overview/Overview.workbook
+++ b/Workbooks/Communication Services/Overview/Overview.workbook
@@ -413,7 +413,7 @@
                       {
                         "type": 1,
                         "content": {
-                          "json": "Streams are classified as healthy if they exhibit telemetry values within the following ranges:\r\n\r\n- Round trip time under 500 miliseconds\r\n- Packet loss rate of less than 10%\r\n- Jitter under 30 miliseconds"
+                          "json": "Streams are classified as healthy if they exhibit telemetry values within the following ranges:\r\n\r\n- Round trip time under 500 milliseconds\r\n- Packet loss rate of less than 10%\r\n- Jitter under 30 milliseconds"
                         },
                         "name": "stream-health-info"
                       },
@@ -2408,7 +2408,7 @@
             "content": {
               "json": "The following visualizations represent data from the SMS Operational logs.\r\n\r\n**Click on any part of the pie charts below to visualize filtered logs.**"
             },
-            "name": "auth-text"
+            "name": "sms-text"
           },
           {
             "type": 12,

--- a/Workbooks/Communication Services/Overview/Overview.workbook
+++ b/Workbooks/Communication Services/Overview/Overview.workbook
@@ -90,7 +90,7 @@
               "additionalResourceOptions": [],
               "showDefault": false
             },
-            "jsonData": "[\r\n    { \"value\":\"1m\", \"label\":\"1 minute\" },\r\n    { \"value\":\"10m\", \"label\":\"10 minutes\" },\r\n    { \"value\":\"15m\", \"label\":\"15 minutes\" },\r\n    { \"value\":\"30m\", \"label\":\"30 minutes\" },\r\n    { \"value\":\"1h\", \"label\":\"1 hour\", \"selected\":true  },\r\n    { \"value\":\"2h\", \"label\":\"2 hours\" },\r\n    { \"value\":\"12h\", \"label\":\"12 hours\" },\r\n    { \"value\":\"1d\", \"label\":\"1 day\"},\r\n    { \"value\":\"2d\", \"label\":\"2 days\" },\r\n    { \"value\":\"3d\", \"label\":\"3 days\" },\r\n    { \"value\":\"1w\", \"label\":\"1 week\" }\r\n]",
+            "jsonData": "[\r\n    { \"value\":\"1m\", \"label\":\"1 minute\" },\r\n    { \"value\":\"10m\", \"label\":\"10 minutes\" },\r\n    { \"value\":\"15m\", \"label\":\"15 minutes\" },\r\n    { \"value\":\"30m\", \"label\":\"30 minutes\" },\r\n    { \"value\":\"1h\", \"label\":\"1 hour\", \"selected\":true  },\r\n    { \"value\":\"2h\", \"label\":\"2 hours\" },\r\n    { \"value\":\"12h\", \"label\":\"12 hours\" },\r\n    { \"value\":\"1d\", \"label\":\"1 day\"},\r\n    { \"value\":\"2d\", \"label\":\"2 days\" },\r\n    { \"value\":\"3d\", \"label\":\"3 days\" },\r\n    { \"value\":\"7d\", \"label\":\"1 week\" }\r\n]",
             "timeContext": {
               "durationMs": 86400000
             }
@@ -200,8 +200,9 @@
               "query": "ACSCallSummary\r\n| where CallStartTime {time_range:query}\r\n| distinct CorrelationId, CallStartTime, CallType\r\n| extend time_span = floor(CallStartTime, {time_granularity})\r\n| make-series Calls=count() default=0 on CallStartTime from {time_range:start} to {time_range:end} step {time_granularity} by time_span\r\n| render {plot_type}",
               "size": 0,
               "title": "Voice and video call counts",
+              "noDataMessage": "No voice and video calls registered in this time period",
               "queryType": 0,
-              "resourceType": "Microsoft.Communication/CommunicationServices"
+              "resourceType": "microsoft.communication/communicationservices"
             },
             "customWidth": "50",
             "name": "voice-video-overview"
@@ -213,8 +214,9 @@
               "query": "ACSChatIncomingOperations\r\n| where TimeGenerated {time_range:query}\r\n//| distinct CorrelationId, CallStartTime, CallType\r\n| extend time_span = floor(TimeGenerated, {time_granularity})\r\n| make-series ChatOperations=count() default=0 on TimeGenerated from {time_range:start} to {time_range:end} step {time_granularity} by time_span\r\n| render {plot_type}",
               "size": 0,
               "title": "Chat API calls",
+              "noDataMessage": "No chat API requests registered in this time period",
               "queryType": 0,
-              "resourceType": "Microsoft.Communication/CommunicationServices"
+              "resourceType": "microsoft.communication/communicationservices"
             },
             "customWidth": "50",
             "name": "chat-overview"
@@ -226,8 +228,9 @@
               "query": "ACSSMSIncomingOperations\r\n| where TimeGenerated {time_range:query}\r\n| extend time_span = floor(TimeGenerated, {time_granularity})\r\n| make-series SMSOperations=count() default=0 on TimeGenerated from {time_range:start} to {time_range:end} step {time_granularity} by time_span\r\n| render {plot_type}",
               "size": 0,
               "title": "SMS API calls",
+              "noDataMessage": "No SMS API requests registered in this time period",
               "queryType": 0,
-              "resourceType": "Microsoft.Communication/CommunicationServices"
+              "resourceType": "microsoft.communication/communicationservices"
             },
             "customWidth": "50",
             "name": "sms-overview"
@@ -239,8 +242,9 @@
               "query": "ACSAuthIncomingOperations\r\n| where TimeGenerated {time_range:query}\r\n| extend time_span = floor(TimeGenerated, {time_granularity})\r\n| make-series AuthOperations=count() default=0 on TimeGenerated from {time_range:start} to {time_range:end} step {time_granularity} by time_span\r\n| render {plot_type}",
               "size": 0,
               "title": "Authentication API calls",
+              "noDataMessage": "No authentication API requests registered in this time period",
               "queryType": 0,
-              "resourceType": "Microsoft.Communication/CommunicationServices"
+              "resourceType": "microsoft.communication/communicationservices"
             },
             "customWidth": "50",
             "name": "auth-overview"
@@ -360,50 +364,125 @@
                         "timeContext": {
                           "durationMs": 86400000
                         },
-                        "id": "2666fe6a-842f-46ad-9f75-5e52e8517ff8"
+                        "id": "2666fe6a-842f-46ad-9f75-5e52e8517ff8",
+                        "value": [
+                          "VoIP",
+                          "PSTN",
+                          "Bot",
+                          "Server",
+                          "Unknown"
+                        ]
+                      },
+                      {
+                        "id": "868602ec-a0f7-4983-a292-4acde38c2f2a",
+                        "version": "KqlParameterItem/1.0",
+                        "name": "call_quality_os",
+                        "label": "OS version",
+                        "type": 2,
+                        "multiSelect": true,
+                        "quote": "'",
+                        "delimiter": ",",
+                        "query": "ACSCallSummary\r\n| where CallStartTime {time_range:query}\r\n| distinct OsVersion\r\n| order by OsVersion",
+                        "value": [
+                          "value::all"
+                        ],
+                        "typeSettings": {
+                          "additionalResourceOptions": [
+                            "value::all"
+                          ],
+                          "showDefault": false
+                        },
+                        "defaultValue": "value::all",
+                        "queryType": 0,
+                        "resourceType": "microsoft.communication/communicationservices"
                       }
                     ],
                     "style": "pills",
                     "queryType": 0,
-                    "resourceType": "Microsoft.Communication/CommunicationServices"
+                    "resourceType": "microsoft.communication/communicationservices"
                   },
                   "name": "voice-video-quality-params"
                 },
                 {
-                  "type": 3,
+                  "type": 12,
                   "content": {
-                    "version": "KqlItem/1.0",
-                    "query": "ACSCallDiagnostics\r\n| join kind=inner ACSCallSummary on CorrelationId, ParticipantId, EndpointId\r\n| where CallStartTime {time_range:query} and MediaType in ({call_quality_media_types}) and EndpointType in ({call_quality_endpoint_types})\r\n| order by CallStartTime asc, ParticipantStartTime asc\r\n| extend JitterQuality = iff(JitterAvg > 30, \"Poor\", \"Good\")\r\n| extend PacketLossRateQuality = iff(PacketLossRateAvg > 0.1, \"Poor\", \"Good\")\r\n| extend RoundTripTimeQuality = iff(RoundTripTimeAvg > 500, \"Poor\", \"Good\")\r\n| extend StreamQuality = iff((JitterQuality == \"Poor\") or (PacketLossRateQuality == \"Poor\") or (RoundTripTimeQuality == \"Poor\"), \"Poor\", \"Good\")\r\n| summarize count() by StreamQuality\r\n| render piechart",
-                    "size": 0,
-                    "title": "Stream quality",
-                    "queryType": 0,
-                    "resourceType": "Microsoft.Communication/CommunicationServices"
+                    "version": "NotebookGroup/1.0",
+                    "groupType": "editable",
+                    "title": "Stream health",
+                    "items": [
+                      {
+                        "type": 1,
+                        "content": {
+                          "json": "Streams are classified as healthy if they exhibit telemetry values within the following ranges:\r\n\r\n- Round trip time under 500 miliseconds\r\n- Packet loss rate of less than 10%\r\n- Jitter under 30 miliseconds"
+                        },
+                        "name": "stream-health-info"
+                      },
+                      {
+                        "type": 3,
+                        "content": {
+                          "version": "KqlItem/1.0",
+                          "query": "ACSCallDiagnostics\r\n| join kind=inner ACSCallSummary on CorrelationId, ParticipantId, EndpointId\r\n| where CallStartTime {time_range:query} and MediaType in ({call_quality_media_types}) and EndpointType in ({call_quality_endpoint_types}) and OsVersion in ({call_quality_os})\r\n| order by CallStartTime asc, ParticipantStartTime asc\r\n| extend JitterQuality = iff(JitterAvg > 30, \"jitter\", \"\")\r\n| extend PacketLossRateQuality = iff(PacketLossRateAvg > 0.1, \"packet loss rate\", \"\")\r\n| extend RoundTripTimeQuality = iff(RoundTripTimeAvg > 500, \"round-trip time\", \"\")\r\n| extend TelemetryString = JitterQuality\r\n| extend TelemetryString = iff(isempty(PacketLossRateQuality), TelemetryString, iff(isempty(TelemetryString), PacketLossRateQuality, strcat_delim(\" and \", TelemetryString, PacketLossRateQuality)))\r\n| extend TelemetryString = iff(isempty(RoundTripTimeQuality), TelemetryString, iff(isempty(TelemetryString), RoundTripTimeQuality, strcat_delim(\" and \", TelemetryString, RoundTripTimeQuality)))\r\n//| extend TelemetryString = strcat_delim(\" and \", JitterQuality, PacketLossRateQuality, RoundTripTimeQuality)\r\n| extend StreamClassification = iff(isempty(TelemetryString), \"Healthy\", strcat(\"Unhealthy \", TelemetryString))\r\n//| extend StreamQuality = iff((JitterQuality == \"Poor\") or (PacketLossRateQuality == \"Poor\") or (RoundTripTimeQuality == \"Poor\"), \"Poor\", \"Good\")\r\n| summarize count() by StreamClassification\r\n| render piechart",
+                          "size": 0,
+                          "noDataMessage": "No streams were found for the specified time range",
+                          "queryType": 0,
+                          "resourceType": "microsoft.communication/communicationservices"
+                        },
+                        "name": "voice-video-quality-streams"
+                      }
+                    ]
                   },
                   "customWidth": "50",
-                  "name": "voice-video-quality-streams"
+                  "name": "stream-health-group"
                 },
                 {
-                  "type": 3,
+                  "type": 12,
                   "content": {
-                    "version": "KqlItem/1.0",
-                    "query": "ACSCallDiagnostics\r\n| join kind=inner ACSCallSummary on CorrelationId, ParticipantId, EndpointId\r\n| where CallStartTime {time_range:query} and MediaType in ({call_quality_media_types}) and EndpointType in ({call_quality_endpoint_types})\r\n| extend JitterQuality = iff(JitterAvg > 30, \"Poor\", \"Good\")\r\n| extend PacketLossRateQuality = iff(PacketLossRateAvg > 0.1, \"Poor\", \"Good\")\r\n| extend RoundTripTimeQuality = iff(RoundTripTimeAvg > 500, \"Poor\", \"Good\")\r\n| extend StreamQuality = iff((JitterQuality == \"Poor\") or (PacketLossRateQuality == \"Poor\") or (RoundTripTimeQuality == \"Poor\"), \"Poor\", \"Good\")\r\n| distinct CorrelationId, StreamQuality\r\n| summarize CallQuality=arg_max(StreamQuality, *) by CorrelationId\r\n| summarize count() by CallQuality\r\n| render piechart",
-                    "size": 0,
+                    "version": "NotebookGroup/1.0",
+                    "groupType": "editable",
                     "title": "Impacted calls",
-                    "queryType": 0,
-                    "resourceType": "Microsoft.Communication/CommunicationServices"
+                    "items": [
+                      {
+                        "type": 1,
+                        "content": {
+                          "json": "An impacted call is defined here as a call that has at least one unhealthy media stream as defined in **Stream health**"
+                        },
+                        "name": "impacted-calls-info"
+                      },
+                      {
+                        "type": 3,
+                        "content": {
+                          "version": "KqlItem/1.0",
+                          "query": "ACSCallDiagnostics\r\n| join kind=inner ACSCallSummary on CorrelationId, ParticipantId, EndpointId\r\n| where CallStartTime {time_range:query} and MediaType in ({call_quality_media_types}) and EndpointType in ({call_quality_endpoint_types}) and OsVersion in ({call_quality_os})\r\n| extend JitterQuality = iff(JitterAvg > 30, \"Poor\", \"Good\")\r\n| extend PacketLossRateQuality = iff(PacketLossRateAvg > 0.1, \"Poor\", \"Good\")\r\n| extend RoundTripTimeQuality = iff(RoundTripTimeAvg > 500, \"Poor\", \"Good\")\r\n| extend StreamQuality = iff((JitterQuality == \"Poor\") or (PacketLossRateQuality == \"Poor\") or (RoundTripTimeQuality == \"Poor\"), \"Impacted\", \"Not impacted\")\r\n| distinct CorrelationId, StreamQuality\r\n| summarize CallQuality=arg_min(StreamQuality, *) by CorrelationId\r\n| summarize count() by CallQuality\r\n| render piechart",
+                          "size": 0,
+                          "noDataMessage": "No calls found in the specified time range",
+                          "queryType": 0,
+                          "resourceType": "microsoft.communication/communicationservices"
+                        },
+                        "name": "voice-video-quality-calls"
+                      }
+                    ]
                   },
                   "customWidth": "50",
-                  "name": "voice-video-quality-calls"
+                  "name": "impacted-calls-group"
                 },
                 {
                   "type": 3,
                   "content": {
                     "version": "KqlItem/1.0",
-                    "query": "ACSCallDiagnostics\r\n| join kind=inner ACSCallSummary on CorrelationId, ParticipantId, EndpointId\r\n| where CallStartTime {time_range:query} and MediaType in ({call_quality_media_types}) and EndpointType in ({call_quality_endpoint_types})\r\n| order by CallStartTime asc, ParticipantStartTime asc\r\n| extend ParticipantEndReason = case(\r\n                                tostring(ParticipantEndReason) startswith \"0\", \"Success\",\r\n                                tostring(ParticipantEndReason) startswith \"1\", \"Provisional\",\r\n                                tostring(ParticipantEndReason) startswith \"2\", \"Success\",\r\n                                tostring(ParticipantEndReason) startswith \"3\", \"Redirection\",\r\n                                tostring(ParticipantEndReason) startswith \"4\", \"Client Failure\",\r\n                                tostring(ParticipantEndReason) startswith \"5\", \"Server Failure\",\r\n                                tostring(ParticipantEndReason) startswith \"6\", \"Global Failure\",\r\n                            ParticipantEndReason\r\n                        )\r\n| summarize count() by ParticipantEndReason\r\n| render piechart",
+                    "query": "ACSCallDiagnostics\r\n| join kind=inner ACSCallSummary on CorrelationId, ParticipantId, EndpointId\r\n| where CallStartTime {time_range:query} and MediaType in ({call_quality_media_types}) and EndpointType in ({call_quality_endpoint_types}) and OsVersion in ({call_quality_os})\r\n| order by CallStartTime asc, ParticipantStartTime asc\r\n| extend ParticipantEndReason = case(\r\n                                tostring(ParticipantEndReason) startswith \"0\", \"Success\",\r\n                                tostring(ParticipantEndReason) startswith \"1\", \"Provisional\",\r\n                                tostring(ParticipantEndReason) startswith \"2\", \"Success\",\r\n                                tostring(ParticipantEndReason) startswith \"3\", \"Redirection\",\r\n                                tostring(ParticipantEndReason) startswith \"4\", \"Client Failure\",\r\n                                tostring(ParticipantEndReason) startswith \"5\", \"Server Failure\",\r\n                                tostring(ParticipantEndReason) startswith \"6\", \"Global Failure\",\r\n                            ParticipantEndReason\r\n                        )\r\n| summarize count() by ParticipantEndReason\r\n| render piechart",
                     "size": 0,
-                    "title": "Participant End Reasons",
+                    "title": "Participant end reason categories",
+                    "noDataMessage": "No participants found in the specified time range",
+                    "exportMultipleValues": true,
+                    "exportedParameters": [
+                      {
+                        "fieldName": "series",
+                        "parameterName": "end_reason_category",
+                        "parameterType": 1
+                      }
+                    ],
                     "queryType": 0,
-                    "resourceType": "Microsoft.Communication/CommunicationServices"
+                    "resourceType": "microsoft.communication/communicationservices"
                   },
                   "customWidth": "50",
                   "name": "voice-video-quality-participant-end-reason-class"
@@ -412,10 +491,12 @@
                   "type": 3,
                   "content": {
                     "version": "KqlItem/1.0",
-                    "query": "ACSCallDiagnostics\r\n| join kind=inner ACSCallSummary on CorrelationId, ParticipantId, EndpointId\r\n| where CallStartTime {time_range:query} and MediaType in ({call_quality_media_types}) and EndpointType in ({call_quality_endpoint_types})\r\n| summarize ParticipantEndReasonCounts=count() by ParticipantEndReason",
+                    "query": "let SIPCodes =  datatable(ParticipantEndReason: string, SIPCode: string)\r\n[\r\n    \"0\",   \"Success\",\r\n    \"100\", \"Trying\",\r\n    \"180\", \"Ringing\",\r\n    \"181\", \"Call Is Being Forwarded\",\r\n    \"182\", \"Queued\",\r\n    \"183\", \"Session Progress\",\r\n    \"199\", \"Early Dialog Terminated\",\r\n    \"200\", \"Success\",\r\n    \"202\", \"Accepted\",\r\n    \"204\", \"No Notification\",\r\n    \"300\", \"Multiple Choices\",\r\n    \"301\", \"Moved Permanently\",\r\n    \"302\", \"Moved Temporarily\",\r\n    \"305\", \"Use Proxy\",\r\n    \"380\", \"Alternative Service\",\r\n    \"400\", \"Bad Request\",\r\n    \"401\", \"Unauthorized\",\r\n    \"402\", \"Payment Required\",\r\n    \"403\", \"Forbidden\",\r\n    \"404\", \"Not Found\",\r\n    \"405\", \"Method Not Allowed\",\r\n    \"406\", \"Not Acceptable\",\r\n    \"407\", \"Proxy Authentication Required\",\r\n    \"408\", \"Request Timeout\",\r\n    \"409\", \"Conflict\",\r\n    \"410\", \"Gone\",\r\n    \"411\", \"Length Required\",\r\n    \"412\", \"Conditional Request Failed\",\r\n    \"413\", \"Request Entity Too Large\",\r\n    \"414\", \"Request-URI Too Large\",\r\n    \"415\", \"Unsupported Media Type\",\r\n    \"416\", \"Unsupported URI Scheme\",\r\n    \"417\", \"Unknown Resource-Priority\",\r\n    \"420\", \"Bad Extension\",\r\n    \"421\", \"Extension Required\",\r\n    \"422\", \"Session Interval Too Small\",\r\n    \"423\", \"Interval Too Brief\",\r\n    \"424\", \"Bad Location Information\",\r\n    \"428\", \"Use Identity Header\",\r\n    \"429\", \"Provide Referrer Identity\",\r\n    \"430\", \"Flow Failed\",\r\n    \"433\", \"Anonymity Disallowed\",\r\n    \"436\", \"Bad Identity-Info\",\r\n    \"437\", \"Unsupported Certificate\",\r\n    \"438\", \"Invalid Identity Header\",\r\n    \"439\", \"First Hop Lacks Outbound Support\",\r\n    \"440\", \"Max-Breadth Exceeded\",\r\n    \"469\", \"Bad Info Package\",\r\n    \"470\", \"Consent Needed\",\r\n    \"480\", \"Temporarily Unavailable\",\r\n    \"481\", \"Call/Transaction Does Not Exist\",\r\n    \"482\", \"Loop Detected\",\r\n    \"483\", \"Too Many Hops\",\r\n    \"484\", \"Address Incomplete\",\r\n    \"485\", \"Ambiguous\",\r\n    \"486\", \"Busy Here\",\r\n    \"487\", \"Request Terminated\",\r\n    \"488\", \"Not Acceptable Here\",\r\n    \"489\", \"Bad Event\",\r\n    \"491\", \"Request Pending\",\r\n    \"493\", \"Undecipherable\",\r\n    \"494\", \"Security Agreement Required\",\r\n    \"500\", \"Internal Server Error\",\r\n    \"501\", \"Not Implemented\",\r\n    \"502\", \"Bad Gateway\",\r\n    \"503\", \"Service Unavailable\",\r\n    \"504\", \"Server Time-out\",\r\n    \"505\", \"Version Not Supported\",\r\n    \"513\", \"Message Too Large\",\r\n    \"555\", \"Push Notification Service Not Supported\",\r\n    \"580\", \"Precondition Failure\",\r\n    \"600\", \"Busy Everywhere\",\r\n    \"603\", \"Decline\",\r\n    \"604\", \"Does Not Exist Anywhere\",\r\n    \"606\", \"Not Acceptable\",\r\n    \"607\", \"Unwanted\",\r\n    \"608\", \"Rejected\",\r\n];\r\n\r\nACSCallDiagnostics\r\n| join kind=inner ACSCallSummary on CorrelationId, ParticipantId, EndpointId\r\n| join kind=leftouter SIPCodes on ParticipantEndReason\r\n| extend EndReason=strcat(ParticipantEndReason, \": \", SIPCode)\r\n| where CallStartTime {time_range:query} and MediaType in ({call_quality_media_types}) and EndpointType in ({call_quality_endpoint_types}) and OsVersion in ({call_quality_os})\r\n| summarize ParticipantEndReasonCounts=count() by EndReason\r\n| order by ParticipantEndReasonCounts",
                     "size": 0,
+                    "title": "Participant end reasons {end_reason_category}",
+                    "noDataMessage": "No participants found in the specified time range",
                     "queryType": 0,
-                    "resourceType": "Microsoft.Communication/CommunicationServices",
+                    "resourceType": "microsoft.communication/communicationservices",
                     "visualization": "table",
                     "gridSettings": {
                       "formatters": [
@@ -462,8 +543,9 @@
                     "query": "let CallOverview = ACSCallDiagnostics\r\n| join kind=inner ACSCallSummary on CorrelationId, ParticipantId, EndpointId;\r\n\r\nCallOverview\r\n| where CallStartTime {time_range:query}\r\n| summarize media_types=count() by MediaType\r\n| render piechart",
                     "size": 0,
                     "title": "Media Type Ratio",
+                    "noDataMessage": "No media streams found in the specified time range",
                     "queryType": 0,
-                    "resourceType": "Microsoft.Communication/CommunicationServices"
+                    "resourceType": "microsoft.communication/communicationservices"
                   },
                   "customWidth": "50",
                   "name": "voice-video-media-types"
@@ -475,8 +557,9 @@
                     "query": "let CallOverview = ACSCallDiagnostics\r\n| join kind=inner ACSCallSummary on CorrelationId, ParticipantId, EndpointId;\r\n\r\nCallOverview\r\n| where CallStartTime {time_range:query}\r\n| summarize endpoint_types=count() by EndpointType\r\n| render piechart",
                     "size": 0,
                     "title": "Endpoint Types",
+                    "noDataMessage": "No endpoints found in the specified time range",
                     "queryType": 0,
-                    "resourceType": "Microsoft.Communication/CommunicationServices"
+                    "resourceType": "microsoft.communication/communicationservices"
                   },
                   "customWidth": "50",
                   "name": "voice-video-endpoint-types"
@@ -488,8 +571,9 @@
                     "query": "ACSCallSummary\r\n| where CallStartTime {time_range:query}\r\n| extend SimpleOs = case(  indexof(OsVersion, \"Android\") != -1, tostring(split(OsVersion, \";\")[0]),\r\n                            indexof(OsVersion, \"Darwin\") != -1, tostring(split(OsVersion, \":\")[0]),\r\n                            indexof(OsVersion, \"Windows\") != -1, tostring(split(OsVersion, \".\")[0]),\r\n                            OsVersion\r\n                        )\r\n| summarize OsCounts=count() by SimpleOs\r\n| render piechart",
                     "size": 0,
                     "title": "OS Usage",
+                    "noDataMessage": "No OS information reported in the specified time range",
                     "queryType": 0,
-                    "resourceType": "Microsoft.Communication/CommunicationServices"
+                    "resourceType": "microsoft.communication/communicationservices"
                   },
                   "customWidth": "50",
                   "name": "voice-video-os-usage"
@@ -498,11 +582,12 @@
                   "type": 3,
                   "content": {
                     "version": "KqlItem/1.0",
-                    "query": "let SIPCodes =  datatable(ParticipantEndReason: string, SIPCode: string)\r\n[\r\n    \"100\", \"Trying\",\r\n    \"180\", \"Ringing\",\r\n    \"181\", \"Call Is Being Forwarded\",\r\n    \"182\", \"Queued\",\r\n    \"183\", \"Session Progress\",\r\n    \"199\", \"Early Dialog Terminated\",\r\n    \"200\", \"OK\",\r\n    \"202\", \"Accepted\",\r\n    \"204\", \"No Notification\",\r\n    \"300\", \"Multiple Choices\",\r\n    \"301\", \"Moved Permanently\",\r\n    \"302\", \"Moved Temporarily\",\r\n    \"305\", \"Use Proxy\",\r\n    \"380\", \"Alternative Service\",\r\n    \"400\", \"Bad Request\",\r\n    \"401\", \"Unauthorized\",\r\n    \"402\", \"Payment Required\",\r\n    \"403\", \"Forbidden\",\r\n    \"404\", \"Not Found\",\r\n    \"405\", \"Method Not Allowed\",\r\n    \"406\", \"Not Acceptable\",\r\n    \"407\", \"Proxy Authentication Required\",\r\n    \"408\", \"Request Timeout\",\r\n    \"409\", \"Conflict\",\r\n    \"410\", \"Gone\",\r\n    \"411\", \"Length Required\",\r\n    \"412\", \"Conditional Request Failed\",\r\n    \"413\", \"Request Entity Too Large\",\r\n    \"414\", \"Request-URI Too Large\",\r\n    \"415\", \"Unsupported Media Type\",\r\n    \"416\", \"Unsupported URI Scheme\",\r\n    \"417\", \"Unknown Resource-Priority\",\r\n    \"420\", \"Bad Extension\",\r\n    \"421\", \"Extension Required\",\r\n    \"422\", \"Session Interval Too Small\",\r\n    \"423\", \"Interval Too Brief\",\r\n    \"424\", \"Bad Location Information\",\r\n    \"428\", \"Use Identity Header\",\r\n    \"429\", \"Provide Referrer Identity\",\r\n    \"430\", \"Flow Failed\",\r\n    \"433\", \"Anonymity Disallowed\",\r\n    \"436\", \"Bad Identity-Info\",\r\n    \"437\", \"Unsupported Certificate\",\r\n    \"438\", \"Invalid Identity Header\",\r\n    \"439\", \"First Hop Lacks Outbound Support\",\r\n    \"440\", \"Max-Breadth Exceeded\",\r\n    \"469\", \"Bad Info Package\",\r\n    \"470\", \"Consent Needed\",\r\n    \"480\", \"Temporarily Unavailable\",\r\n    \"481\", \"Call/Transaction Does Not Exist\",\r\n    \"482\", \"Loop Detected\",\r\n    \"483\", \"Too Many Hops\",\r\n    \"484\", \"Address Incomplete\",\r\n    \"485\", \"Ambiguous\",\r\n    \"486\", \"Busy Here\",\r\n    \"487\", \"Request Terminated\",\r\n    \"488\", \"Not Acceptable Here\",\r\n    \"489\", \"Bad Event\",\r\n    \"491\", \"Request Pending\",\r\n    \"493\", \"Undecipherable\",\r\n    \"494\", \"Security Agreement Required\",\r\n    \"500\", \"Internal Server Error\",\r\n    \"501\", \"Not Implemented\",\r\n    \"502\", \"Bad Gateway\",\r\n    \"503\", \"Service Unavailable\",\r\n    \"504\", \"Server Time-out\",\r\n    \"505\", \"Version Not Supported\",\r\n    \"513\", \"Message Too Large\",\r\n    \"555\", \"Push Notification Service Not Supported\",\r\n    \"580\", \"Precondition Failure\",\r\n    \"600\", \"Busy Everywhere\",\r\n    \"603\", \"Decline\",\r\n    \"604\", \"Does Not Exist Anywhere\",\r\n    \"606\", \"Not Acceptable\",\r\n    \"607\", \"Unwanted\",\r\n    \"608\", \"Rejected\",\r\n];\r\n\r\n\r\nACSCallSummary\r\n| where CallStartTime {time_range:query}\r\n| join kind=inner SIPCodes on ParticipantEndReason\r\n| extend EndReason=strcat(ParticipantEndReason, \": \", SIPCode)\r\n| summarize EndReasonCounts=count() by EndReason//ParticipantEndReason, SIPCode=SIPCode\r\n| render piechart",
+                    "query": "let SIPCodes =  datatable(ParticipantEndReason: string, SIPCode: string)\r\n[\r\n    \"0\",   \"Success\",\r\n    \"100\", \"Trying\",\r\n    \"180\", \"Ringing\",\r\n    \"181\", \"Call Is Being Forwarded\",\r\n    \"182\", \"Queued\",\r\n    \"183\", \"Session Progress\",\r\n    \"199\", \"Early Dialog Terminated\",\r\n    \"200\", \"Success\",\r\n    \"202\", \"Accepted\",\r\n    \"204\", \"No Notification\",\r\n    \"300\", \"Multiple Choices\",\r\n    \"301\", \"Moved Permanently\",\r\n    \"302\", \"Moved Temporarily\",\r\n    \"305\", \"Use Proxy\",\r\n    \"380\", \"Alternative Service\",\r\n    \"400\", \"Bad Request\",\r\n    \"401\", \"Unauthorized\",\r\n    \"402\", \"Payment Required\",\r\n    \"403\", \"Forbidden\",\r\n    \"404\", \"Not Found\",\r\n    \"405\", \"Method Not Allowed\",\r\n    \"406\", \"Not Acceptable\",\r\n    \"407\", \"Proxy Authentication Required\",\r\n    \"408\", \"Request Timeout\",\r\n    \"409\", \"Conflict\",\r\n    \"410\", \"Gone\",\r\n    \"411\", \"Length Required\",\r\n    \"412\", \"Conditional Request Failed\",\r\n    \"413\", \"Request Entity Too Large\",\r\n    \"414\", \"Request-URI Too Large\",\r\n    \"415\", \"Unsupported Media Type\",\r\n    \"416\", \"Unsupported URI Scheme\",\r\n    \"417\", \"Unknown Resource-Priority\",\r\n    \"420\", \"Bad Extension\",\r\n    \"421\", \"Extension Required\",\r\n    \"422\", \"Session Interval Too Small\",\r\n    \"423\", \"Interval Too Brief\",\r\n    \"424\", \"Bad Location Information\",\r\n    \"428\", \"Use Identity Header\",\r\n    \"429\", \"Provide Referrer Identity\",\r\n    \"430\", \"Flow Failed\",\r\n    \"433\", \"Anonymity Disallowed\",\r\n    \"436\", \"Bad Identity-Info\",\r\n    \"437\", \"Unsupported Certificate\",\r\n    \"438\", \"Invalid Identity Header\",\r\n    \"439\", \"First Hop Lacks Outbound Support\",\r\n    \"440\", \"Max-Breadth Exceeded\",\r\n    \"469\", \"Bad Info Package\",\r\n    \"470\", \"Consent Needed\",\r\n    \"480\", \"Temporarily Unavailable\",\r\n    \"481\", \"Call/Transaction Does Not Exist\",\r\n    \"482\", \"Loop Detected\",\r\n    \"483\", \"Too Many Hops\",\r\n    \"484\", \"Address Incomplete\",\r\n    \"485\", \"Ambiguous\",\r\n    \"486\", \"Busy Here\",\r\n    \"487\", \"Request Terminated\",\r\n    \"488\", \"Not Acceptable Here\",\r\n    \"489\", \"Bad Event\",\r\n    \"491\", \"Request Pending\",\r\n    \"493\", \"Undecipherable\",\r\n    \"494\", \"Security Agreement Required\",\r\n    \"500\", \"Internal Server Error\",\r\n    \"501\", \"Not Implemented\",\r\n    \"502\", \"Bad Gateway\",\r\n    \"503\", \"Service Unavailable\",\r\n    \"504\", \"Server Time-out\",\r\n    \"505\", \"Version Not Supported\",\r\n    \"513\", \"Message Too Large\",\r\n    \"555\", \"Push Notification Service Not Supported\",\r\n    \"580\", \"Precondition Failure\",\r\n    \"600\", \"Busy Everywhere\",\r\n    \"603\", \"Decline\",\r\n    \"604\", \"Does Not Exist Anywhere\",\r\n    \"606\", \"Not Acceptable\",\r\n    \"607\", \"Unwanted\",\r\n    \"608\", \"Rejected\",\r\n];\r\n\r\n\r\nACSCallSummary\r\n| where CallStartTime {time_range:query}\r\n| join kind=leftouter SIPCodes on ParticipantEndReason\r\n| extend EndReason=strcat(ParticipantEndReason, \": \", SIPCode)\r\n| summarize EndReasonCounts=count() by EndReason//ParticipantEndReason, SIPCode=SIPCode\r\n| render piechart",
                     "size": 0,
                     "title": "Participant End Reasons",
+                    "noDataMessage": "No participants found in the specified time range",
                     "queryType": 0,
-                    "resourceType": "Microsoft.Communication/CommunicationServices"
+                    "resourceType": "microsoft.communication/communicationservices"
                   },
                   "customWidth": "50",
                   "name": "voice-video-participant-end-reasons"
@@ -540,20 +625,33 @@
                         "name": "usage_grouping",
                         "label": "Grouping",
                         "type": 2,
-                        "value": "by CallType",
+                        "value": "by Interop",
                         "typeSettings": {
                           "additionalResourceOptions": [],
                           "showDefault": false
                         },
-                        "jsonData": "[\r\n    {\"value\": \"by Interop\", \"label\": \"Interop Calls\"},\r\n    {\"value\": \"by CallType\", \"label\": \"Call type\"}\r\n]",
+                        "jsonData": "[\r\n    {\"value\": \"by Interop\", \"label\": \"Interop type\"},\r\n    {\"value\": \"by CallType\", \"label\": \"Call type\"}\r\n]",
                         "timeContext": {
                           "durationMs": 86400000
                         }
+                      },
+                      {
+                        "id": "1ca814c8-26f3-457f-9170-c41449e167a7",
+                        "version": "KqlParameterItem/1.0",
+                        "name": "duration_unit",
+                        "label": "Duration unit",
+                        "type": 2,
+                        "isRequired": true,
+                        "value": "3600",
+                        "typeSettings": {
+                          "additionalResourceOptions": []
+                        },
+                        "jsonData": "[\r\n    { \"value\":\"1\", \"label\":\"Seconds\" },\r\n    { \"value\":\"60\", \"label\":\"Minutes\", \"selected\":true },\r\n    { \"value\":\"3600\", \"label\":\"Hours\" },\r\n    { \"value\":\"86400\", \"label\":\"Days\" }\r\n]"
                       }
                     ],
                     "style": "pills",
                     "queryType": 0,
-                    "resourceType": "Microsoft.Communication/CommunicationServices"
+                    "resourceType": "microsoft.communication/communicationservices"
                   },
                   "name": "voice-video-volume-params"
                 },
@@ -561,11 +659,12 @@
                   "type": 3,
                   "content": {
                     "version": "KqlItem/1.0",
-                    "query": "ACSCallSummary\r\n| distinct CorrelationId, TeamsThreadId, CallStartTime, CallType\r\n//| extend Interop=iff(isnull(TeamsThreadId), \"ACS\", \"Teams Interop\") // Current data might not have the right null format\r\n| extend Interop=iff(TeamsThreadId == \"null\", \"ACS\", \"Teams Interop\")\r\n| make-series event_count=count() default=0 on CallStartTime from {time_range:start} to {time_range:end} step {time_granularity} {usage_grouping}",
+                    "query": "ACSCallSummary\r\n| distinct CorrelationId, TeamsThreadId, CallStartTime, CallType, CallDuration\r\n//| extend Interop=iff(isnull(TeamsThreadId), \"ACS\", \"Teams Interop\") // Current data might not have the right null format\r\n| extend Interop=iff(TeamsThreadId == \"null\", \"ACS\", \"Teams Interop\")\r\n| make-series time_seconds=toreal(sum(CallDuration)) / {duration_unit} default=0 on CallStartTime from {time_range:start} to {time_range:end} step {time_granularity} by '{usage_grouping}'",
                     "size": 0,
-                    "title": "Calls",
+                    "title": "Calling time in {duration_unit:label} {usage_grouping}",
+                    "noDataMessage": "No calls found in the specified time range",
                     "queryType": 0,
-                    "resourceType": "Microsoft.Communication/CommunicationServices",
+                    "resourceType": "microsoft.communication/communicationservices",
                     "visualization": "barchart"
                   },
                   "customWidth": "50",
@@ -575,11 +674,12 @@
                   "type": 3,
                   "content": {
                     "version": "KqlItem/1.0",
-                    "query": "ACSCallSummary\r\n| distinct CorrelationId, TeamsThreadId, CallStartTime, CallType, ParticipantId, EndpointId, Identifier\r\n//| extend Interop=iff(isnull(TeamsThreadId), \"ACS\", \"Teams Interop\")\r\n| extend Interop=iff(Identifier startswith \"acs:\", \"ACS\", \"Teams Interop\")\r\n| make-series event_count=count() default=0 on CallStartTime from {time_range:start} to {time_range:end} step {time_granularity} {usage_grouping}",
+                    "query": "ACSCallSummary\r\n| distinct CorrelationId, TeamsThreadId, CallStartTime, CallType, ParticipantId, ParticipantDuration, EndpointId, Identifier\r\n//| extend Interop=iff(isnull(TeamsThreadId), \"ACS\", \"Teams Interop\")\r\n| extend Interop=iff(Identifier startswith \"acs:\", \"ACS\", \"Teams Interop\")\r\n| make-series time_seconds=toreal(sum(ParticipantDuration)) / {duration_unit} default=0 on CallStartTime from {time_range:start} to {time_range:end} step {time_granularity} {usage_grouping}",
                     "size": 0,
-                    "title": "Participants",
+                    "title": "Participant calling time in {duration_unit:label} {usage_grouping}",
+                    "noDataMessage": "No participant found in the specified time range",
                     "queryType": 0,
-                    "resourceType": "Microsoft.Communication/CommunicationServices",
+                    "resourceType": "microsoft.communication/communicationservices",
                     "visualization": "barchart"
                   },
                   "customWidth": "50",
@@ -599,55 +699,107 @@
             "content": {
               "version": "NotebookGroup/1.0",
               "groupType": "editable",
+              "title": "Call drill-down",
               "items": [
                 {
                   "type": 1,
                   "content": {
-                    "json": "The Details tab within \"Voice and video\" displays an expandable view of individual calls, broken down to the participant and stream level, with duration and quality metrics."
+                    "json": "The Details tab within \"Voice and video\" displays an expandable view of individual calls, broken down to the participant and stream level, with duration and quality metrics.\r\n\r\nTo easily detect problematic calls and participants, the following icons denote specific situations:\r\n- 🛑 indicates a failed participant end reason\r\n- 🚩 indicates a call with at least one stream with unhealthy telemetry values\r\n- 🔄 marks Teams interop calls or participants\r\n- 📞 marks a call that consists entirely of Azure Communication Services (ACS)"
                   },
-                  "name": "voice-video-details-text"
+                  "name": "text - 5"
                 },
                 {
                   "type": 3,
                   "content": {
                     "version": "KqlItem/1.0",
-                    "query": "ACSCallDiagnostics\r\n| join kind=inner ACSCallSummary on CorrelationId, ParticipantId, EndpointId\r\n| where CallStartTime {time_range:query}\r\n| order by CallStartTime asc, ParticipantStartTime asc\r\n| extend CallDate=format_datetime(CallStartTime, 'MM/dd/y')\r\n| extend CallTime=format_datetime(CallStartTime, 'hh:mm:ss')\r\n| extend ParticipantTime=format_datetime(ParticipantStartTime, 'hh:mm:ss')\r\n| extend ProportionalDuration=(toreal(ParticipantDuration) / toreal(CallDuration))\r\n| extend CallInfo=strcat(\"☎️ \", CallTime, \" (\", CallDuration, \" seconds) ----- CorrelationId = \", CorrelationId)\r\n| extend EndpointType = case(  indexof(EndpointType, \"VoIP\") != -1, strcat(\"🗣️ \", EndpointType),\r\n                            indexof(EndpointType, \"PSTN\") != -1, strcat(\"📞 \", EndpointType),\r\n                            indexof(EndpointType, \"Bot\") != -1, strcat(\"🤖 \", EndpointType),\r\n                            indexof(EndpointType, \"Server\") != -1, strcat(\"🖥️ \", EndpointType),\r\n                            indexof(EndpointType, \"Unknown\") != -1, strcat(\"👽 \", EndpointType),\r\n                            EndpointType\r\n                        )\r\n| extend ParticipantInfo=strcat(EndpointType, \" \", ParticipantTime, \" (\", ParticipantDuration, \" seconds)  ----- ParticipantId = \", ParticipantId)//, \" 🆔 EndpointId = \", EndpointId)\r\n| extend MediaType = case(  indexof(MediaType, \"Audio\") != -1, strcat(\"🔊 \", MediaType),\r\n                            indexof(MediaType, \"Video\") != -1, strcat(\"🎥 \", MediaType),\r\n                            indexof(MediaType, \"VBSS\") != -1, strcat(\"💻 \", MediaType),\r\n                            indexof(MediaType, \"AppSharing\") != -1, strcat(\"📲 \", MediaType),\r\n                            MediaType\r\n                        )\r\n//| project CallInfo, ParticipantInfo, MediaType, JitterAvg, PacketLossRateAvg, RoundTripTimeAvg\r\n| project CallDate, CallInfo, ParticipantInfo, ProportionalDuration, MediaType, JitterAvg, PacketLossRateAvg, RoundTripTimeAvg",
+                    "query": "ACSCallDiagnostics\r\n| join kind=inner ACSCallSummary on CorrelationId, ParticipantId, EndpointId\r\n| where CallStartTime {time_range:query}\r\n| order by CallStartTime asc, ParticipantStartTime asc\r\n| extend CallDate=format_datetime(CallStartTime, 'MM/dd/y')\r\n| extend CallTime=format_datetime(CallStartTime, 'hh:mm:ss')\r\n| extend UnsuccessfulEndReason = iff((ParticipantEndReason startswith \"0\") or (ParticipantEndReason startswith \"2\"), \"\", \"🛑\")\r\n| extend InteropType = iff(isempty(TeamsThreadId), \"📞 ACS call\", \"🔄 Teams interop\")\r\n| extend JitterQuality = iff(JitterAvg > 30, \"Poor\", \"Good\")\r\n| extend PacketLossRateQuality = iff(PacketLossRateAvg > 0.1, \"Poor\", \"Good\")\r\n| extend RoundTripTimeQuality = iff(RoundTripTimeAvg > 500, \"Poor\", \"Good\")\r\n| extend StreamQuality = iff((JitterQuality == \"Poor\") or (PacketLossRateQuality == \"Poor\") or (RoundTripTimeQuality == \"Poor\"), \"🚩\", \"\")\r\n| extend CallLabel = strcat(CallTime, \" \", UnsuccessfulEndReason, \" \", StreamQuality)\r\n| summarize arg_max(CallLabel, *) by CorrelationId\r\n| project CallDate, InteropType, CallLabel, CallId = CorrelationId",
                     "size": 0,
+                    "noDataMessage": "No calls found for the specified time range",
+                    "timeContext": {
+                      "durationMs": 86400000
+                    },
+                    "exportFieldName": "CallId",
+                    "exportParameterName": "call_id",
                     "queryType": 0,
-                    "resourceType": "Microsoft.Communication/CommunicationServices",
+                    "resourceType": "microsoft.communication/communicationservices",
                     "gridSettings": {
                       "formatters": [
-                        {
-                          "columnMatch": "$gen_group",
-                          "formatter": 0,
-                          "formatOptions": {
-                            "customColumnWidthSetting": "50ch"
-                          }
-                        },
                         {
                           "columnMatch": "CallDate",
                           "formatter": 5
                         },
                         {
-                          "columnMatch": "CallInfo",
+                          "columnMatch": "CallLabel",
                           "formatter": 5
                         },
                         {
-                          "columnMatch": "ParticipantInfo",
+                          "columnMatch": "CallTime",
+                          "formatter": 5
+                        }
+                      ],
+                      "hierarchySettings": {
+                        "treeType": 1,
+                        "groupBy": [
+                          "CallDate"
+                        ],
+                        "expandTopLevel": true,
+                        "finalBy": "CallLabel"
+                      }
+                    }
+                  },
+                  "customWidth": "30",
+                  "name": "call_ids"
+                },
+                {
+                  "type": 3,
+                  "content": {
+                    "version": "KqlItem/1.0",
+                    "query": "let SIPCodes =  datatable(ParticipantEndReason: string, SIPCode: string)\r\n[\r\n    \"0\", \"Success\",\r\n    \"100\", \"Trying\",\r\n    \"180\", \"Ringing\",\r\n    \"181\", \"Call Is Being Forwarded\",\r\n    \"182\", \"Queued\",\r\n    \"183\", \"Session Progress\",\r\n    \"199\", \"Early Dialog Terminated\",\r\n    \"200\", \"Success\",\r\n    \"202\", \"Accepted\",\r\n    \"204\", \"No Notification\",\r\n    \"300\", \"Multiple Choices\",\r\n    \"301\", \"Moved Permanently\",\r\n    \"302\", \"Moved Temporarily\",\r\n    \"305\", \"Use Proxy\",\r\n    \"380\", \"Alternative Service\",\r\n    \"400\", \"Bad Request\",\r\n    \"401\", \"Unauthorized\",\r\n    \"402\", \"Payment Required\",\r\n    \"403\", \"Forbidden\",\r\n    \"404\", \"Not Found\",\r\n    \"405\", \"Method Not Allowed\",\r\n    \"406\", \"Not Acceptable\",\r\n    \"407\", \"Proxy Authentication Required\",\r\n    \"408\", \"Request Timeout\",\r\n    \"409\", \"Conflict\",\r\n    \"410\", \"Gone\",\r\n    \"411\", \"Length Required\",\r\n    \"412\", \"Conditional Request Failed\",\r\n    \"413\", \"Request Entity Too Large\",\r\n    \"414\", \"Request-URI Too Large\",\r\n    \"415\", \"Unsupported Media Type\",\r\n    \"416\", \"Unsupported URI Scheme\",\r\n    \"417\", \"Unknown Resource-Priority\",\r\n    \"420\", \"Bad Extension\",\r\n    \"421\", \"Extension Required\",\r\n    \"422\", \"Session Interval Too Small\",\r\n    \"423\", \"Interval Too Brief\",\r\n    \"424\", \"Bad Location Information\",\r\n    \"428\", \"Use Identity Header\",\r\n    \"429\", \"Provide Referrer Identity\",\r\n    \"430\", \"Flow Failed\",\r\n    \"433\", \"Anonymity Disallowed\",\r\n    \"436\", \"Bad Identity-Info\",\r\n    \"437\", \"Unsupported Certificate\",\r\n    \"438\", \"Invalid Identity Header\",\r\n    \"439\", \"First Hop Lacks Outbound Support\",\r\n    \"440\", \"Max-Breadth Exceeded\",\r\n    \"469\", \"Bad Info Package\",\r\n    \"470\", \"Consent Needed\",\r\n    \"480\", \"Temporarily Unavailable\",\r\n    \"481\", \"Call/Transaction Does Not Exist\",\r\n    \"482\", \"Loop Detected\",\r\n    \"483\", \"Too Many Hops\",\r\n    \"484\", \"Address Incomplete\",\r\n    \"485\", \"Ambiguous\",\r\n    \"486\", \"Busy Here\",\r\n    \"487\", \"Request Terminated\",\r\n    \"488\", \"Not Acceptable Here\",\r\n    \"489\", \"Bad Event\",\r\n    \"491\", \"Request Pending\",\r\n    \"493\", \"Undecipherable\",\r\n    \"494\", \"Security Agreement Required\",\r\n    \"500\", \"Internal Server Error\",\r\n    \"501\", \"Not Implemented\",\r\n    \"502\", \"Bad Gateway\",\r\n    \"503\", \"Service Unavailable\",\r\n    \"504\", \"Server Time-out\",\r\n    \"505\", \"Version Not Supported\",\r\n    \"513\", \"Message Too Large\",\r\n    \"555\", \"Push Notification Service Not Supported\",\r\n    \"580\", \"Precondition Failure\",\r\n    \"600\", \"Busy Everywhere\",\r\n    \"603\", \"Decline\",\r\n    \"604\", \"Does Not Exist Anywhere\",\r\n    \"606\", \"Not Acceptable\",\r\n    \"607\", \"Unwanted\",\r\n    \"608\", \"Rejected\",\r\n];\r\n\r\nACSCallDiagnostics\r\n| where CorrelationId == \"{call_id}\"\r\n| join kind=inner ACSCallSummary on CorrelationId, ParticipantId, EndpointId\r\n| join kind=leftouter SIPCodes on ParticipantEndReason\r\n| extend EndReason=strcat(ParticipantEndReason, \": \", SIPCode)\r\n| extend UnsuccessfulEndReason = iff((ParticipantEndReason startswith \"0\") or (ParticipantEndReason startswith \"2\"), \"\", \"🛑\")\r\n| extend ParticipantTime=format_datetime(ParticipantStartTime, 'hh:mm:ss')\r\n| extend EndpointType = case(  indexof(EndpointType, \"VoIP\") != -1, strcat(\"🗣️ \", EndpointType),\r\n                            indexof(EndpointType, \"PSTN\") != -1, strcat(\"📞 \", EndpointType),\r\n                            indexof(EndpointType, \"Bot\") != -1, strcat(\"🤖 \", EndpointType),\r\n                            indexof(EndpointType, \"Server\") != -1, strcat(\"🖥️ \", EndpointType),\r\n                            indexof(EndpointType, \"Unknown\") != -1, strcat(\"👽 \", EndpointType),\r\n                            EndpointType\r\n                        )\r\n| extend IsInterop = Identifier !startswith \"acs:\"\r\n| extend ParticipantType = iff(IsInterop, \"🔄 Teams\", EndpointType)\r\n| extend JitterQuality = iff(JitterAvg > 30, \"Poor\", \"Good\")\r\n| extend PacketLossRateQuality = iff(PacketLossRateAvg > 0.1, \"Poor\", \"Good\")\r\n| extend RoundTripTimeQuality = iff(RoundTripTimeAvg > 500, \"Poor\", \"Good\")\r\n| extend StreamQuality = iff((JitterQuality == \"Poor\") or (PacketLossRateQuality == \"Poor\") or (RoundTripTimeQuality == \"Poor\"), \"🚩\", \"\")\r\n| extend Participant = strcat(ParticipantType, \" \", UnsuccessfulEndReason, \" \", StreamQuality, \" \", ParticipantTime, \" (\", ParticipantId, \")\")\r\n| extend MediaType = case(  indexof(MediaType, \"Audio\") != -1, strcat(\"🔊 \", MediaType),\r\n                            indexof(MediaType, \"Video\") != -1, strcat(\"🎥 \", MediaType),\r\n                            indexof(MediaType, \"VBSS\") != -1, strcat(\"💻 \", MediaType),\r\n                            indexof(MediaType, \"AppSharing\") != -1, strcat(\"📲 \", MediaType),\r\n                            MediaType\r\n                        )\r\n| project CallId = strcat(\"📞 \", CorrelationId), Participant, MediaType, ParticipantDuration, EndReason, JitterAvg, PacketLossRateAvg, RoundTripTimeAvg",
+                    "size": 0,
+                    "title": "Details for call {call_id}",
+                    "noDataMessage": "Please select a call from the left column",
+                    "queryType": 0,
+                    "resourceType": "microsoft.communication/communicationservices",
+                    "gridSettings": {
+                      "formatters": [
+                        {
+                          "columnMatch": "CallId",
                           "formatter": 5
                         },
                         {
-                          "columnMatch": "ProportionalDuration",
-                          "formatter": 3,
-                          "formatOptions": {
-                            "min": 0,
-                            "max": 1,
-                            "palette": "blue"
-                          }
+                          "columnMatch": "Participant",
+                          "formatter": 5
                         },
                         {
                           "columnMatch": "MediaType",
                           "formatter": 5
+                        },
+                        {
+                          "columnMatch": "EndReason",
+                          "formatter": 18,
+                          "formatOptions": {
+                            "thresholdsOptions": "icons",
+                            "thresholdsGrid": [
+                              {
+                                "operator": "startsWith",
+                                "thresholdValue": "2",
+                                "representation": "success",
+                                "text": "{0}{1}"
+                              },
+                              {
+                                "operator": "startsWith",
+                                "thresholdValue": "0",
+                                "representation": "success",
+                                "text": "{0}{1}"
+                              },
+                              {
+                                "operator": "Default",
+                                "thresholdValue": null,
+                                "representation": "3",
+                                "text": "{0}{1}"
+                              }
+                            ]
+                          }
                         },
                         {
                           "columnMatch": "JitterAvg",
@@ -667,9 +819,6 @@
                                 "text": "{0}{1}"
                               }
                             ]
-                          },
-                          "tooltipFormat": {
-                            "tooltip": "The threshold for a poor quality jitter value is currently set at 30ms"
                           }
                         },
                         {
@@ -680,7 +829,7 @@
                             "thresholdsGrid": [
                               {
                                 "operator": ">",
-                                "thresholdValue": "0.1",
+                                "thresholdValue": ".1",
                                 "representation": "redBright",
                                 "text": "{0}{1}"
                               },
@@ -690,9 +839,6 @@
                                 "text": "{0}{1}"
                               }
                             ]
-                          },
-                          "tooltipFormat": {
-                            "tooltip": "The threshold for a poor quality packet loss rate value is currently set at 10% (0.1)"
                           }
                         },
                         {
@@ -713,75 +859,39 @@
                                 "text": "{0}{1}"
                               }
                             ]
-                          },
-                          "tooltipFormat": {
-                            "tooltip": "The threshold for a poor quality round trip time is currently set at 500ms"
                           }
-                        },
-                        {
-                          "columnMatch": "$gen_group",
-                          "formatter": 0,
-                          "formatOptions": {
-                            "customColumnWidthSetting": "50ch"
-                          }
-                        },
-                        {
-                          "columnMatch": "ParticipantDuration",
-                          "formatter": 19,
-                          "formatOptions": {
-                            "palette": "blue"
-                          }
-                        },
-                        {
-                          "columnMatch": "CorrelationId",
-                          "formatter": 5
-                        },
-                        {
-                          "columnMatch": "ParticipantId",
-                          "formatter": 5
-                        },
-                        {
-                          "columnMatch": "EndpointId",
-                          "formatter": 5
                         }
                       ],
                       "hierarchySettings": {
                         "treeType": 1,
                         "groupBy": [
-                          "CallDate",
-                          "CallInfo",
-                          "ParticipantInfo"
+                          "CallId",
+                          "Participant"
                         ],
                         "expandTopLevel": true,
                         "finalBy": "MediaType"
                       }
-                    },
-                    "tileSettings": {
-                      "titleContent": {
-                        "columnMatch": "CallDate",
-                        "formatter": 1
-                      },
-                      "leftContent": {
-                        "columnMatch": "CallInfo",
-                        "formatter": 1,
-                        "formatOptions": {
-                          "linkColumn": "ParticipantInfo",
-                          "linkTarget": "CellDetails",
-                          "linkIsContextBlade": true
-                        },
-                        "numberFormat": {
-                          "unit": 17,
-                          "options": {
-                            "style": "decimal",
-                            "maximumFractionDigits": 2,
-                            "maximumSignificantDigits": 3
-                          }
-                        }
-                      },
-                      "showBorder": false
                     }
                   },
-                  "name": "voice-video-details-call-tree"
+                  "customWidth": "70",
+                  "conditionalVisibility": {
+                    "parameterName": "call_id",
+                    "comparison": "isNotEqualTo"
+                  },
+                  "name": "call-details"
+                },
+                {
+                  "type": 1,
+                  "content": {
+                    "json": "**Select a call from the left column to visualize its details**",
+                    "style": "info"
+                  },
+                  "customWidth": "70",
+                  "conditionalVisibility": {
+                    "parameterName": "call_id",
+                    "comparison": "isEqualTo"
+                  },
+                  "name": "call-drill-down-message"
                 }
               ]
             },
@@ -790,7 +900,7 @@
               "comparison": "isEqualTo",
               "value": "details"
             },
-            "name": "voice-video-details"
+            "name": "call-drill-down"
           }
         ]
       },
@@ -810,61 +920,620 @@
           {
             "type": 1,
             "content": {
-              "json": "The following visualizations represent data from the Authentication Operational logs."
+              "json": "The following visualizations represent data from the Authentication Operational logs.\r\n\r\n**Click on any part of the pie charts below to visualize filtered logs.**"
             },
             "name": "auth-text"
           },
           {
-            "type": 3,
+            "type": 12,
             "content": {
-              "version": "KqlItem/1.0",
-              "query": "ACSAuthIncomingOperations\r\n| where TimeGenerated {time_range:query}\r\n| summarize count() by ResultType\r\n| render piechart",
-              "size": 0,
-              "title": "Auth API Results",
-              "queryType": 0,
-              "resourceType": "Microsoft.Communication/CommunicationServices"
+              "version": "NotebookGroup/1.0",
+              "groupType": "editable",
+              "title": "Authentication API Results",
+              "items": [
+                {
+                  "type": 3,
+                  "content": {
+                    "version": "KqlItem/1.0",
+                    "query": "ACSAuthIncomingOperations\r\n| where TimeGenerated {time_range:query}\r\n| summarize count() by ResultType\r\n| render piechart",
+                    "size": 0,
+                    "noDataMessage": "No authentication operations found in the specified time range",
+                    "exportMultipleValues": true,
+                    "exportedParameters": [
+                      {
+                        "fieldName": "series",
+                        "parameterName": "auth_result",
+                        "parameterType": 1
+                      }
+                    ],
+                    "queryType": 0,
+                    "resourceType": "microsoft.communication/communicationservices"
+                  },
+                  "name": "auth-result-types"
+                },
+                {
+                  "type": 3,
+                  "content": {
+                    "version": "KqlItem/1.0",
+                    "query": "let SIPCodesChat =  datatable(ResultSignature: string, SIPCode: string)\r\n[\r\n    \"0\", \"Success\",\r\n    \"100\", \"Trying\",\r\n    \"180\", \"Ringing\",\r\n    \"181\", \"Call Is Being Forwarded\",\r\n    \"182\", \"Queued\",\r\n    \"183\", \"Session Progress\",\r\n    \"199\", \"Early Dialog Terminated\",\r\n    \"200\", \"Success\",\r\n    \"202\", \"Accepted\",\r\n    \"204\", \"No Notification\",\r\n    \"300\", \"Multiple Choices\",\r\n    \"301\", \"Moved Permanently\",\r\n    \"302\", \"Moved Temporarily\",\r\n    \"305\", \"Use Proxy\",\r\n    \"380\", \"Alternative Service\",\r\n    \"400\", \"Bad Request\",\r\n    \"401\", \"Unauthorized\",\r\n    \"402\", \"Payment Required\",\r\n    \"403\", \"Forbidden\",\r\n    \"404\", \"Not Found\",\r\n    \"405\", \"Method Not Allowed\",\r\n    \"406\", \"Not Acceptable\",\r\n    \"407\", \"Proxy Authentication Required\",\r\n    \"408\", \"Request Timeout\",\r\n    \"409\", \"Conflict\",\r\n    \"410\", \"Gone\",\r\n    \"411\", \"Length Required\",\r\n    \"412\", \"Conditional Request Failed\",\r\n    \"413\", \"Request Entity Too Large\",\r\n    \"414\", \"Request-URI Too Large\",\r\n    \"415\", \"Unsupported Media Type\",\r\n    \"416\", \"Unsupported URI Scheme\",\r\n    \"417\", \"Unknown Resource-Priority\",\r\n    \"420\", \"Bad Extension\",\r\n    \"421\", \"Extension Required\",\r\n    \"422\", \"Session Interval Too Small\",\r\n    \"423\", \"Interval Too Brief\",\r\n    \"424\", \"Bad Location Information\",\r\n    \"428\", \"Use Identity Header\",\r\n    \"429\", \"Provide Referrer Identity\",\r\n    \"430\", \"Flow Failed\",\r\n    \"433\", \"Anonymity Disallowed\",\r\n    \"436\", \"Bad Identity-Info\",\r\n    \"437\", \"Unsupported Certificate\",\r\n    \"438\", \"Invalid Identity Header\",\r\n    \"439\", \"First Hop Lacks Outbound Support\",\r\n    \"440\", \"Max-Breadth Exceeded\",\r\n    \"469\", \"Bad Info Package\",\r\n    \"470\", \"Consent Needed\",\r\n    \"480\", \"Temporarily Unavailable\",\r\n    \"481\", \"Call/Transaction Does Not Exist\",\r\n    \"482\", \"Loop Detected\",\r\n    \"483\", \"Too Many Hops\",\r\n    \"484\", \"Address Incomplete\",\r\n    \"485\", \"Ambiguous\",\r\n    \"486\", \"Busy Here\",\r\n    \"487\", \"Request Terminated\",\r\n    \"488\", \"Not Acceptable Here\",\r\n    \"489\", \"Bad Event\",\r\n    \"491\", \"Request Pending\",\r\n    \"493\", \"Undecipherable\",\r\n    \"494\", \"Security Agreement Required\",\r\n    \"500\", \"Internal Server Error\",\r\n    \"501\", \"Not Implemented\",\r\n    \"502\", \"Bad Gateway\",\r\n    \"503\", \"Service Unavailable\",\r\n    \"504\", \"Server Time-out\",\r\n    \"505\", \"Version Not Supported\",\r\n    \"513\", \"Message Too Large\",\r\n    \"555\", \"Push Notification Service Not Supported\",\r\n    \"580\", \"Precondition Failure\",\r\n    \"600\", \"Busy Everywhere\",\r\n    \"603\", \"Decline\",\r\n    \"604\", \"Does Not Exist Anywhere\",\r\n    \"606\", \"Not Acceptable\",\r\n    \"607\", \"Unwanted\",\r\n    \"608\", \"Rejected\",\r\n];\r\n\r\nACSAuthIncomingOperations\r\n| where TimeGenerated {time_range:query} and ResultType in ({auth_result})\r\n| join kind=leftouter SIPCodesChat on ResultSignature\r\n| extend OperationDate=strcat(\"📅\", format_datetime(TimeGenerated, 'MM/dd/y'))\r\n| extend OperationTime=format_datetime(TimeGenerated, 'hh:mm:ss')\r\n| extend ResultIcon=iff(ResultType == \"Succeeded\", \"✔️\", \"❌\")\r\n| extend Result=strcat(ResultIcon, \" \", ResultSignature, \": \", SIPCode)\r\n| order by TimeGenerated\r\n| project OperationName, Level, Result, OperationDate, OperationTime, DurationMs\r\n",
+                    "size": 0,
+                    "title": "Authentication operations with result type {auth_result}",
+                    "noDataMessage": "No authentication operations found for the specified time range and result type",
+                    "queryType": 0,
+                    "resourceType": "microsoft.communication/communicationservices",
+                    "gridSettings": {
+                      "formatters": [
+                        {
+                          "columnMatch": "Level",
+                          "formatter": 18,
+                          "formatOptions": {
+                            "thresholdsOptions": "icons",
+                            "thresholdsGrid": [
+                              {
+                                "operator": "==",
+                                "thresholdValue": "Warning",
+                                "representation": "warning",
+                                "text": "{0}{1}"
+                              },
+                              {
+                                "operator": "Default",
+                                "thresholdValue": null,
+                                "representation": "info",
+                                "text": "{0}{1}"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "columnMatch": "OperationDate",
+                          "formatter": 5
+                        },
+                        {
+                          "columnMatch": "OperationTime",
+                          "formatter": 5
+                        }
+                      ],
+                      "hierarchySettings": {
+                        "treeType": 1,
+                        "groupBy": [
+                          "OperationDate"
+                        ],
+                        "expandTopLevel": true,
+                        "finalBy": "OperationTime"
+                      }
+                    },
+                    "sortBy": []
+                  },
+                  "conditionalVisibility": {
+                    "parameterName": "auth_result",
+                    "comparison": "isNotEqualTo"
+                  },
+                  "name": "auth-by-result"
+                }
+              ]
             },
             "customWidth": "50",
-            "name": "auth-result-types"
+            "name": "auth-results-group"
           },
           {
-            "type": 3,
+            "type": 12,
             "content": {
-              "version": "KqlItem/1.0",
-              "query": "ACSAuthIncomingOperations\r\n| where TimeGenerated {time_range:query}\r\n| summarize count() by ResultSignature\r\n| render piechart",
-              "size": 0,
-              "title": "Auth API Results Signature",
-              "queryType": 0,
-              "resourceType": "Microsoft.Communication/CommunicationServices"
+              "version": "NotebookGroup/1.0",
+              "groupType": "editable",
+              "title": "Authentication API Result Signatures",
+              "items": [
+                {
+                  "type": 3,
+                  "content": {
+                    "version": "KqlItem/1.0",
+                    "query": "ACSAuthIncomingOperations\r\n| where TimeGenerated {time_range:query}\r\n| summarize count() by ResultSignature\r\n| render piechart",
+                    "size": 0,
+                    "noDataMessage": "No authentication operations found in the specified time range",
+                    "exportMultipleValues": true,
+                    "exportedParameters": [
+                      {
+                        "fieldName": "series",
+                        "parameterName": "auth_signature",
+                        "parameterType": 1
+                      }
+                    ],
+                    "queryType": 0,
+                    "resourceType": "microsoft.communication/communicationservices"
+                  },
+                  "name": "auth-results-signature"
+                },
+                {
+                  "type": 3,
+                  "content": {
+                    "version": "KqlItem/1.0",
+                    "query": "let SIPCodesChat =  datatable(ResultSignature: string, SIPCode: string)\r\n[\r\n    \"0\", \"Success\",\r\n    \"100\", \"Trying\",\r\n    \"180\", \"Ringing\",\r\n    \"181\", \"Call Is Being Forwarded\",\r\n    \"182\", \"Queued\",\r\n    \"183\", \"Session Progress\",\r\n    \"199\", \"Early Dialog Terminated\",\r\n    \"200\", \"Success\",\r\n    \"202\", \"Accepted\",\r\n    \"204\", \"No Notification\",\r\n    \"300\", \"Multiple Choices\",\r\n    \"301\", \"Moved Permanently\",\r\n    \"302\", \"Moved Temporarily\",\r\n    \"305\", \"Use Proxy\",\r\n    \"380\", \"Alternative Service\",\r\n    \"400\", \"Bad Request\",\r\n    \"401\", \"Unauthorized\",\r\n    \"402\", \"Payment Required\",\r\n    \"403\", \"Forbidden\",\r\n    \"404\", \"Not Found\",\r\n    \"405\", \"Method Not Allowed\",\r\n    \"406\", \"Not Acceptable\",\r\n    \"407\", \"Proxy Authentication Required\",\r\n    \"408\", \"Request Timeout\",\r\n    \"409\", \"Conflict\",\r\n    \"410\", \"Gone\",\r\n    \"411\", \"Length Required\",\r\n    \"412\", \"Conditional Request Failed\",\r\n    \"413\", \"Request Entity Too Large\",\r\n    \"414\", \"Request-URI Too Large\",\r\n    \"415\", \"Unsupported Media Type\",\r\n    \"416\", \"Unsupported URI Scheme\",\r\n    \"417\", \"Unknown Resource-Priority\",\r\n    \"420\", \"Bad Extension\",\r\n    \"421\", \"Extension Required\",\r\n    \"422\", \"Session Interval Too Small\",\r\n    \"423\", \"Interval Too Brief\",\r\n    \"424\", \"Bad Location Information\",\r\n    \"428\", \"Use Identity Header\",\r\n    \"429\", \"Provide Referrer Identity\",\r\n    \"430\", \"Flow Failed\",\r\n    \"433\", \"Anonymity Disallowed\",\r\n    \"436\", \"Bad Identity-Info\",\r\n    \"437\", \"Unsupported Certificate\",\r\n    \"438\", \"Invalid Identity Header\",\r\n    \"439\", \"First Hop Lacks Outbound Support\",\r\n    \"440\", \"Max-Breadth Exceeded\",\r\n    \"469\", \"Bad Info Package\",\r\n    \"470\", \"Consent Needed\",\r\n    \"480\", \"Temporarily Unavailable\",\r\n    \"481\", \"Call/Transaction Does Not Exist\",\r\n    \"482\", \"Loop Detected\",\r\n    \"483\", \"Too Many Hops\",\r\n    \"484\", \"Address Incomplete\",\r\n    \"485\", \"Ambiguous\",\r\n    \"486\", \"Busy Here\",\r\n    \"487\", \"Request Terminated\",\r\n    \"488\", \"Not Acceptable Here\",\r\n    \"489\", \"Bad Event\",\r\n    \"491\", \"Request Pending\",\r\n    \"493\", \"Undecipherable\",\r\n    \"494\", \"Security Agreement Required\",\r\n    \"500\", \"Internal Server Error\",\r\n    \"501\", \"Not Implemented\",\r\n    \"502\", \"Bad Gateway\",\r\n    \"503\", \"Service Unavailable\",\r\n    \"504\", \"Server Time-out\",\r\n    \"505\", \"Version Not Supported\",\r\n    \"513\", \"Message Too Large\",\r\n    \"555\", \"Push Notification Service Not Supported\",\r\n    \"580\", \"Precondition Failure\",\r\n    \"600\", \"Busy Everywhere\",\r\n    \"603\", \"Decline\",\r\n    \"604\", \"Does Not Exist Anywhere\",\r\n    \"606\", \"Not Acceptable\",\r\n    \"607\", \"Unwanted\",\r\n    \"608\", \"Rejected\",\r\n];\r\n\r\nACSAuthIncomingOperations\r\n| where TimeGenerated {time_range:query} and ResultSignature in ({auth_signature})\r\n| join kind=leftouter SIPCodesChat on ResultSignature\r\n| extend OperationDate=strcat(\"📅\", format_datetime(TimeGenerated, 'MM/dd/y'))\r\n| extend OperationTime=format_datetime(TimeGenerated, 'hh:mm:ss')\r\n| extend ResultIcon=iff(ResultType == \"Succeeded\", \"✔️\", \"❌\")\r\n| extend Result=strcat(ResultIcon, \" \", ResultSignature, \": \", SIPCode)\r\n| order by TimeGenerated\r\n| project OperationName, Level, Result, OperationDate, OperationTime, DurationMs",
+                    "size": 0,
+                    "title": "Authentication operations with result type {auth_signature}",
+                    "noDataMessage": "No authentication operations found for the specified time range and result type",
+                    "queryType": 0,
+                    "resourceType": "microsoft.communication/communicationservices",
+                    "gridSettings": {
+                      "formatters": [
+                        {
+                          "columnMatch": "Level",
+                          "formatter": 18,
+                          "formatOptions": {
+                            "thresholdsOptions": "icons",
+                            "thresholdsGrid": [
+                              {
+                                "operator": "==",
+                                "thresholdValue": "Warning",
+                                "representation": "warning",
+                                "text": "{0}{1}"
+                              },
+                              {
+                                "operator": "Default",
+                                "thresholdValue": null,
+                                "representation": "info",
+                                "text": "{0}{1}"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "columnMatch": "OperationDate",
+                          "formatter": 5
+                        },
+                        {
+                          "columnMatch": "OperationTime",
+                          "formatter": 5
+                        }
+                      ],
+                      "hierarchySettings": {
+                        "treeType": 1,
+                        "groupBy": [
+                          "OperationDate"
+                        ],
+                        "expandTopLevel": true,
+                        "finalBy": "OperationTime"
+                      }
+                    },
+                    "sortBy": []
+                  },
+                  "conditionalVisibility": {
+                    "parameterName": "auth_signature",
+                    "comparison": "isNotEqualTo"
+                  },
+                  "name": "auth-by-signature"
+                }
+              ]
             },
             "customWidth": "50",
-            "name": "auth-results-signature"
+            "name": "auth-signatures-group"
           },
           {
-            "type": 3,
+            "type": 12,
             "content": {
-              "version": "KqlItem/1.0",
-              "query": "ACSAuthIncomingOperations\r\n| where TimeGenerated {time_range:query}\r\n| summarize count() by OperationName\r\n| render piechart",
-              "size": 0,
-              "title": "Auth Operation Names",
-              "queryType": 0,
-              "resourceType": "Microsoft.Communication/CommunicationServices"
+              "version": "NotebookGroup/1.0",
+              "groupType": "editable",
+              "title": "Authentication Operation Names",
+              "items": [
+                {
+                  "type": 3,
+                  "content": {
+                    "version": "KqlItem/1.0",
+                    "query": "ACSAuthIncomingOperations\r\n| where TimeGenerated {time_range:query}\r\n| summarize count() by OperationName\r\n| render piechart",
+                    "size": 0,
+                    "noDataMessage": "No authentication operations found in the specified time range",
+                    "exportMultipleValues": true,
+                    "exportedParameters": [
+                      {
+                        "fieldName": "series",
+                        "parameterName": "auth_operation",
+                        "parameterType": 1
+                      }
+                    ],
+                    "queryType": 0,
+                    "resourceType": "microsoft.communication/communicationservices"
+                  },
+                  "name": "auth-operation-names"
+                },
+                {
+                  "type": 3,
+                  "content": {
+                    "version": "KqlItem/1.0",
+                    "query": "let SIPCodesChat =  datatable(ResultSignature: string, SIPCode: string)\r\n[\r\n    \"0\", \"Success\",\r\n    \"100\", \"Trying\",\r\n    \"180\", \"Ringing\",\r\n    \"181\", \"Call Is Being Forwarded\",\r\n    \"182\", \"Queued\",\r\n    \"183\", \"Session Progress\",\r\n    \"199\", \"Early Dialog Terminated\",\r\n    \"200\", \"Success\",\r\n    \"202\", \"Accepted\",\r\n    \"204\", \"No Notification\",\r\n    \"300\", \"Multiple Choices\",\r\n    \"301\", \"Moved Permanently\",\r\n    \"302\", \"Moved Temporarily\",\r\n    \"305\", \"Use Proxy\",\r\n    \"380\", \"Alternative Service\",\r\n    \"400\", \"Bad Request\",\r\n    \"401\", \"Unauthorized\",\r\n    \"402\", \"Payment Required\",\r\n    \"403\", \"Forbidden\",\r\n    \"404\", \"Not Found\",\r\n    \"405\", \"Method Not Allowed\",\r\n    \"406\", \"Not Acceptable\",\r\n    \"407\", \"Proxy Authentication Required\",\r\n    \"408\", \"Request Timeout\",\r\n    \"409\", \"Conflict\",\r\n    \"410\", \"Gone\",\r\n    \"411\", \"Length Required\",\r\n    \"412\", \"Conditional Request Failed\",\r\n    \"413\", \"Request Entity Too Large\",\r\n    \"414\", \"Request-URI Too Large\",\r\n    \"415\", \"Unsupported Media Type\",\r\n    \"416\", \"Unsupported URI Scheme\",\r\n    \"417\", \"Unknown Resource-Priority\",\r\n    \"420\", \"Bad Extension\",\r\n    \"421\", \"Extension Required\",\r\n    \"422\", \"Session Interval Too Small\",\r\n    \"423\", \"Interval Too Brief\",\r\n    \"424\", \"Bad Location Information\",\r\n    \"428\", \"Use Identity Header\",\r\n    \"429\", \"Provide Referrer Identity\",\r\n    \"430\", \"Flow Failed\",\r\n    \"433\", \"Anonymity Disallowed\",\r\n    \"436\", \"Bad Identity-Info\",\r\n    \"437\", \"Unsupported Certificate\",\r\n    \"438\", \"Invalid Identity Header\",\r\n    \"439\", \"First Hop Lacks Outbound Support\",\r\n    \"440\", \"Max-Breadth Exceeded\",\r\n    \"469\", \"Bad Info Package\",\r\n    \"470\", \"Consent Needed\",\r\n    \"480\", \"Temporarily Unavailable\",\r\n    \"481\", \"Call/Transaction Does Not Exist\",\r\n    \"482\", \"Loop Detected\",\r\n    \"483\", \"Too Many Hops\",\r\n    \"484\", \"Address Incomplete\",\r\n    \"485\", \"Ambiguous\",\r\n    \"486\", \"Busy Here\",\r\n    \"487\", \"Request Terminated\",\r\n    \"488\", \"Not Acceptable Here\",\r\n    \"489\", \"Bad Event\",\r\n    \"491\", \"Request Pending\",\r\n    \"493\", \"Undecipherable\",\r\n    \"494\", \"Security Agreement Required\",\r\n    \"500\", \"Internal Server Error\",\r\n    \"501\", \"Not Implemented\",\r\n    \"502\", \"Bad Gateway\",\r\n    \"503\", \"Service Unavailable\",\r\n    \"504\", \"Server Time-out\",\r\n    \"505\", \"Version Not Supported\",\r\n    \"513\", \"Message Too Large\",\r\n    \"555\", \"Push Notification Service Not Supported\",\r\n    \"580\", \"Precondition Failure\",\r\n    \"600\", \"Busy Everywhere\",\r\n    \"603\", \"Decline\",\r\n    \"604\", \"Does Not Exist Anywhere\",\r\n    \"606\", \"Not Acceptable\",\r\n    \"607\", \"Unwanted\",\r\n    \"608\", \"Rejected\",\r\n];\r\n\r\nACSAuthIncomingOperations\r\n| where TimeGenerated {time_range:query} and OperationName in ({auth_operation})\r\n| join kind=leftouter SIPCodesChat on ResultSignature\r\n| extend OperationDate=strcat(\"📅\", format_datetime(TimeGenerated, 'MM/dd/y'))\r\n| extend OperationTime=format_datetime(TimeGenerated, 'hh:mm:ss')\r\n| extend ResultIcon=iff(ResultType == \"Succeeded\", \"✔️\", \"❌\")\r\n| extend Result=strcat(ResultIcon, \" \", ResultSignature, \": \", SIPCode)\r\n| order by TimeGenerated\r\n| project OperationName, Identity, Level, Result, OperationDate, OperationTime, DurationMs",
+                    "size": 0,
+                    "title": "Authentication operations with result type {auth_operation}",
+                    "noDataMessage": "No authentication operations found for the specified time range and result type",
+                    "queryType": 0,
+                    "resourceType": "microsoft.communication/communicationservices",
+                    "gridSettings": {
+                      "formatters": [
+                        {
+                          "columnMatch": "Level",
+                          "formatter": 18,
+                          "formatOptions": {
+                            "thresholdsOptions": "icons",
+                            "thresholdsGrid": [
+                              {
+                                "operator": "==",
+                                "thresholdValue": "Warning",
+                                "representation": "warning",
+                                "text": "{0}{1}"
+                              },
+                              {
+                                "operator": "Default",
+                                "thresholdValue": null,
+                                "representation": "info",
+                                "text": "{0}{1}"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "columnMatch": "OperationDate",
+                          "formatter": 5
+                        },
+                        {
+                          "columnMatch": "OperationTime",
+                          "formatter": 5
+                        }
+                      ],
+                      "hierarchySettings": {
+                        "treeType": 1,
+                        "groupBy": [
+                          "OperationDate"
+                        ],
+                        "expandTopLevel": true,
+                        "finalBy": "OperationTime"
+                      }
+                    },
+                    "sortBy": []
+                  },
+                  "conditionalVisibility": {
+                    "parameterName": "auth_operation",
+                    "comparison": "isNotEqualTo"
+                  },
+                  "name": "auth-by-operation"
+                }
+              ]
             },
             "customWidth": "50",
-            "name": "auth-operation-names"
+            "name": "auth-operation-names-group"
           },
           {
-            "type": 3,
+            "type": 12,
             "content": {
-              "version": "KqlItem/1.0",
-              "query": "ACSAuthIncomingOperations\r\n| where TimeGenerated {time_range:query}\r\n| summarize count() by OperationVersion\r\n| render piechart",
-              "size": 0,
-              "title": "Auth Operation Versions",
-              "queryType": 0,
-              "resourceType": "Microsoft.Communication/CommunicationServices"
+              "version": "NotebookGroup/1.0",
+              "groupType": "editable",
+              "title": "Authentication Operation Versions",
+              "items": [
+                {
+                  "type": 3,
+                  "content": {
+                    "version": "KqlItem/1.0",
+                    "query": "ACSAuthIncomingOperations\r\n| where TimeGenerated {time_range:query}\r\n| summarize count() by OperationVersion\r\n| render piechart",
+                    "size": 0,
+                    "noDataMessage": "No authentication operations found in the specified time range",
+                    "exportMultipleValues": true,
+                    "exportedParameters": [
+                      {
+                        "fieldName": "series",
+                        "parameterName": "auth_version",
+                        "parameterType": 1
+                      }
+                    ],
+                    "queryType": 0,
+                    "resourceType": "microsoft.communication/communicationservices"
+                  },
+                  "showPin": false,
+                  "name": "auth-operation-versions"
+                },
+                {
+                  "type": 3,
+                  "content": {
+                    "version": "KqlItem/1.0",
+                    "query": "let SIPCodesChat =  datatable(ResultSignature: string, SIPCode: string)\r\n[\r\n    \"0\", \"Success\",\r\n    \"100\", \"Trying\",\r\n    \"180\", \"Ringing\",\r\n    \"181\", \"Call Is Being Forwarded\",\r\n    \"182\", \"Queued\",\r\n    \"183\", \"Session Progress\",\r\n    \"199\", \"Early Dialog Terminated\",\r\n    \"200\", \"Success\",\r\n    \"202\", \"Accepted\",\r\n    \"204\", \"No Notification\",\r\n    \"300\", \"Multiple Choices\",\r\n    \"301\", \"Moved Permanently\",\r\n    \"302\", \"Moved Temporarily\",\r\n    \"305\", \"Use Proxy\",\r\n    \"380\", \"Alternative Service\",\r\n    \"400\", \"Bad Request\",\r\n    \"401\", \"Unauthorized\",\r\n    \"402\", \"Payment Required\",\r\n    \"403\", \"Forbidden\",\r\n    \"404\", \"Not Found\",\r\n    \"405\", \"Method Not Allowed\",\r\n    \"406\", \"Not Acceptable\",\r\n    \"407\", \"Proxy Authentication Required\",\r\n    \"408\", \"Request Timeout\",\r\n    \"409\", \"Conflict\",\r\n    \"410\", \"Gone\",\r\n    \"411\", \"Length Required\",\r\n    \"412\", \"Conditional Request Failed\",\r\n    \"413\", \"Request Entity Too Large\",\r\n    \"414\", \"Request-URI Too Large\",\r\n    \"415\", \"Unsupported Media Type\",\r\n    \"416\", \"Unsupported URI Scheme\",\r\n    \"417\", \"Unknown Resource-Priority\",\r\n    \"420\", \"Bad Extension\",\r\n    \"421\", \"Extension Required\",\r\n    \"422\", \"Session Interval Too Small\",\r\n    \"423\", \"Interval Too Brief\",\r\n    \"424\", \"Bad Location Information\",\r\n    \"428\", \"Use Identity Header\",\r\n    \"429\", \"Provide Referrer Identity\",\r\n    \"430\", \"Flow Failed\",\r\n    \"433\", \"Anonymity Disallowed\",\r\n    \"436\", \"Bad Identity-Info\",\r\n    \"437\", \"Unsupported Certificate\",\r\n    \"438\", \"Invalid Identity Header\",\r\n    \"439\", \"First Hop Lacks Outbound Support\",\r\n    \"440\", \"Max-Breadth Exceeded\",\r\n    \"469\", \"Bad Info Package\",\r\n    \"470\", \"Consent Needed\",\r\n    \"480\", \"Temporarily Unavailable\",\r\n    \"481\", \"Call/Transaction Does Not Exist\",\r\n    \"482\", \"Loop Detected\",\r\n    \"483\", \"Too Many Hops\",\r\n    \"484\", \"Address Incomplete\",\r\n    \"485\", \"Ambiguous\",\r\n    \"486\", \"Busy Here\",\r\n    \"487\", \"Request Terminated\",\r\n    \"488\", \"Not Acceptable Here\",\r\n    \"489\", \"Bad Event\",\r\n    \"491\", \"Request Pending\",\r\n    \"493\", \"Undecipherable\",\r\n    \"494\", \"Security Agreement Required\",\r\n    \"500\", \"Internal Server Error\",\r\n    \"501\", \"Not Implemented\",\r\n    \"502\", \"Bad Gateway\",\r\n    \"503\", \"Service Unavailable\",\r\n    \"504\", \"Server Time-out\",\r\n    \"505\", \"Version Not Supported\",\r\n    \"513\", \"Message Too Large\",\r\n    \"555\", \"Push Notification Service Not Supported\",\r\n    \"580\", \"Precondition Failure\",\r\n    \"600\", \"Busy Everywhere\",\r\n    \"603\", \"Decline\",\r\n    \"604\", \"Does Not Exist Anywhere\",\r\n    \"606\", \"Not Acceptable\",\r\n    \"607\", \"Unwanted\",\r\n    \"608\", \"Rejected\",\r\n];\r\n\r\nACSAuthIncomingOperations\r\n| where TimeGenerated {time_range:query} and OperationVersion in ({auth_version})\r\n| join kind=leftouter SIPCodesChat on ResultSignature\r\n| extend OperationDate=strcat(\"📅\", format_datetime(TimeGenerated, 'MM/dd/y'))\r\n| extend OperationTime=format_datetime(TimeGenerated, 'hh:mm:ss')\r\n| extend ResultIcon=iff(ResultType == \"Succeeded\", \"✔️\", \"❌\")\r\n| extend Result=strcat(ResultIcon, \" \", ResultSignature, \": \", SIPCode)\r\n| order by TimeGenerated\r\n| project OperationName, Identity, Level, Result, OperationDate, OperationTime, DurationMs",
+                    "size": 0,
+                    "title": "Authentication operations with result type {auth_version}",
+                    "noDataMessage": "No authentication operations found for the specified time range and result type",
+                    "queryType": 0,
+                    "resourceType": "microsoft.communication/communicationservices",
+                    "gridSettings": {
+                      "formatters": [
+                        {
+                          "columnMatch": "Level",
+                          "formatter": 18,
+                          "formatOptions": {
+                            "thresholdsOptions": "icons",
+                            "thresholdsGrid": [
+                              {
+                                "operator": "==",
+                                "thresholdValue": "Warning",
+                                "representation": "warning",
+                                "text": "{0}{1}"
+                              },
+                              {
+                                "operator": "Default",
+                                "thresholdValue": null,
+                                "representation": "info",
+                                "text": "{0}{1}"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "columnMatch": "OperationDate",
+                          "formatter": 5
+                        },
+                        {
+                          "columnMatch": "OperationTime",
+                          "formatter": 5
+                        }
+                      ],
+                      "hierarchySettings": {
+                        "treeType": 1,
+                        "groupBy": [
+                          "OperationDate"
+                        ],
+                        "expandTopLevel": true,
+                        "finalBy": "OperationTime"
+                      }
+                    },
+                    "sortBy": []
+                  },
+                  "conditionalVisibility": {
+                    "parameterName": "auth_version",
+                    "comparison": "isNotEqualTo"
+                  },
+                  "name": "auth-by-version"
+                }
+              ]
             },
             "customWidth": "50",
-            "name": "auth-operation-versions"
+            "name": "auth-operation-versions-group"
+          },
+          {
+            "type": 12,
+            "content": {
+              "version": "NotebookGroup/1.0",
+              "groupType": "editable",
+              "title": "Identity drill-down",
+              "items": [
+                {
+                  "type": 9,
+                  "content": {
+                    "version": "KqlParameterItem/1.0",
+                    "parameters": [
+                      {
+                        "id": "0c0b56fd-ffd9-4761-b14e-c916660f9ccc",
+                        "version": "KqlParameterItem/1.0",
+                        "name": "identity",
+                        "label": "Identity",
+                        "type": 2,
+                        "description": "Choose an identity to visualize",
+                        "query": "ACSAuthIncomingOperations\r\n| where TimeGenerated {time_range:query}\r\n| order by TimeGenerated\r\n| distinct Identity",
+                        "value": null,
+                        "typeSettings": {
+                          "additionalResourceOptions": [],
+                          "showDefault": false
+                        },
+                        "queryType": 0,
+                        "resourceType": "microsoft.communication/communicationservices"
+                      }
+                    ],
+                    "style": "pills",
+                    "queryType": 0,
+                    "resourceType": "microsoft.communication/communicationservices"
+                  },
+                  "name": "parameters - 2"
+                },
+                {
+                  "type": 1,
+                  "content": {
+                    "json": "**Select an identity from the drop-down menu to display its associated data**",
+                    "style": "info"
+                  },
+                  "conditionalVisibility": {
+                    "parameterName": "identity",
+                    "comparison": "isEqualTo"
+                  },
+                  "name": "identity-drilldown-info"
+                },
+                {
+                  "type": 3,
+                  "content": {
+                    "version": "KqlItem/1.0",
+                    "query": "let SIPCodes =  datatable(ParticipantEndReason: string, SIPCode: string)\r\n[\r\n    \"0\", \"Success\",\r\n    \"100\", \"Trying\",\r\n    \"180\", \"Ringing\",\r\n    \"181\", \"Call Is Being Forwarded\",\r\n    \"182\", \"Queued\",\r\n    \"183\", \"Session Progress\",\r\n    \"199\", \"Early Dialog Terminated\",\r\n    \"200\", \"Success\",\r\n    \"202\", \"Accepted\",\r\n    \"204\", \"No Notification\",\r\n    \"300\", \"Multiple Choices\",\r\n    \"301\", \"Moved Permanently\",\r\n    \"302\", \"Moved Temporarily\",\r\n    \"305\", \"Use Proxy\",\r\n    \"380\", \"Alternative Service\",\r\n    \"400\", \"Bad Request\",\r\n    \"401\", \"Unauthorized\",\r\n    \"402\", \"Payment Required\",\r\n    \"403\", \"Forbidden\",\r\n    \"404\", \"Not Found\",\r\n    \"405\", \"Method Not Allowed\",\r\n    \"406\", \"Not Acceptable\",\r\n    \"407\", \"Proxy Authentication Required\",\r\n    \"408\", \"Request Timeout\",\r\n    \"409\", \"Conflict\",\r\n    \"410\", \"Gone\",\r\n    \"411\", \"Length Required\",\r\n    \"412\", \"Conditional Request Failed\",\r\n    \"413\", \"Request Entity Too Large\",\r\n    \"414\", \"Request-URI Too Large\",\r\n    \"415\", \"Unsupported Media Type\",\r\n    \"416\", \"Unsupported URI Scheme\",\r\n    \"417\", \"Unknown Resource-Priority\",\r\n    \"420\", \"Bad Extension\",\r\n    \"421\", \"Extension Required\",\r\n    \"422\", \"Session Interval Too Small\",\r\n    \"423\", \"Interval Too Brief\",\r\n    \"424\", \"Bad Location Information\",\r\n    \"428\", \"Use Identity Header\",\r\n    \"429\", \"Provide Referrer Identity\",\r\n    \"430\", \"Flow Failed\",\r\n    \"433\", \"Anonymity Disallowed\",\r\n    \"436\", \"Bad Identity-Info\",\r\n    \"437\", \"Unsupported Certificate\",\r\n    \"438\", \"Invalid Identity Header\",\r\n    \"439\", \"First Hop Lacks Outbound Support\",\r\n    \"440\", \"Max-Breadth Exceeded\",\r\n    \"469\", \"Bad Info Package\",\r\n    \"470\", \"Consent Needed\",\r\n    \"480\", \"Temporarily Unavailable\",\r\n    \"481\", \"Call/Transaction Does Not Exist\",\r\n    \"482\", \"Loop Detected\",\r\n    \"483\", \"Too Many Hops\",\r\n    \"484\", \"Address Incomplete\",\r\n    \"485\", \"Ambiguous\",\r\n    \"486\", \"Busy Here\",\r\n    \"487\", \"Request Terminated\",\r\n    \"488\", \"Not Acceptable Here\",\r\n    \"489\", \"Bad Event\",\r\n    \"491\", \"Request Pending\",\r\n    \"493\", \"Undecipherable\",\r\n    \"494\", \"Security Agreement Required\",\r\n    \"500\", \"Internal Server Error\",\r\n    \"501\", \"Not Implemented\",\r\n    \"502\", \"Bad Gateway\",\r\n    \"503\", \"Service Unavailable\",\r\n    \"504\", \"Server Time-out\",\r\n    \"505\", \"Version Not Supported\",\r\n    \"513\", \"Message Too Large\",\r\n    \"555\", \"Push Notification Service Not Supported\",\r\n    \"580\", \"Precondition Failure\",\r\n    \"600\", \"Busy Everywhere\",\r\n    \"603\", \"Decline\",\r\n    \"604\", \"Does Not Exist Anywhere\",\r\n    \"606\", \"Not Acceptable\",\r\n    \"607\", \"Unwanted\",\r\n    \"608\", \"Rejected\",\r\n];\r\n\r\nACSCallDiagnostics\r\n| join kind=inner ACSCallSummary on CorrelationId, ParticipantId, EndpointId\r\n| where CallStartTime {time_range:query} and Identifier == substring(\"{identity}\", indexof(\"{identity}\", \"acs:\"))\r\n| join kind=leftouter SIPCodes on ParticipantEndReason\r\n| extend EndReason=strcat(ParticipantEndReason, \": \", SIPCode)\r\n| extend CallDate=strcat(\"📅\", format_datetime(CallStartTime, 'MM/dd/y'))\r\n| extend UnsuccessfulEndReason = iff((ParticipantEndReason startswith \"0\") or (ParticipantEndReason startswith \"2\"), \"\", \"🛑\")\r\n| extend ParticipantTime=format_datetime(ParticipantStartTime, 'hh:mm:ss')\r\n| extend EndpointType = case(  indexof(EndpointType, \"VoIP\") != -1, strcat(\"🗣️ \", EndpointType),\r\n                            indexof(EndpointType, \"PSTN\") != -1, strcat(\"📞 \", EndpointType),\r\n                            indexof(EndpointType, \"Bot\") != -1, strcat(\"🤖 \", EndpointType),\r\n                            indexof(EndpointType, \"Server\") != -1, strcat(\"🖥️ \", EndpointType),\r\n                            indexof(EndpointType, \"Unknown\") != -1, strcat(\"👽 \", EndpointType),\r\n                            EndpointType\r\n                        )\r\n| extend Participant = strcat(EndpointType, \" \", UnsuccessfulEndReason, \" \", ParticipantTime, \" (\", ParticipantId, \")\")\r\n| extend MediaType = case(  indexof(MediaType, \"Audio\") != -1, strcat(\"🔊 \", MediaType),\r\n                            indexof(MediaType, \"Video\") != -1, strcat(\"🎥 \", MediaType),\r\n                            indexof(MediaType, \"VBSS\") != -1, strcat(\"💻 \", MediaType),\r\n                            indexof(MediaType, \"AppSharing\") != -1, strcat(\"📲 \", MediaType),\r\n                            MediaType\r\n                        )\r\n| project CallDate, CallId = strcat(\"📞 \", CorrelationId), Participant, MediaType, ParticipantDuration, EndReason, JitterAvg, PacketLossRateAvg, RoundTripTimeAvg",
+                    "size": 0,
+                    "title": "Calls for identity {identity}",
+                    "noDataMessage": "No calls found for the specified time range and identity",
+                    "queryType": 0,
+                    "resourceType": "microsoft.communication/communicationservices",
+                    "gridSettings": {
+                      "formatters": [
+                        {
+                          "columnMatch": "CallDate",
+                          "formatter": 5
+                        },
+                        {
+                          "columnMatch": "CallId",
+                          "formatter": 5
+                        },
+                        {
+                          "columnMatch": "Participant",
+                          "formatter": 5
+                        },
+                        {
+                          "columnMatch": "MediaType",
+                          "formatter": 5
+                        },
+                        {
+                          "columnMatch": "EndReason",
+                          "formatter": 18,
+                          "formatOptions": {
+                            "thresholdsOptions": "icons",
+                            "thresholdsGrid": [
+                              {
+                                "operator": "startsWith",
+                                "thresholdValue": "2",
+                                "representation": "success",
+                                "text": "{0}{1}"
+                              },
+                              {
+                                "operator": "startsWith",
+                                "thresholdValue": "0",
+                                "representation": "success",
+                                "text": "{0}{1}"
+                              },
+                              {
+                                "operator": "Default",
+                                "thresholdValue": null,
+                                "representation": "3",
+                                "text": "{0}{1}"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "columnMatch": "JitterAvg",
+                          "formatter": 18,
+                          "formatOptions": {
+                            "thresholdsOptions": "colors",
+                            "thresholdsGrid": [
+                              {
+                                "operator": ">",
+                                "thresholdValue": "30",
+                                "representation": "redBright",
+                                "text": "{0}{1}"
+                              },
+                              {
+                                "operator": "Default",
+                                "thresholdValue": null,
+                                "text": "{0}{1}"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "columnMatch": "PacketLossRateAvg",
+                          "formatter": 18,
+                          "formatOptions": {
+                            "thresholdsOptions": "colors",
+                            "thresholdsGrid": [
+                              {
+                                "operator": ">",
+                                "thresholdValue": ".1",
+                                "representation": "redBright",
+                                "text": "{0}{1}"
+                              },
+                              {
+                                "operator": "Default",
+                                "thresholdValue": null,
+                                "text": "{0}{1}"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "columnMatch": "RoundTripTimeAvg",
+                          "formatter": 18,
+                          "formatOptions": {
+                            "thresholdsOptions": "colors",
+                            "thresholdsGrid": [
+                              {
+                                "operator": ">",
+                                "thresholdValue": "500",
+                                "representation": "redBright",
+                                "text": "{0}{1}"
+                              },
+                              {
+                                "operator": "Default",
+                                "thresholdValue": null,
+                                "text": "{0}{1}"
+                              }
+                            ]
+                          }
+                        }
+                      ],
+                      "hierarchySettings": {
+                        "treeType": 1,
+                        "groupBy": [
+                          "CallDate",
+                          "CallId",
+                          "Participant"
+                        ],
+                        "expandTopLevel": true,
+                        "finalBy": "MediaType"
+                      }
+                    }
+                  },
+                  "customWidth": "50",
+                  "conditionalVisibility": {
+                    "parameterName": "identity",
+                    "comparison": "isNotEqualTo"
+                  },
+                  "name": "identity-call-details"
+                },
+                {
+                  "type": 3,
+                  "content": {
+                    "version": "KqlItem/1.0",
+                    "query": "let SIPCodesChat =  datatable(ResultSignature: string, SIPCode: string)\r\n[\r\n    \"0\", \"Success\",\r\n    \"100\", \"Trying\",\r\n    \"180\", \"Ringing\",\r\n    \"181\", \"Call Is Being Forwarded\",\r\n    \"182\", \"Queued\",\r\n    \"183\", \"Session Progress\",\r\n    \"199\", \"Early Dialog Terminated\",\r\n    \"200\", \"Success\",\r\n    \"202\", \"Accepted\",\r\n    \"204\", \"No Notification\",\r\n    \"300\", \"Multiple Choices\",\r\n    \"301\", \"Moved Permanently\",\r\n    \"302\", \"Moved Temporarily\",\r\n    \"305\", \"Use Proxy\",\r\n    \"380\", \"Alternative Service\",\r\n    \"400\", \"Bad Request\",\r\n    \"401\", \"Unauthorized\",\r\n    \"402\", \"Payment Required\",\r\n    \"403\", \"Forbidden\",\r\n    \"404\", \"Not Found\",\r\n    \"405\", \"Method Not Allowed\",\r\n    \"406\", \"Not Acceptable\",\r\n    \"407\", \"Proxy Authentication Required\",\r\n    \"408\", \"Request Timeout\",\r\n    \"409\", \"Conflict\",\r\n    \"410\", \"Gone\",\r\n    \"411\", \"Length Required\",\r\n    \"412\", \"Conditional Request Failed\",\r\n    \"413\", \"Request Entity Too Large\",\r\n    \"414\", \"Request-URI Too Large\",\r\n    \"415\", \"Unsupported Media Type\",\r\n    \"416\", \"Unsupported URI Scheme\",\r\n    \"417\", \"Unknown Resource-Priority\",\r\n    \"420\", \"Bad Extension\",\r\n    \"421\", \"Extension Required\",\r\n    \"422\", \"Session Interval Too Small\",\r\n    \"423\", \"Interval Too Brief\",\r\n    \"424\", \"Bad Location Information\",\r\n    \"428\", \"Use Identity Header\",\r\n    \"429\", \"Provide Referrer Identity\",\r\n    \"430\", \"Flow Failed\",\r\n    \"433\", \"Anonymity Disallowed\",\r\n    \"436\", \"Bad Identity-Info\",\r\n    \"437\", \"Unsupported Certificate\",\r\n    \"438\", \"Invalid Identity Header\",\r\n    \"439\", \"First Hop Lacks Outbound Support\",\r\n    \"440\", \"Max-Breadth Exceeded\",\r\n    \"469\", \"Bad Info Package\",\r\n    \"470\", \"Consent Needed\",\r\n    \"480\", \"Temporarily Unavailable\",\r\n    \"481\", \"Call/Transaction Does Not Exist\",\r\n    \"482\", \"Loop Detected\",\r\n    \"483\", \"Too Many Hops\",\r\n    \"484\", \"Address Incomplete\",\r\n    \"485\", \"Ambiguous\",\r\n    \"486\", \"Busy Here\",\r\n    \"487\", \"Request Terminated\",\r\n    \"488\", \"Not Acceptable Here\",\r\n    \"489\", \"Bad Event\",\r\n    \"491\", \"Request Pending\",\r\n    \"493\", \"Undecipherable\",\r\n    \"494\", \"Security Agreement Required\",\r\n    \"500\", \"Internal Server Error\",\r\n    \"501\", \"Not Implemented\",\r\n    \"502\", \"Bad Gateway\",\r\n    \"503\", \"Service Unavailable\",\r\n    \"504\", \"Server Time-out\",\r\n    \"505\", \"Version Not Supported\",\r\n    \"513\", \"Message Too Large\",\r\n    \"555\", \"Push Notification Service Not Supported\",\r\n    \"580\", \"Precondition Failure\",\r\n    \"600\", \"Busy Everywhere\",\r\n    \"603\", \"Decline\",\r\n    \"604\", \"Does Not Exist Anywhere\",\r\n    \"606\", \"Not Acceptable\",\r\n    \"607\", \"Unwanted\",\r\n    \"608\", \"Rejected\",\r\n];\r\n\r\nACSChatIncomingOperations\r\n| where TimeGenerated {time_range:query} and UserId == \"{identity}\"\r\n| join kind=leftouter SIPCodesChat on ResultSignature\r\n| extend OperationDate=strcat(\"📅\", format_datetime(TimeGenerated, 'MM/dd/y'))\r\n| extend OperationTime=format_datetime(TimeGenerated, 'hh:mm:ss')\r\n| extend ResultIcon=iff(ResultType == \"Succeeded\", \"✔️\", \"❌\")\r\n| extend Result=strcat(ResultIcon, \" \", ResultSignature, \": \", SIPCode)\r\n| order by TimeGenerated\r\n| project OperationName, Level, Result, OperationDate, OperationTime, DurationMs\r\n",
+                    "size": 0,
+                    "title": "Chat operations for identity {identity}",
+                    "noDataMessage": "No chat operations found for the specified  time range and identity",
+                    "queryType": 0,
+                    "resourceType": "microsoft.communication/communicationservices",
+                    "gridSettings": {
+                      "formatters": [
+                        {
+                          "columnMatch": "Level",
+                          "formatter": 18,
+                          "formatOptions": {
+                            "thresholdsOptions": "icons",
+                            "thresholdsGrid": [
+                              {
+                                "operator": "==",
+                                "thresholdValue": "Warning",
+                                "representation": "warning",
+                                "text": "{0}{1}"
+                              },
+                              {
+                                "operator": "Default",
+                                "thresholdValue": null,
+                                "representation": "info",
+                                "text": "{0}{1}"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "columnMatch": "OperationDate",
+                          "formatter": 5
+                        },
+                        {
+                          "columnMatch": "OperationTime",
+                          "formatter": 5
+                        }
+                      ],
+                      "hierarchySettings": {
+                        "treeType": 1,
+                        "groupBy": [
+                          "OperationDate"
+                        ],
+                        "expandTopLevel": true,
+                        "finalBy": "OperationTime"
+                      }
+                    },
+                    "sortBy": []
+                  },
+                  "customWidth": "50",
+                  "conditionalVisibility": {
+                    "parameterName": "identity",
+                    "comparison": "isNotEqualTo"
+                  },
+                  "name": "identity-chat-details"
+                }
+              ]
+            },
+            "name": "identity-drill-down-group"
           }
         ]
       },
@@ -884,61 +1553,840 @@
           {
             "type": 1,
             "content": {
-              "json": "The following visualizations represent data from the Chat Operational logs."
+              "json": "The following visualizations represent data from the Chat Operational logs.\r\n\r\n**Click on any part of the pie charts below to visualize filtered logs.**"
             },
-            "name": "chat-text"
+            "name": "auth-text"
           },
           {
-            "type": 3,
+            "type": 12,
             "content": {
-              "version": "KqlItem/1.0",
-              "query": "ACSChatIncomingOperations\r\n| where TimeGenerated {time_range:query}\r\n| summarize count() by ResultType\r\n| render piechart",
-              "size": 0,
-              "title": "Chat Result Types",
-              "queryType": 0,
-              "resourceType": "Microsoft.Communication/CommunicationServices"
+              "version": "NotebookGroup/1.0",
+              "groupType": "editable",
+              "title": "Chat API Results",
+              "items": [
+                {
+                  "type": 3,
+                  "content": {
+                    "version": "KqlItem/1.0",
+                    "query": "ACSChatIncomingOperations\r\n| where TimeGenerated {time_range:query}\r\n| summarize count() by ResultType\r\n| render piechart",
+                    "size": 0,
+                    "noDataMessage": "No chat operations found in the specified time range",
+                    "exportMultipleValues": true,
+                    "exportedParameters": [
+                      {
+                        "fieldName": "series",
+                        "parameterName": "chat_result",
+                        "parameterType": 1
+                      }
+                    ],
+                    "queryType": 0,
+                    "resourceType": "microsoft.communication/communicationservices"
+                  },
+                  "name": "chat-result-types"
+                },
+                {
+                  "type": 3,
+                  "content": {
+                    "version": "KqlItem/1.0",
+                    "query": "let SIPCodesChat =  datatable(ResultSignature: string, SIPCode: string)\r\n[\r\n    \"0\", \"Success\",\r\n    \"100\", \"Trying\",\r\n    \"180\", \"Ringing\",\r\n    \"181\", \"Call Is Being Forwarded\",\r\n    \"182\", \"Queued\",\r\n    \"183\", \"Session Progress\",\r\n    \"199\", \"Early Dialog Terminated\",\r\n    \"200\", \"Success\",\r\n    \"202\", \"Accepted\",\r\n    \"204\", \"No Notification\",\r\n    \"300\", \"Multiple Choices\",\r\n    \"301\", \"Moved Permanently\",\r\n    \"302\", \"Moved Temporarily\",\r\n    \"305\", \"Use Proxy\",\r\n    \"380\", \"Alternative Service\",\r\n    \"400\", \"Bad Request\",\r\n    \"401\", \"Unauthorized\",\r\n    \"402\", \"Payment Required\",\r\n    \"403\", \"Forbidden\",\r\n    \"404\", \"Not Found\",\r\n    \"405\", \"Method Not Allowed\",\r\n    \"406\", \"Not Acceptable\",\r\n    \"407\", \"Proxy Authentication Required\",\r\n    \"408\", \"Request Timeout\",\r\n    \"409\", \"Conflict\",\r\n    \"410\", \"Gone\",\r\n    \"411\", \"Length Required\",\r\n    \"412\", \"Conditional Request Failed\",\r\n    \"413\", \"Request Entity Too Large\",\r\n    \"414\", \"Request-URI Too Large\",\r\n    \"415\", \"Unsupported Media Type\",\r\n    \"416\", \"Unsupported URI Scheme\",\r\n    \"417\", \"Unknown Resource-Priority\",\r\n    \"420\", \"Bad Extension\",\r\n    \"421\", \"Extension Required\",\r\n    \"422\", \"Session Interval Too Small\",\r\n    \"423\", \"Interval Too Brief\",\r\n    \"424\", \"Bad Location Information\",\r\n    \"428\", \"Use Identity Header\",\r\n    \"429\", \"Provide Referrer Identity\",\r\n    \"430\", \"Flow Failed\",\r\n    \"433\", \"Anonymity Disallowed\",\r\n    \"436\", \"Bad Identity-Info\",\r\n    \"437\", \"Unsupported Certificate\",\r\n    \"438\", \"Invalid Identity Header\",\r\n    \"439\", \"First Hop Lacks Outbound Support\",\r\n    \"440\", \"Max-Breadth Exceeded\",\r\n    \"469\", \"Bad Info Package\",\r\n    \"470\", \"Consent Needed\",\r\n    \"480\", \"Temporarily Unavailable\",\r\n    \"481\", \"Call/Transaction Does Not Exist\",\r\n    \"482\", \"Loop Detected\",\r\n    \"483\", \"Too Many Hops\",\r\n    \"484\", \"Address Incomplete\",\r\n    \"485\", \"Ambiguous\",\r\n    \"486\", \"Busy Here\",\r\n    \"487\", \"Request Terminated\",\r\n    \"488\", \"Not Acceptable Here\",\r\n    \"489\", \"Bad Event\",\r\n    \"491\", \"Request Pending\",\r\n    \"493\", \"Undecipherable\",\r\n    \"494\", \"Security Agreement Required\",\r\n    \"500\", \"Internal Server Error\",\r\n    \"501\", \"Not Implemented\",\r\n    \"502\", \"Bad Gateway\",\r\n    \"503\", \"Service Unavailable\",\r\n    \"504\", \"Server Time-out\",\r\n    \"505\", \"Version Not Supported\",\r\n    \"513\", \"Message Too Large\",\r\n    \"555\", \"Push Notification Service Not Supported\",\r\n    \"580\", \"Precondition Failure\",\r\n    \"600\", \"Busy Everywhere\",\r\n    \"603\", \"Decline\",\r\n    \"604\", \"Does Not Exist Anywhere\",\r\n    \"606\", \"Not Acceptable\",\r\n    \"607\", \"Unwanted\",\r\n    \"608\", \"Rejected\",\r\n];\r\n\r\nACSChatIncomingOperations\r\n| where TimeGenerated {time_range:query} and ResultType in ({chat_result})\r\n| join kind=leftouter SIPCodesChat on ResultSignature\r\n| extend OperationDate=strcat(\"📅\", format_datetime(TimeGenerated, 'MM/dd/y'))\r\n| extend OperationTime=format_datetime(TimeGenerated, 'hh:mm:ss')\r\n| extend ResultIcon=iff(ResultType == \"Succeeded\", \"✔️\", \"❌\")\r\n| extend Result=strcat(ResultIcon, \" \", ResultSignature, \": \", SIPCode)\r\n| order by TimeGenerated\r\n| project OperationName, Level, Result, ResultDescription, OperationDate, OperationTime, DurationMs\r\n",
+                    "size": 0,
+                    "title": "Chat operations with result type {chat_result}",
+                    "noDataMessage": "No chat operations found for the specified time range and result type",
+                    "queryType": 0,
+                    "resourceType": "microsoft.communication/communicationservices",
+                    "gridSettings": {
+                      "formatters": [
+                        {
+                          "columnMatch": "Level",
+                          "formatter": 18,
+                          "formatOptions": {
+                            "thresholdsOptions": "icons",
+                            "thresholdsGrid": [
+                              {
+                                "operator": "==",
+                                "thresholdValue": "Warning",
+                                "representation": "warning",
+                                "text": "{0}{1}"
+                              },
+                              {
+                                "operator": "Default",
+                                "thresholdValue": null,
+                                "representation": "info",
+                                "text": "{0}{1}"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "columnMatch": "OperationDate",
+                          "formatter": 5
+                        },
+                        {
+                          "columnMatch": "OperationTime",
+                          "formatter": 5
+                        }
+                      ],
+                      "hierarchySettings": {
+                        "treeType": 1,
+                        "groupBy": [
+                          "OperationDate"
+                        ],
+                        "expandTopLevel": true,
+                        "finalBy": "OperationTime"
+                      }
+                    },
+                    "sortBy": []
+                  },
+                  "conditionalVisibility": {
+                    "parameterName": "chat_result",
+                    "comparison": "isNotEqualTo"
+                  },
+                  "name": "chat-by-result"
+                }
+              ]
             },
             "customWidth": "50",
-            "name": "chat-result-types"
+            "name": "chat-results-group"
           },
           {
-            "type": 3,
+            "type": 12,
             "content": {
-              "version": "KqlItem/1.0",
-              "query": "ACSChatIncomingOperations\r\n| where TimeGenerated {time_range:query}\r\n| summarize count() by ResultSignature\r\n| render piechart",
-              "size": 0,
-              "title": "Chat Results Signature",
-              "queryType": 0,
-              "resourceType": "Microsoft.Communication/CommunicationServices"
+              "version": "NotebookGroup/1.0",
+              "groupType": "editable",
+              "title": "Chat API Result Signatures",
+              "items": [
+                {
+                  "type": 3,
+                  "content": {
+                    "version": "KqlItem/1.0",
+                    "query": "ACSChatIncomingOperations\r\n| where TimeGenerated {time_range:query}\r\n| summarize count() by ResultSignature\r\n| render piechart",
+                    "size": 0,
+                    "noDataMessage": "No chat operations found in the specified time range",
+                    "exportMultipleValues": true,
+                    "exportedParameters": [
+                      {
+                        "fieldName": "series",
+                        "parameterName": "chat_signature",
+                        "parameterType": 1
+                      }
+                    ],
+                    "queryType": 0,
+                    "resourceType": "microsoft.communication/communicationservices"
+                  },
+                  "name": "sms-results-signature"
+                },
+                {
+                  "type": 3,
+                  "content": {
+                    "version": "KqlItem/1.0",
+                    "query": "let SIPCodesChat =  datatable(ResultSignature: string, SIPCode: string)\r\n[\r\n    \"0\", \"Success\",\r\n    \"100\", \"Trying\",\r\n    \"180\", \"Ringing\",\r\n    \"181\", \"Call Is Being Forwarded\",\r\n    \"182\", \"Queued\",\r\n    \"183\", \"Session Progress\",\r\n    \"199\", \"Early Dialog Terminated\",\r\n    \"200\", \"Success\",\r\n    \"202\", \"Accepted\",\r\n    \"204\", \"No Notification\",\r\n    \"300\", \"Multiple Choices\",\r\n    \"301\", \"Moved Permanently\",\r\n    \"302\", \"Moved Temporarily\",\r\n    \"305\", \"Use Proxy\",\r\n    \"380\", \"Alternative Service\",\r\n    \"400\", \"Bad Request\",\r\n    \"401\", \"Unauthorized\",\r\n    \"402\", \"Payment Required\",\r\n    \"403\", \"Forbidden\",\r\n    \"404\", \"Not Found\",\r\n    \"405\", \"Method Not Allowed\",\r\n    \"406\", \"Not Acceptable\",\r\n    \"407\", \"Proxy Authentication Required\",\r\n    \"408\", \"Request Timeout\",\r\n    \"409\", \"Conflict\",\r\n    \"410\", \"Gone\",\r\n    \"411\", \"Length Required\",\r\n    \"412\", \"Conditional Request Failed\",\r\n    \"413\", \"Request Entity Too Large\",\r\n    \"414\", \"Request-URI Too Large\",\r\n    \"415\", \"Unsupported Media Type\",\r\n    \"416\", \"Unsupported URI Scheme\",\r\n    \"417\", \"Unknown Resource-Priority\",\r\n    \"420\", \"Bad Extension\",\r\n    \"421\", \"Extension Required\",\r\n    \"422\", \"Session Interval Too Small\",\r\n    \"423\", \"Interval Too Brief\",\r\n    \"424\", \"Bad Location Information\",\r\n    \"428\", \"Use Identity Header\",\r\n    \"429\", \"Provide Referrer Identity\",\r\n    \"430\", \"Flow Failed\",\r\n    \"433\", \"Anonymity Disallowed\",\r\n    \"436\", \"Bad Identity-Info\",\r\n    \"437\", \"Unsupported Certificate\",\r\n    \"438\", \"Invalid Identity Header\",\r\n    \"439\", \"First Hop Lacks Outbound Support\",\r\n    \"440\", \"Max-Breadth Exceeded\",\r\n    \"469\", \"Bad Info Package\",\r\n    \"470\", \"Consent Needed\",\r\n    \"480\", \"Temporarily Unavailable\",\r\n    \"481\", \"Call/Transaction Does Not Exist\",\r\n    \"482\", \"Loop Detected\",\r\n    \"483\", \"Too Many Hops\",\r\n    \"484\", \"Address Incomplete\",\r\n    \"485\", \"Ambiguous\",\r\n    \"486\", \"Busy Here\",\r\n    \"487\", \"Request Terminated\",\r\n    \"488\", \"Not Acceptable Here\",\r\n    \"489\", \"Bad Event\",\r\n    \"491\", \"Request Pending\",\r\n    \"493\", \"Undecipherable\",\r\n    \"494\", \"Security Agreement Required\",\r\n    \"500\", \"Internal Server Error\",\r\n    \"501\", \"Not Implemented\",\r\n    \"502\", \"Bad Gateway\",\r\n    \"503\", \"Service Unavailable\",\r\n    \"504\", \"Server Time-out\",\r\n    \"505\", \"Version Not Supported\",\r\n    \"513\", \"Message Too Large\",\r\n    \"555\", \"Push Notification Service Not Supported\",\r\n    \"580\", \"Precondition Failure\",\r\n    \"600\", \"Busy Everywhere\",\r\n    \"603\", \"Decline\",\r\n    \"604\", \"Does Not Exist Anywhere\",\r\n    \"606\", \"Not Acceptable\",\r\n    \"607\", \"Unwanted\",\r\n    \"608\", \"Rejected\",\r\n];\r\n\r\nACSChatIncomingOperations\r\n| where TimeGenerated {time_range:query} and ResultSignature in ({chat_signature})\r\n| join kind=leftouter SIPCodesChat on ResultSignature\r\n| extend OperationDate=strcat(\"📅\", format_datetime(TimeGenerated, 'MM/dd/y'))\r\n| extend OperationTime=format_datetime(TimeGenerated, 'hh:mm:ss')\r\n| extend ResultIcon=iff(ResultType == \"Succeeded\", \"✔️\", \"❌\")\r\n| extend Result=strcat(ResultIcon, \" \", ResultSignature, \": \", SIPCode)\r\n| order by TimeGenerated\r\n| project OperationName, Level, Result, ResultDescription, OperationDate, OperationTime, DurationMs",
+                    "size": 0,
+                    "title": "Chat operations with result signature {chat_signature}",
+                    "noDataMessage": "No chat operations found for the specified time range and result signature",
+                    "queryType": 0,
+                    "resourceType": "microsoft.communication/communicationservices",
+                    "gridSettings": {
+                      "formatters": [
+                        {
+                          "columnMatch": "Level",
+                          "formatter": 18,
+                          "formatOptions": {
+                            "thresholdsOptions": "icons",
+                            "thresholdsGrid": [
+                              {
+                                "operator": "==",
+                                "thresholdValue": "Warning",
+                                "representation": "warning",
+                                "text": "{0}{1}"
+                              },
+                              {
+                                "operator": "Default",
+                                "thresholdValue": null,
+                                "representation": "info",
+                                "text": "{0}{1}"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "columnMatch": "OperationDate",
+                          "formatter": 5
+                        },
+                        {
+                          "columnMatch": "OperationTime",
+                          "formatter": 5
+                        }
+                      ],
+                      "hierarchySettings": {
+                        "treeType": 1,
+                        "groupBy": [
+                          "OperationDate"
+                        ],
+                        "expandTopLevel": true,
+                        "finalBy": "OperationTime"
+                      }
+                    },
+                    "sortBy": []
+                  },
+                  "conditionalVisibility": {
+                    "parameterName": "chat_signature",
+                    "comparison": "isNotEqualTo"
+                  },
+                  "name": "chat-by-signature"
+                }
+              ]
             },
             "customWidth": "50",
-            "name": "chat-results-signature"
+            "name": "chat-signatures-group"
           },
           {
-            "type": 3,
+            "type": 12,
             "content": {
-              "version": "KqlItem/1.0",
-              "query": "ACSChatIncomingOperations\r\n| where TimeGenerated {time_range:query}\r\n| summarize count() by OperationName\r\n| render piechart",
-              "size": 0,
+              "version": "NotebookGroup/1.0",
+              "groupType": "editable",
               "title": "Chat Operation Names",
-              "queryType": 0,
-              "resourceType": "Microsoft.Communication/CommunicationServices"
+              "items": [
+                {
+                  "type": 3,
+                  "content": {
+                    "version": "KqlItem/1.0",
+                    "query": "ACSChatIncomingOperations\r\n| where TimeGenerated {time_range:query}\r\n| summarize count() by OperationName\r\n| render piechart",
+                    "size": 0,
+                    "noDataMessage": "No chat operations found in the specified time range",
+                    "exportMultipleValues": true,
+                    "exportedParameters": [
+                      {
+                        "fieldName": "series",
+                        "parameterName": "chat_operation",
+                        "parameterType": 1
+                      }
+                    ],
+                    "queryType": 0,
+                    "resourceType": "microsoft.communication/communicationservices"
+                  },
+                  "name": "chat-operation-names"
+                },
+                {
+                  "type": 3,
+                  "content": {
+                    "version": "KqlItem/1.0",
+                    "query": "let SIPCodesChat =  datatable(ResultSignature: string, SIPCode: string)\r\n[\r\n    \"0\", \"Success\",\r\n    \"100\", \"Trying\",\r\n    \"180\", \"Ringing\",\r\n    \"181\", \"Call Is Being Forwarded\",\r\n    \"182\", \"Queued\",\r\n    \"183\", \"Session Progress\",\r\n    \"199\", \"Early Dialog Terminated\",\r\n    \"200\", \"Success\",\r\n    \"202\", \"Accepted\",\r\n    \"204\", \"No Notification\",\r\n    \"300\", \"Multiple Choices\",\r\n    \"301\", \"Moved Permanently\",\r\n    \"302\", \"Moved Temporarily\",\r\n    \"305\", \"Use Proxy\",\r\n    \"380\", \"Alternative Service\",\r\n    \"400\", \"Bad Request\",\r\n    \"401\", \"Unauthorized\",\r\n    \"402\", \"Payment Required\",\r\n    \"403\", \"Forbidden\",\r\n    \"404\", \"Not Found\",\r\n    \"405\", \"Method Not Allowed\",\r\n    \"406\", \"Not Acceptable\",\r\n    \"407\", \"Proxy Authentication Required\",\r\n    \"408\", \"Request Timeout\",\r\n    \"409\", \"Conflict\",\r\n    \"410\", \"Gone\",\r\n    \"411\", \"Length Required\",\r\n    \"412\", \"Conditional Request Failed\",\r\n    \"413\", \"Request Entity Too Large\",\r\n    \"414\", \"Request-URI Too Large\",\r\n    \"415\", \"Unsupported Media Type\",\r\n    \"416\", \"Unsupported URI Scheme\",\r\n    \"417\", \"Unknown Resource-Priority\",\r\n    \"420\", \"Bad Extension\",\r\n    \"421\", \"Extension Required\",\r\n    \"422\", \"Session Interval Too Small\",\r\n    \"423\", \"Interval Too Brief\",\r\n    \"424\", \"Bad Location Information\",\r\n    \"428\", \"Use Identity Header\",\r\n    \"429\", \"Provide Referrer Identity\",\r\n    \"430\", \"Flow Failed\",\r\n    \"433\", \"Anonymity Disallowed\",\r\n    \"436\", \"Bad Identity-Info\",\r\n    \"437\", \"Unsupported Certificate\",\r\n    \"438\", \"Invalid Identity Header\",\r\n    \"439\", \"First Hop Lacks Outbound Support\",\r\n    \"440\", \"Max-Breadth Exceeded\",\r\n    \"469\", \"Bad Info Package\",\r\n    \"470\", \"Consent Needed\",\r\n    \"480\", \"Temporarily Unavailable\",\r\n    \"481\", \"Call/Transaction Does Not Exist\",\r\n    \"482\", \"Loop Detected\",\r\n    \"483\", \"Too Many Hops\",\r\n    \"484\", \"Address Incomplete\",\r\n    \"485\", \"Ambiguous\",\r\n    \"486\", \"Busy Here\",\r\n    \"487\", \"Request Terminated\",\r\n    \"488\", \"Not Acceptable Here\",\r\n    \"489\", \"Bad Event\",\r\n    \"491\", \"Request Pending\",\r\n    \"493\", \"Undecipherable\",\r\n    \"494\", \"Security Agreement Required\",\r\n    \"500\", \"Internal Server Error\",\r\n    \"501\", \"Not Implemented\",\r\n    \"502\", \"Bad Gateway\",\r\n    \"503\", \"Service Unavailable\",\r\n    \"504\", \"Server Time-out\",\r\n    \"505\", \"Version Not Supported\",\r\n    \"513\", \"Message Too Large\",\r\n    \"555\", \"Push Notification Service Not Supported\",\r\n    \"580\", \"Precondition Failure\",\r\n    \"600\", \"Busy Everywhere\",\r\n    \"603\", \"Decline\",\r\n    \"604\", \"Does Not Exist Anywhere\",\r\n    \"606\", \"Not Acceptable\",\r\n    \"607\", \"Unwanted\",\r\n    \"608\", \"Rejected\",\r\n];\r\n\r\nACSChatIncomingOperations\r\n| where TimeGenerated {time_range:query} and OperationName in ({chat_operation})\r\n| join kind=leftouter SIPCodesChat on ResultSignature\r\n| extend OperationDate=strcat(\"📅\", format_datetime(TimeGenerated, 'MM/dd/y'))\r\n| extend OperationTime=format_datetime(TimeGenerated, 'hh:mm:ss')\r\n| extend ResultIcon=iff(ResultType == \"Succeeded\", \"✔️\", \"❌\")\r\n| extend Result=strcat(ResultIcon, \" \", ResultSignature, \": \", SIPCode)\r\n| order by TimeGenerated\r\n| project OperationName, Result, UserId, ChatThreadId, CallerIpAddress, Level, OperationDate, OperationTime, DurationMs",
+                    "size": 0,
+                    "title": "Chat operations with operation name {chat_operation}",
+                    "noDataMessage": "No chat operations found for the specified time range and operation name",
+                    "queryType": 0,
+                    "resourceType": "microsoft.communication/communicationservices",
+                    "gridSettings": {
+                      "formatters": [
+                        {
+                          "columnMatch": "Level",
+                          "formatter": 18,
+                          "formatOptions": {
+                            "thresholdsOptions": "icons",
+                            "thresholdsGrid": [
+                              {
+                                "operator": "==",
+                                "thresholdValue": "Warning",
+                                "representation": "warning",
+                                "text": "{0}{1}"
+                              },
+                              {
+                                "operator": "Default",
+                                "thresholdValue": null,
+                                "representation": "info",
+                                "text": "{0}{1}"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "columnMatch": "OperationDate",
+                          "formatter": 5
+                        },
+                        {
+                          "columnMatch": "OperationTime",
+                          "formatter": 5
+                        }
+                      ],
+                      "hierarchySettings": {
+                        "treeType": 1,
+                        "groupBy": [
+                          "OperationDate"
+                        ],
+                        "expandTopLevel": true,
+                        "finalBy": "OperationTime"
+                      }
+                    },
+                    "sortBy": []
+                  },
+                  "conditionalVisibility": {
+                    "parameterName": "chat_operation",
+                    "comparison": "isNotEqualTo"
+                  },
+                  "name": "chat-by-operation"
+                }
+              ]
             },
             "customWidth": "50",
-            "name": "chat-operation-names"
+            "name": "chat-operation-names-group"
           },
           {
-            "type": 3,
+            "type": 12,
             "content": {
-              "version": "KqlItem/1.0",
-              "query": "ACSChatIncomingOperations\r\n| where TimeGenerated {time_range:query}\r\n| summarize count() by OperationVersion\r\n| render piechart",
-              "size": 0,
+              "version": "NotebookGroup/1.0",
+              "groupType": "editable",
               "title": "Chat Operation Versions",
-              "queryType": 0,
-              "resourceType": "Microsoft.Communication/CommunicationServices"
+              "items": [
+                {
+                  "type": 3,
+                  "content": {
+                    "version": "KqlItem/1.0",
+                    "query": "ACSChatIncomingOperations\r\n| where TimeGenerated {time_range:query}\r\n| summarize count() by OperationVersion\r\n| render piechart",
+                    "size": 0,
+                    "noDataMessage": "No chat operations found in the specified time range",
+                    "exportMultipleValues": true,
+                    "exportedParameters": [
+                      {
+                        "fieldName": "series",
+                        "parameterName": "chat_version",
+                        "parameterType": 1
+                      }
+                    ],
+                    "queryType": 0,
+                    "resourceType": "microsoft.communication/communicationservices"
+                  },
+                  "showPin": false,
+                  "name": "chat-operation-versions"
+                },
+                {
+                  "type": 3,
+                  "content": {
+                    "version": "KqlItem/1.0",
+                    "query": "let SIPCodesChat =  datatable(ResultSignature: string, SIPCode: string)\r\n[\r\n    \"0\", \"Success\",\r\n    \"100\", \"Trying\",\r\n    \"180\", \"Ringing\",\r\n    \"181\", \"Call Is Being Forwarded\",\r\n    \"182\", \"Queued\",\r\n    \"183\", \"Session Progress\",\r\n    \"199\", \"Early Dialog Terminated\",\r\n    \"200\", \"Success\",\r\n    \"202\", \"Accepted\",\r\n    \"204\", \"No Notification\",\r\n    \"300\", \"Multiple Choices\",\r\n    \"301\", \"Moved Permanently\",\r\n    \"302\", \"Moved Temporarily\",\r\n    \"305\", \"Use Proxy\",\r\n    \"380\", \"Alternative Service\",\r\n    \"400\", \"Bad Request\",\r\n    \"401\", \"Unauthorized\",\r\n    \"402\", \"Payment Required\",\r\n    \"403\", \"Forbidden\",\r\n    \"404\", \"Not Found\",\r\n    \"405\", \"Method Not Allowed\",\r\n    \"406\", \"Not Acceptable\",\r\n    \"407\", \"Proxy Authentication Required\",\r\n    \"408\", \"Request Timeout\",\r\n    \"409\", \"Conflict\",\r\n    \"410\", \"Gone\",\r\n    \"411\", \"Length Required\",\r\n    \"412\", \"Conditional Request Failed\",\r\n    \"413\", \"Request Entity Too Large\",\r\n    \"414\", \"Request-URI Too Large\",\r\n    \"415\", \"Unsupported Media Type\",\r\n    \"416\", \"Unsupported URI Scheme\",\r\n    \"417\", \"Unknown Resource-Priority\",\r\n    \"420\", \"Bad Extension\",\r\n    \"421\", \"Extension Required\",\r\n    \"422\", \"Session Interval Too Small\",\r\n    \"423\", \"Interval Too Brief\",\r\n    \"424\", \"Bad Location Information\",\r\n    \"428\", \"Use Identity Header\",\r\n    \"429\", \"Provide Referrer Identity\",\r\n    \"430\", \"Flow Failed\",\r\n    \"433\", \"Anonymity Disallowed\",\r\n    \"436\", \"Bad Identity-Info\",\r\n    \"437\", \"Unsupported Certificate\",\r\n    \"438\", \"Invalid Identity Header\",\r\n    \"439\", \"First Hop Lacks Outbound Support\",\r\n    \"440\", \"Max-Breadth Exceeded\",\r\n    \"469\", \"Bad Info Package\",\r\n    \"470\", \"Consent Needed\",\r\n    \"480\", \"Temporarily Unavailable\",\r\n    \"481\", \"Call/Transaction Does Not Exist\",\r\n    \"482\", \"Loop Detected\",\r\n    \"483\", \"Too Many Hops\",\r\n    \"484\", \"Address Incomplete\",\r\n    \"485\", \"Ambiguous\",\r\n    \"486\", \"Busy Here\",\r\n    \"487\", \"Request Terminated\",\r\n    \"488\", \"Not Acceptable Here\",\r\n    \"489\", \"Bad Event\",\r\n    \"491\", \"Request Pending\",\r\n    \"493\", \"Undecipherable\",\r\n    \"494\", \"Security Agreement Required\",\r\n    \"500\", \"Internal Server Error\",\r\n    \"501\", \"Not Implemented\",\r\n    \"502\", \"Bad Gateway\",\r\n    \"503\", \"Service Unavailable\",\r\n    \"504\", \"Server Time-out\",\r\n    \"505\", \"Version Not Supported\",\r\n    \"513\", \"Message Too Large\",\r\n    \"555\", \"Push Notification Service Not Supported\",\r\n    \"580\", \"Precondition Failure\",\r\n    \"600\", \"Busy Everywhere\",\r\n    \"603\", \"Decline\",\r\n    \"604\", \"Does Not Exist Anywhere\",\r\n    \"606\", \"Not Acceptable\",\r\n    \"607\", \"Unwanted\",\r\n    \"608\", \"Rejected\",\r\n];\r\n\r\nACSChatIncomingOperations\r\n| where TimeGenerated {time_range:query} and OperationVersion in ({chat_version})\r\n| join kind=leftouter SIPCodesChat on ResultSignature\r\n| extend OperationDate=strcat(\"📅\", format_datetime(TimeGenerated, 'MM/dd/y'))\r\n| extend OperationTime=format_datetime(TimeGenerated, 'hh:mm:ss')\r\n| extend ResultIcon=iff(ResultType == \"Succeeded\", \"✔️\", \"❌\")\r\n| extend Result=strcat(ResultIcon, \" \", ResultSignature, \": \", SIPCode)\r\n| order by TimeGenerated\r\n| project OperationName, Result, UserId, ChatThreadId, CallerIpAddress, Level, OperationDate, OperationTime, DurationMs",
+                    "size": 0,
+                    "title": "Chat operations with operation version {chat_version}",
+                    "noDataMessage": "No chat operations found for the specified time range and operation version",
+                    "queryType": 0,
+                    "resourceType": "microsoft.communication/communicationservices",
+                    "gridSettings": {
+                      "formatters": [
+                        {
+                          "columnMatch": "Level",
+                          "formatter": 18,
+                          "formatOptions": {
+                            "thresholdsOptions": "icons",
+                            "thresholdsGrid": [
+                              {
+                                "operator": "==",
+                                "thresholdValue": "Warning",
+                                "representation": "warning",
+                                "text": "{0}{1}"
+                              },
+                              {
+                                "operator": "Default",
+                                "thresholdValue": null,
+                                "representation": "info",
+                                "text": "{0}{1}"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "columnMatch": "OperationDate",
+                          "formatter": 5
+                        },
+                        {
+                          "columnMatch": "OperationTime",
+                          "formatter": 5
+                        }
+                      ],
+                      "hierarchySettings": {
+                        "treeType": 1,
+                        "groupBy": [
+                          "OperationDate"
+                        ],
+                        "expandTopLevel": true,
+                        "finalBy": "OperationTime"
+                      }
+                    },
+                    "sortBy": []
+                  },
+                  "conditionalVisibility": {
+                    "parameterName": "chat_version",
+                    "comparison": "isNotEqualTo"
+                  },
+                  "name": "chat-by-version"
+                }
+              ]
             },
             "customWidth": "50",
-            "name": "chat-operation-versions"
+            "name": "chat-operation-versions-group"
+          },
+          {
+            "type": 12,
+            "content": {
+              "version": "NotebookGroup/1.0",
+              "groupType": "editable",
+              "title": "Identity drill-down",
+              "items": [
+                {
+                  "type": 9,
+                  "content": {
+                    "version": "KqlParameterItem/1.0",
+                    "parameters": [
+                      {
+                        "id": "0c0b56fd-ffd9-4761-b14e-c916660f9ccc",
+                        "version": "KqlParameterItem/1.0",
+                        "name": "chat_identity",
+                        "label": "Identity",
+                        "type": 2,
+                        "description": "Choose an identity to visualize",
+                        "query": "ACSChatIncomingOperations\r\n| where TimeGenerated {time_range:query}\r\n| order by TimeGenerated\r\n| distinct UserId",
+                        "value": null,
+                        "typeSettings": {
+                          "additionalResourceOptions": [],
+                          "showDefault": false
+                        },
+                        "queryType": 0,
+                        "resourceType": "microsoft.communication/communicationservices"
+                      }
+                    ],
+                    "style": "pills",
+                    "queryType": 0,
+                    "resourceType": "microsoft.communication/communicationservices"
+                  },
+                  "name": "parameters - 2"
+                },
+                {
+                  "type": 1,
+                  "content": {
+                    "json": "**Select an identity from the drop-down menu to display its associated data**",
+                    "style": "info"
+                  },
+                  "conditionalVisibility": {
+                    "parameterName": "chat_identity",
+                    "comparison": "isEqualTo"
+                  },
+                  "name": "chat-identity-drilldown-info"
+                },
+                {
+                  "type": 3,
+                  "content": {
+                    "version": "KqlItem/1.0",
+                    "query": "let SIPCodes =  datatable(ParticipantEndReason: string, SIPCode: string)\r\n[\r\n    \"0\", \"Success\",\r\n    \"100\", \"Trying\",\r\n    \"180\", \"Ringing\",\r\n    \"181\", \"Call Is Being Forwarded\",\r\n    \"182\", \"Queued\",\r\n    \"183\", \"Session Progress\",\r\n    \"199\", \"Early Dialog Terminated\",\r\n    \"200\", \"Success\",\r\n    \"202\", \"Accepted\",\r\n    \"204\", \"No Notification\",\r\n    \"300\", \"Multiple Choices\",\r\n    \"301\", \"Moved Permanently\",\r\n    \"302\", \"Moved Temporarily\",\r\n    \"305\", \"Use Proxy\",\r\n    \"380\", \"Alternative Service\",\r\n    \"400\", \"Bad Request\",\r\n    \"401\", \"Unauthorized\",\r\n    \"402\", \"Payment Required\",\r\n    \"403\", \"Forbidden\",\r\n    \"404\", \"Not Found\",\r\n    \"405\", \"Method Not Allowed\",\r\n    \"406\", \"Not Acceptable\",\r\n    \"407\", \"Proxy Authentication Required\",\r\n    \"408\", \"Request Timeout\",\r\n    \"409\", \"Conflict\",\r\n    \"410\", \"Gone\",\r\n    \"411\", \"Length Required\",\r\n    \"412\", \"Conditional Request Failed\",\r\n    \"413\", \"Request Entity Too Large\",\r\n    \"414\", \"Request-URI Too Large\",\r\n    \"415\", \"Unsupported Media Type\",\r\n    \"416\", \"Unsupported URI Scheme\",\r\n    \"417\", \"Unknown Resource-Priority\",\r\n    \"420\", \"Bad Extension\",\r\n    \"421\", \"Extension Required\",\r\n    \"422\", \"Session Interval Too Small\",\r\n    \"423\", \"Interval Too Brief\",\r\n    \"424\", \"Bad Location Information\",\r\n    \"428\", \"Use Identity Header\",\r\n    \"429\", \"Provide Referrer Identity\",\r\n    \"430\", \"Flow Failed\",\r\n    \"433\", \"Anonymity Disallowed\",\r\n    \"436\", \"Bad Identity-Info\",\r\n    \"437\", \"Unsupported Certificate\",\r\n    \"438\", \"Invalid Identity Header\",\r\n    \"439\", \"First Hop Lacks Outbound Support\",\r\n    \"440\", \"Max-Breadth Exceeded\",\r\n    \"469\", \"Bad Info Package\",\r\n    \"470\", \"Consent Needed\",\r\n    \"480\", \"Temporarily Unavailable\",\r\n    \"481\", \"Call/Transaction Does Not Exist\",\r\n    \"482\", \"Loop Detected\",\r\n    \"483\", \"Too Many Hops\",\r\n    \"484\", \"Address Incomplete\",\r\n    \"485\", \"Ambiguous\",\r\n    \"486\", \"Busy Here\",\r\n    \"487\", \"Request Terminated\",\r\n    \"488\", \"Not Acceptable Here\",\r\n    \"489\", \"Bad Event\",\r\n    \"491\", \"Request Pending\",\r\n    \"493\", \"Undecipherable\",\r\n    \"494\", \"Security Agreement Required\",\r\n    \"500\", \"Internal Server Error\",\r\n    \"501\", \"Not Implemented\",\r\n    \"502\", \"Bad Gateway\",\r\n    \"503\", \"Service Unavailable\",\r\n    \"504\", \"Server Time-out\",\r\n    \"505\", \"Version Not Supported\",\r\n    \"513\", \"Message Too Large\",\r\n    \"555\", \"Push Notification Service Not Supported\",\r\n    \"580\", \"Precondition Failure\",\r\n    \"600\", \"Busy Everywhere\",\r\n    \"603\", \"Decline\",\r\n    \"604\", \"Does Not Exist Anywhere\",\r\n    \"606\", \"Not Acceptable\",\r\n    \"607\", \"Unwanted\",\r\n    \"608\", \"Rejected\",\r\n];\r\n\r\nACSCallDiagnostics\r\n| join kind=inner ACSCallSummary on CorrelationId, ParticipantId, EndpointId\r\n| where CallStartTime {time_range:query} and Identifier == substring(\"{chat_identity}\", indexof(\"{chat_identity}\", \"acs:\"))\r\n| join kind=leftouter SIPCodes on ParticipantEndReason\r\n| extend EndReason=strcat(ParticipantEndReason, \": \", SIPCode)\r\n| extend CallDate=strcat(\"📅\", format_datetime(CallStartTime, 'MM/dd/y'))\r\n| extend UnsuccessfulEndReason = iff((ParticipantEndReason startswith \"0\") or (ParticipantEndReason startswith \"2\"), \"\", \"🛑\")\r\n| extend ParticipantTime=format_datetime(ParticipantStartTime, 'hh:mm:ss')\r\n| extend EndpointType = case(  indexof(EndpointType, \"VoIP\") != -1, strcat(\"🗣️ \", EndpointType),\r\n                            indexof(EndpointType, \"PSTN\") != -1, strcat(\"📞 \", EndpointType),\r\n                            indexof(EndpointType, \"Bot\") != -1, strcat(\"🤖 \", EndpointType),\r\n                            indexof(EndpointType, \"Server\") != -1, strcat(\"🖥️ \", EndpointType),\r\n                            indexof(EndpointType, \"Unknown\") != -1, strcat(\"👽 \", EndpointType),\r\n                            EndpointType\r\n                        )\r\n| extend Participant = strcat(EndpointType, \" \", UnsuccessfulEndReason, \" \", ParticipantTime, \" (\", ParticipantId, \")\")\r\n| extend MediaType = case(  indexof(MediaType, \"Audio\") != -1, strcat(\"🔊 \", MediaType),\r\n                            indexof(MediaType, \"Video\") != -1, strcat(\"🎥 \", MediaType),\r\n                            indexof(MediaType, \"VBSS\") != -1, strcat(\"💻 \", MediaType),\r\n                            indexof(MediaType, \"AppSharing\") != -1, strcat(\"📲 \", MediaType),\r\n                            MediaType\r\n                        )\r\n| project CallDate, CallId = strcat(\"📞 \", CorrelationId), Participant, MediaType, ParticipantDuration, EndReason, JitterAvg, PacketLossRateAvg, RoundTripTimeAvg",
+                    "size": 0,
+                    "title": "Calls for identity {chat_identity}",
+                    "noDataMessage": "No calls found for the specified time range and identity",
+                    "queryType": 0,
+                    "resourceType": "microsoft.communication/communicationservices",
+                    "gridSettings": {
+                      "formatters": [
+                        {
+                          "columnMatch": "CallDate",
+                          "formatter": 5
+                        },
+                        {
+                          "columnMatch": "CallId",
+                          "formatter": 5
+                        },
+                        {
+                          "columnMatch": "Participant",
+                          "formatter": 5
+                        },
+                        {
+                          "columnMatch": "MediaType",
+                          "formatter": 5
+                        },
+                        {
+                          "columnMatch": "EndReason",
+                          "formatter": 18,
+                          "formatOptions": {
+                            "thresholdsOptions": "icons",
+                            "thresholdsGrid": [
+                              {
+                                "operator": "startsWith",
+                                "thresholdValue": "2",
+                                "representation": "success",
+                                "text": "{0}{1}"
+                              },
+                              {
+                                "operator": "startsWith",
+                                "thresholdValue": "0",
+                                "representation": "success",
+                                "text": "{0}{1}"
+                              },
+                              {
+                                "operator": "Default",
+                                "thresholdValue": null,
+                                "representation": "3",
+                                "text": "{0}{1}"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "columnMatch": "JitterAvg",
+                          "formatter": 18,
+                          "formatOptions": {
+                            "thresholdsOptions": "colors",
+                            "thresholdsGrid": [
+                              {
+                                "operator": ">",
+                                "thresholdValue": "30",
+                                "representation": "redBright",
+                                "text": "{0}{1}"
+                              },
+                              {
+                                "operator": "Default",
+                                "thresholdValue": null,
+                                "text": "{0}{1}"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "columnMatch": "PacketLossRateAvg",
+                          "formatter": 18,
+                          "formatOptions": {
+                            "thresholdsOptions": "colors",
+                            "thresholdsGrid": [
+                              {
+                                "operator": ">",
+                                "thresholdValue": ".1",
+                                "representation": "redBright",
+                                "text": "{0}{1}"
+                              },
+                              {
+                                "operator": "Default",
+                                "thresholdValue": null,
+                                "text": "{0}{1}"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "columnMatch": "RoundTripTimeAvg",
+                          "formatter": 18,
+                          "formatOptions": {
+                            "thresholdsOptions": "colors",
+                            "thresholdsGrid": [
+                              {
+                                "operator": ">",
+                                "thresholdValue": "500",
+                                "representation": "redBright",
+                                "text": "{0}{1}"
+                              },
+                              {
+                                "operator": "Default",
+                                "thresholdValue": null,
+                                "text": "{0}{1}"
+                              }
+                            ]
+                          }
+                        }
+                      ],
+                      "hierarchySettings": {
+                        "treeType": 1,
+                        "groupBy": [
+                          "CallDate",
+                          "CallId",
+                          "Participant"
+                        ],
+                        "expandTopLevel": true,
+                        "finalBy": "MediaType"
+                      }
+                    }
+                  },
+                  "customWidth": "50",
+                  "conditionalVisibility": {
+                    "parameterName": "chat_identity",
+                    "comparison": "isNotEqualTo"
+                  },
+                  "name": "chat-identity-call-details"
+                },
+                {
+                  "type": 3,
+                  "content": {
+                    "version": "KqlItem/1.0",
+                    "query": "let SIPCodesChat =  datatable(ResultSignature: string, SIPCode: string)\r\n[\r\n    \"0\", \"Success\",\r\n    \"100\", \"Trying\",\r\n    \"180\", \"Ringing\",\r\n    \"181\", \"Call Is Being Forwarded\",\r\n    \"182\", \"Queued\",\r\n    \"183\", \"Session Progress\",\r\n    \"199\", \"Early Dialog Terminated\",\r\n    \"200\", \"Success\",\r\n    \"202\", \"Accepted\",\r\n    \"204\", \"No Notification\",\r\n    \"300\", \"Multiple Choices\",\r\n    \"301\", \"Moved Permanently\",\r\n    \"302\", \"Moved Temporarily\",\r\n    \"305\", \"Use Proxy\",\r\n    \"380\", \"Alternative Service\",\r\n    \"400\", \"Bad Request\",\r\n    \"401\", \"Unauthorized\",\r\n    \"402\", \"Payment Required\",\r\n    \"403\", \"Forbidden\",\r\n    \"404\", \"Not Found\",\r\n    \"405\", \"Method Not Allowed\",\r\n    \"406\", \"Not Acceptable\",\r\n    \"407\", \"Proxy Authentication Required\",\r\n    \"408\", \"Request Timeout\",\r\n    \"409\", \"Conflict\",\r\n    \"410\", \"Gone\",\r\n    \"411\", \"Length Required\",\r\n    \"412\", \"Conditional Request Failed\",\r\n    \"413\", \"Request Entity Too Large\",\r\n    \"414\", \"Request-URI Too Large\",\r\n    \"415\", \"Unsupported Media Type\",\r\n    \"416\", \"Unsupported URI Scheme\",\r\n    \"417\", \"Unknown Resource-Priority\",\r\n    \"420\", \"Bad Extension\",\r\n    \"421\", \"Extension Required\",\r\n    \"422\", \"Session Interval Too Small\",\r\n    \"423\", \"Interval Too Brief\",\r\n    \"424\", \"Bad Location Information\",\r\n    \"428\", \"Use Identity Header\",\r\n    \"429\", \"Provide Referrer Identity\",\r\n    \"430\", \"Flow Failed\",\r\n    \"433\", \"Anonymity Disallowed\",\r\n    \"436\", \"Bad Identity-Info\",\r\n    \"437\", \"Unsupported Certificate\",\r\n    \"438\", \"Invalid Identity Header\",\r\n    \"439\", \"First Hop Lacks Outbound Support\",\r\n    \"440\", \"Max-Breadth Exceeded\",\r\n    \"469\", \"Bad Info Package\",\r\n    \"470\", \"Consent Needed\",\r\n    \"480\", \"Temporarily Unavailable\",\r\n    \"481\", \"Call/Transaction Does Not Exist\",\r\n    \"482\", \"Loop Detected\",\r\n    \"483\", \"Too Many Hops\",\r\n    \"484\", \"Address Incomplete\",\r\n    \"485\", \"Ambiguous\",\r\n    \"486\", \"Busy Here\",\r\n    \"487\", \"Request Terminated\",\r\n    \"488\", \"Not Acceptable Here\",\r\n    \"489\", \"Bad Event\",\r\n    \"491\", \"Request Pending\",\r\n    \"493\", \"Undecipherable\",\r\n    \"494\", \"Security Agreement Required\",\r\n    \"500\", \"Internal Server Error\",\r\n    \"501\", \"Not Implemented\",\r\n    \"502\", \"Bad Gateway\",\r\n    \"503\", \"Service Unavailable\",\r\n    \"504\", \"Server Time-out\",\r\n    \"505\", \"Version Not Supported\",\r\n    \"513\", \"Message Too Large\",\r\n    \"555\", \"Push Notification Service Not Supported\",\r\n    \"580\", \"Precondition Failure\",\r\n    \"600\", \"Busy Everywhere\",\r\n    \"603\", \"Decline\",\r\n    \"604\", \"Does Not Exist Anywhere\",\r\n    \"606\", \"Not Acceptable\",\r\n    \"607\", \"Unwanted\",\r\n    \"608\", \"Rejected\",\r\n];\r\n\r\nACSChatIncomingOperations\r\n| where TimeGenerated {time_range:query} and UserId == \"{chat_identity}\"\r\n| join kind=leftouter SIPCodesChat on ResultSignature\r\n| extend OperationDate=strcat(\"📅\", format_datetime(TimeGenerated, 'MM/dd/y'))\r\n| extend OperationTime=format_datetime(TimeGenerated, 'hh:mm:ss')\r\n| extend ResultIcon=iff(ResultType == \"Succeeded\", \"✔️\", \"❌\")\r\n| extend Result=strcat(ResultIcon, \" \", ResultSignature, \": \", SIPCode)\r\n| order by TimeGenerated\r\n| project OperationName, Level, Result, OperationDate, OperationTime, DurationMs\r\n",
+                    "size": 0,
+                    "title": "Chat operations for identity {chat_identity}",
+                    "noDataMessage": "No chat operations found for the specified  time range and identity",
+                    "queryType": 0,
+                    "resourceType": "microsoft.communication/communicationservices",
+                    "gridSettings": {
+                      "formatters": [
+                        {
+                          "columnMatch": "Level",
+                          "formatter": 18,
+                          "formatOptions": {
+                            "thresholdsOptions": "icons",
+                            "thresholdsGrid": [
+                              {
+                                "operator": "==",
+                                "thresholdValue": "Warning",
+                                "representation": "warning",
+                                "text": "{0}{1}"
+                              },
+                              {
+                                "operator": "Default",
+                                "thresholdValue": null,
+                                "representation": "info",
+                                "text": "{0}{1}"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "columnMatch": "OperationDate",
+                          "formatter": 5
+                        },
+                        {
+                          "columnMatch": "OperationTime",
+                          "formatter": 5
+                        }
+                      ],
+                      "hierarchySettings": {
+                        "treeType": 1,
+                        "groupBy": [
+                          "OperationDate"
+                        ],
+                        "expandTopLevel": true,
+                        "finalBy": "OperationTime"
+                      }
+                    },
+                    "sortBy": []
+                  },
+                  "customWidth": "50",
+                  "conditionalVisibility": {
+                    "parameterName": "chat_identity",
+                    "comparison": "isNotEqualTo"
+                  },
+                  "name": "chat-identity-chat-details"
+                }
+              ]
+            },
+            "name": "chat-identity-drill-down-group"
+          },
+          {
+            "type": 12,
+            "content": {
+              "version": "NotebookGroup/1.0",
+              "groupType": "editable",
+              "title": "Chat meeting drill-down",
+              "items": [
+                {
+                  "type": 9,
+                  "content": {
+                    "version": "KqlParameterItem/1.0",
+                    "parameters": [
+                      {
+                        "id": "0c0b56fd-ffd9-4761-b14e-c916660f9ccc",
+                        "version": "KqlParameterItem/1.0",
+                        "name": "chat_meeting",
+                        "label": "Chat meeting ID",
+                        "type": 2,
+                        "description": "Choose a chat meeting ID to visualize",
+                        "query": "ACSChatIncomingOperations\r\n| where TimeGenerated {time_range:query}\r\n| order by TimeGenerated\r\n| distinct ChatThreadId",
+                        "value": null,
+                        "typeSettings": {
+                          "additionalResourceOptions": [],
+                          "showDefault": false
+                        },
+                        "queryType": 0,
+                        "resourceType": "microsoft.communication/communicationservices"
+                      }
+                    ],
+                    "style": "pills",
+                    "queryType": 0,
+                    "resourceType": "microsoft.communication/communicationservices"
+                  },
+                  "name": "sms-phone-parameters"
+                },
+                {
+                  "type": 1,
+                  "content": {
+                    "json": "**Select a chat meeting ID from the drop-down menu to display its associated data**",
+                    "style": "info"
+                  },
+                  "conditionalVisibility": {
+                    "parameterName": "chat_meeting",
+                    "comparison": "isEqualTo"
+                  },
+                  "name": "chat-meeting-drilldown-info"
+                },
+                {
+                  "type": 3,
+                  "content": {
+                    "version": "KqlItem/1.0",
+                    "query": "let SIPCodesChat =  datatable(ResultSignature: string, SIPCode: string)\r\n[\r\n    \"0\", \"Success\",\r\n    \"100\", \"Trying\",\r\n    \"180\", \"Ringing\",\r\n    \"181\", \"Call Is Being Forwarded\",\r\n    \"182\", \"Queued\",\r\n    \"183\", \"Session Progress\",\r\n    \"199\", \"Early Dialog Terminated\",\r\n    \"200\", \"Success\",\r\n    \"202\", \"Accepted\",\r\n    \"204\", \"No Notification\",\r\n    \"300\", \"Multiple Choices\",\r\n    \"301\", \"Moved Permanently\",\r\n    \"302\", \"Moved Temporarily\",\r\n    \"305\", \"Use Proxy\",\r\n    \"380\", \"Alternative Service\",\r\n    \"400\", \"Bad Request\",\r\n    \"401\", \"Unauthorized\",\r\n    \"402\", \"Payment Required\",\r\n    \"403\", \"Forbidden\",\r\n    \"404\", \"Not Found\",\r\n    \"405\", \"Method Not Allowed\",\r\n    \"406\", \"Not Acceptable\",\r\n    \"407\", \"Proxy Authentication Required\",\r\n    \"408\", \"Request Timeout\",\r\n    \"409\", \"Conflict\",\r\n    \"410\", \"Gone\",\r\n    \"411\", \"Length Required\",\r\n    \"412\", \"Conditional Request Failed\",\r\n    \"413\", \"Request Entity Too Large\",\r\n    \"414\", \"Request-URI Too Large\",\r\n    \"415\", \"Unsupported Media Type\",\r\n    \"416\", \"Unsupported URI Scheme\",\r\n    \"417\", \"Unknown Resource-Priority\",\r\n    \"420\", \"Bad Extension\",\r\n    \"421\", \"Extension Required\",\r\n    \"422\", \"Session Interval Too Small\",\r\n    \"423\", \"Interval Too Brief\",\r\n    \"424\", \"Bad Location Information\",\r\n    \"428\", \"Use Identity Header\",\r\n    \"429\", \"Provide Referrer Identity\",\r\n    \"430\", \"Flow Failed\",\r\n    \"433\", \"Anonymity Disallowed\",\r\n    \"436\", \"Bad Identity-Info\",\r\n    \"437\", \"Unsupported Certificate\",\r\n    \"438\", \"Invalid Identity Header\",\r\n    \"439\", \"First Hop Lacks Outbound Support\",\r\n    \"440\", \"Max-Breadth Exceeded\",\r\n    \"469\", \"Bad Info Package\",\r\n    \"470\", \"Consent Needed\",\r\n    \"480\", \"Temporarily Unavailable\",\r\n    \"481\", \"Call/Transaction Does Not Exist\",\r\n    \"482\", \"Loop Detected\",\r\n    \"483\", \"Too Many Hops\",\r\n    \"484\", \"Address Incomplete\",\r\n    \"485\", \"Ambiguous\",\r\n    \"486\", \"Busy Here\",\r\n    \"487\", \"Request Terminated\",\r\n    \"488\", \"Not Acceptable Here\",\r\n    \"489\", \"Bad Event\",\r\n    \"491\", \"Request Pending\",\r\n    \"493\", \"Undecipherable\",\r\n    \"494\", \"Security Agreement Required\",\r\n    \"500\", \"Internal Server Error\",\r\n    \"501\", \"Not Implemented\",\r\n    \"502\", \"Bad Gateway\",\r\n    \"503\", \"Service Unavailable\",\r\n    \"504\", \"Server Time-out\",\r\n    \"505\", \"Version Not Supported\",\r\n    \"513\", \"Message Too Large\",\r\n    \"555\", \"Push Notification Service Not Supported\",\r\n    \"580\", \"Precondition Failure\",\r\n    \"600\", \"Busy Everywhere\",\r\n    \"603\", \"Decline\",\r\n    \"604\", \"Does Not Exist Anywhere\",\r\n    \"606\", \"Not Acceptable\",\r\n    \"607\", \"Unwanted\",\r\n    \"608\", \"Rejected\",\r\n];\r\n\r\nACSChatIncomingOperations\r\n| where TimeGenerated {time_range:query} and ChatThreadId == \"{chat_meeting}\"\r\n| join kind=leftouter SIPCodesChat on ResultSignature\r\n| extend OperationDate=strcat(\"📅\", format_datetime(TimeGenerated, 'MM/dd/y'))\r\n| extend OperationTime=format_datetime(TimeGenerated, 'hh:mm:ss')\r\n| extend ResultIcon=iff(ResultType == \"Succeeded\", \"✔️\", \"❌\")\r\n| extend Result=strcat(ResultIcon, \" \", ResultSignature, \": \", SIPCode)\r\n| order by TimeGenerated\r\n| project OperationName, Level, Result, OperationDate, OperationTime, DurationMs\r\n",
+                    "size": 0,
+                    "title": "Chat operations for meeting {chat_meeting}",
+                    "noDataMessage": "No chat operations found for the specified time range and meeting ID",
+                    "queryType": 0,
+                    "resourceType": "microsoft.communication/communicationservices",
+                    "gridSettings": {
+                      "formatters": [
+                        {
+                          "columnMatch": "Level",
+                          "formatter": 18,
+                          "formatOptions": {
+                            "thresholdsOptions": "icons",
+                            "thresholdsGrid": [
+                              {
+                                "operator": "==",
+                                "thresholdValue": "Warning",
+                                "representation": "warning",
+                                "text": "{0}{1}"
+                              },
+                              {
+                                "operator": "Default",
+                                "thresholdValue": null,
+                                "representation": "info",
+                                "text": "{0}{1}"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "columnMatch": "OperationDate",
+                          "formatter": 5
+                        },
+                        {
+                          "columnMatch": "OperationTime",
+                          "formatter": 5
+                        }
+                      ],
+                      "hierarchySettings": {
+                        "treeType": 1,
+                        "groupBy": [
+                          "OperationDate"
+                        ],
+                        "expandTopLevel": true,
+                        "finalBy": "OperationTime"
+                      }
+                    },
+                    "sortBy": []
+                  },
+                  "conditionalVisibility": {
+                    "parameterName": "chat_meeting",
+                    "comparison": "isNotEqualTo"
+                  },
+                  "name": "chat-meeting-details"
+                }
+              ]
+            },
+            "name": "chat-meeting-drill-down-group"
+          },
+          {
+            "type": 12,
+            "content": {
+              "version": "NotebookGroup/1.0",
+              "groupType": "editable",
+              "title": "Chat IP address drill-down",
+              "items": [
+                {
+                  "type": 9,
+                  "content": {
+                    "version": "KqlParameterItem/1.0",
+                    "parameters": [
+                      {
+                        "id": "0c0b56fd-ffd9-4761-b14e-c916660f9ccc",
+                        "version": "KqlParameterItem/1.0",
+                        "name": "chat_ip",
+                        "label": "IP address",
+                        "type": 2,
+                        "description": "Choose an IP address to visualize",
+                        "query": "ACSChatIncomingOperations\r\n| where TimeGenerated {time_range:query}\r\n| order by TimeGenerated\r\n| distinct CallerIpAddress",
+                        "value": null,
+                        "typeSettings": {
+                          "additionalResourceOptions": [],
+                          "showDefault": false
+                        },
+                        "queryType": 0,
+                        "resourceType": "microsoft.communication/communicationservices"
+                      }
+                    ],
+                    "style": "pills",
+                    "queryType": 0,
+                    "resourceType": "microsoft.communication/communicationservices"
+                  },
+                  "name": "sms-phone-parameters"
+                },
+                {
+                  "type": 1,
+                  "content": {
+                    "json": "**Select an IP address from the drop-down menu to display its associated data**",
+                    "style": "info"
+                  },
+                  "conditionalVisibility": {
+                    "parameterName": "chat_ip",
+                    "comparison": "isEqualTo"
+                  },
+                  "name": "chat-ip-drilldown-info"
+                },
+                {
+                  "type": 3,
+                  "content": {
+                    "version": "KqlItem/1.0",
+                    "query": "let SIPCodesChat =  datatable(ResultSignature: string, SIPCode: string)\r\n[\r\n    \"0\", \"Success\",\r\n    \"100\", \"Trying\",\r\n    \"180\", \"Ringing\",\r\n    \"181\", \"Call Is Being Forwarded\",\r\n    \"182\", \"Queued\",\r\n    \"183\", \"Session Progress\",\r\n    \"199\", \"Early Dialog Terminated\",\r\n    \"200\", \"Success\",\r\n    \"202\", \"Accepted\",\r\n    \"204\", \"No Notification\",\r\n    \"300\", \"Multiple Choices\",\r\n    \"301\", \"Moved Permanently\",\r\n    \"302\", \"Moved Temporarily\",\r\n    \"305\", \"Use Proxy\",\r\n    \"380\", \"Alternative Service\",\r\n    \"400\", \"Bad Request\",\r\n    \"401\", \"Unauthorized\",\r\n    \"402\", \"Payment Required\",\r\n    \"403\", \"Forbidden\",\r\n    \"404\", \"Not Found\",\r\n    \"405\", \"Method Not Allowed\",\r\n    \"406\", \"Not Acceptable\",\r\n    \"407\", \"Proxy Authentication Required\",\r\n    \"408\", \"Request Timeout\",\r\n    \"409\", \"Conflict\",\r\n    \"410\", \"Gone\",\r\n    \"411\", \"Length Required\",\r\n    \"412\", \"Conditional Request Failed\",\r\n    \"413\", \"Request Entity Too Large\",\r\n    \"414\", \"Request-URI Too Large\",\r\n    \"415\", \"Unsupported Media Type\",\r\n    \"416\", \"Unsupported URI Scheme\",\r\n    \"417\", \"Unknown Resource-Priority\",\r\n    \"420\", \"Bad Extension\",\r\n    \"421\", \"Extension Required\",\r\n    \"422\", \"Session Interval Too Small\",\r\n    \"423\", \"Interval Too Brief\",\r\n    \"424\", \"Bad Location Information\",\r\n    \"428\", \"Use Identity Header\",\r\n    \"429\", \"Provide Referrer Identity\",\r\n    \"430\", \"Flow Failed\",\r\n    \"433\", \"Anonymity Disallowed\",\r\n    \"436\", \"Bad Identity-Info\",\r\n    \"437\", \"Unsupported Certificate\",\r\n    \"438\", \"Invalid Identity Header\",\r\n    \"439\", \"First Hop Lacks Outbound Support\",\r\n    \"440\", \"Max-Breadth Exceeded\",\r\n    \"469\", \"Bad Info Package\",\r\n    \"470\", \"Consent Needed\",\r\n    \"480\", \"Temporarily Unavailable\",\r\n    \"481\", \"Call/Transaction Does Not Exist\",\r\n    \"482\", \"Loop Detected\",\r\n    \"483\", \"Too Many Hops\",\r\n    \"484\", \"Address Incomplete\",\r\n    \"485\", \"Ambiguous\",\r\n    \"486\", \"Busy Here\",\r\n    \"487\", \"Request Terminated\",\r\n    \"488\", \"Not Acceptable Here\",\r\n    \"489\", \"Bad Event\",\r\n    \"491\", \"Request Pending\",\r\n    \"493\", \"Undecipherable\",\r\n    \"494\", \"Security Agreement Required\",\r\n    \"500\", \"Internal Server Error\",\r\n    \"501\", \"Not Implemented\",\r\n    \"502\", \"Bad Gateway\",\r\n    \"503\", \"Service Unavailable\",\r\n    \"504\", \"Server Time-out\",\r\n    \"505\", \"Version Not Supported\",\r\n    \"513\", \"Message Too Large\",\r\n    \"555\", \"Push Notification Service Not Supported\",\r\n    \"580\", \"Precondition Failure\",\r\n    \"600\", \"Busy Everywhere\",\r\n    \"603\", \"Decline\",\r\n    \"604\", \"Does Not Exist Anywhere\",\r\n    \"606\", \"Not Acceptable\",\r\n    \"607\", \"Unwanted\",\r\n    \"608\", \"Rejected\",\r\n];\r\n\r\nACSChatIncomingOperations\r\n| where TimeGenerated {time_range:query} and CallerIpAddress == \"{chat_ip}\"\r\n| join kind=leftouter SIPCodesChat on ResultSignature\r\n| extend OperationDate=strcat(\"📅\", format_datetime(TimeGenerated, 'MM/dd/y'))\r\n| extend OperationTime=format_datetime(TimeGenerated, 'hh:mm:ss')\r\n| extend ResultIcon=iff(ResultType == \"Succeeded\", \"✔️\", \"❌\")\r\n| extend Result=strcat(ResultIcon, \" \", ResultSignature, \": \", SIPCode)\r\n| order by TimeGenerated\r\n| project OperationName, Level, Result, OperationDate, OperationTime, DurationMs\r\n",
+                    "size": 0,
+                    "title": "Chat operations for IP address {chat_ip}",
+                    "noDataMessage": "No chat operations found for the specified time range and IP address",
+                    "queryType": 0,
+                    "resourceType": "microsoft.communication/communicationservices",
+                    "gridSettings": {
+                      "formatters": [
+                        {
+                          "columnMatch": "Level",
+                          "formatter": 18,
+                          "formatOptions": {
+                            "thresholdsOptions": "icons",
+                            "thresholdsGrid": [
+                              {
+                                "operator": "==",
+                                "thresholdValue": "Warning",
+                                "representation": "warning",
+                                "text": "{0}{1}"
+                              },
+                              {
+                                "operator": "Default",
+                                "thresholdValue": null,
+                                "representation": "info",
+                                "text": "{0}{1}"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "columnMatch": "OperationDate",
+                          "formatter": 5
+                        },
+                        {
+                          "columnMatch": "OperationTime",
+                          "formatter": 5
+                        }
+                      ],
+                      "hierarchySettings": {
+                        "treeType": 1,
+                        "groupBy": [
+                          "OperationDate"
+                        ],
+                        "expandTopLevel": true,
+                        "finalBy": "OperationTime"
+                      }
+                    },
+                    "sortBy": []
+                  },
+                  "conditionalVisibility": {
+                    "parameterName": "chat_ip",
+                    "comparison": "isNotEqualTo"
+                  },
+                  "name": "chat-ip-details"
+                }
+              ]
+            },
+            "name": "chat-ip-drill-down-group"
           }
         ]
       },
@@ -947,7 +2395,7 @@
         "comparison": "isEqualTo",
         "value": "chat"
       },
-      "name": "Chat-group"
+      "name": "chat-group"
     },
     {
       "type": 12,
@@ -958,61 +2406,825 @@
           {
             "type": 1,
             "content": {
-              "json": "The following visualizations represent data from the SMS Operational logs."
+              "json": "The following visualizations represent data from the SMS Operational logs.\r\n\r\n**Click on any part of the pie charts below to visualize filtered logs.**"
             },
-            "name": "sms-text"
+            "name": "auth-text"
           },
           {
-            "type": 3,
+            "type": 12,
             "content": {
-              "version": "KqlItem/1.0",
-              "query": "ACSSMSIncomingOperations\r\n| where TimeGenerated {time_range:query}\r\n| summarize count() by ResultType\r\n| render piechart",
-              "size": 0,
-              "title": "SMS Result Types",
-              "queryType": 0,
-              "resourceType": "Microsoft.Communication/CommunicationServices"
-            },
-            "customWidth": "50",
-            "name": "sms-result-types"
-          },
-          {
-            "type": 3,
-            "content": {
-              "version": "KqlItem/1.0",
-              "query": "ACSSMSIncomingOperations\r\n| where TimeGenerated {time_range:query}\r\n| summarize count() by ResultSignature\r\n| render piechart",
-              "size": 0,
-              "title": "SMS Results Signature",
-              "queryType": 0,
-              "resourceType": "Microsoft.Communication/CommunicationServices"
+              "version": "NotebookGroup/1.0",
+              "groupType": "editable",
+              "title": "SMS Outgoing Message Lengths",
+              "items": [
+                {
+                  "type": 3,
+                  "content": {
+                    "version": "KqlItem/1.0",
+                    "query": "ACSSMSIncomingOperations\r\n| where TimeGenerated {time_range:query}\r\n| summarize NumMessages=count() by bin(OutgoingMessageLength, 10)\r\n| order by OutgoingMessageLength asc\r\n| render columnchart ",
+                    "size": 0,
+                    "noDataMessage": "No SMS messages found in the specified time range",
+                    "queryType": 0,
+                    "resourceType": "microsoft.communication/communicationservices"
+                  },
+                  "name": "sms-outgoing-msg"
+                }
+              ]
             },
             "customWidth": "50",
-            "name": "sms-results-signature"
+            "name": "sms-outgoing-msg-group"
           },
           {
-            "type": 3,
+            "type": 12,
             "content": {
-              "version": "KqlItem/1.0",
-              "query": "ACSSMSIncomingOperations\r\n| where TimeGenerated {time_range:query}\r\n| summarize count() by OperationName\r\n| render piechart",
-              "size": 0,
+              "version": "NotebookGroup/1.0",
+              "groupType": "editable",
+              "title": "SMS Incoming Message Lengths",
+              "items": [
+                {
+                  "type": 3,
+                  "content": {
+                    "version": "KqlItem/1.0",
+                    "query": "ACSSMSIncomingOperations\r\n| where TimeGenerated {time_range:query}\r\n| summarize NumMessages=count() by bin(IncomingMessageLength, 10)\r\n| order by IncomingMessageLength asc\r\n| render columnchart ",
+                    "size": 0,
+                    "noDataMessage": "No SMS messages found in the specified time range",
+                    "queryType": 0,
+                    "resourceType": "microsoft.communication/communicationservices"
+                  },
+                  "name": "sms-outgoing-msg"
+                }
+              ]
+            },
+            "customWidth": "50",
+            "name": "sms-incoming-msg-group"
+          },
+          {
+            "type": 12,
+            "content": {
+              "version": "NotebookGroup/1.0",
+              "groupType": "editable",
+              "title": "SMS API Results",
+              "items": [
+                {
+                  "type": 3,
+                  "content": {
+                    "version": "KqlItem/1.0",
+                    "query": "ACSSMSIncomingOperations\r\n| where TimeGenerated {time_range:query}\r\n| summarize count() by ResultType\r\n| render piechart",
+                    "size": 0,
+                    "noDataMessage": "No SMS operations found in the specified time range",
+                    "exportMultipleValues": true,
+                    "exportedParameters": [
+                      {
+                        "fieldName": "series",
+                        "parameterName": "sms_result",
+                        "parameterType": 1
+                      }
+                    ],
+                    "queryType": 0,
+                    "resourceType": "microsoft.communication/communicationservices"
+                  },
+                  "name": "sms-result-types"
+                },
+                {
+                  "type": 3,
+                  "content": {
+                    "version": "KqlItem/1.0",
+                    "query": "let SIPCodesSMS =  datatable(ResultSignature: string, SIPCode: string)\r\n[\r\n    \"0\", \"Success\",\r\n    \"100\", \"Trying\",\r\n    \"180\", \"Ringing\",\r\n    \"181\", \"Call Is Being Forwarded\",\r\n    \"182\", \"Queued\",\r\n    \"183\", \"Session Progress\",\r\n    \"199\", \"Early Dialog Terminated\",\r\n    \"200\", \"Success\",\r\n    \"202\", \"Accepted\",\r\n    \"204\", \"No Notification\",\r\n    \"300\", \"Multiple Choices\",\r\n    \"301\", \"Moved Permanently\",\r\n    \"302\", \"Moved Temporarily\",\r\n    \"305\", \"Use Proxy\",\r\n    \"380\", \"Alternative Service\",\r\n    \"400\", \"Bad Request\",\r\n    \"401\", \"Unauthorized\",\r\n    \"402\", \"Payment Required\",\r\n    \"403\", \"Forbidden\",\r\n    \"404\", \"Not Found\",\r\n    \"405\", \"Method Not Allowed\",\r\n    \"406\", \"Not Acceptable\",\r\n    \"407\", \"Proxy Authentication Required\",\r\n    \"408\", \"Request Timeout\",\r\n    \"409\", \"Conflict\",\r\n    \"410\", \"Gone\",\r\n    \"411\", \"Length Required\",\r\n    \"412\", \"Conditional Request Failed\",\r\n    \"413\", \"Request Entity Too Large\",\r\n    \"414\", \"Request-URI Too Large\",\r\n    \"415\", \"Unsupported Media Type\",\r\n    \"416\", \"Unsupported URI Scheme\",\r\n    \"417\", \"Unknown Resource-Priority\",\r\n    \"420\", \"Bad Extension\",\r\n    \"421\", \"Extension Required\",\r\n    \"422\", \"Session Interval Too Small\",\r\n    \"423\", \"Interval Too Brief\",\r\n    \"424\", \"Bad Location Information\",\r\n    \"428\", \"Use Identity Header\",\r\n    \"429\", \"Provide Referrer Identity\",\r\n    \"430\", \"Flow Failed\",\r\n    \"433\", \"Anonymity Disallowed\",\r\n    \"436\", \"Bad Identity-Info\",\r\n    \"437\", \"Unsupported Certificate\",\r\n    \"438\", \"Invalid Identity Header\",\r\n    \"439\", \"First Hop Lacks Outbound Support\",\r\n    \"440\", \"Max-Breadth Exceeded\",\r\n    \"469\", \"Bad Info Package\",\r\n    \"470\", \"Consent Needed\",\r\n    \"480\", \"Temporarily Unavailable\",\r\n    \"481\", \"Call/Transaction Does Not Exist\",\r\n    \"482\", \"Loop Detected\",\r\n    \"483\", \"Too Many Hops\",\r\n    \"484\", \"Address Incomplete\",\r\n    \"485\", \"Ambiguous\",\r\n    \"486\", \"Busy Here\",\r\n    \"487\", \"Request Terminated\",\r\n    \"488\", \"Not Acceptable Here\",\r\n    \"489\", \"Bad Event\",\r\n    \"491\", \"Request Pending\",\r\n    \"493\", \"Undecipherable\",\r\n    \"494\", \"Security Agreement Required\",\r\n    \"500\", \"Internal Server Error\",\r\n    \"501\", \"Not Implemented\",\r\n    \"502\", \"Bad Gateway\",\r\n    \"503\", \"Service Unavailable\",\r\n    \"504\", \"Server Time-out\",\r\n    \"505\", \"Version Not Supported\",\r\n    \"513\", \"Message Too Large\",\r\n    \"555\", \"Push Notification Service Not Supported\",\r\n    \"580\", \"Precondition Failure\",\r\n    \"600\", \"Busy Everywhere\",\r\n    \"603\", \"Decline\",\r\n    \"604\", \"Does Not Exist Anywhere\",\r\n    \"606\", \"Not Acceptable\",\r\n    \"607\", \"Unwanted\",\r\n    \"608\", \"Rejected\",\r\n];\r\n\r\nACSSMSIncomingOperations\r\n| where TimeGenerated {time_range:query} and ResultType in ({sms_result})\r\n| join kind=leftouter SIPCodesSMS on ResultSignature\r\n| extend OperationDate=strcat(\"📅\", format_datetime(TimeGenerated, 'MM/dd/y'))\r\n| extend OperationTime=format_datetime(TimeGenerated, 'hh:mm:ss')\r\n| extend ResultIcon=iff(ResultType == \"Succeeded\", \"✔️\", \"❌\")\r\n| extend Result=strcat(ResultIcon, \" \", ResultSignature, \": \", SIPCode)\r\n| order by TimeGenerated\r\n| project OperationName, Level, Result, ResultDescription, OperationDate, OperationTime, DurationMs\r\n",
+                    "size": 0,
+                    "title": "SMS operations with result type {sms_result}",
+                    "noDataMessage": "No SMS operations found for the specified time range and result type",
+                    "queryType": 0,
+                    "resourceType": "microsoft.communication/communicationservices",
+                    "gridSettings": {
+                      "formatters": [
+                        {
+                          "columnMatch": "Level",
+                          "formatter": 18,
+                          "formatOptions": {
+                            "thresholdsOptions": "icons",
+                            "thresholdsGrid": [
+                              {
+                                "operator": "==",
+                                "thresholdValue": "Warning",
+                                "representation": "warning",
+                                "text": "{0}{1}"
+                              },
+                              {
+                                "operator": "Default",
+                                "thresholdValue": null,
+                                "representation": "info",
+                                "text": "{0}{1}"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "columnMatch": "OperationDate",
+                          "formatter": 5
+                        },
+                        {
+                          "columnMatch": "OperationTime",
+                          "formatter": 5
+                        }
+                      ],
+                      "hierarchySettings": {
+                        "treeType": 1,
+                        "groupBy": [
+                          "OperationDate"
+                        ],
+                        "expandTopLevel": true,
+                        "finalBy": "OperationTime"
+                      }
+                    },
+                    "sortBy": []
+                  },
+                  "conditionalVisibility": {
+                    "parameterName": "sms_result",
+                    "comparison": "isNotEqualTo"
+                  },
+                  "name": "sms-by-result"
+                }
+              ]
+            },
+            "customWidth": "50",
+            "name": "sms-results-group"
+          },
+          {
+            "type": 12,
+            "content": {
+              "version": "NotebookGroup/1.0",
+              "groupType": "editable",
+              "title": "SMS API Result Signatures",
+              "items": [
+                {
+                  "type": 3,
+                  "content": {
+                    "version": "KqlItem/1.0",
+                    "query": "ACSSMSIncomingOperations\r\n| where TimeGenerated {time_range:query}\r\n| summarize count() by ResultSignature\r\n| render piechart",
+                    "size": 0,
+                    "noDataMessage": "No SMS operations found in the specified time range",
+                    "exportMultipleValues": true,
+                    "exportedParameters": [
+                      {
+                        "fieldName": "series",
+                        "parameterName": "sms_signature",
+                        "parameterType": 1
+                      }
+                    ],
+                    "queryType": 0,
+                    "resourceType": "microsoft.communication/communicationservices"
+                  },
+                  "name": "sms-results-signature"
+                },
+                {
+                  "type": 3,
+                  "content": {
+                    "version": "KqlItem/1.0",
+                    "query": "let SIPCodesSMS =  datatable(ResultSignature: string, SIPCode: string)\r\n[\r\n    \"0\", \"Success\",\r\n    \"100\", \"Trying\",\r\n    \"180\", \"Ringing\",\r\n    \"181\", \"Call Is Being Forwarded\",\r\n    \"182\", \"Queued\",\r\n    \"183\", \"Session Progress\",\r\n    \"199\", \"Early Dialog Terminated\",\r\n    \"200\", \"Success\",\r\n    \"202\", \"Accepted\",\r\n    \"204\", \"No Notification\",\r\n    \"300\", \"Multiple Choices\",\r\n    \"301\", \"Moved Permanently\",\r\n    \"302\", \"Moved Temporarily\",\r\n    \"305\", \"Use Proxy\",\r\n    \"380\", \"Alternative Service\",\r\n    \"400\", \"Bad Request\",\r\n    \"401\", \"Unauthorized\",\r\n    \"402\", \"Payment Required\",\r\n    \"403\", \"Forbidden\",\r\n    \"404\", \"Not Found\",\r\n    \"405\", \"Method Not Allowed\",\r\n    \"406\", \"Not Acceptable\",\r\n    \"407\", \"Proxy Authentication Required\",\r\n    \"408\", \"Request Timeout\",\r\n    \"409\", \"Conflict\",\r\n    \"410\", \"Gone\",\r\n    \"411\", \"Length Required\",\r\n    \"412\", \"Conditional Request Failed\",\r\n    \"413\", \"Request Entity Too Large\",\r\n    \"414\", \"Request-URI Too Large\",\r\n    \"415\", \"Unsupported Media Type\",\r\n    \"416\", \"Unsupported URI Scheme\",\r\n    \"417\", \"Unknown Resource-Priority\",\r\n    \"420\", \"Bad Extension\",\r\n    \"421\", \"Extension Required\",\r\n    \"422\", \"Session Interval Too Small\",\r\n    \"423\", \"Interval Too Brief\",\r\n    \"424\", \"Bad Location Information\",\r\n    \"428\", \"Use Identity Header\",\r\n    \"429\", \"Provide Referrer Identity\",\r\n    \"430\", \"Flow Failed\",\r\n    \"433\", \"Anonymity Disallowed\",\r\n    \"436\", \"Bad Identity-Info\",\r\n    \"437\", \"Unsupported Certificate\",\r\n    \"438\", \"Invalid Identity Header\",\r\n    \"439\", \"First Hop Lacks Outbound Support\",\r\n    \"440\", \"Max-Breadth Exceeded\",\r\n    \"469\", \"Bad Info Package\",\r\n    \"470\", \"Consent Needed\",\r\n    \"480\", \"Temporarily Unavailable\",\r\n    \"481\", \"Call/Transaction Does Not Exist\",\r\n    \"482\", \"Loop Detected\",\r\n    \"483\", \"Too Many Hops\",\r\n    \"484\", \"Address Incomplete\",\r\n    \"485\", \"Ambiguous\",\r\n    \"486\", \"Busy Here\",\r\n    \"487\", \"Request Terminated\",\r\n    \"488\", \"Not Acceptable Here\",\r\n    \"489\", \"Bad Event\",\r\n    \"491\", \"Request Pending\",\r\n    \"493\", \"Undecipherable\",\r\n    \"494\", \"Security Agreement Required\",\r\n    \"500\", \"Internal Server Error\",\r\n    \"501\", \"Not Implemented\",\r\n    \"502\", \"Bad Gateway\",\r\n    \"503\", \"Service Unavailable\",\r\n    \"504\", \"Server Time-out\",\r\n    \"505\", \"Version Not Supported\",\r\n    \"513\", \"Message Too Large\",\r\n    \"555\", \"Push Notification Service Not Supported\",\r\n    \"580\", \"Precondition Failure\",\r\n    \"600\", \"Busy Everywhere\",\r\n    \"603\", \"Decline\",\r\n    \"604\", \"Does Not Exist Anywhere\",\r\n    \"606\", \"Not Acceptable\",\r\n    \"607\", \"Unwanted\",\r\n    \"608\", \"Rejected\",\r\n];\r\n\r\nACSSMSIncomingOperations\r\n| where TimeGenerated {time_range:query} and ResultSignature in ({sms_signature})\r\n| join kind=leftouter SIPCodesSMS on ResultSignature\r\n| extend OperationDate=strcat(\"📅\", format_datetime(TimeGenerated, 'MM/dd/y'))\r\n| extend OperationTime=format_datetime(TimeGenerated, 'hh:mm:ss')\r\n| extend ResultIcon=iff(ResultType == \"Succeeded\", \"✔️\", \"❌\")\r\n| extend Result=strcat(ResultIcon, \" \", ResultSignature, \": \", SIPCode)\r\n| order by TimeGenerated\r\n| project OperationName, Level, Result, ResultDescription, OperationDate, OperationTime, DurationMs",
+                    "size": 0,
+                    "title": "SMS operations with result signature {sms_signature}",
+                    "noDataMessage": "No SMS operations found for the specified time range and result signature",
+                    "queryType": 0,
+                    "resourceType": "microsoft.communication/communicationservices",
+                    "gridSettings": {
+                      "formatters": [
+                        {
+                          "columnMatch": "Level",
+                          "formatter": 18,
+                          "formatOptions": {
+                            "thresholdsOptions": "icons",
+                            "thresholdsGrid": [
+                              {
+                                "operator": "==",
+                                "thresholdValue": "Warning",
+                                "representation": "warning",
+                                "text": "{0}{1}"
+                              },
+                              {
+                                "operator": "Default",
+                                "thresholdValue": null,
+                                "representation": "info",
+                                "text": "{0}{1}"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "columnMatch": "OperationDate",
+                          "formatter": 5
+                        },
+                        {
+                          "columnMatch": "OperationTime",
+                          "formatter": 5
+                        }
+                      ],
+                      "hierarchySettings": {
+                        "treeType": 1,
+                        "groupBy": [
+                          "OperationDate"
+                        ],
+                        "expandTopLevel": true,
+                        "finalBy": "OperationTime"
+                      }
+                    },
+                    "sortBy": []
+                  },
+                  "conditionalVisibility": {
+                    "parameterName": "sms_signature",
+                    "comparison": "isNotEqualTo"
+                  },
+                  "name": "sms-by-signature"
+                }
+              ]
+            },
+            "customWidth": "50",
+            "name": "sms-signatures-group"
+          },
+          {
+            "type": 12,
+            "content": {
+              "version": "NotebookGroup/1.0",
+              "groupType": "editable",
               "title": "SMS Operation Names",
-              "queryType": 0,
-              "resourceType": "Microsoft.Communication/CommunicationServices"
+              "items": [
+                {
+                  "type": 3,
+                  "content": {
+                    "version": "KqlItem/1.0",
+                    "query": "ACSSMSIncomingOperations\r\n| where TimeGenerated {time_range:query}\r\n| summarize count() by OperationName\r\n| render piechart",
+                    "size": 0,
+                    "noDataMessage": "No SMS operations found in the specified time range",
+                    "exportMultipleValues": true,
+                    "exportedParameters": [
+                      {
+                        "fieldName": "series",
+                        "parameterName": "sms_operation",
+                        "parameterType": 1
+                      }
+                    ],
+                    "queryType": 0,
+                    "resourceType": "microsoft.communication/communicationservices"
+                  },
+                  "name": "sms-operation-names"
+                },
+                {
+                  "type": 3,
+                  "content": {
+                    "version": "KqlItem/1.0",
+                    "query": "let SIPCodesSMS =  datatable(ResultSignature: string, SIPCode: string)\r\n[\r\n    \"0\", \"Success\",\r\n    \"100\", \"Trying\",\r\n    \"180\", \"Ringing\",\r\n    \"181\", \"Call Is Being Forwarded\",\r\n    \"182\", \"Queued\",\r\n    \"183\", \"Session Progress\",\r\n    \"199\", \"Early Dialog Terminated\",\r\n    \"200\", \"Success\",\r\n    \"202\", \"Accepted\",\r\n    \"204\", \"No Notification\",\r\n    \"300\", \"Multiple Choices\",\r\n    \"301\", \"Moved Permanently\",\r\n    \"302\", \"Moved Temporarily\",\r\n    \"305\", \"Use Proxy\",\r\n    \"380\", \"Alternative Service\",\r\n    \"400\", \"Bad Request\",\r\n    \"401\", \"Unauthorized\",\r\n    \"402\", \"Payment Required\",\r\n    \"403\", \"Forbidden\",\r\n    \"404\", \"Not Found\",\r\n    \"405\", \"Method Not Allowed\",\r\n    \"406\", \"Not Acceptable\",\r\n    \"407\", \"Proxy Authentication Required\",\r\n    \"408\", \"Request Timeout\",\r\n    \"409\", \"Conflict\",\r\n    \"410\", \"Gone\",\r\n    \"411\", \"Length Required\",\r\n    \"412\", \"Conditional Request Failed\",\r\n    \"413\", \"Request Entity Too Large\",\r\n    \"414\", \"Request-URI Too Large\",\r\n    \"415\", \"Unsupported Media Type\",\r\n    \"416\", \"Unsupported URI Scheme\",\r\n    \"417\", \"Unknown Resource-Priority\",\r\n    \"420\", \"Bad Extension\",\r\n    \"421\", \"Extension Required\",\r\n    \"422\", \"Session Interval Too Small\",\r\n    \"423\", \"Interval Too Brief\",\r\n    \"424\", \"Bad Location Information\",\r\n    \"428\", \"Use Identity Header\",\r\n    \"429\", \"Provide Referrer Identity\",\r\n    \"430\", \"Flow Failed\",\r\n    \"433\", \"Anonymity Disallowed\",\r\n    \"436\", \"Bad Identity-Info\",\r\n    \"437\", \"Unsupported Certificate\",\r\n    \"438\", \"Invalid Identity Header\",\r\n    \"439\", \"First Hop Lacks Outbound Support\",\r\n    \"440\", \"Max-Breadth Exceeded\",\r\n    \"469\", \"Bad Info Package\",\r\n    \"470\", \"Consent Needed\",\r\n    \"480\", \"Temporarily Unavailable\",\r\n    \"481\", \"Call/Transaction Does Not Exist\",\r\n    \"482\", \"Loop Detected\",\r\n    \"483\", \"Too Many Hops\",\r\n    \"484\", \"Address Incomplete\",\r\n    \"485\", \"Ambiguous\",\r\n    \"486\", \"Busy Here\",\r\n    \"487\", \"Request Terminated\",\r\n    \"488\", \"Not Acceptable Here\",\r\n    \"489\", \"Bad Event\",\r\n    \"491\", \"Request Pending\",\r\n    \"493\", \"Undecipherable\",\r\n    \"494\", \"Security Agreement Required\",\r\n    \"500\", \"Internal Server Error\",\r\n    \"501\", \"Not Implemented\",\r\n    \"502\", \"Bad Gateway\",\r\n    \"503\", \"Service Unavailable\",\r\n    \"504\", \"Server Time-out\",\r\n    \"505\", \"Version Not Supported\",\r\n    \"513\", \"Message Too Large\",\r\n    \"555\", \"Push Notification Service Not Supported\",\r\n    \"580\", \"Precondition Failure\",\r\n    \"600\", \"Busy Everywhere\",\r\n    \"603\", \"Decline\",\r\n    \"604\", \"Does Not Exist Anywhere\",\r\n    \"606\", \"Not Acceptable\",\r\n    \"607\", \"Unwanted\",\r\n    \"608\", \"Rejected\",\r\n];\r\n\r\nACSSMSIncomingOperations\r\n| where TimeGenerated {time_range:query} and OperationName in ({sms_operation})\r\n| join kind=leftouter SIPCodesSMS on ResultSignature\r\n| extend OperationDate=strcat(\"📅\", format_datetime(TimeGenerated, 'MM/dd/y'))\r\n| extend OperationTime=format_datetime(TimeGenerated, 'hh:mm:ss')\r\n| extend ResultIcon=iff(ResultType == \"Succeeded\", \"✔️\", \"❌\")\r\n| extend Result=strcat(ResultIcon, \" \", ResultSignature, \": \", SIPCode)\r\n| order by TimeGenerated\r\n| project OperationName, Result, PhoneNumber, CallerIpAddress, OutgoingMessageLength, IncomingMessageLength, DeliveryAttempts, Method, Level, OperationDate, OperationTime, DurationMs",
+                    "size": 0,
+                    "title": "SMS operations with operation name {sms_operation}",
+                    "noDataMessage": "No SMS operations found for the specified time range and operation name",
+                    "queryType": 0,
+                    "resourceType": "microsoft.communication/communicationservices",
+                    "gridSettings": {
+                      "formatters": [
+                        {
+                          "columnMatch": "Level",
+                          "formatter": 18,
+                          "formatOptions": {
+                            "thresholdsOptions": "icons",
+                            "thresholdsGrid": [
+                              {
+                                "operator": "==",
+                                "thresholdValue": "Warning",
+                                "representation": "warning",
+                                "text": "{0}{1}"
+                              },
+                              {
+                                "operator": "Default",
+                                "thresholdValue": null,
+                                "representation": "info",
+                                "text": "{0}{1}"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "columnMatch": "OperationDate",
+                          "formatter": 5
+                        },
+                        {
+                          "columnMatch": "OperationTime",
+                          "formatter": 5
+                        }
+                      ],
+                      "hierarchySettings": {
+                        "treeType": 1,
+                        "groupBy": [
+                          "OperationDate"
+                        ],
+                        "expandTopLevel": true,
+                        "finalBy": "OperationTime"
+                      }
+                    },
+                    "sortBy": []
+                  },
+                  "conditionalVisibility": {
+                    "parameterName": "sms_operation",
+                    "comparison": "isNotEqualTo"
+                  },
+                  "name": "sms-by-operation"
+                }
+              ]
             },
             "customWidth": "50",
-            "name": "sms-operation-names"
+            "name": "sms-operation-names-group"
           },
           {
-            "type": 3,
+            "type": 12,
             "content": {
-              "version": "KqlItem/1.0",
-              "query": "ACSSMSIncomingOperations\r\n| where TimeGenerated {time_range:query}\r\n| summarize count() by OperationVersion\r\n| render piechart",
-              "size": 0,
+              "version": "NotebookGroup/1.0",
+              "groupType": "editable",
               "title": "SMS Operation Versions",
-              "queryType": 0,
-              "resourceType": "Microsoft.Communication/CommunicationServices"
+              "items": [
+                {
+                  "type": 3,
+                  "content": {
+                    "version": "KqlItem/1.0",
+                    "query": "ACSSMSIncomingOperations\r\n| where TimeGenerated {time_range:query}\r\n| summarize count() by OperationVersion\r\n| render piechart",
+                    "size": 0,
+                    "noDataMessage": "No SMS operations found in the specified time range",
+                    "exportMultipleValues": true,
+                    "exportedParameters": [
+                      {
+                        "fieldName": "series",
+                        "parameterName": "sms_version",
+                        "parameterType": 1
+                      }
+                    ],
+                    "queryType": 0,
+                    "resourceType": "microsoft.communication/communicationservices"
+                  },
+                  "showPin": false,
+                  "name": "sms-operation-versions"
+                },
+                {
+                  "type": 3,
+                  "content": {
+                    "version": "KqlItem/1.0",
+                    "query": "let SIPCodesSMS =  datatable(ResultSignature: string, SIPCode: string)\r\n[\r\n    \"0\", \"Success\",\r\n    \"100\", \"Trying\",\r\n    \"180\", \"Ringing\",\r\n    \"181\", \"Call Is Being Forwarded\",\r\n    \"182\", \"Queued\",\r\n    \"183\", \"Session Progress\",\r\n    \"199\", \"Early Dialog Terminated\",\r\n    \"200\", \"Success\",\r\n    \"202\", \"Accepted\",\r\n    \"204\", \"No Notification\",\r\n    \"300\", \"Multiple Choices\",\r\n    \"301\", \"Moved Permanently\",\r\n    \"302\", \"Moved Temporarily\",\r\n    \"305\", \"Use Proxy\",\r\n    \"380\", \"Alternative Service\",\r\n    \"400\", \"Bad Request\",\r\n    \"401\", \"Unauthorized\",\r\n    \"402\", \"Payment Required\",\r\n    \"403\", \"Forbidden\",\r\n    \"404\", \"Not Found\",\r\n    \"405\", \"Method Not Allowed\",\r\n    \"406\", \"Not Acceptable\",\r\n    \"407\", \"Proxy Authentication Required\",\r\n    \"408\", \"Request Timeout\",\r\n    \"409\", \"Conflict\",\r\n    \"410\", \"Gone\",\r\n    \"411\", \"Length Required\",\r\n    \"412\", \"Conditional Request Failed\",\r\n    \"413\", \"Request Entity Too Large\",\r\n    \"414\", \"Request-URI Too Large\",\r\n    \"415\", \"Unsupported Media Type\",\r\n    \"416\", \"Unsupported URI Scheme\",\r\n    \"417\", \"Unknown Resource-Priority\",\r\n    \"420\", \"Bad Extension\",\r\n    \"421\", \"Extension Required\",\r\n    \"422\", \"Session Interval Too Small\",\r\n    \"423\", \"Interval Too Brief\",\r\n    \"424\", \"Bad Location Information\",\r\n    \"428\", \"Use Identity Header\",\r\n    \"429\", \"Provide Referrer Identity\",\r\n    \"430\", \"Flow Failed\",\r\n    \"433\", \"Anonymity Disallowed\",\r\n    \"436\", \"Bad Identity-Info\",\r\n    \"437\", \"Unsupported Certificate\",\r\n    \"438\", \"Invalid Identity Header\",\r\n    \"439\", \"First Hop Lacks Outbound Support\",\r\n    \"440\", \"Max-Breadth Exceeded\",\r\n    \"469\", \"Bad Info Package\",\r\n    \"470\", \"Consent Needed\",\r\n    \"480\", \"Temporarily Unavailable\",\r\n    \"481\", \"Call/Transaction Does Not Exist\",\r\n    \"482\", \"Loop Detected\",\r\n    \"483\", \"Too Many Hops\",\r\n    \"484\", \"Address Incomplete\",\r\n    \"485\", \"Ambiguous\",\r\n    \"486\", \"Busy Here\",\r\n    \"487\", \"Request Terminated\",\r\n    \"488\", \"Not Acceptable Here\",\r\n    \"489\", \"Bad Event\",\r\n    \"491\", \"Request Pending\",\r\n    \"493\", \"Undecipherable\",\r\n    \"494\", \"Security Agreement Required\",\r\n    \"500\", \"Internal Server Error\",\r\n    \"501\", \"Not Implemented\",\r\n    \"502\", \"Bad Gateway\",\r\n    \"503\", \"Service Unavailable\",\r\n    \"504\", \"Server Time-out\",\r\n    \"505\", \"Version Not Supported\",\r\n    \"513\", \"Message Too Large\",\r\n    \"555\", \"Push Notification Service Not Supported\",\r\n    \"580\", \"Precondition Failure\",\r\n    \"600\", \"Busy Everywhere\",\r\n    \"603\", \"Decline\",\r\n    \"604\", \"Does Not Exist Anywhere\",\r\n    \"606\", \"Not Acceptable\",\r\n    \"607\", \"Unwanted\",\r\n    \"608\", \"Rejected\",\r\n];\r\n\r\nACSSMSIncomingOperations\r\n| where TimeGenerated {time_range:query} and OperationVersion in ({sms_version})\r\n| join kind=leftouter SIPCodesSMS on ResultSignature\r\n| extend OperationDate=strcat(\"📅\", format_datetime(TimeGenerated, 'MM/dd/y'))\r\n| extend OperationTime=format_datetime(TimeGenerated, 'hh:mm:ss')\r\n| extend ResultIcon=iff(ResultType == \"Succeeded\", \"✔️\", \"❌\")\r\n| extend Result=strcat(ResultIcon, \" \", ResultSignature, \": \", SIPCode)\r\n| order by TimeGenerated\r\n| project OperationName, Result, PhoneNumber, CallerIpAddress, OutgoingMessageLength, IncomingMessageLength, DeliveryAttempts, Method, Level, OperationDate, OperationTime, DurationMs",
+                    "size": 0,
+                    "title": "SMS operations with operation version {sms_version}",
+                    "noDataMessage": "No SMS operations found for the specified time range and operation version",
+                    "queryType": 0,
+                    "resourceType": "microsoft.communication/communicationservices",
+                    "gridSettings": {
+                      "formatters": [
+                        {
+                          "columnMatch": "Level",
+                          "formatter": 18,
+                          "formatOptions": {
+                            "thresholdsOptions": "icons",
+                            "thresholdsGrid": [
+                              {
+                                "operator": "==",
+                                "thresholdValue": "Warning",
+                                "representation": "warning",
+                                "text": "{0}{1}"
+                              },
+                              {
+                                "operator": "Default",
+                                "thresholdValue": null,
+                                "representation": "info",
+                                "text": "{0}{1}"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "columnMatch": "OperationDate",
+                          "formatter": 5
+                        },
+                        {
+                          "columnMatch": "OperationTime",
+                          "formatter": 5
+                        }
+                      ],
+                      "hierarchySettings": {
+                        "treeType": 1,
+                        "groupBy": [
+                          "OperationDate"
+                        ],
+                        "expandTopLevel": true,
+                        "finalBy": "OperationTime"
+                      }
+                    },
+                    "sortBy": []
+                  },
+                  "conditionalVisibility": {
+                    "parameterName": "sms_version",
+                    "comparison": "isNotEqualTo"
+                  },
+                  "name": "sms-by-version"
+                }
+              ]
             },
             "customWidth": "50",
-            "name": "sms-operation-versions"
+            "name": "sms-operation-versions-group"
+          },
+          {
+            "type": 12,
+            "content": {
+              "version": "NotebookGroup/1.0",
+              "groupType": "editable",
+              "title": "SMS Method",
+              "items": [
+                {
+                  "type": 3,
+                  "content": {
+                    "version": "KqlItem/1.0",
+                    "query": "ACSSMSIncomingOperations\r\n| where TimeGenerated {time_range:query}\r\n| summarize count() by Method\r\n| render piechart",
+                    "size": 0,
+                    "noDataMessage": "No SMS operations found in the specified time range",
+                    "exportMultipleValues": true,
+                    "exportedParameters": [
+                      {
+                        "fieldName": "series",
+                        "parameterName": "sms_method",
+                        "parameterType": 1
+                      }
+                    ],
+                    "queryType": 0,
+                    "resourceType": "microsoft.communication/communicationservices"
+                  },
+                  "name": "sms-operation-names"
+                },
+                {
+                  "type": 3,
+                  "content": {
+                    "version": "KqlItem/1.0",
+                    "query": "let SIPCodesSMS =  datatable(ResultSignature: string, SIPCode: string)\r\n[\r\n    \"0\", \"Success\",\r\n    \"100\", \"Trying\",\r\n    \"180\", \"Ringing\",\r\n    \"181\", \"Call Is Being Forwarded\",\r\n    \"182\", \"Queued\",\r\n    \"183\", \"Session Progress\",\r\n    \"199\", \"Early Dialog Terminated\",\r\n    \"200\", \"Success\",\r\n    \"202\", \"Accepted\",\r\n    \"204\", \"No Notification\",\r\n    \"300\", \"Multiple Choices\",\r\n    \"301\", \"Moved Permanently\",\r\n    \"302\", \"Moved Temporarily\",\r\n    \"305\", \"Use Proxy\",\r\n    \"380\", \"Alternative Service\",\r\n    \"400\", \"Bad Request\",\r\n    \"401\", \"Unauthorized\",\r\n    \"402\", \"Payment Required\",\r\n    \"403\", \"Forbidden\",\r\n    \"404\", \"Not Found\",\r\n    \"405\", \"Method Not Allowed\",\r\n    \"406\", \"Not Acceptable\",\r\n    \"407\", \"Proxy Authentication Required\",\r\n    \"408\", \"Request Timeout\",\r\n    \"409\", \"Conflict\",\r\n    \"410\", \"Gone\",\r\n    \"411\", \"Length Required\",\r\n    \"412\", \"Conditional Request Failed\",\r\n    \"413\", \"Request Entity Too Large\",\r\n    \"414\", \"Request-URI Too Large\",\r\n    \"415\", \"Unsupported Media Type\",\r\n    \"416\", \"Unsupported URI Scheme\",\r\n    \"417\", \"Unknown Resource-Priority\",\r\n    \"420\", \"Bad Extension\",\r\n    \"421\", \"Extension Required\",\r\n    \"422\", \"Session Interval Too Small\",\r\n    \"423\", \"Interval Too Brief\",\r\n    \"424\", \"Bad Location Information\",\r\n    \"428\", \"Use Identity Header\",\r\n    \"429\", \"Provide Referrer Identity\",\r\n    \"430\", \"Flow Failed\",\r\n    \"433\", \"Anonymity Disallowed\",\r\n    \"436\", \"Bad Identity-Info\",\r\n    \"437\", \"Unsupported Certificate\",\r\n    \"438\", \"Invalid Identity Header\",\r\n    \"439\", \"First Hop Lacks Outbound Support\",\r\n    \"440\", \"Max-Breadth Exceeded\",\r\n    \"469\", \"Bad Info Package\",\r\n    \"470\", \"Consent Needed\",\r\n    \"480\", \"Temporarily Unavailable\",\r\n    \"481\", \"Call/Transaction Does Not Exist\",\r\n    \"482\", \"Loop Detected\",\r\n    \"483\", \"Too Many Hops\",\r\n    \"484\", \"Address Incomplete\",\r\n    \"485\", \"Ambiguous\",\r\n    \"486\", \"Busy Here\",\r\n    \"487\", \"Request Terminated\",\r\n    \"488\", \"Not Acceptable Here\",\r\n    \"489\", \"Bad Event\",\r\n    \"491\", \"Request Pending\",\r\n    \"493\", \"Undecipherable\",\r\n    \"494\", \"Security Agreement Required\",\r\n    \"500\", \"Internal Server Error\",\r\n    \"501\", \"Not Implemented\",\r\n    \"502\", \"Bad Gateway\",\r\n    \"503\", \"Service Unavailable\",\r\n    \"504\", \"Server Time-out\",\r\n    \"505\", \"Version Not Supported\",\r\n    \"513\", \"Message Too Large\",\r\n    \"555\", \"Push Notification Service Not Supported\",\r\n    \"580\", \"Precondition Failure\",\r\n    \"600\", \"Busy Everywhere\",\r\n    \"603\", \"Decline\",\r\n    \"604\", \"Does Not Exist Anywhere\",\r\n    \"606\", \"Not Acceptable\",\r\n    \"607\", \"Unwanted\",\r\n    \"608\", \"Rejected\",\r\n];\r\n\r\nACSSMSIncomingOperations\r\n| where TimeGenerated {time_range:query} and Method in ({sms_method})\r\n| join kind=leftouter SIPCodesSMS on ResultSignature\r\n| extend OperationDate=strcat(\"📅\", format_datetime(TimeGenerated, 'MM/dd/y'))\r\n| extend OperationTime=format_datetime(TimeGenerated, 'hh:mm:ss')\r\n| extend ResultIcon=iff(ResultType == \"Succeeded\", \"✔️\", \"❌\")\r\n| extend Result=strcat(ResultIcon, \" \", ResultSignature, \": \", SIPCode)\r\n| order by TimeGenerated\r\n| project OperationName, Result, PhoneNumber, CallerIpAddress, OutgoingMessageLength, IncomingMessageLength, DeliveryAttempts, Method, Level, OperationDate, OperationTime, DurationMs",
+                    "size": 0,
+                    "title": "SMS operations with {sms_method} method",
+                    "noDataMessage": "No SMS operations found for the specified time range and result type",
+                    "queryType": 0,
+                    "resourceType": "microsoft.communication/communicationservices",
+                    "gridSettings": {
+                      "formatters": [
+                        {
+                          "columnMatch": "Level",
+                          "formatter": 18,
+                          "formatOptions": {
+                            "thresholdsOptions": "icons",
+                            "thresholdsGrid": [
+                              {
+                                "operator": "==",
+                                "thresholdValue": "Warning",
+                                "representation": "warning",
+                                "text": "{0}{1}"
+                              },
+                              {
+                                "operator": "Default",
+                                "thresholdValue": null,
+                                "representation": "info",
+                                "text": "{0}{1}"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "columnMatch": "OperationDate",
+                          "formatter": 5
+                        },
+                        {
+                          "columnMatch": "OperationTime",
+                          "formatter": 5
+                        }
+                      ],
+                      "hierarchySettings": {
+                        "treeType": 1,
+                        "groupBy": [
+                          "OperationDate"
+                        ],
+                        "expandTopLevel": true,
+                        "finalBy": "OperationTime"
+                      }
+                    },
+                    "sortBy": []
+                  },
+                  "conditionalVisibility": {
+                    "parameterName": "sms_method",
+                    "comparison": "isNotEqualTo"
+                  },
+                  "name": "sms-by-method"
+                }
+              ]
+            },
+            "customWidth": "50",
+            "name": "sms-method-group"
+          },
+          {
+            "type": 12,
+            "content": {
+              "version": "NotebookGroup/1.0",
+              "groupType": "editable",
+              "title": "SMS Delivery Attempts",
+              "items": [
+                {
+                  "type": 3,
+                  "content": {
+                    "version": "KqlItem/1.0",
+                    "query": "ACSSMSIncomingOperations\r\n| where TimeGenerated {time_range:query}\r\n| summarize NumMessages=count() by tostring(DeliveryAttempts)\r\n| render piechart",
+                    "size": 0,
+                    "noDataMessage": "No SMS operations found in the specified time range",
+                    "showRefreshButton": true,
+                    "exportMultipleValues": true,
+                    "exportedParameters": [
+                      {
+                        "fieldName": "series",
+                        "parameterName": "sms_attempts",
+                        "parameterType": 1
+                      }
+                    ],
+                    "queryType": 0,
+                    "resourceType": "microsoft.communication/communicationservices"
+                  },
+                  "name": "sms-delivery-attempts"
+                },
+                {
+                  "type": 3,
+                  "content": {
+                    "version": "KqlItem/1.0",
+                    "query": "let SIPCodesSMS =  datatable(ResultSignature: string, SIPCode: string)\r\n[\r\n    \"0\", \"Success\",\r\n    \"100\", \"Trying\",\r\n    \"180\", \"Ringing\",\r\n    \"181\", \"Call Is Being Forwarded\",\r\n    \"182\", \"Queued\",\r\n    \"183\", \"Session Progress\",\r\n    \"199\", \"Early Dialog Terminated\",\r\n    \"200\", \"Success\",\r\n    \"202\", \"Accepted\",\r\n    \"204\", \"No Notification\",\r\n    \"300\", \"Multiple Choices\",\r\n    \"301\", \"Moved Permanently\",\r\n    \"302\", \"Moved Temporarily\",\r\n    \"305\", \"Use Proxy\",\r\n    \"380\", \"Alternative Service\",\r\n    \"400\", \"Bad Request\",\r\n    \"401\", \"Unauthorized\",\r\n    \"402\", \"Payment Required\",\r\n    \"403\", \"Forbidden\",\r\n    \"404\", \"Not Found\",\r\n    \"405\", \"Method Not Allowed\",\r\n    \"406\", \"Not Acceptable\",\r\n    \"407\", \"Proxy Authentication Required\",\r\n    \"408\", \"Request Timeout\",\r\n    \"409\", \"Conflict\",\r\n    \"410\", \"Gone\",\r\n    \"411\", \"Length Required\",\r\n    \"412\", \"Conditional Request Failed\",\r\n    \"413\", \"Request Entity Too Large\",\r\n    \"414\", \"Request-URI Too Large\",\r\n    \"415\", \"Unsupported Media Type\",\r\n    \"416\", \"Unsupported URI Scheme\",\r\n    \"417\", \"Unknown Resource-Priority\",\r\n    \"420\", \"Bad Extension\",\r\n    \"421\", \"Extension Required\",\r\n    \"422\", \"Session Interval Too Small\",\r\n    \"423\", \"Interval Too Brief\",\r\n    \"424\", \"Bad Location Information\",\r\n    \"428\", \"Use Identity Header\",\r\n    \"429\", \"Provide Referrer Identity\",\r\n    \"430\", \"Flow Failed\",\r\n    \"433\", \"Anonymity Disallowed\",\r\n    \"436\", \"Bad Identity-Info\",\r\n    \"437\", \"Unsupported Certificate\",\r\n    \"438\", \"Invalid Identity Header\",\r\n    \"439\", \"First Hop Lacks Outbound Support\",\r\n    \"440\", \"Max-Breadth Exceeded\",\r\n    \"469\", \"Bad Info Package\",\r\n    \"470\", \"Consent Needed\",\r\n    \"480\", \"Temporarily Unavailable\",\r\n    \"481\", \"Call/Transaction Does Not Exist\",\r\n    \"482\", \"Loop Detected\",\r\n    \"483\", \"Too Many Hops\",\r\n    \"484\", \"Address Incomplete\",\r\n    \"485\", \"Ambiguous\",\r\n    \"486\", \"Busy Here\",\r\n    \"487\", \"Request Terminated\",\r\n    \"488\", \"Not Acceptable Here\",\r\n    \"489\", \"Bad Event\",\r\n    \"491\", \"Request Pending\",\r\n    \"493\", \"Undecipherable\",\r\n    \"494\", \"Security Agreement Required\",\r\n    \"500\", \"Internal Server Error\",\r\n    \"501\", \"Not Implemented\",\r\n    \"502\", \"Bad Gateway\",\r\n    \"503\", \"Service Unavailable\",\r\n    \"504\", \"Server Time-out\",\r\n    \"505\", \"Version Not Supported\",\r\n    \"513\", \"Message Too Large\",\r\n    \"555\", \"Push Notification Service Not Supported\",\r\n    \"580\", \"Precondition Failure\",\r\n    \"600\", \"Busy Everywhere\",\r\n    \"603\", \"Decline\",\r\n    \"604\", \"Does Not Exist Anywhere\",\r\n    \"606\", \"Not Acceptable\",\r\n    \"607\", \"Unwanted\",\r\n    \"608\", \"Rejected\",\r\n];\r\n\r\nACSSMSIncomingOperations\r\n| where TimeGenerated {time_range:query} and DeliveryAttempts in ({sms_attempts})\r\n| join kind=leftouter SIPCodesSMS on ResultSignature\r\n| extend OperationDate=strcat(\"📅\", format_datetime(TimeGenerated, 'MM/dd/y'))\r\n| extend OperationTime=format_datetime(TimeGenerated, 'hh:mm:ss')\r\n| extend ResultIcon=iff(ResultType == \"Succeeded\", \"✔️\", \"❌\")\r\n| extend Result=strcat(ResultIcon, \" \", ResultSignature, \": \", SIPCode)\r\n| order by TimeGenerated\r\n| project OperationName, PhoneNumber, Method, Level, Result, OperationDate, OperationTime, DurationMs",
+                    "size": 0,
+                    "title": "SMS operations with {sms_attempts} delivery attempts",
+                    "noDataMessage": "No SMS operations found for the specified time range and result type",
+                    "queryType": 0,
+                    "resourceType": "microsoft.communication/communicationservices",
+                    "gridSettings": {
+                      "formatters": [
+                        {
+                          "columnMatch": "Level",
+                          "formatter": 18,
+                          "formatOptions": {
+                            "thresholdsOptions": "icons",
+                            "thresholdsGrid": [
+                              {
+                                "operator": "==",
+                                "thresholdValue": "Warning",
+                                "representation": "warning",
+                                "text": "{0}{1}"
+                              },
+                              {
+                                "operator": "Default",
+                                "thresholdValue": null,
+                                "representation": "info",
+                                "text": "{0}{1}"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "columnMatch": "OperationDate",
+                          "formatter": 5
+                        },
+                        {
+                          "columnMatch": "OperationTime",
+                          "formatter": 5
+                        }
+                      ],
+                      "hierarchySettings": {
+                        "treeType": 1,
+                        "groupBy": [
+                          "OperationDate"
+                        ],
+                        "expandTopLevel": true,
+                        "finalBy": "OperationTime"
+                      }
+                    },
+                    "sortBy": []
+                  },
+                  "conditionalVisibility": {
+                    "parameterName": "sms_attempts",
+                    "comparison": "isNotEqualTo"
+                  },
+                  "name": "sms-by-attempts"
+                }
+              ]
+            },
+            "customWidth": "50",
+            "name": "sms-delivery-attempts-group"
+          },
+          {
+            "type": 12,
+            "content": {
+              "version": "NotebookGroup/1.0",
+              "groupType": "editable",
+              "title": "SMS phone drill-down",
+              "items": [
+                {
+                  "type": 9,
+                  "content": {
+                    "version": "KqlParameterItem/1.0",
+                    "parameters": [
+                      {
+                        "id": "0c0b56fd-ffd9-4761-b14e-c916660f9ccc",
+                        "version": "KqlParameterItem/1.0",
+                        "name": "sms_phone",
+                        "label": "Phone number",
+                        "type": 2,
+                        "description": "Choose an phone number to visualize",
+                        "query": "ACSSMSIncomingOperations\r\n| where TimeGenerated {time_range:query}\r\n| order by TimeGenerated\r\n| distinct PhoneNumber",
+                        "value": null,
+                        "typeSettings": {
+                          "additionalResourceOptions": [],
+                          "showDefault": false
+                        },
+                        "queryType": 0,
+                        "resourceType": "microsoft.communication/communicationservices"
+                      }
+                    ],
+                    "style": "pills",
+                    "queryType": 0,
+                    "resourceType": "microsoft.communication/communicationservices"
+                  },
+                  "name": "sms-phone-parameters"
+                },
+                {
+                  "type": 1,
+                  "content": {
+                    "json": "**Select a phone number from the drop-down menu to display its associated data**",
+                    "style": "info"
+                  },
+                  "conditionalVisibility": {
+                    "parameterName": "sms_phone",
+                    "comparison": "isEqualTo"
+                  },
+                  "name": "sms-phone-drilldown-info"
+                },
+                {
+                  "type": 3,
+                  "content": {
+                    "version": "KqlItem/1.0",
+                    "query": "let SIPCodesSMS =  datatable(ResultSignature: string, SIPCode: string)\r\n[\r\n    \"0\", \"Success\",\r\n    \"100\", \"Trying\",\r\n    \"180\", \"Ringing\",\r\n    \"181\", \"Call Is Being Forwarded\",\r\n    \"182\", \"Queued\",\r\n    \"183\", \"Session Progress\",\r\n    \"199\", \"Early Dialog Terminated\",\r\n    \"200\", \"Success\",\r\n    \"202\", \"Accepted\",\r\n    \"204\", \"No Notification\",\r\n    \"300\", \"Multiple Choices\",\r\n    \"301\", \"Moved Permanently\",\r\n    \"302\", \"Moved Temporarily\",\r\n    \"305\", \"Use Proxy\",\r\n    \"380\", \"Alternative Service\",\r\n    \"400\", \"Bad Request\",\r\n    \"401\", \"Unauthorized\",\r\n    \"402\", \"Payment Required\",\r\n    \"403\", \"Forbidden\",\r\n    \"404\", \"Not Found\",\r\n    \"405\", \"Method Not Allowed\",\r\n    \"406\", \"Not Acceptable\",\r\n    \"407\", \"Proxy Authentication Required\",\r\n    \"408\", \"Request Timeout\",\r\n    \"409\", \"Conflict\",\r\n    \"410\", \"Gone\",\r\n    \"411\", \"Length Required\",\r\n    \"412\", \"Conditional Request Failed\",\r\n    \"413\", \"Request Entity Too Large\",\r\n    \"414\", \"Request-URI Too Large\",\r\n    \"415\", \"Unsupported Media Type\",\r\n    \"416\", \"Unsupported URI Scheme\",\r\n    \"417\", \"Unknown Resource-Priority\",\r\n    \"420\", \"Bad Extension\",\r\n    \"421\", \"Extension Required\",\r\n    \"422\", \"Session Interval Too Small\",\r\n    \"423\", \"Interval Too Brief\",\r\n    \"424\", \"Bad Location Information\",\r\n    \"428\", \"Use Identity Header\",\r\n    \"429\", \"Provide Referrer Identity\",\r\n    \"430\", \"Flow Failed\",\r\n    \"433\", \"Anonymity Disallowed\",\r\n    \"436\", \"Bad Identity-Info\",\r\n    \"437\", \"Unsupported Certificate\",\r\n    \"438\", \"Invalid Identity Header\",\r\n    \"439\", \"First Hop Lacks Outbound Support\",\r\n    \"440\", \"Max-Breadth Exceeded\",\r\n    \"469\", \"Bad Info Package\",\r\n    \"470\", \"Consent Needed\",\r\n    \"480\", \"Temporarily Unavailable\",\r\n    \"481\", \"Call/Transaction Does Not Exist\",\r\n    \"482\", \"Loop Detected\",\r\n    \"483\", \"Too Many Hops\",\r\n    \"484\", \"Address Incomplete\",\r\n    \"485\", \"Ambiguous\",\r\n    \"486\", \"Busy Here\",\r\n    \"487\", \"Request Terminated\",\r\n    \"488\", \"Not Acceptable Here\",\r\n    \"489\", \"Bad Event\",\r\n    \"491\", \"Request Pending\",\r\n    \"493\", \"Undecipherable\",\r\n    \"494\", \"Security Agreement Required\",\r\n    \"500\", \"Internal Server Error\",\r\n    \"501\", \"Not Implemented\",\r\n    \"502\", \"Bad Gateway\",\r\n    \"503\", \"Service Unavailable\",\r\n    \"504\", \"Server Time-out\",\r\n    \"505\", \"Version Not Supported\",\r\n    \"513\", \"Message Too Large\",\r\n    \"555\", \"Push Notification Service Not Supported\",\r\n    \"580\", \"Precondition Failure\",\r\n    \"600\", \"Busy Everywhere\",\r\n    \"603\", \"Decline\",\r\n    \"604\", \"Does Not Exist Anywhere\",\r\n    \"606\", \"Not Acceptable\",\r\n    \"607\", \"Unwanted\",\r\n    \"608\", \"Rejected\",\r\n];\r\n\r\nACSSMSIncomingOperations\r\n| where TimeGenerated {time_range:query} and PhoneNumber == \"{sms_phone}\"\r\n| join kind=leftouter SIPCodesSMS on ResultSignature\r\n| extend OperationDate=strcat(\"📅\", format_datetime(TimeGenerated, 'MM/dd/y'))\r\n| extend OperationTime=format_datetime(TimeGenerated, 'hh:mm:ss')\r\n| extend ResultIcon=iff(ResultType == \"Succeeded\", \"✔️\", \"❌\")\r\n| extend Result=strcat(ResultIcon, \" \", ResultSignature, \": \", SIPCode)\r\n| order by TimeGenerated\r\n| project OperationName, Result, OutgoingMessageLength, IncomingMessageLength, DeliveryAttempts, CallerIpAddress, Method, Level, OperationDate, OperationTime, DurationMs\r\n",
+                    "size": 0,
+                    "title": "SMS operations for phone number {sms_phone}",
+                    "noDataMessage": "No SMS operations found for the specified time range and phone number",
+                    "queryType": 0,
+                    "resourceType": "microsoft.communication/communicationservices",
+                    "gridSettings": {
+                      "formatters": [
+                        {
+                          "columnMatch": "Level",
+                          "formatter": 18,
+                          "formatOptions": {
+                            "thresholdsOptions": "icons",
+                            "thresholdsGrid": [
+                              {
+                                "operator": "==",
+                                "thresholdValue": "Warning",
+                                "representation": "warning",
+                                "text": "{0}{1}"
+                              },
+                              {
+                                "operator": "Default",
+                                "thresholdValue": null,
+                                "representation": "info",
+                                "text": "{0}{1}"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "columnMatch": "OperationDate",
+                          "formatter": 5
+                        },
+                        {
+                          "columnMatch": "OperationTime",
+                          "formatter": 5
+                        }
+                      ],
+                      "hierarchySettings": {
+                        "treeType": 1,
+                        "groupBy": [
+                          "OperationDate"
+                        ],
+                        "expandTopLevel": true,
+                        "finalBy": "OperationTime"
+                      }
+                    },
+                    "sortBy": []
+                  },
+                  "conditionalVisibility": {
+                    "parameterName": "sms_phone",
+                    "comparison": "isNotEqualTo"
+                  },
+                  "name": "sms-phone-details"
+                }
+              ]
+            },
+            "name": "sms-phone-drill-down-group"
+          },
+          {
+            "type": 12,
+            "content": {
+              "version": "NotebookGroup/1.0",
+              "groupType": "editable",
+              "title": "SMS IP address drill-down",
+              "items": [
+                {
+                  "type": 9,
+                  "content": {
+                    "version": "KqlParameterItem/1.0",
+                    "parameters": [
+                      {
+                        "id": "0c0b56fd-ffd9-4761-b14e-c916660f9ccc",
+                        "version": "KqlParameterItem/1.0",
+                        "name": "sms_ip",
+                        "label": "IP address",
+                        "type": 2,
+                        "description": "Choose an phone number to visualize",
+                        "query": "ACSSMSIncomingOperations\r\n| where TimeGenerated {time_range:query}\r\n| order by TimeGenerated\r\n| distinct CallerIpAddress",
+                        "value": null,
+                        "typeSettings": {
+                          "additionalResourceOptions": [],
+                          "showDefault": false
+                        },
+                        "queryType": 0,
+                        "resourceType": "microsoft.communication/communicationservices"
+                      }
+                    ],
+                    "style": "pills",
+                    "queryType": 0,
+                    "resourceType": "microsoft.communication/communicationservices"
+                  },
+                  "name": "sms-phone-parameters"
+                },
+                {
+                  "type": 1,
+                  "content": {
+                    "json": "**Select an IP address from the drop-down menu to display its associated data**",
+                    "style": "info"
+                  },
+                  "conditionalVisibility": {
+                    "parameterName": "sms_ip",
+                    "comparison": "isEqualTo"
+                  },
+                  "name": "sms-ip-drilldown-info"
+                },
+                {
+                  "type": 3,
+                  "content": {
+                    "version": "KqlItem/1.0",
+                    "query": "let SIPCodesSMS =  datatable(ResultSignature: string, SIPCode: string)\r\n[\r\n    \"0\", \"Success\",\r\n    \"100\", \"Trying\",\r\n    \"180\", \"Ringing\",\r\n    \"181\", \"Call Is Being Forwarded\",\r\n    \"182\", \"Queued\",\r\n    \"183\", \"Session Progress\",\r\n    \"199\", \"Early Dialog Terminated\",\r\n    \"200\", \"Success\",\r\n    \"202\", \"Accepted\",\r\n    \"204\", \"No Notification\",\r\n    \"300\", \"Multiple Choices\",\r\n    \"301\", \"Moved Permanently\",\r\n    \"302\", \"Moved Temporarily\",\r\n    \"305\", \"Use Proxy\",\r\n    \"380\", \"Alternative Service\",\r\n    \"400\", \"Bad Request\",\r\n    \"401\", \"Unauthorized\",\r\n    \"402\", \"Payment Required\",\r\n    \"403\", \"Forbidden\",\r\n    \"404\", \"Not Found\",\r\n    \"405\", \"Method Not Allowed\",\r\n    \"406\", \"Not Acceptable\",\r\n    \"407\", \"Proxy Authentication Required\",\r\n    \"408\", \"Request Timeout\",\r\n    \"409\", \"Conflict\",\r\n    \"410\", \"Gone\",\r\n    \"411\", \"Length Required\",\r\n    \"412\", \"Conditional Request Failed\",\r\n    \"413\", \"Request Entity Too Large\",\r\n    \"414\", \"Request-URI Too Large\",\r\n    \"415\", \"Unsupported Media Type\",\r\n    \"416\", \"Unsupported URI Scheme\",\r\n    \"417\", \"Unknown Resource-Priority\",\r\n    \"420\", \"Bad Extension\",\r\n    \"421\", \"Extension Required\",\r\n    \"422\", \"Session Interval Too Small\",\r\n    \"423\", \"Interval Too Brief\",\r\n    \"424\", \"Bad Location Information\",\r\n    \"428\", \"Use Identity Header\",\r\n    \"429\", \"Provide Referrer Identity\",\r\n    \"430\", \"Flow Failed\",\r\n    \"433\", \"Anonymity Disallowed\",\r\n    \"436\", \"Bad Identity-Info\",\r\n    \"437\", \"Unsupported Certificate\",\r\n    \"438\", \"Invalid Identity Header\",\r\n    \"439\", \"First Hop Lacks Outbound Support\",\r\n    \"440\", \"Max-Breadth Exceeded\",\r\n    \"469\", \"Bad Info Package\",\r\n    \"470\", \"Consent Needed\",\r\n    \"480\", \"Temporarily Unavailable\",\r\n    \"481\", \"Call/Transaction Does Not Exist\",\r\n    \"482\", \"Loop Detected\",\r\n    \"483\", \"Too Many Hops\",\r\n    \"484\", \"Address Incomplete\",\r\n    \"485\", \"Ambiguous\",\r\n    \"486\", \"Busy Here\",\r\n    \"487\", \"Request Terminated\",\r\n    \"488\", \"Not Acceptable Here\",\r\n    \"489\", \"Bad Event\",\r\n    \"491\", \"Request Pending\",\r\n    \"493\", \"Undecipherable\",\r\n    \"494\", \"Security Agreement Required\",\r\n    \"500\", \"Internal Server Error\",\r\n    \"501\", \"Not Implemented\",\r\n    \"502\", \"Bad Gateway\",\r\n    \"503\", \"Service Unavailable\",\r\n    \"504\", \"Server Time-out\",\r\n    \"505\", \"Version Not Supported\",\r\n    \"513\", \"Message Too Large\",\r\n    \"555\", \"Push Notification Service Not Supported\",\r\n    \"580\", \"Precondition Failure\",\r\n    \"600\", \"Busy Everywhere\",\r\n    \"603\", \"Decline\",\r\n    \"604\", \"Does Not Exist Anywhere\",\r\n    \"606\", \"Not Acceptable\",\r\n    \"607\", \"Unwanted\",\r\n    \"608\", \"Rejected\",\r\n];\r\n\r\nACSSMSIncomingOperations\r\n| where TimeGenerated {time_range:query} and CallerIpAddress == \"{sms_ip}\"\r\n| join kind=leftouter SIPCodesSMS on ResultSignature\r\n| extend OperationDate=strcat(\"📅\", format_datetime(TimeGenerated, 'MM/dd/y'))\r\n| extend OperationTime=format_datetime(TimeGenerated, 'hh:mm:ss')\r\n| extend ResultIcon=iff(ResultType == \"Succeeded\", \"✔️\", \"❌\")\r\n| extend Result=strcat(ResultIcon, \" \", ResultSignature, \": \", SIPCode)\r\n| order by TimeGenerated\r\n| project OperationName, Result, OutgoingMessageLength, IncomingMessageLength, DeliveryAttempts, PhoneNumber, Method, Level, OperationDate, OperationTime, DurationMs\r\n",
+                    "size": 0,
+                    "title": "SMS operations for IP address {sms_ip}",
+                    "noDataMessage": "No SMS operations found for the specified time range and IP address",
+                    "queryType": 0,
+                    "resourceType": "microsoft.communication/communicationservices",
+                    "gridSettings": {
+                      "formatters": [
+                        {
+                          "columnMatch": "Level",
+                          "formatter": 18,
+                          "formatOptions": {
+                            "thresholdsOptions": "icons",
+                            "thresholdsGrid": [
+                              {
+                                "operator": "==",
+                                "thresholdValue": "Warning",
+                                "representation": "warning",
+                                "text": "{0}{1}"
+                              },
+                              {
+                                "operator": "Default",
+                                "thresholdValue": null,
+                                "representation": "info",
+                                "text": "{0}{1}"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "columnMatch": "OperationDate",
+                          "formatter": 5
+                        },
+                        {
+                          "columnMatch": "OperationTime",
+                          "formatter": 5
+                        }
+                      ],
+                      "hierarchySettings": {
+                        "treeType": 1,
+                        "groupBy": [
+                          "OperationDate"
+                        ],
+                        "expandTopLevel": true,
+                        "finalBy": "OperationTime"
+                      }
+                    },
+                    "sortBy": []
+                  },
+                  "conditionalVisibility": {
+                    "parameterName": "sms_ip",
+                    "comparison": "isNotEqualTo"
+                  },
+                  "name": "sms-ip-details"
+                }
+              ]
+            },
+            "name": "sms-ip-drill-down-group"
           }
         ]
       },


### PR DESCRIPTION
New version of the Azure Communication Services Insights tab

- Followed the Azure Workbooks team's advice and made the text more informational when queries return no results:
<img width="296" alt="image" src="https://user-images.githubusercontent.com/85182102/144477348-ddccb90b-e685-442b-959a-369a184a259b.png">

- Improved the text descriptions in some sections:
<img width="757" alt="image" src="https://user-images.githubusercontent.com/85182102/144477549-548980ef-a342-42c7-a26b-bd7ebd85e856.png">

- Added drill-down functionality to improve dashboard navigation experience:
  - On grids:
<img width="524" alt="image" src="https://user-images.githubusercontent.com/85182102/144477696-dddfdb13-2169-44fd-a00c-e5d1b9b69a1f.png">
<img width="585" alt="image" src="https://user-images.githubusercontent.com/85182102/144477742-eb241d7b-38d3-48e9-b5ff-215f604c5f79.png">
<img width="337" alt="image" src="https://user-images.githubusercontent.com/85182102/144477871-6409fcac-93b6-4c49-84b0-1ca675f16136.png">

  - And on pie charts:
<img width="337" alt="image" src="https://user-images.githubusercontent.com/85182102/144477937-75c544c5-4755-4f48-8729-4df092d7bb2f.png">
<img width="396" alt="image" src="https://user-images.githubusercontent.com/85182102/144477983-77216e72-5491-4fbc-9397-48e8a40beedf.png">

- Added drill-down for specific IDs, users, or meetings:
<img width="426" alt="image" src="https://user-images.githubusercontent.com/85182102/144478133-e1e5d571-6996-4fe0-a375-0be0b9a70a6a.png">
<img width="812" alt="image" src="https://user-images.githubusercontent.com/85182102/144478204-745e975f-40fd-49d9-a55e-20dcc1ff1e20.png">


## PR Checklist

* [X] Explain your changes, so people looking at the PR know *what* and *why*, the code changes are the *how*.

### If adding or updating templates:
* [X] post a screenshot of templates and/or gallery changes
* [X] ensure your template has a corresponding gallery entry in the gallery folder
* [X] If you are adding a new template, add your team and template/gallery file(s) to the CODEOWNERS file. CODEOWNERS entries should be teams, not individuals
* [X] ensure all steps have meaningful names
* [X] ensure all parameters and grid columns have display names set so they can be localized
* [X] ensure that parameters id values are unique __or they will fail PR validation__ (parameter ids are used for localization)
* [X] ensure that steps names are unique __or they will fail PR validation__ (step names are used for localization)
* [X] grep `/subscription/` and ensure that your parameters don't have any hardcoded resourceIds __or they will fail PR validation__
* [X] remove `fallbackResourceIds` and `fromTemplateId` fields from your template workbook __or they will fail PR validation__