### PR TITLE
Updated Alerts to show successful Provider Instances

### DIFF
--- a/Workbooks/SapMonitor2.0/Alerts/Create Alert rule (step 1 of 2)/Create Alert rule (step 1 of 2).workbook
+++ b/Workbooks/SapMonitor2.0/Alerts/Create Alert rule (step 1 of 2)/Create Alert rule (step 1 of 2).workbook
@@ -412,7 +412,7 @@
             "type": 2,
             "description": "Select a provider instance for this alert rule",
             "isRequired": true,
-            "query": "{\"version\":\"ARMEndpoint/1.0\",\"data\":null,\"headers\":[],\"method\":\"GET\",\"path\":\"{AmsResource}/providerInstances/\",\"urlParams\":[{\"key\":\"api-version\",\"value\":\"2021-12-01-preview\"}],\"batchDisabled\":false,\"transformers\":[{\"type\":\"jsonpath\",\"settings\":{\"tablePath\":\"$.value[?(@.properties.providerSettings.providerType=='{ProviderType}')]\",\"columns\":[{\"path\":\"name\",\"columnid\":\"name\"}]}}]}",
+            "query": "{\"version\":\"ARMEndpoint/1.0\",\"data\":null,\"headers\":[],\"method\":\"GET\",\"path\":\"{AmsResource}/providerInstances/\",\"urlParams\":[{\"key\":\"api-version\",\"value\":\"2021-12-01-preview\"}],\"batchDisabled\":false,\"transformers\":[{\"type\":\"jsonpath\",\"settings\":{\"tablePath\":\"$.value[?(@.properties.providerSettings.providerType=='{ProviderType}' && @.properties.provisioningState=='Succeeded')]\",\"columns\":[{\"path\":\"name\",\"columnid\":\"name\"}]}}]}",
             "value": "SapHana",
             "typeSettings": {
               "additionalResourceOptions": [],

--- a/Workbooks/SapMonitor2.0/SapNetWeaver/SapNetWeaver.workbook
+++ b/Workbooks/SapMonitor2.0/SapNetWeaver/SapNetWeaver.workbook
@@ -54,7 +54,7 @@
             "version": "KqlParameterItem/1.0",
             "name": "param_provider_type",
             "type": 1,
-            "value": "SapNetweaver",
+            "value": "SapNetWeaver",
             "isHiddenWhenLocked": true
           },
           {


### PR DESCRIPTION
## PR Checklist

* [x] Explain your changes, so people looking at the PR know *what* and *why*, the code changes are the *how*.

### If adding or updating templates:
* [ ] post a screenshot of templates and/or gallery changes
* [x] ensure your template has a corresponding gallery entry in the gallery folder
* [x] If you are adding a new template, add your team and template/gallery file(s) to the CODEOWNERS file. CODEOWNERS entries should be teams, not individuals
* [x] ensure all steps have meaningful names
* [x] ensure all parameters and grid columns have display names set so they can be localized
* [x] ensure that parameters id values are unique __or they will fail PR validation__ (parameter ids are used for localization)
* [x] ensure that steps names are unique __or they will fail PR validation__ (step names are used for localization)
* [x] grep `/subscription/` and ensure that your parameters don't have any hardcoded resourceIds __or they will fail PR validation__
* [x] remove `fallbackResourceIds` and `fromTemplateId` fields from your template workbook __or they will fail PR validation__

This PR consists of following changes on the SapNetWeaver Provider Workbook Template:
- make the SapNetWeaver nomenclature and case to match the ProviderType in the response. 
- Update the Alerts template to show only successful Provider Instances in the list.