### PR TITLE
Fix Vnet Connection Count bug in VWan workbook

### DIFF
--- a/Workbooks/Network Insights/VirtualWANWorkbooks/NetworkInsights-VirtualWANMetrics/NetworkInsights-VirtualWANMetrics.workbook
+++ b/Workbooks/Network Insights/VirtualWANWorkbooks/NetworkInsights-VirtualWANMetrics/NetworkInsights-VirtualWANMetrics.workbook
@@ -182,6 +182,20 @@
             "timeContext": {
               "durationMs": 86400000
             }
+          },
+          {
+            "id": "ae5bf44c-0afd-48e4-9e46-26cd8f7f0adb",
+            "version": "KqlParameterItem/1.0",
+            "name": "virtualHubQuery",
+            "type": 1,
+            "description": "Query to get VWAN Vnet Connection Counts",
+            "query": "resources\r\n| where type =~ \"microsoft.network/virtualhubs\"\r\n| where properties.virtualWan.id =~ '{virtualWAN}'\r\n| project id, name\r\n| extend d = pack(\"httpMethod\", \"GET\", \"requestHeaderDetails\", pack(\"commandName\", \"Microsoft_Azure_HybridNetworking\") ,\"url\", strcat(\"https://management.azure.com\", id, \"/hubVirtualNetworkConnections/?api-version=2021-03-01\"))\r\n| summarize mylist = make_list(d)\r\n| extend request = pack(\"requests\", mylist)\r\n| project request",
+            "crossComponentResources": [
+              "value::all"
+            ],
+            "isHiddenWhenLocked": true,
+            "queryType": 1,
+            "resourceType": "microsoft.resourcegraph/resources"
           }
         ],
         "style": "pills",
