### PR TITLE
remove invalid users from codeowners file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -31,7 +31,7 @@
 
 /Workbooks/Azure*Backup/** @microsoft/azure-backup-workbook 
 
-/Workbooks/Azure*Blockchain/** @keikumata @microsoft/applicationinsights-devtools
+/Workbooks/Azure*Blockchain/** @microsoft/applicationinsights-devtools
 
 /Workbooks/HDInsight/** @microsoft/hdinsight-workbooks-team @microsoft/applicationinsights-devtools
 
@@ -55,7 +55,7 @@
 
 /Workbooks/Azure*Center*for*SAP*solutions/** @microsoft/sap-embrace-acs @microsoft/applicationinsights-devtools
 
-/Workbooks/Virtual*Machine*/** @andrewki-msft @nasundar @rakshith210 @microsoft/applicationinsights-devtools
+/Workbooks/Virtual*Machine*/** @nasundar @microsoft/applicationinsights-devtools
 
 /Workbooks/Availability/** @microsoft/ApplicationInsights-PortalExperiences @microsoft/applicationinsights-devtools
 /Workbooks/Usage/** @microsoft/ApplicationInsights-PortalExperiences @microsoft/applicationinsights-devtools @microsoft/applicationinsights-heart


### PR DESCRIPTION
There were users who no longer are valid in github's user info that had codeownership, removed them to keep the file valid.

Its nice that github now has UX for this!