### PR TITLE
Removing deprecated metric from Overview Workbook

### DIFF
--- a/Workbooks/CosmosDb/Overview/Overview.workbook
+++ b/Workbooks/CosmosDb/Overview/Overview.workbook
@@ -848,7 +848,7 @@
               ],
               "timeContextFromParameter": "TimeRange",
               "timeContext": {
-                "durationMs": 14400000
+                "durationMs": 0
               },
               "metrics": [
                 {
@@ -870,14 +870,6 @@
                 {
                   "namespace": "microsoft.documentdb/databaseaccounts",
                   "metric": "microsoft.documentdb/databaseaccounts-Requests-IndexUsage",
-                  "aggregation": 4,
-                  "splitBy": "CollectionName",
-                  "splitBySortOrder": -1,
-                  "splitByLimit": 5
-                },
-                {
-                  "namespace": "microsoft.documentdb/databaseaccounts",
-                  "metric": "microsoft.documentdb/databaseaccounts-Requests-AvailableStorage",
                   "aggregation": 4,
                   "splitBy": "CollectionName",
                   "splitBySortOrder": -1,
@@ -1014,6 +1006,14 @@
                 ],
                 "labelSettings": [
                   {
+                    "columnId": "Subscription",
+                    "label": "Subscription/Database/Collection"
+                  },
+                  {
+                    "columnId": "Name",
+                    "label": "Collections"
+                  },
+                  {
                     "columnId": "Segment",
                     "label": "CollectionName"
                   },
@@ -1040,14 +1040,6 @@
                   {
                     "columnId": "microsoft.documentdb/databaseaccounts-Requests-IndexUsage Timeline",
                     "label": "Index Usage (Sum) Timeline"
-                  },
-                  {
-                    "columnId": "microsoft.documentdb/databaseaccounts-Requests-AvailableStorage",
-                    "label": "Available Storage"
-                  },
-                  {
-                    "columnId": "microsoft.documentdb/databaseaccounts-Requests-AvailableStorage Timeline",
-                    "label": "Available Storage (Sum) Timeline"
                   }
                 ]
               },

--- a/Workbooks/CosmosDb/Overview/Overview.workbook
+++ b/Workbooks/CosmosDb/Overview/Overview.workbook
@@ -29,7 +29,10 @@
               "showDefault": false
             },
             "queryType": 1,
-            "resourceType": "microsoft.resourcegraph/resources"
+            "resourceType": "microsoft.resourcegraph/resources",
+            "value": [
+              "/subscriptions/80be3961-0521-4a0a-8570-5cd5a4e2f98c"
+            ]
           },
           {
             "id": "138881c1-d041-4acd-acc9-e7a7af02d2ef",
@@ -52,7 +55,14 @@
               "showDefault": false
             },
             "queryType": 1,
