### PR TITLE
Add CODEOWNERS for SapMonitor2.0 workbooks

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -49,6 +49,7 @@
 /Workbooks/Traffic*Analytics/** @microsoft/network-watcher-traffic-analytics @microsoft/applicationinsights-devtools
  
 /Workbooks/SapMonitor/** @microsoft/sap-embrace-idc-monitor @microsoft/azuremonitorforsapsolutions @microsoft/applicationinsights-devtools
+/Workbooks/SapMonitor2.0/** @microsoft/sap-embrace-idc-monitor @microsoft/applicationinsights-devtools
 
 /Workbooks/Virtual*Machine*/** @andrewki-msft @nasundar @rakshith210 @microsoft/applicationinsights-devtools
 
@@ -99,6 +100,7 @@
 /gallery/workbook/Azure*Security*Center.json @microsoft/azure-security-center-workbooks
 /gallery/workbook/microsoft.aadiam-tenant.json @microsoft/azure-ad-workbooks
 /gallery/workbook/Microsoft.HanaOnAzure-sapMonitors.json @microsoft/sap-embrace-idc-monitor @microsoft/azuremonitorforsapsolutions
+/gallery/workbook/microsoft.workloads-monitors.json @microsoft/sap-embrace-idc-monitor
 /gallery/workbook/microsoft.intune-tenant.json @microsoft/intune-insights-and-analysis @microsoft/applicationinsights-devtools
 /gallery/workbook/microsoft.intune-reports.json @microsoft/intune-reportingv2-trends
 /gallery/container-insights/** @microsoft/container-insights-workbook-contributors @microsoft/applicationinsights-devtools


### PR DESCRIPTION
## PR Checklist
Add IDC Azure Monitor for sap solutions team as code owners for v2 workbooks and gallery file as well

### If adding or updating templates:
* [x] If you are adding a new template, add your team and template/gallery file(s) to the CODEOWNERS file. CODEOWNERS entries should be teams, not individuals