### PR TITLE
[SqlInsights] Make KV optional as per customer feedback

### DIFF
--- a/Workbooks/Workloads/SQL/Add monitoring virtual machine/Add monitoring virtual machine.workbook
+++ b/Workbooks/Workloads/SQL/Add monitoring virtual machine/Add monitoring virtual machine.workbook
@@ -331,7 +331,7 @@
     {
       "type": 1,
       "content": {
-        "json": "#### Improtant\r\nFor a secure configuration, it is required to store the password as a Key Vault secret. [Grant access](https://go.microsoft.com/fwlink/?linkid=2183235) to the managed identity of monitoring VM and [enable network connectivity](https://go.microsoft.com/fwlink/?linkid=2183302) from the monitoring VM to the key vault where the secret is stored.",
+        "json": "#### Important\r\nFor a secure configuration, it is required to store the password as a Key Vault secret. [Grant access](https://go.microsoft.com/fwlink/?linkid=2183235) to the managed identity of monitoring VM and [enable network connectivity](https://go.microsoft.com/fwlink/?linkid=2183302) from the monitoring VM to the key vault where the secret is stored.",
         "style": "info"
       },
       "name": "text - 11"

--- a/Workbooks/Workloads/SQL/Add monitoring virtual machine/Add monitoring virtual machine.workbook
+++ b/Workbooks/Workloads/SQL/Add monitoring virtual machine/Add monitoring virtual machine.workbook
@@ -331,7 +331,7 @@
     {
       "type": 1,
       "content": {
-        "json": "Please reference passwords stored as [Key Vault](https://docs.microsoft.com/en-us/azure/key-vault/general/overview) secrets.",
+        "json": "#### Improtant\r\nFor a secure configuration, it is required to store the password as a Key Vault secret. [Grant access](https://go.microsoft.com/fwlink/?linkid=2183235) to the managed identity of monitoring VM and [enable network connectivity](https://go.microsoft.com/fwlink/?linkid=2183302) from the monitoring VM to the key vault where the secret is stored.",
         "style": "info"
       },
       "name": "text - 11"

--- a/Workbooks/Workloads/SQL/Add monitoring virtual machine/Add monitoring virtual machine.workbook
+++ b/Workbooks/Workloads/SQL/Add monitoring virtual machine/Add monitoring virtual machine.workbook
@@ -331,7 +331,7 @@
     {
       "type": 1,
       "content": {
-        "json": "Please reference passwords stored as Key Vault secrets.",
+        "json": "Please reference passwords stored as [Key Vault](https://docs.microsoft.com/en-us/azure/key-vault/general/overview) secrets.",
         "style": "info"
       },
       "name": "text - 11"
@@ -713,52 +713,12 @@
                 }
               ]
             },
-            "conditionalVisibilities": [
-              {
-                "parameterName": "isFormValid",
-                "comparison": "isEqualTo",
-                "value": "true"
-              },
-              {
-                "parameterName": "KeyVaultSubscriptions",
-                "comparison": "isNotEqualTo"
-              },
-              {
-                "parameterName": "KeyVaults",
-                "comparison": "isNotEqualTo"
-              }
-            ],
-            "name": "links - 5"
-          },
-          {
-            "type": 1,
-            "content": {
-              "json": "Please provide access to Key Vault.",
-              "style": "error"
-            },
             "conditionalVisibility": {
-              "parameterName": "KeyVaultSubscriptions",
-              "comparison": "isEqualTo"
+              "parameterName": "isFormValid",
+              "comparison": "isEqualTo",
+              "value": "true"
             },
-            "name": "text - 7"
-          },
-          {
-            "type": 1,
-            "content": {
-              "json": "Please provide access to Key Vault.",
-              "style": "error"
-            },
-            "conditionalVisibilities": [
-              {
-                "parameterName": "KeyVaultSubscriptions",
-                "comparison": "isNotEqualTo"
-              },
-              {
-                "parameterName": "KeyVaults",
-                "comparison": "isEqualTo"
-              }
-            ],
-            "name": "text - 8"
+            "name": "links - 5"
           }
         ]
       },