-            "resourceType": "microsoft.resourcegraph/resources"
+            "resourceType": "microsoft.resourcegraph/resources",
+            "value": [
+              "/subscriptions/80be3961-0521-4a0a-8570-5cd5a4e2f98c/resourceGroups/soeom-test/providers/Microsoft.DocumentDb/databaseAccounts/0000fix",
+              "/subscriptions/80be3961-0521-4a0a-8570-5cd5a4e2f98c/resourceGroups/kristynh/providers/Microsoft.DocumentDb/databaseAccounts/201026",
+              "/subscriptions/80be3961-0521-4a0a-8570-5cd5a4e2f98c/resourceGroups/artrejo/providers/Microsoft.DocumentDb/databaseAccounts/20210419-sql",
+              "/subscriptions/80be3961-0521-4a0a-8570-5cd5a4e2f98c/resourceGroups/artrejo/providers/Microsoft.DocumentDb/databaseAccounts/20210420-cassandra",
+              "/subscriptions/80be3961-0521-4a0a-8570-5cd5a4e2f98c/resourceGroups/artrejo/providers/Microsoft.DocumentDb/databaseAccounts/20210420-mongo"
+            ]
           },
           {
             "id": "c4b69c01-2263-4ada-8d9c-43433b739ff3",
@@ -301,7 +311,7 @@
               ],
               "timeContextFromParameter": "TimeRange",
               "timeContext": {
-                "durationMs": 14400000
+                "durationMs": 0
               },
               "metrics": [
                 {
@@ -848,7 +858,7 @@
               ],
               "timeContextFromParameter": "TimeRange",
               "timeContext": {
-                "durationMs": 14400000
+                "durationMs": 0
               },
               "metrics": [
                 {
@@ -870,14 +880,6 @@
                 {
                   "namespace": "microsoft.documentdb/databaseaccounts",
                   "metric": "microsoft.documentdb/databaseaccounts-Requests-IndexUsage",
-                  "aggregation": 4,
-                  "splitBy": "CollectionName",
-                  "splitBySortOrder": -1,
-                  "splitByLimit": 5
-                },
-                {
-                  "namespace": "microsoft.documentdb/databaseaccounts",
-                  "metric": "microsoft.documentdb/databaseaccounts-Requests-AvailableStorage",
                   "aggregation": 4,
                   "splitBy": "CollectionName",
                   "splitBySortOrder": -1,
@@ -1014,7 +1016,8 @@
                 ],
                 "labelSettings": [
                   {
-                    "columnId": "Name"
+                    "columnId": "Subscription",
+                    "label": "Subscription/Database/Collection"
                   },
                   {
                     "columnId": "Segment",
@@ -1043,14 +1046,6 @@
                   {
                     "columnId": "microsoft.documentdb/databaseaccounts-Requests-IndexUsage Timeline",
                     "label": "Index Usage (Sum) Timeline"
-                  },
-                  {
-                    "columnId": "microsoft.documentdb/databaseaccounts-Requests-AvailableStorage",
-                    "label": "Available Storage"
-                  },
-                  {
-                    "columnId": "microsoft.documentdb/databaseaccounts-Requests-AvailableStorage Timeline",
-                    "label": "Available Storage (Sum) Timeline"
                   }
                 ]
               },

--- a/Workbooks/CosmosDb/Overview/Overview.workbook
+++ b/Workbooks/CosmosDb/Overview/Overview.workbook
@@ -52,14 +52,7 @@
               "showDefault": false
             },
             "queryType": 1,
-            "resourceType": "microsoft.resourcegraph/resources",
-            "value": [
-              "/subscriptions/80be3961-0521-4a0a-8570-5cd5a4e2f98c/resourceGroups/soeom-test/providers/Microsoft.DocumentDb/databaseAccounts/0000fix",
-              "/subscriptions/80be3961-0521-4a0a-8570-5cd5a4e2f98c/resourceGroups/kristynh/providers/Microsoft.DocumentDb/databaseAccounts/201026",
-              "/subscriptions/80be3961-0521-4a0a-8570-5cd5a4e2f98c/resourceGroups/artrejo/providers/Microsoft.DocumentDb/databaseAccounts/20210419-sql",
-              "/subscriptions/80be3961-0521-4a0a-8570-5cd5a4e2f98c/resourceGroups/artrejo/providers/Microsoft.DocumentDb/databaseAccounts/20210420-cassandra",
-              "/subscriptions/80be3961-0521-4a0a-8570-5cd5a4e2f98c/resourceGroups/artrejo/providers/Microsoft.DocumentDb/databaseAccounts/20210420-mongo"
-            ]
+            "resourceType": "microsoft.resourcegraph/resources"
           },
           {
             "id": "c4b69c01-2263-4ada-8d9c-43433b739ff3",

--- a/Workbooks/CosmosDb/Overview/Overview.workbook
+++ b/Workbooks/CosmosDb/Overview/Overview.workbook
@@ -29,10 +29,7 @@
               "showDefault": false
             },
             "queryType": 1,
-            "resourceType": "microsoft.resourcegraph/resources",
-            "value": [
-              "/subscriptions/80be3961-0521-4a0a-8570-5cd5a4e2f98c"
-            ]
+            "resourceType": "microsoft.resourcegraph/resources"
           },
           {
             "id": "138881c1-d041-4acd-acc9-e7a7af02d2ef",
@@ -311,7 +308,7 @@
               ],
               "timeContextFromParameter": "TimeRange",
               "timeContext": {
-                "durationMs": 0
+                "durationMs": 14400000
               },
               "metrics": [
                 {
@@ -858,7 +855,7 @@
               ],
               "timeContextFromParameter": "TimeRange",
               "timeContext": {
-                "durationMs": 0
+                "durationMs": 14400000
               },
               "metrics": [
                 {
@@ -880,6 +877,14 @@
                 {
                   "namespace": "microsoft.documentdb/databaseaccounts",
                   "metric": "microsoft.documentdb/databaseaccounts-Requests-IndexUsage",
+                  "aggregation": 4,
+                  "splitBy": "CollectionName",
+                  "splitBySortOrder": -1,
+                  "splitByLimit": 5
+                },
+                {
+                  "namespace": "microsoft.documentdb/databaseaccounts",
+                  "metric": "microsoft.documentdb/databaseaccounts-Requests-AvailableStorage",
                   "aggregation": 4,
                   "splitBy": "CollectionName",
                   "splitBySortOrder": -1,
@@ -1016,10 +1021,6 @@
                 ],
                 "labelSettings": [
                   {
-                    "columnId": "Subscription",
-                    "label": "Subscription/Database/Collection"
-                  },
-                  {
                     "columnId": "Segment",
                     "label": "CollectionName"
                   },
@@ -1046,6 +1047,14 @@
                   {
                     "columnId": "microsoft.documentdb/databaseaccounts-Requests-IndexUsage Timeline",
                     "label": "Index Usage (Sum) Timeline"
+                  },
+                  {
+                    "columnId": "microsoft.documentdb/databaseaccounts-Requests-AvailableStorage",
+                    "label": "Available Storage"
+                  },
+                  {
+                    "columnId": "microsoft.documentdb/databaseaccounts-Requests-AvailableStorage Timeline",
+                    "label": "Available Storage (Sum) Timeline"
                   }
                 ]
               },


### PR DESCRIPTION
## PR Checklist

* [ ] Explain your changes, so people looking at the PR know *what* and *why*, the code changes are the *how*.
Addressing this open ADO item to remove deprecated metric from Overview page.
https://msazure.visualstudio.com/One/_workitems/edit/12841181 

### If adding or updating templates:
* [ ] post a screenshot of templates and/or gallery changes
https://msazure.visualstudio.com/One/_workitems/edit/12841181
* [ ] ensure your template has a corresponding gallery entry in the gallery folder
* [ ] If you are adding a new template, add your team and template/gallery file(s) to the CODEOWNERS file. CODEOWNERS entries should be teams, not individuals
* [ ] ensure all steps have meaningful names
* [ ] ensure all parameters and grid columns have display names set so they can be localized
* [ ] ensure that parameters id values are unique __or they will fail PR validation__ (parameter ids are used for localization)
* [ ] ensure that steps names are unique __or they will fail PR validation__ (step names are used for localization)
* [ ] grep `/subscription/` and ensure that your parameters don't have any hardcoded resourceIds __or they will fail PR validation__
* [ ] remove `fallbackResourceIds` and `fromTemplateId` fields from your template workbook __or they will fail PR validation__