@@ -573,7 +587,7 @@
         ],
         "timeContextFromParameter": "TimeRange",
         "timeContext": {
-          "durationMs": 0
+          "durationMs": 86400000
         },
         "metrics": [
           {
@@ -849,31 +863,6 @@
           "filter": true,
           "labelSettings": [
             {
-              "columnId": "Virtual Hub",
-              "label": ""
-            },
-            {
-              "columnId": "Hub Deployment Status"
-            },
-            {
-              "columnId": "VPN Gateway Status"
-            },
-            {
-              "columnId": "VPN Gateway Scale Units"
-            },
-            {
-              "columnId": "P2S Gateway Status"
-            },
-            {
-              "columnId": "P2S Gateway Scale Units"
-            },
-            {
-              "columnId": "ER Gateway Status"
-            },
-            {
-              "columnId": "ER Gateway Scale Units"
-            },
-            {
               "columnId": "firewallStatus",
               "label": "Firewall Status"
             },
@@ -951,133 +940,190 @@
       }
     },
     {
-      "type": 3,
+      "type": 12,
       "content": {
-        "version": "KqlItem/1.0",
-        "query": "resources\r\n| where type =~ \"microsoft.network/virtualhubs\"\r\n| where properties.virtualWan.id =~ '{virtualWAN}'\r\n| project hubId = tolower(id), vnetConnectionCount = array_length(properties.virtualNetworkConnections)\r\n| join kind=leftouter (\r\nresources\r\n| where type =~ \"microsoft.network/vpngateways\"\r\n| project hubId = tolower(properties.virtualHub.id), vpnConnectionCount = array_length(properties.connections)\r\n) on hubId\r\n| join kind=leftouter (\r\nresources\r\n| where type =~ \"microsoft.network/p2svpngateways\"\r\n| project hubId = tolower(properties.virtualHub.id), p2sConnectionCount = array_length(properties.p2SConnectionConfigurations)\r\n) on hubId\r\n| join kind=leftouter (\r\nresources\r\n| where type =~ \"microsoft.network/expressroutegateways\"\r\n| project hubId = tolower(properties.virtualHub.id), erConnectionCount = array_length(properties.expressRouteConnections)\r\n) on hubId\r\n| extend vpnConnectionCount = iff(isnotempty(vpnConnectionCount), vpnConnectionCount, 0),\r\n         p2sConnectionCount = iff(isnotempty(p2sConnectionCount), p2sConnectionCount, 0),\r\n         erConnectionCount = iff(isnotempty(erConnectionCount), erConnectionCount, 0),\r\n         vnetConnectionCount = iff(isnotempty(vnetConnectionCount), vnetConnectionCount, 0)\r\n| project hubId, vpnConnectionCount, p2sConnectionCount, erConnectionCount, vnetConnectionCount, totalConnectionCount = (vpnConnectionCount + p2sConnectionCount + erConnectionCount + vnetConnectionCount)\r\n",
-        "size": 3,
-        "title": "Virtual WAN Connection Counts",
-        "noDataMessage": "No Connections found",
-        "showExportToExcel": true,
-        "queryType": 1,
-        "resourceType": "microsoft.resourcegraph/resources",
-        "crossComponentResources": [
-          "value::all"
-        ],
-        "gridSettings": {
-          "formatters": [
-            {
-              "columnMatch": "hubId",
-              "formatter": 13,
-              "formatOptions": {
-                "linkTarget": "OpenBlade",
-                "showIcon": true,
-                "bladeOpenContext": {
-                  "bladeName": "VirtualHubManagementViewModel",
-                  "extensionName": "Microsoft_Azure_HybridNetworking",
-                  "bladeParameters": [
-                    {
-                      "name": "virtualHubId",
-                      "source": "cell",
-                      "value": ""
+        "version": "NotebookGroup/1.0",
+        "groupType": "editable",
+        "items": [
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "resources\r\n| where type =~ \"microsoft.network/virtualhubs\"\r\n| where properties.virtualWan.id =~ '{virtualWAN}'\r\n| project hubId = tolower(id), hubName=name, vnetConnectionCount = array_length(properties.virtualNetworkConnections)\r\n| join kind=leftouter (\r\nresources\r\n| where type =~ \"microsoft.network/vpngateways\"\r\n| project hubId = tolower(properties.virtualHub.id), vpnConnectionCount = array_length(properties.connections)\r\n) on hubId\r\n| join kind=leftouter (\r\nresources\r\n| where type =~ \"microsoft.network/p2svpngateways\"\r\n| project hubId = tolower(properties.virtualHub.id), p2sConnectionCount = array_length(properties.p2SConnectionConfigurations)\r\n) on hubId\r\n| join kind=leftouter (\r\nresources\r\n| where type =~ \"microsoft.network/expressroutegateways\"\r\n| project hubId = tolower(properties.virtualHub.id), erConnectionCount = array_length(properties.expressRouteConnections)\r\n) on hubId\r\n| extend vpnConnectionCount = iff(isnotempty(vpnConnectionCount), vpnConnectionCount, 0),\r\n         p2sConnectionCount = iff(isnotempty(p2sConnectionCount), p2sConnectionCount, 0),\r\n         erConnectionCount = iff(isnotempty(erConnectionCount), erConnectionCount, 0),\r\n         vnetConnectionCount = iff(isnotempty(vnetConnectionCount), vnetConnectionCount, 0)\r\n| project hubId, hubName, vpnConnectionCount, p2sConnectionCount, erConnectionCount\r\n",
+              "size": 3,
+              "title": "Virtual WAN Connection Counts",
+              "noDataMessage": "No Connections found",
+              "showExportToExcel": true,
+              "queryType": 1,
+              "resourceType": "microsoft.resourcegraph/resources",
+              "crossComponentResources": [
+                "value::all"
+              ],
+              "gridSettings": {
+                "formatters": [
+                  {
+                    "columnMatch": "hubId",
+                    "formatter": 13,
+                    "formatOptions": {
+                      "linkTarget": "OpenBlade",
+                      "showIcon": true,
+                      "bladeOpenContext": {
+                        "bladeName": "VirtualHubManagementViewModel",
+                        "extensionName": "Microsoft_Azure_HybridNetworking",
+                        "bladeParameters": [
+                          {
+                            "name": "virtualHubId",
+                            "source": "cell",
+                            "value": ""
+                          }
+                        ]
+                      }
                     }
-                  ]
+                  }
+                ],
+                "filter": true,
+                "labelSettings": [
+                  {
+                    "columnId": "hubId",
+                    "label": "Virtual Hub"
+                  },
+                  {
+                    "columnId": "vpnConnectionCount",
+                    "label": "VPN Connection Count"
+                  },
+                  {
+                    "columnId": "p2sConnectionCount",
+                    "label": "P2S Connection Configuration Count"
+                  },
+                  {
+                    "columnId": "erConnectionCount",
+                    "label": "ER Connection Count"
+                  }
+                ]
+              },
+              "tileSettings": {
+                "titleContent": {
+                  "columnMatch": "Column1",
+                  "formatter": 13,
+                  "formatOptions": {
+                    "linkTarget": null,
+                    "showIcon": true
+                  }
+                },
+                "leftContent": {
+                  "columnMatch": "Column1",
+                  "formatter": 12,
+                  "formatOptions": {
+                    "palette": "auto"
+                  },
+                  "numberFormat": {
+                    "unit": 17,
+                    "options": {
+                      "maximumSignificantDigits": 3,
+                      "maximumFractionDigits": 2
+                    }
+                  }
+                },
+                "showBorder": false
+              },
+              "graphSettings": {
+                "type": 0,
+                "topContent": {
+                  "columnMatch": "Column1",
+                  "formatter": 1
+                },
+                "centerContent": {
+                  "columnMatch": "Column2",
+                  "formatter": 1,
+                  "numberFormat": {
+                    "unit": 17,
+                    "options": {
+                      "maximumSignificantDigits": 3,
+                      "maximumFractionDigits": 2
+                    }
+                  }
                 }
+              },
+              "mapSettings": {
+                "locInfo": "AzureResource",
+                "sizeSettings": "Column2",
+                "sizeAggregation": "Sum",
+                "legendMetric": "Column2",
+                "legendAggregation": "Sum",
+                "itemColorSettings": {
+                  "type": "heatmap",
+                  "colorAggregation": "Sum",
+                  "nodeColorField": "Column2",
+                  "heatmapPalette": "greenRed"
+                },
+                "locInfoColumn": "Column1"
               }
-            }
-          ],
-          "filter": true,
-          "labelSettings": [
-            {
-              "columnId": "hubId",
-              "label": "Virtual Hub"
             },
-            {
-              "columnId": "vpnConnectionCount",
-              "label": "VPN Connection Count"
+            "conditionalVisibility": {
+              "parameterName": "tab",
+              "comparison": "isEqualTo",
+              "value": "-1"
             },
-            {
-              "columnId": "p2sConnectionCount",
-              "label": "P2S Connection Configuration Count"
-            },
-            {
-              "columnId": "erConnectionCount",
-              "label": "ER Connection Count"
-            },
-            {
-              "columnId": "vnetConnectionCount",
-              "label": "Virtual Network Connection Count"
-            },
-            {
-              "columnId": "totalConnectionCount",
-              "label": "Total Connection Count"
-            }
-          ]
-        },
-        "tileSettings": {
-          "titleContent": {
-            "columnMatch": "Column1",
-            "formatter": 13,
-            "formatOptions": {
-              "linkTarget": null,
-              "showIcon": true
-            }
+            "name": "Virtual WAN Connection Counts"
           },
-          "leftContent": {
-            "columnMatch": "Column1",
-            "formatter": 12,
-            "formatOptions": {
-              "palette": "auto"
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "{\"version\":\"ARMEndpoint/1.0\",\"data\":\"{{virtualHubQuery:escapejson}}\",\"headers\":[],\"method\":\"POST\",\"path\":\"/batch\",\"urlParams\":[{\"key\":\"api-version\",\"value\":\"2020-06-01\"}],\"batchDisabled\":false,\"transformers\":[{\"type\":\"jsonpath\",\"settings\":{\"tablePath\":\"$.responses[*].content.value\",\"columns\":[{\"path\":\"$.length\",\"columnid\":\"Vnet_Count\"},{\"path\":\"$[0].id\",\"columnid\":\"HubName\",\"substringRegexMatch\":\"(.*)/(.*)/(.*)/(.*).*\",\"substringReplace\":\"$2\"}]}}]}",
+              "size": 0,
+              "queryType": 12,
+              "sortBy": []
             },
-            "numberFormat": {
-              "unit": 17,
-              "options": {
-                "maximumSignificantDigits": 3,
-                "maximumFractionDigits": 2
+            "conditionalVisibility": {
+              "parameterName": "tab",
+              "comparison": "isEqualTo",
+              "value": "-1"
+            },
+            "name": "Virtual WAN VNet Connection Count"
+          },
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "{\"version\":\"Merge/1.0\",\"merges\":[{\"id\":\"f2aecb87-affc-469c-9818-c16135e3f1c3\",\"mergeType\":\"leftouter\",\"leftTable\":\"Virtual WAN Connection Counts\",\"rightTable\":\"Virtual WAN VNet Connection Count\",\"leftColumn\":\"hubName\",\"rightColumn\":\"HubName\"}],\"projectRename\":[{\"originalName\":\"[Virtual WAN Connection Counts].hubId\",\"mergedName\":\"Virtual Hub\",\"fromId\":\"f2aecb87-affc-469c-9818-c16135e3f1c3\"},{\"originalName\":\"[Virtual WAN Connection Counts].vpnConnectionCount\",\"mergedName\":\"VPN Connection Count\",\"fromId\":\"f2aecb87-affc-469c-9818-c16135e3f1c3\"},{\"originalName\":\"[Virtual WAN Connection Counts].p2sConnectionCount\",\"mergedName\":\"P2S Connection Configuration Count\",\"fromId\":\"f2aecb87-affc-469c-9818-c16135e3f1c3\"},{\"originalName\":\"[Virtual WAN Connection Counts].erConnectionCount\",\"mergedName\":\"ER Connection Count\",\"fromId\":\"f2aecb87-affc-469c-9818-c16135e3f1c3\"},{\"originalName\":\"[Virtual WAN VNet Connection Count].Vnet_Count\",\"mergedName\":\"Virtual Network Connection Count\",\"fromId\":\"f2aecb87-affc-469c-9818-c16135e3f1c3\"},{\"originalName\":\"[Virtual WAN VNet Connection Count].HubName\",\"mergedName\":\"HubName\",\"fromId\":\"f2aecb87-affc-469c-9818-c16135e3f1c3\"},{\"originalName\":\"[Total Connection Count]\",\"mergedName\":\"Total Connection Count\",\"fromId\":null,\"isNewItem\":true,\"newItemData\":[{\"criteriaContext\":{\"operator\":\"Default\",\"rightValType\":\"column\",\"resultValType\":\"expression\",\"resultVal\":\"[\\\"Virtual Network Connection Count\\\"] + [\\\"VPN Connection Count\\\"] + [\\\"P2S Connection Configuration Count\\\"] + [\\\"ER Connection Count\\\"]\"}}]},{\"originalName\":\"[Virtual WAN Connection Counts].hubName\"}]}",
+              "size": 0,
+              "queryType": 7,
+              "gridSettings": {
+                "formatters": [
+                  {
+                    "columnMatch": "Virtual Network Connection Count",
+                    "formatter": 0,
+                    "numberFormat": {
+                      "unit": 0,
+                      "options": {
+                        "style": "decimal"
+                      },
+                      "emptyValCustomText": "0"
+                    }
+                  },
+                  {
+                    "columnMatch": "HubName",
+                    "formatter": 5
+                  }
+                ]
               }
-            }
-          },
-          "showBorder": false
-        },
-        "graphSettings": {
-          "type": 0,
-          "topContent": {
-            "columnMatch": "Column1",
-            "formatter": 1
-          },
-          "centerContent": {
-            "columnMatch": "Column2",
-            "formatter": 1,
-            "numberFormat": {
-              "unit": 17,
-              "options": {
-                "maximumSignificantDigits": 3,
-                "maximumFractionDigits": 2
-              }
-            }
+            },
+            "conditionalVisibility": {
+              "parameterName": "tab",
+              "comparison": "isEqualTo",
+              "value": "0"
+            },
+            "name": "Virtual VWan Connections"
           }
-        },
-        "mapSettings": {
-          "locInfo": "AzureResource",
-          "sizeSettings": "Column2",
-          "sizeAggregation": "Sum",
-          "legendMetric": "Column2",
-          "legendAggregation": "Sum",
-          "itemColorSettings": {
-            "type": "heatmap",
-            "colorAggregation": "Sum",
-            "nodeColorField": "Column2",
-            "heatmapPalette": "greenRed"
-          },
-          "locInfoColumn": "Column1"
-        }
+        ]
       },
       "conditionalVisibility": {
         "parameterName": "tab",
         "comparison": "isEqualTo",
         "value": "0"
       },
-      "name": "Virtual WAN Connection Counts"
+      "name": "Hub Gateway Level Metrics Group"
     },
     {
       "type": 10,
@@ -1518,24 +1564,8 @@
           },
           "labelSettings": [
             {
-              "columnId": "Subscription",
-              "label": ""
-            },
-            {
               "columnId": "Name",
               "label": "VPN Gateway"
-            },
-            {
-              "columnId": "Namespace"
-            },
-            {
-              "columnId": "Metric"
-            },
-            {
-              "columnId": "Metric ID"
-            },
-            {
-              "columnId": "Aggregation"
             },
             {
               "columnId": "Segment Field",
@@ -1544,12 +1574,6 @@
             {
               "columnId": "Segment",
               "label": "Connected Site"
-            },
-            {
-              "columnId": "Value"
-            },
-            {
-              "columnId": "Timeline"
             }
           ]
         }


### PR DESCRIPTION
## PR Checklist

* [x] Explain your changes, so people looking at the PR know *what* and *why*, the code changes are the *how*.

### If adding or updating templates:
* [x] post a screenshot of templates and/or gallery changes
* [x] ensure your template has a corresponding gallery entry in the gallery folder
* [x] If you are adding a new template, add your team and template/gallery file(s) to the CODEOWNERS file. CODEOWNERS entries should be teams, not individuals
* [x] ensure all steps have meaningful names
* [ ] ensure all parameters and grid columns have display names set so they can be localized
* [x] ensure that parameters id values are unique __or they will fail PR validation__ (parameter ids are used for localization)
* [x] ensure that steps names are unique __or they will fail PR validation__ (step names are used for localization)
* [x] grep `/subscription/` and ensure that your parameters don't have any hardcoded resourceIds __or they will fail PR validation__
* [x] remove `fallbackResourceIds` and `fromTemplateId` fields from your template workbook __or they will fail PR validation__


Fix bug where Vnet connection count was always 0 due to change in ARG result of VWan.
Solution: Get the Vnet count through ARM Query

![image](https://user-images.githubusercontent.com/95475229/156990133-693e3fd1-eac8-46ef-bc79-032a0defe40f.png)