--- a/Workbooks/Workloads/Update monitoring vm config/Update monitoring vm config.workbook
+++ b/Workbooks/Workloads/Update monitoring vm config/Update monitoring vm config.workbook
@@ -153,7 +153,7 @@
     {
       "type": 1,
       "content": {
-        "json": "#### Improtant\r\nFor a secure configuration, it is required to store the password as a Key Vault secret. [Grant access](https://go.microsoft.com/fwlink/?linkid=2183235) to the managed identity of monitoring VM and [enable network connectivity](https://go.microsoft.com/fwlink/?linkid=2183302) from the monitoring VM to the key vault where the secret is stored.",
+        "json": "#### Important\r\nFor a secure configuration, it is required to store the password as a Key Vault secret. [Grant access](https://go.microsoft.com/fwlink/?linkid=2183235) to the managed identity of monitoring VM and [enable network connectivity](https://go.microsoft.com/fwlink/?linkid=2183302) from the monitoring VM to the key vault where the secret is stored.",
         "style": "info"
       },
       "name": "text - 16"

--- a/Workbooks/Workloads/Update monitoring vm config/Update monitoring vm config.workbook
+++ b/Workbooks/Workloads/Update monitoring vm config/Update monitoring vm config.workbook
@@ -153,7 +153,7 @@
     {
       "type": 1,
       "content": {
-        "json": "Please reference passwords stored as Key Vault secrets.",
+        "json": "Please reference passwords stored as [Key Vault](https://docs.microsoft.com/en-us/azure/key-vault/general/overview) secrets.",
         "style": "info"
       },
       "name": "text - 16"
@@ -501,52 +501,12 @@
           }
         ]
       },
-      "conditionalVisibilities": [
-        {
-          "parameterName": "isValidJson",
-          "comparison": "isEqualTo",
-          "value": "true"
-        },
-        {
-          "parameterName": "KeyVaultSubscriptions",
-          "comparison": "isNotEqualTo"
-        },
-        {
-          "parameterName": "KeyVaults",
-          "comparison": "isNotEqualTo"
-        }
-      ],
-      "name": "Valid Form"
-    },
-    {
-      "type": 1,
-      "content": {
-        "json": "Please provide access to Key Vault.",
-        "style": "error"
-      },
       "conditionalVisibility": {
-        "parameterName": "KeyVaultSubscriptions",
-        "comparison": "isEqualTo"
+        "parameterName": "isValidJson",
+        "comparison": "isEqualTo",
+        "value": "true"
       },
-      "name": "text - 14"
-    },
-    {
-      "type": 1,
-      "content": {
-        "json": "Please provide access to Key Vault.",
-        "style": "error"
-      },
-      "conditionalVisibilities": [
-        {
-          "parameterName": "KeyVaultSubscriptions",
-          "comparison": "isNotEqualTo"
-        },
-        {
-          "parameterName": "KeyVaults",
-          "comparison": "isEqualTo"
-        }
-      ],
-      "name": "text - 15"
+      "name": "Valid Form"
     }
   ],
   "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"

--- a/Workbooks/Workloads/Update monitoring vm config/Update monitoring vm config.workbook
+++ b/Workbooks/Workloads/Update monitoring vm config/Update monitoring vm config.workbook
@@ -153,7 +153,7 @@
     {
       "type": 1,
       "content": {
-        "json": "Please reference passwords stored as [Key Vault](https://docs.microsoft.com/en-us/azure/key-vault/general/overview) secrets.",
+        "json": "#### Improtant\r\nFor a secure configuration, it is required to store the password as a Key Vault secret. [Grant access](https://go.microsoft.com/fwlink/?linkid=2183235) to the managed identity of monitoring VM and [enable network connectivity](https://go.microsoft.com/fwlink/?linkid=2183302) from the monitoring VM to the key vault where the secret is stored.",
         "style": "info"
       },
       "name": "text - 16"


### PR DESCRIPTION
Make Key Vaulty optional as per customer feedback. Added link to Key Vault documentation in messages.



## PR Checklist

* [x] Explain your changes, so people looking at the PR know *what* and *why*, the code changes are the *how*.

### If adding or updating templates:
* [x] post a screenshot of templates and/or gallery changes
* [x] grep `/subscription/` and ensure that your parameters don't have any hardcoded resourceIds __or they will fail PR validation__
* [x] remove `fallbackResourceIds` and `fromTemplateId` fields from your template workbook __or they will fail PR validation__
 
![image](https://user-images.githubusercontent.com/72472578/145302884-704ab2ba-af4b-489f-bd1d-23d6febd192f.png)
![image](https://user-images.githubusercontent.com/72472578/145302863-bfa83ffd-4a87-4afe-8ef3-5e99e055e40e.png)


link to gallery: https://ms.portal.azure.com/?feature.includePreviewTemplates=true&feature.localtemplates=true&feature.workloadinsights=true&feature.workbookGalleryRedirect=https%3A%2F%2Freadablesecondaries.blob.core.windows.net%2Fazure-monitor-workbook-templates%2Fpackage#blade/Microsoft_Azure_Monitoring/AzureMonitoringBrowseBlade/sqlWorkloadInsights