### PR TITLE
Fixed hard-coded time range in Voice and video -> Details tab

### DIFF
--- a/Workbooks/Communication Services/Overview/Overview.workbook
+++ b/Workbooks/Communication Services/Overview/Overview.workbook
@@ -715,9 +715,6 @@
                     "query": "ACSCallDiagnostics\r\n| join kind=inner ACSCallSummary on CorrelationId, ParticipantId, EndpointId\r\n| where CallStartTime {time_range:query}\r\n| order by CallStartTime asc, ParticipantStartTime asc\r\n| extend CallDate=format_datetime(CallStartTime, 'MM/dd/y')\r\n| extend CallTime=format_datetime(CallStartTime, 'hh:mm:ss')\r\n| extend UnsuccessfulEndReason = iff((ParticipantEndReason startswith \"0\") or (ParticipantEndReason startswith \"2\"), \"\", \"🛑\")\r\n| extend InteropType = iff(isempty(TeamsThreadId), \"📞 ACS call\", \"🔄 Teams interop\")\r\n| extend JitterQuality = iff(JitterAvg > 30, \"Poor\", \"Good\")\r\n| extend PacketLossRateQuality = iff(PacketLossRateAvg > 0.1, \"Poor\", \"Good\")\r\n| extend RoundTripTimeQuality = iff(RoundTripTimeAvg > 500, \"Poor\", \"Good\")\r\n| extend StreamQuality = iff((JitterQuality == \"Poor\") or (PacketLossRateQuality == \"Poor\") or (RoundTripTimeQuality == \"Poor\"), \"🚩\", \"\")\r\n| extend CallLabel = strcat(CallTime, \" \", UnsuccessfulEndReason, \" \", StreamQuality)\r\n| summarize arg_max(CallLabel, *) by CorrelationId\r\n| project CallDate, InteropType, CallLabel, CallId = CorrelationId",
                     "size": 0,
                     "noDataMessage": "No calls found for the specified time range",
-                    "timeContext": {
-                      "durationMs": 86400000
-                    },
                     "exportFieldName": "CallId",
                     "exportParameterName": "call_id",
                     "queryType": 0,


### PR DESCRIPTION
## PR Checklist

Changed hard-coded time range value in **Voice and video** -> **Details** tab that was only showing the call details for calls made in the last 24 hours

<img width="82" alt="image" src="https://user-images.githubusercontent.com/85182102/144898371-ae7c8a7c-4189-4369-ad2c-f349c88fd791.png">


* [X] Explain your changes, so people looking at the PR know *what* and *why*, the code changes are the *how*.

### If adding or updating templates:
* [X] post a screenshot of templates and/or gallery changes
* [X] ensure your template has a corresponding gallery entry in the gallery folder
* [X] If you are adding a new template, add your team and template/gallery file(s) to the CODEOWNERS file. CODEOWNERS entries should be teams, not individuals
* [X] ensure all steps have meaningful names
* [X] ensure all parameters and grid columns have display names set so they can be localized
* [X] ensure that parameters id values are unique __or they will fail PR validation__ (parameter ids are used for localization)
* [X] ensure that steps names are unique __or they will fail PR validation__ (step names are used for localization)
* [X] grep `/subscription/` and ensure that your parameters don't have any hardcoded resourceIds __or they will fail PR validation__
* [X] remove `fallbackResourceIds` and `fromTemplateId` fields from your template workbook __or they will fail PR validation__