### PR TITLE
ADX Insights - fix Streaming Ingest Result metric - count aggregation

### DIFF
--- a/Workbooks/ADXCluster/AtResource/ResourceInsights.workbook
+++ b/Workbooks/ADXCluster/AtResource/ResourceInsights.workbook
@@ -1215,41 +1215,12 @@
                 ],
                 "labelSettings": [
                   {
-                    "columnId": "Name"
-                  },
-                  {
-                    "columnId": "Availability state"
-                  },
-                  {
-                    "columnId": "Detailed status"
-                  },
-                  {
                     "columnId": "Occurred time",
                     "label": "Started on"
                   },
                   {
-                    "columnId": "Reason chronicity",
-                    "label": "",
-                    "comment": ""
-                  },
-                  {
-                    "columnId": "Reason type"
-                  },
-                  {
                     "columnId": "Reported time",
                     "label": "Last updated"
-                  },
-                  {
-                    "columnId": "Summary"
-                  },
-                  {
-                    "columnId": "Title"
-                  },
-                  {
-                    "columnId": "Resource group"
-                  },
-                  {
-                    "columnId": "Subscription"
                   }
                 ]
               }
@@ -2643,7 +2614,7 @@
                       {
                         "namespace": "microsoft.kusto/clusters",
                         "metric": "microsoft.kusto/clusters-Streaming Ingest-StreamingIngestResults",
-                        "aggregation": 4,
+                        "aggregation": 7,
                         "splitBy": "Result"
                       }
                     ],


### PR DESCRIPTION
Streaming Ingest Result metric – now has only “count” aggregation.
Removed the AVG aggregation from the Insights.

![image](https://user-images.githubusercontent.com/45633598/146159635-4c1b1911-62f8-4606-8132-7c2ad38fdefd.png)
