### PR TITLE
Updated the queries for the Worker Process Type on Performance Tab

### DIFF
--- a/Workbooks/SapMonitor2.0/SapNetWeaver/SapNetWeaver.workbook
+++ b/Workbooks/SapMonitor2.0/SapNetWeaver/SapNetWeaver.workbook
@@ -1894,7 +1894,7 @@
                   "type": 3,
                   "content": {
                     "version": "KqlItem/1.0",
-                    "query": "let appServerList = dynamic([{ApplicationServer}]);\r\nlet workProcessType = dynamic([{CPUWorkProcessType}]);\r\nSapNetweaver_ABAPGetWPTable_CL\r\n| where serverTimestamp_t between (todatetime({TimeRange:start}) .. todatetime({TimeRange:end}))\r\n| where SID_s == '{SID}'\r\n| extend instanceNr_s = tostring(toint(instanceNr_d))\r\n| extend instanceNr_s = iff(strlen(instanceNr_s) == 2, instanceNr_s, strcat( \"0\", instanceNr_s))\r\n| extend appServer = strcat(hostname_s, \"_\", instanceNr_s)\r\n| where array_length(appServerList) == 0 or appServer in (appServerList)\r\n| where array_length(workProcessType) == 0 or Typ_s in (workProcessType)\r\n| summarize totalWP = count(), freeWP = countif(Status_s == \"Wait\") by bin(serverTimestamp_t, 1m), Typ_s\r\n| extend activeWP = totalWP - freeWP",
+                    "query": "let appServerList = dynamic([{ApplicationServer}]);\r\nlet workProcessType = dynamic([{CPUWorkProcessType}]);\r\nSapNetweaver_ABAPGetWPTable_CL\r\n| where serverTimestamp_t between (todatetime({TimeRange:start}) .. todatetime({TimeRange:end}))\r\n| where SID_s == '{SID}'\r\n| extend instanceNr_s = tostring(toint(instanceNr_d))\r\n| extend instanceNr_s = iff(strlen(instanceNr_s) == 2, instanceNr_s, strcat( \"0\", instanceNr_s))\r\n| extend appServer = strcat(hostname_s, \"_\", instanceNr_s)\r\n| where array_length(appServerList) == 0 or appServer in (appServerList)\r\n| where array_length(workProcessType) == 0 or Typ_s in (workProcessType)\r\n| summarize totalWP = count(), freeWP = countif(Status_s == \"Wait\") by bin(serverTimestamp_t, 1m), Typ_s\r\n| extend activeWP = totalWP - freeWP\r\n| summarize sum(activeWP) by bin(serverTimestamp_t, 1m), Typ_s",
                     "size": 0,
                     "aggregation": 3,
                     "title": "Workprocess Utilization​",
@@ -1904,9 +1904,10 @@
                     "chartSettings": {
                       "xAxis": "serverTimestamp_t",
                       "yAxis": [
-                        "activeWP",
-                        "freeWP"
+                        "sum_activeWP"
                       ],
+                      "group": "Typ_s",
+                      "createOtherGroup": null,
                       "seriesLabelSettings": [
                         {
                           "seriesName": "activeWP",
@@ -1932,7 +1933,7 @@
                   "type": 3,
                   "content": {
                     "version": "KqlItem/1.0",
-                    "query": "let workProcessType = dynamic([{CPUWorkProcessType}]);\r\nlet appServerList = dynamic([{ApplicationServer}]);\r\nlet maxTimestamp = SapNetweaver_ABAPGetWPTable_CL\r\n| where SID_s == '{SID}'\r\n| extend instanceNr_s = tostring(toint(instanceNr_d))\r\n| extend instanceNr_s = iff(strlen(instanceNr_s) == 2, instanceNr_s, strcat( \"0\", instanceNr_s))\r\n| extend appServer = strcat(hostname_s, \"_\", instanceNr_s)\r\n| where array_length(appServerList) == 0 or appServer in (appServerList)\r\n| where array_length(workProcessType) == 0 or Typ_s in (workProcessType)\r\n| where Status_s == 'Run' or Status_s == 'On Hold'\r\n| summarize max(serverTimestamp_t);\r\n\r\nSapNetweaver_ABAPGetWPTable_CL\r\n| where serverTimestamp_t == toscalar(maxTimestamp)\r\n| where SID_s == '{SID}'\r\n| extend instanceNr_s = tostring(toint(instanceNr_d))\r\n| extend instanceNr_s = iff(strlen(instanceNr_s) == 2, instanceNr_s, strcat( \"0\", instanceNr_s))\r\n| extend appServer = strcat(hostname_s, \"_\", instanceNr_s)\r\n| where array_length(appServerList) == 0 or appServer in (appServerList)\r\n| where array_length(workProcessType) == 0 or Typ_s in (workProcessType)\r\n| where Status_s == 'Run' or Status_s == 'On-Hold'\r\n| extend ApplicationServerInstance = strcat(hostname_s, \"_\", SID_s,\"_\", instanceNr_s), ProcessNumber = No_d, ProcessType = Typ_s, ProcessId = Pid_d, Status = Status_s, Reason = Reason_s, Error = Err_s, CPU = Cpu_s, Time = Time_s, Program = Program_s, User = User_s, Client = Client_s\r\n| project ApplicationServerInstance, ProcessNumber, ProcessType, ProcessId, Status, Reason, Error , CPU,Time, Program, User, Client\r\n",
+                    "query": "let workProcessType = dynamic([{CPUWorkProcessType}]);\r\nlet appServerList = dynamic([{ApplicationServer}]);\r\n\r\nSapNetweaver_ABAPGetWPTable_CL\r\n| where SID_s == '{SID}'\r\n| extend instanceNr_s = tostring(toint(instanceNr_d))\r\n| extend instanceNr_s = iff(strlen(instanceNr_s) == 2, instanceNr_s, strcat( \"0\", instanceNr_s))\r\n| extend appServer = strcat(hostname_s, \"_\", instanceNr_s)\r\n| where array_length(appServerList) == 0 or appServer in (appServerList)\r\n| where array_length(workProcessType) == 0 or Typ_s in (workProcessType)\r\n| where Status_s != \"Wait\"\r\n| extend\r\n    ApplicationServerInstance = strcat(hostname_s, \"_\", SID_s, \"_\", instanceNr_s),\r\n    ProcessNumber = No_d,\r\n    ProcessType = Typ_s,\r\n    ProcessId = Pid_d,\r\n    Status = Status_s,\r\n    Reason = Reason_s,\r\n    Error = Err_s,\r\n    CPU = Cpu_s,\r\n    Time = Time_s,\r\n    Program = Program_s,\r\n    User = User_s,\r\n    Client = Client_s\r\n| summarize arg_max(serverTimestamp_t, *) by ProcessType, ApplicationServerInstance\r\n| project ApplicationServerInstance, ProcessNumber, ProcessType, ProcessId, Status, Reason, Error , CPU,Time, Program, User, Client\r\n",
                     "size": 3,
                     "title": "Active Work Process (SM66)",
                     "queryType": 0,
@@ -3122,7 +3123,7 @@
     {
       "type": 1,
       "content": {
-        "json": "<div style=\"float: right\">\r\nUpdated Every 60 sec\r\n</div>"
+        "json": "<div style=\"float: right\">\r\nUpdated every 60 seconds.\r\n</div>"
       },
       "name": "CheckFrequency"
     }


### PR DESCRIPTION
## PR Checklist

* [x] Explain your changes, so people looking at the PR know *what* and *why*, the code changes are the *how*.

### If adding or updating templates:
* [x] post a screenshot of templates and/or gallery changes
* [x] ensure your template has a corresponding gallery entry in the gallery folder
* [x] If you are adding a new template, add your team and template/gallery file(s) to the CODEOWNERS file. CODEOWNERS entries should be teams, not individuals
* [x] ensure all steps have meaningful names
* [x] ensure all parameters and grid columns have display names set so they can be localized
* [x] ensure that parameters id values are unique __or they will fail PR validation__ (parameter ids are used for localization)
* [x] ensure that steps names are unique __or they will fail PR validation__ (step names are used for localization)
* [x] grep `/subscription/` and ensure that your parameters don't have any hardcoded resourceIds __or they will fail PR validation__
* [x] remove `fallbackResourceIds` and `fromTemplateId` fields from your template workbook __or they will fail PR validation__

This PR consists of changes in two queries and one minor change in the footer of the workbook. 
- The area chart now shows the work process utilization based on each work-process type, instead of cumulative. 
- The table below will now show the latest active work process according to the time stamp. 
- The footer is updated with proper casing. 

![image](https://user-images.githubusercontent.com/86314060/153309594-0d7dde89-6a01-4d0b-89d8-26cee9c05459.png)
