### PR TITLE
Correct the endTime being used to create the time series

### DIFF
--- a/Workbooks/IoT Central/IoT Edge device details/IoT Edge device details.workbook
+++ b/Workbooks/IoT Central/IoT Edge device details/IoT Edge device details.workbook
@@ -3380,7 +3380,7 @@
                   "type": 3,
                   "content": {
                     "version": "KqlItem/1.0",
-                    "query": "let minPeriod = time(\"{samplingFrequency}\");\nlet startTime = {timeRange:start} - minPeriod;\nlet endTime = {timeRange:end} + minPeriod;\nInsightsMetrics\n| where TimeGenerated between (startTime .. endTime)\n| where Name == \"edgeAgent_used_cpu_percent\" and Tags contains \"host\"\n| extend dimensions=parse_json(Tags)\n| extend quantile = tostring(dimensions.quantile)\n| where quantile == \"0.9\"\n| extend device = tostring(dimensions.edge_device)\n| where device == '{SelectedDevice}'\n| extend value = round(toint(Val),2)\n| make-series CPU=max(value) on TimeGenerated from startTime to endTime step minPeriod;",
+                    "query": "let minPeriod = time(\"{samplingFrequency}\");\nlet startTime = {timeRange:start} - minPeriod;\nlet endTime = {timeRange:end};\nInsightsMetrics\n| where TimeGenerated between (startTime .. endTime)\n| where Name == \"edgeAgent_used_cpu_percent\" and Tags contains \"host\"\n| extend dimensions=parse_json(Tags)\n| extend quantile = tostring(dimensions.quantile)\n| where quantile == \"0.9\"\n| extend device = tostring(dimensions.edge_device)\n| where device == '{SelectedDevice}'\n| extend value = round(toint(Val),2)\n| make-series CPU=max(value) on TimeGenerated from startTime to endTime step minPeriod;",
                     "size": 1,
                     "aggregation": 3,
                     "title": "CPU utilization (P90)",
@@ -3435,7 +3435,7 @@
                   "type": 3,
                   "content": {
                     "version": "KqlItem/1.0",
-                    "query": "let minPeriod = time(\"{samplingFrequency}\");\nlet startTime = {timeRange:start} - minPeriod;\nlet endTime = {timeRange:end} + minPeriod;\nInsightsMetrics\n| where TimeGenerated between (startTime .. endTime)\n| where Name == \"edgeAgent_available_disk_space_bytes\" or Name == \"edgeAgent_total_disk_space_bytes\"\n| extend dimensions=parse_json(Tags)\n| extend device = tostring(dimensions.edge_device)\n| where device == '{SelectedDevice}'\n| extend value = tolong(Val)\n| extend diskname = tostring(dimensions.disk_name)\n| extend diskfs = tostring(dimensions.disk_filesystem)\n| where diskfs != \"overlay\"\n| order by TimeGenerated, diskname, Name asc\n| summarize values = make_list(value) by TimeGenerated, diskname\n| extend value = (toreal(values[1]) - toreal(values[0])) / toreal(values[1]) * 100.0\n| make-series Disk=max(value) on TimeGenerated from startTime to endTime step minPeriod by diskname;",
+                    "query": "let minPeriod = time(\"{samplingFrequency}\");\nlet startTime = {timeRange:start} - minPeriod;\nlet endTime = {timeRange:end};\nInsightsMetrics\n| where TimeGenerated between (startTime .. endTime)\n| where Name == \"edgeAgent_available_disk_space_bytes\" or Name == \"edgeAgent_total_disk_space_bytes\"\n| extend dimensions=parse_json(Tags)\n| extend device = tostring(dimensions.edge_device)\n| where device == '{SelectedDevice}'\n| extend value = tolong(Val)\n| extend diskname = tostring(dimensions.disk_name)\n| extend diskfs = tostring(dimensions.disk_filesystem)\n| where diskfs != \"overlay\"\n| order by TimeGenerated, diskname, Name asc\n| summarize values = make_list(value) by TimeGenerated, diskname\n| extend value = (toreal(values[1]) - toreal(values[0])) / toreal(values[1]) * 100.0\n| make-series Disk=max(value) on TimeGenerated from startTime to endTime step minPeriod by diskname;",
                     "size": 1,
                     "aggregation": 5,
                     "title": "Disk space usage (%)",
@@ -3484,7 +3484,7 @@
                   "type": 3,
                   "content": {
                     "version": "KqlItem/1.0",
-                    "query": "let minPeriod = time(\"{samplingFrequency}\");\nlet startTime = {timeRange:start} - minPeriod;\nlet endTime = {timeRange:end} + minPeriod;\nInsightsMetrics\n| where TimeGenerated between (startTime .. endTime)\n| where Name == \"edgeAgent_used_memory_bytes\" and Tags contains \"host\"\n| extend dimensions=parse_json(Tags)\n| extend device = tostring(dimensions.edge_device)\n| where device == '{SelectedDevice}'\n| extend value = tolong(Val)\n| make-series Memory=max(value) on TimeGenerated from startTime to endTime step minPeriod;\n",
+                    "query": "let minPeriod = time(\"{samplingFrequency}\");\nlet startTime = {timeRange:start} - minPeriod;\nlet endTime = {timeRange:end};\nInsightsMetrics\n| where TimeGenerated between (startTime .. endTime)\n| where Name == \"edgeAgent_used_memory_bytes\" and Tags contains \"host\"\n| extend dimensions=parse_json(Tags)\n| extend device = tostring(dimensions.edge_device)\n| where device == '{SelectedDevice}'\n| extend value = tolong(Val)\n| make-series Memory=max(value) on TimeGenerated from startTime to endTime step minPeriod;\n",
                     "size": 1,
                     "aggregation": 2,
                     "title": "Memory usage",

--- a/Workbooks/IoTHub/IoT Edge device details/IoT Edge device details.workbook
+++ b/Workbooks/IoTHub/IoT Edge device details/IoT Edge device details.workbook
@@ -3380,7 +3380,7 @@
                   "type": 3,
                   "content": {
                     "version": "KqlItem/1.0",
-                    "query": "let minPeriod = time(\"{samplingFrequency}\");\nlet startTime = {timeRange:start} - minPeriod;\nlet endTime = {timeRange:end} + minPeriod;\nInsightsMetrics\n| where TimeGenerated between (startTime .. endTime)\n| where Name == \"edgeAgent_used_cpu_percent\" and Tags contains \"host\"\n| extend dimensions=parse_json(Tags)\n| extend quantile = tostring(dimensions.quantile)\n| where quantile == \"0.9\"\n| extend device = tostring(dimensions.edge_device)\n| where device == '{SelectedDevice}'\n| extend value = round(toint(Val),2)\n| make-series CPU=max(value) on TimeGenerated from startTime to endTime step minPeriod;",
+                    "query": "let minPeriod = time(\"{samplingFrequency}\");\nlet startTime = {timeRange:start} - minPeriod;\nlet endTime = {timeRange:end};\nInsightsMetrics\n| where TimeGenerated between (startTime .. endTime)\n| where Name == \"edgeAgent_used_cpu_percent\" and Tags contains \"host\"\n| extend dimensions=parse_json(Tags)\n| extend quantile = tostring(dimensions.quantile)\n| where quantile == \"0.9\"\n| extend device = tostring(dimensions.edge_device)\n| where device == '{SelectedDevice}'\n| extend value = round(toint(Val),2)\n| make-series CPU=max(value) on TimeGenerated from startTime to endTime step minPeriod;",
                     "size": 1,
                     "aggregation": 3,
                     "title": "CPU utilization (P90)",
@@ -3435,7 +3435,7 @@
                   "type": 3,
                   "content": {
                     "version": "KqlItem/1.0",
-                    "query": "let minPeriod = time(\"{samplingFrequency}\");\nlet startTime = {timeRange:start} - minPeriod;\nlet endTime = {timeRange:end} + minPeriod;\nInsightsMetrics\n| where TimeGenerated between (startTime .. endTime)\n| where Name == \"edgeAgent_available_disk_space_bytes\" or Name == \"edgeAgent_total_disk_space_bytes\"\n| extend dimensions=parse_json(Tags)\n| extend device = tostring(dimensions.edge_device)\n| where device == '{SelectedDevice}'\n| extend value = tolong(Val)\n| extend diskname = tostring(dimensions.disk_name)\n| extend diskfs = tostring(dimensions.disk_filesystem)\n| where diskfs != \"overlay\"\n| order by TimeGenerated, diskname, Name asc\n| summarize values = make_list(value) by TimeGenerated, diskname\n| extend value = (toreal(values[1]) - toreal(values[0])) / toreal(values[1]) * 100.0\n| make-series Disk=max(value) on TimeGenerated from startTime to endTime step minPeriod by diskname;",
+                    "query": "let minPeriod = time(\"{samplingFrequency}\");\nlet startTime = {timeRange:start} - minPeriod;\nlet endTime = {timeRange:end};\nInsightsMetrics\n| where TimeGenerated between (startTime .. endTime)\n| where Name == \"edgeAgent_available_disk_space_bytes\" or Name == \"edgeAgent_total_disk_space_bytes\"\n| extend dimensions=parse_json(Tags)\n| extend device = tostring(dimensions.edge_device)\n| where device == '{SelectedDevice}'\n| extend value = tolong(Val)\n| extend diskname = tostring(dimensions.disk_name)\n| extend diskfs = tostring(dimensions.disk_filesystem)\n| where diskfs != \"overlay\"\n| order by TimeGenerated, diskname, Name asc\n| summarize values = make_list(value) by TimeGenerated, diskname\n| extend value = (toreal(values[1]) - toreal(values[0])) / toreal(values[1]) * 100.0\n| make-series Disk=max(value) on TimeGenerated from startTime to endTime step minPeriod by diskname;",
                     "size": 1,
                     "aggregation": 5,
                     "title": "Disk space usage (%)",
@@ -3484,7 +3484,7 @@
                   "type": 3,
                   "content": {
                     "version": "KqlItem/1.0",
-                    "query": "let minPeriod = time(\"{samplingFrequency}\");\nlet startTime = {timeRange:start} - minPeriod;\nlet endTime = {timeRange:end} + minPeriod;\nInsightsMetrics\n| where TimeGenerated between (startTime .. endTime)\n| where Name == \"edgeAgent_used_memory_bytes\" and Tags contains \"host\"\n| extend dimensions=parse_json(Tags)\n| extend device = tostring(dimensions.edge_device)\n| where device == '{SelectedDevice}'\n| extend value = tolong(Val)\n| make-series Memory=max(value) on TimeGenerated from startTime to endTime step minPeriod;\n",
+                    "query": "let minPeriod = time(\"{samplingFrequency}\");\nlet startTime = {timeRange:start} - minPeriod;\nlet endTime = {timeRange:end};\nInsightsMetrics\n| where TimeGenerated between (startTime .. endTime)\n| where Name == \"edgeAgent_used_memory_bytes\" and Tags contains \"host\"\n| extend dimensions=parse_json(Tags)\n| extend device = tostring(dimensions.edge_device)\n| where device == '{SelectedDevice}'\n| extend value = tolong(Val)\n| make-series Memory=max(value) on TimeGenerated from startTime to endTime step minPeriod;\n",
                     "size": 1,
                     "aggregation": 2,
                     "title": "Memory usage",


### PR DESCRIPTION
The endTime variable in the time series for the host CPU, memory, disk graphs was including an extra period of time for which we won't have any reported metric (which is then assumed to be zero).  This fixes it to stop at the specified end time.

Try with [https://ms.portal.azure.com/**?feature.workbookGalleryBranch=users%2Fmicahl%2Fgraph-updates**](https://ms.portal.azure.com/?feature.workbookGalleryBranch=users%2Fmicahl%2Fgraph-updates)

**Before**
![image](https://user-images.githubusercontent.com/1009123/150868812-3ae56c4b-7e59-45de-bfca-16c795cbf095.png)

**After**
![image](https://user-images.githubusercontent.com/1009123/150868943-fc25d131-22ca-4ba3-8aa6-93a5f624f3e3.png)
