### PR TITLE
remove the preview flag for new ConnectedVehicle workbook

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -133,7 +133,7 @@
 /gallery/usage/microsoft.insights-components.json @microsoft/applicationinsights-heart @microsoft/ApplicationInsights-PortalExperiences @microsoft/applicationinsights-devtools
 /gallery/workbook/microsoft.insights-components.json @microsoft/applicationinsights-heart @microsoft/ApplicationInsights-PortalExperiences @microsoft/applicationinsights-devtools
 /gallery/all-resource-types/** @microsoft/applicationinsights-devtools
-/gallery/workbook/microsoft.connectedvehicle* @microsoft/mcvp-workbooks
+/gallery/workbook/Microsoft.ConnectedVehicle* @microsoft/mcvp-workbooks
 
 # leave this at the bottom!
 # EVERYTHING ending with resjson* is for loc, and is owned by the workbooks team and the loc team

--- a/gallery/workbook/Microsoft.ConnectedVehicle-platformAccounts.json
+++ b/gallery/workbook/Microsoft.ConnectedVehicle-platformAccounts.json
@@ -10,8 +10,7 @@
 					"id": "Workbooks/ConnectedVehicle/PlatformAccount Message Counts",
 					"name": "Messages In & Out",
 					"description": "View counts of messages in & out of the platform",
-					"author": "Microsoft",
-					"isPreview": true
+					"author": "Microsoft"
 				}
 			]
 		}


### PR DESCRIPTION
NOTE: CODEOWNERS broken for the gallery file, so need AI team approval.

Remove the preview flag for the workbook that was previously deployed and fix casing in the CODEOWNERS file

## PR Checklist

* [x] Explain your changes, so people looking at the PR know *what* and *why*, the code changes are the *how*.

### If adding or updating templates:
* [x] ensure your template has a corresponding gallery entry in the gallery folder