### PR TITLE
Select any one hostname by default

### DIFF
--- a/Workbooks/SapMonitor2.0/PrometheusOS/PrometheusOS.workbook
+++ b/Workbooks/SapMonitor2.0/PrometheusOS/PrometheusOS.workbook
@@ -71,11 +71,13 @@
                         "description": "Select the host that needs to be monitored",
                         "isRequired": true,
                         "query": "Prometheus_OSExporter_CL\r\n|where name_s contains \"uname\"\r\n|extend hostname = parse_json(labels_s).nodename\r\n|distinct tostring(hostname)\r\n",
-                        "value": null,
                         "typeSettings": {
-                          "additionalResourceOptions": [],
+                          "additionalResourceOptions": [
+                            "value::1"
+                          ],
                           "showDefault": false
                         },
+                        "defaultValue": "value::1",
                         "queryType": 0,
                         "resourceType": "microsoft.operationalinsights/workspaces"
                       }
@@ -1756,11 +1758,13 @@
                               "quote": "'",
                               "delimiter": ",",
                               "query": "Prometheus_OSExporter_CL\r\n|where instance_s == '{instance}' and name_s contains \"disk\"\r\n|extend device = parse_json(labels_s).device\r\n//|where tostring(device) in (\"sda\",\"sdb\",\"sdc\",\"sdd\")\r\n|distinct tostring(device)",
-                              "value": [],
                               "typeSettings": {
-                                "additionalResourceOptions": [],
+                                "additionalResourceOptions": [
+                                  "value::all"
+                                ],
                                 "showDefault": false
                               },
+                              "defaultValue": "value::all",
                               "queryType": 0,
                               "resourceType": "microsoft.operationalinsights/workspaces"
                             }
@@ -2006,14 +2010,16 @@
                               "quote": "'",
                               "delimiter": ",",
                               "query": "Prometheus_OSExporter_CL\r\n|where instance_s == '{instance}' and name_s contains \"node_network\"\r\n|extend interface = parse_json(labels_s).device\r\n|where interface!=\"lo\"\r\n|distinct tostring(interface)",
-                              "value": [],
                               "typeSettings": {
-                                "additionalResourceOptions": [],
+                                "additionalResourceOptions": [
+                                  "value::all"
+                                ],
                                 "showDefault": false
                               },
                               "timeContext": {
                                 "durationMs": 2592000000
                               },
+                              "defaultValue": "value::all",
                               "queryType": 0,
                               "resourceType": "microsoft.operationalinsights/workspaces"
                             }


### PR DESCRIPTION
Select any one hostname by default in OS provider workbook


### If adding or updating templates:
* [ ] ensure all steps have meaningful names
* [ ] ensure all parameters and grid columns have display names set so they can be localized
* [ ] ensure that parameters id values are unique __or they will fail PR validation__ (parameter ids are used for localization)
* [ ] ensure that steps names are unique __or they will fail PR validation__ (step names are used for localization)
* [ ] grep `/subscription/` and ensure that your parameters don't have any hardcoded resourceIds __or they will fail PR validation__
* [ ] remove `fallbackResourceIds` and `fromTemplateId` fields from your template workbook __or they will fail PR validation__