### PR TITLE
adding filter capability to AWS/GCP tables in Coverage workbook

### DIFF
--- a/Workbooks/Azure Security Center/Coverage/Coverage.workbook
+++ b/Workbooks/Azure Security Center/Coverage/Coverage.workbook
@@ -840,6 +840,7 @@
                     }
                   }
                 ],
+                "filter": true,
                 "labelSettings": [
                   {
                     "columnId": "id",
@@ -1018,6 +1019,7 @@
                     }
                   }
                 ],
+                "filter": true,
                 "labelSettings": [
                   {
                     "columnId": "id",


### PR DESCRIPTION
## PR Checklist

* [X] Explain your changes, so people looking at the PR know *what* and *why*, the code changes are the *how*.
This change will add a filter capability to AWS/GCP tables in the Defender for Cloud Coverage workbook.

### If adding or updating templates:
* [x] post a screenshot of templates and/or gallery changes
![coverage4](https://user-images.githubusercontent.com/32520935/162220166-71501264-75bc-42b7-b737-597d638a818a.png)

* [x] ensure your template has a corresponding gallery entry in the gallery folder
* [x] If you are adding a new template, add your team and template/gallery file(s) to the CODEOWNERS file. CODEOWNERS entries should be teams, not individuals
* [x] ensure all steps have meaningful names
* [x] ensure all parameters and grid columns have display names set so they can be localized
* [x] ensure that parameters id values are unique __or they will fail PR validation__ (parameter ids are used for localization)
* [x] ensure that steps names are unique __or they will fail PR validation__ (step names are used for localization)
* [x] grep `/subscription/` and ensure that your parameters don't have any hardcoded resourceIds __or they will fail PR validation__
* [x] remove `fallbackResourceIds` and `fromTemplateId` fields from your template workbook __or they will fail PR validation__