### PR TITLE
fixing table in coverage workbook

### DIFF
--- a/Workbooks/Azure Security Center/Coverage/Coverage.workbook
+++ b/Workbooks/Azure Security Center/Coverage/Coverage.workbook
@@ -158,11 +158,9 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "{\"version\":\"Merge/1.0\",\"merges\":[{\"id\":\"6583ee8b-8e44-4ed2-a278-ee310b45804a\",\"mergeType\":\"table\",\"leftTable\":\"Azure numbers\"}],\"projectRename\":[{\"originalName\":\"[query - 3].totalSubs\",\"mergedName\":\"totalSubs\",\"fromId\":\"6583ee8b-8e44-4ed2-a278-ee310b45804a\"},{\"originalName\":\"[query - 3].Servers\",\"mergedName\":\"Servers\",\"fromId\":\"6583ee8b-8e44-4ed2-a278-ee310b45804a\"},{\"originalName\":\"[query - 3].AppSrv\",\"mergedName\":\"AppSrv\",\"fromId\":\"6583ee8b-8e44-4ed2-a278-ee310b45804a\"},{\"originalName\":\"[query - 3].SqlServers\",\"mergedName\":\"SqlServers\",\"fromId\":\"6583ee8b-8e44-4ed2-a278-ee310b45804a\"},{\"originalName\":\"[query - 3].SqlServerVirtualMachines\",\"mergedName\":\"SqlServerVirtualMachines\",\"fromId\":\"6583ee8b-8e44-4ed2-a278-ee310b45804a\"},{\"originalName\":\"[query - 3].OpenSourceRelationalDatabases\",\"mergedName\":\"OpenSourceRelationalDatabases\",\"fromId\":\"6583ee8b-8e44-4ed2-a278-ee310b45804a\"},{\"originalName\":\"[query - 3].CosmosDB\",\"mergedName\":\"CosmosDB\",\"fromId\":\"6583ee8b-8e44-4ed2-a278-ee310b45804a\"},{\"originalName\":\"[query - 3].StorageAccounts\",\"mergedName\":\"StorageAccounts\",\"fromId\":\"6583ee8b-8e44-4ed2-a278-ee310b45804a\"},{\"originalName\":\"[query - 3].Containers\",\"mergedName\":\"Containers\",\"fromId\":\"6583ee8b-8e44-4ed2-a278-ee310b45804a\"},{\"originalName\":\"[query - 3].KeyVaults\",\"mergedName\":\"KeyVaults\",\"fromId\":\"6583ee8b-8e44-4ed2-a278-ee310b45804a\"},{\"originalName\":\"[query - 3].Arm\",\"mergedName\":\"Arm\",\"fromId\":\"6583ee8b-8e44-4ed2-a278-ee310b45804a\"},{\"originalName\":\"[query - 3].DNS\",\"mergedName\":\"DNS\",\"fromId\":\"6583ee8b-8e44-4ed2-a278-ee310b45804a\"},{\"originalName\":\"[query - 3].KubernetesService\",\"mergedName\":\"KubernetesService\",\"fromId\":\"6583ee8b-8e44-4ed2-a278-ee310b45804a\"},{\"originalName\":\"[query - 3].ContainerRegistry\",\"mergedName\":\"ContainerRegistry\",\"fromId\":\"6583ee8b-8e44-4ed2-a278-ee310b45804a\"},{\"originalName\":\"[Added column]\",\"mergedName\":\"Servers1\",\"fromId\":null,\"isNewItem\":true,\"newItemData\":[{\"criteriaContext\":{\"operator\":\"Default\",\"rightValType\":\"column\",\"resultValType\":\"expression\",\"resultVal\":\"[\\\"Servers\\\"]/[\\\"totalSubs\\\"]*100\"}}]},{\"originalName\":\"[Added column]\",\"mergedName\":\"App Services\",\"fromId\":null,\"isNewItem\":true,\"newItemData\":[{\"criteriaContext\":{\"operator\":\"Default\",\"rightValType\":\"column\",\"resultValType\":\"expression\",\"resultVal\":\"[\\\"AppSrv\\\"]/[\\\"totalSubs\\\"]*100\"}}]},{\"originalName\":\"[Added column]\",\"mergedName\":\"SQL\",\"fromId\":null,\"isNewItem\":true,\"newItemData\":[{\"criteriaContext\":{\"operator\":\"Default\",\"rightValType\":\"column\",\"resultValType\":\"expression\",\"resultVal\":\"[\\\"SqlServers\\\"]/[\\\"totalSubs\\\"]*100\"}}]},{\"originalName\":\"[Added column]\",\"mergedName\":\"SQL Server on machines\",\"fromId\":null,\"isNewItem\":true,\"newItemData\":[{\"criteriaContext\":{\"operator\":\"Default\",\"rightValType\":\"column\",\"resultValType\":\"expression\",\"resultVal\":\"[\\\"SqlServerVirtualMachines\\\"]/[\\\"totalSubs\\\"]*100\"}}]},{\"originalName\":\"[Added column]\",\"mergedName\":\"OSRDB\",\"fromId\":null,\"isNewItem\":true,\"newItemData\":[{\"criteriaContext\":{\"operator\":\"Default\",\"rightValType\":\"column\",\"resultValType\":\"expression\",\"resultVal\":\"[\\\"OpenSourceRelationalDatabases\\\"]/[\\\"totalSubs\\\"]*100\"}}]},{\"originalName\":\"[Added column]\",\"mergedName\":\"Cosmos DB\",\"fromId\":null,\"isNewItem\":true,\"newItemData\":[{\"criteriaContext\":{\"operator\":\"Default\",\"rightValType\":\"column\",\"resultValType\":\"expression\",\"resultVal\":\"[\\\"CosmosDB\\\"]/[\\\"totalSubs\\\"]*100\"}}]},{\"originalName\":\"[Added column]\",\"mergedName\":\"Storage\",\"fromId\":null,\"isNewItem\":true,\"newItemData\":[{\"criteriaContext\":{\"operator\":\"Default\",\"rightValType\":\"column\",\"resultValType\":\"expression\",\"resultVal\":\"[\\\"StorageAccounts\\\"]/[\\\"totalSubs\\\"]*100\"}}]},{\"originalName\":\"[Added column]\",\"mergedName\":\"Containers\",\"fromId\":null,\"isNewItem\":true,\"newItemData\":[{\"criteriaContext\":{\"operator\":\"Default\",\"rightValType\":\"column\",\"resultValType\":\"expression\",\"resultVal\":\"[\\\"Containers\\\"]/[\\\"totalSubs\\\"]*100\"}}]},{\"originalName\":\"[Added column]\",\"mergedName\":\"Key Vaults\",\"fromId\":null,\"isNewItem\":true,\"newItemData\":[{\"criteriaContext\":{\"operator\":\"Default\",\"rightValType\":\"column\",\"resultValType\":\"expression\",\"resultVal\":\"[\\\"KeyVaults\\\"]/[\\\"totalSubs\\\"]*100\"}}]},{\"originalName\":\"[Added column]\",\"mergedName\":\"ARM\",\"fromId\":null,\"isNewItem\":true,\"newItemData\":[{\"criteriaContext\":{\"operator\":\"Default\",\"rightValType\":\"column\",\"resultValType\":\"expression\",\"resultVal\":\"[\\\"Arm\\\"]/[\\\"totalSubs\\\"]*100\"}}]},{\"originalName\":\"[Added column]\",\"mergedName\":\"DNS\",\"fromId\":null,\"isNewItem\":true,\"newItemData\":[{\"criteriaContext\":{\"operator\":\"Default\",\"rightValType\":\"column\",\"resultValType\":\"expression\",\"resultVal\":\"[\\\"DNS\\\"]/[\\\"totalSubs\\\"]*100\"}}]},{\"originalName\":\"[Added column]\",\"mergedName\":\"Kubernetes\",\"fromId\":null,\"isNewItem\":true,\"newItemData\":[{\"criteriaContext\":{\"operator\":\"Default\",\"rightValType\":\"column\",\"resultValType\":\"expression\",\"resultVal\":\"[\\\"KubernetesService\\\"]/[\\\"totalSubs\\\"]*100\"}}]},{\"originalName\":\"[Added column]\",\"mergedName\":\"Container Registries\",\"fromId\":null,\"isNewItem\":true,\"newItemData\":[{\"criteriaContext\":{\"operator\":\"Default\",\"rightValType\":\"column\",\"resultValType\":\"expression\",\"resultVal\":\"[\\\"ContainerRegistry\\\"]/[\\\"totalSubs\\\"]*100\"}}]},{\"originalName\":\"[Azure numbers].totalSubs\",\"mergedName\":\"totalSubs\",\"fromId\":\"unknown\"},{\"originalName\":\"[Azure numbers].Servers\",\"mergedName\":\"Servers\",\"fromId\":\"unknown\"},{\"originalName\":\"[Azure numbers].AppSrv\",\"mergedName\":\"AppSrv\",\"fromId\":\"unknown\"},{\"originalName\":\"[Azure numbers].SqlServers\",\"mergedName\":\"SqlServers\",\"fromId\":\"unknown\"},{\"originalName\":\"[Azure numbers].SqlServerVirtualMachines\",\"mergedName\":\"SqlServerVirtualMachines\",\"fromId\":\"unknown\"},{\"originalName\":\"[Azure numbers].OpenSourceRelationalDatabases\",\"mergedName\":\"OpenSourceRelationalDatabases\",\"fromId\":\"unknown\"},{\"originalName\":\"[Azure numbers].CosmosDB\",\"mergedName\":\"CosmosDB\",\"fromId\":\"unknown\"},{\"originalName\":\"[Azure numbers].StorageAccounts\",\"mergedName\":\"StorageAccounts\",\"fromId\":\"unknown\"},{\"originalName\":\"[Azure numbers].Containers\",\"mergedName\":\"Containers\",\"fromId\":\"unknown\"},{\"originalName\":\"[Azure numbers].KeyVaults\",\"mergedName\":\"KeyVaults\",\"fromId\":\"unknown\"},{\"originalName\":\"[Azure numbers].Arm\",\"mergedName\":\"Arm\",\"fromId\":\"unknown\"},{\"originalName\":\"[Azure numbers].DNS\",\"mergedName\":\"DNS\",\"fromId\":\"unknown\"},{\"originalName\":\"[Azure numbers].KubernetesService\",\"mergedName\":\"KubernetesService\",\"fromId\":\"unknown\"},{\"originalName\":\"[Azure numbers].ContainerRegistry\",\"mergedName\":\"ContainerRegistry\",\"fromId\":\"unknown\"}]}",
+              "query": "{\"version\":\"Merge/1.0\",\"merges\":[{\"id\":\"17975ef8-d504-4965-a0ca-3e25f6c5203c\",\"mergeType\":\"table\",\"leftTable\":\"Azure numbers\"}],\"projectRename\":[{\"originalName\":\"[Azure numbers].totalSubs\",\"mergedName\":\"totalSubs\",\"fromId\":\"17975ef8-d504-4965-a0ca-3e25f6c5203c\"},{\"originalName\":\"[Azure numbers].Servers\",\"mergedName\":\"Servers\",\"fromId\":\"17975ef8-d504-4965-a0ca-3e25f6c5203c\"},{\"originalName\":\"[Azure numbers].AppSrv\",\"mergedName\":\"AppSrv\",\"fromId\":\"17975ef8-d504-4965-a0ca-3e25f6c5203c\"},{\"originalName\":\"[Azure numbers].SqlServers\",\"mergedName\":\"SqlServers\",\"fromId\":\"17975ef8-d504-4965-a0ca-3e25f6c5203c\"},{\"originalName\":\"[Azure numbers].SqlServerVirtualMachines\",\"mergedName\":\"SqlServerVirtualMachines\",\"fromId\":\"17975ef8-d504-4965-a0ca-3e25f6c5203c\"},{\"originalName\":\"[Azure numbers].OpenSourceRelationalDatabases\",\"mergedName\":\"OpenSourceRelationalDatabases\",\"fromId\":\"17975ef8-d504-4965-a0ca-3e25f6c5203c\"},{\"originalName\":\"[Azure numbers].CosmosDB\",\"mergedName\":\"CosmosDB\",\"fromId\":\"17975ef8-d504-4965-a0ca-3e25f6c5203c\"},{\"originalName\":\"[Azure numbers].StorageAccounts\",\"mergedName\":\"StorageAccounts\",\"fromId\":\"17975ef8-d504-4965-a0ca-3e25f6c5203c\"},{\"originalName\":\"[Azure numbers].Containers\",\"mergedName\":\"Containers\",\"fromId\":\"17975ef8-d504-4965-a0ca-3e25f6c5203c\"},{\"originalName\":\"[Azure numbers].KeyVaults\",\"mergedName\":\"KeyVaults\",\"fromId\":\"17975ef8-d504-4965-a0ca-3e25f6c5203c\"},{\"originalName\":\"[Azure numbers].Arm\",\"mergedName\":\"Arm\",\"fromId\":\"17975ef8-d504-4965-a0ca-3e25f6c5203c\"},{\"originalName\":\"[Azure numbers].DNS\",\"mergedName\":\"DNS\",\"fromId\":\"17975ef8-d504-4965-a0ca-3e25f6c5203c\"},{\"originalName\":\"[Azure numbers].KubernetesService\",\"mergedName\":\"KubernetesService\",\"fromId\":\"17975ef8-d504-4965-a0ca-3e25f6c5203c\"},{\"originalName\":\"[Azure numbers].ContainerRegistry\",\"mergedName\":\"ContainerRegistry\",\"fromId\":\"17975ef8-d504-4965-a0ca-3e25f6c5203c\"},{\"originalName\":\"[Added column]\",\"mergedName\":\"Servers1\",\"fromId\":null,\"isNewItem\":true,\"newItemData\":[{\"criteriaContext\":{\"operator\":\"Default\",\"rightValType\":\"column\",\"resultValType\":\"expression\",\"resultVal\":\"[\\\"Servers\\\"]/[\\\"totalSubs\\\"]*100\"}}]},{\"originalName\":\"[Added column]\",\"mergedName\":\"AppSrv1\",\"fromId\":null,\"isNewItem\":true,\"newItemData\":[{\"criteriaContext\":{\"operator\":\"Default\",\"rightValType\":\"column\",\"resultValType\":\"expression\",\"resultVal\":\"[\\\"AppSrv\\\"]/[\\\"totalSubs\\\"]*100\"}}]},{\"originalName\":\"[Added column]\",\"mergedName\":\"SQL1\",\"fromId\":null,\"isNewItem\":true,\"newItemData\":[{\"criteriaContext\":{\"operator\":\"Default\",\"rightValType\":\"column\",\"resultValType\":\"expression\",\"resultVal\":\"[\\\"SqlServers\\\"]/[\\\"totalSubs\\\"]*100\"}}]},{\"originalName\":\"[Added column]\",\"mergedName\":\"SQL Server on machines\",\"fromId\":null,\"isNewItem\":true,\"newItemData\":[{\"criteriaContext\":{\"operator\":\"Default\",\"rightValType\":\"column\",\"resultValType\":\"expression\",\"resultVal\":\"[\\\"SqlServerVirtualMachines\\\"]/[\\\"totalSubs\\\"]*100\"}}]},{\"originalName\":\"[Added column]\",\"mergedName\":\"Open-source relational DBs\",\"fromId\":null,\"isNewItem\":true,\"newItemData\":[{\"criteriaContext\":{\"operator\":\"Default\",\"rightValType\":\"column\",\"resultValType\":\"expression\",\"resultVal\":\"[\\\"OpenSourceRelationalDatabases\\\"]/[\\\"totalSubs\\\"]*100\"}}]},{\"originalName\":\"[Added column]\",\"mergedName\":\"Cosmos DB\",\"fromId\":null,\"isNewItem\":true,\"newItemData\":[{\"criteriaContext\":{\"operator\":\"Default\",\"rightValType\":\"column\",\"resultValType\":\"expression\",\"resultVal\":\"[\\\"CosmosDB\\\"]/[\\\"totalSubs\\\"]*100\"}}]},{\"originalName\":\"[Added column]\",\"mergedName\":\"Storage1\",\"fromId\":null,\"isNewItem\":true,\"newItemData\":[{\"criteriaContext\":{\"operator\":\"Default\",\"rightValType\":\"column\",\"resultValType\":\"expression\",\"resultVal\":\"[\\\"StorageAccounts\\\"]/[\\\"totalSubs\\\"]*100\"}}]},{\"originalName\":\"[Added column]\",\"mergedName\":\"Containers1\",\"fromId\":null,\"isNewItem\":true,\"newItemData\":[{\"criteriaContext\":{\"operator\":\"Default\",\"rightValType\":\"column\",\"resultValType\":\"expression\",\"resultVal\":\"[\\\"Containers\\\"]/[\\\"totalSubs\\\"]*100\"}}]},{\"originalName\":\"[Added column]\",\"mergedName\":\"Key Vaults\",\"fromId\":null,\"isNewItem\":true,\"newItemData\":[{\"criteriaContext\":{\"operator\":\"Default\",\"rightValType\":\"column\",\"resultValType\":\"expression\",\"resultVal\":\"[\\\"KeyVaults\\\"]/[\\\"totalSubs\\\"]*100\"}}]},{\"originalName\":\"[Added column]\",\"mergedName\":\"Resource Manager\",\"fromId\":null,\"isNewItem\":true,\"newItemData\":[{\"criteriaContext\":{\"operator\":\"Default\",\"rightValType\":\"column\",\"resultValType\":\"expression\",\"resultVal\":\"[\\\"Arm\\\"]/[\\\"totalSubs\\\"]*100\"}}]},{\"originalName\":\"[Added column]\",\"mergedName\":\"DNS1\",\"fromId\":null,\"isNewItem\":true,\"newItemData\":[{\"criteriaContext\":{\"operator\":\"Default\",\"rightValType\":\"column\",\"resultValType\":\"expression\",\"resultVal\":\"[\\\"DNS\\\"]/[\\\"totalSubs\\\"]*100\"}}]},{\"originalName\":\"[Added column]\",\"mergedName\":\"K8s (deprecated)\",\"fromId\":null,\"isNewItem\":true,\"newItemData\":[{\"criteriaContext\":{\"operator\":\"Default\",\"rightValType\":\"column\",\"resultValType\":\"expression\",\"resultVal\":\"[\\\"KubernetesService\\\"]/[\\\"totalSubs\\\"]*100\"}}]},{\"originalName\":\"[Added column]\",\"mergedName\":\"Container Registry (deprecated)\",\"fromId\":null,\"isNewItem\":true,\"newItemData\":[{\"criteriaContext\":{\"operator\":\"Default\",\"rightValType\":\"column\",\"resultValType\":\"expression\",\"resultVal\":\"[\\\"ContainerRegistry\\\"]/[\\\"totalSubs\\\"]*100\"}}]}]}",
               "size": 3,
-              "title": "Relative coverage across Azure subscriptions",
               "queryType": 7,
-              "visualization": "table",
               "gridSettings": {
                 "formatters": [
                   {
@@ -222,7 +220,7 @@
                     "formatter": 5
                   },
                   {
-                    "columnMatch": "Server",
+                    "columnMatch": "Servers1",
                     "formatter": 8,
                     "formatOptions": {
                       "min": 0,
@@ -238,7 +236,7 @@
                     }
                   },
                   {
-                    "columnMatch": "App Services",
+                    "columnMatch": "AppSrv1",
                     "formatter": 8,
                     "formatOptions": {
                       "min": 0,
@@ -254,7 +252,7 @@
                     }
                   },
                   {
-                    "columnMatch": "SQL",
+                    "columnMatch": "SQL1",
                     "formatter": 8,
                     "formatOptions": {
                       "min": 0,
@@ -286,7 +284,7 @@
                     }
                   },
                   {
-                    "columnMatch": "OSRDB",
+                    "columnMatch": "Open-source relational DBs",
                     "formatter": 8,
                     "formatOptions": {
                       "min": 0,
@@ -318,7 +316,23 @@
                     }
                   },
                   {
-                    "columnMatch": "Storage",
+                    "columnMatch": "Storage1",
+                    "formatter": 8,
+                    "formatOptions": {
+                      "min": 0,
+                      "max": 100,
+                      "palette": "lightBlue"
+                    },
+                    "numberFormat": {
+                      "unit": 1,
+                      "options": {
+                        "style": "decimal",
+                        "maximumFractionDigits": 1
+                      }
+                    }
+                  },
+                  {
+                    "columnMatch": "Containers1",
                     "formatter": 8,
                     "formatOptions": {
                       "min": 0,
@@ -350,7 +364,7 @@
                     }
                   },
                   {
-                    "columnMatch": "ARM",
+                    "columnMatch": "Resource Manager",
                     "formatter": 8,
                     "formatOptions": {
                       "min": 0,
@@ -366,7 +380,7 @@
                     }
                   },
                   {
-                    "columnMatch": "Kubernetes",
+                    "columnMatch": "DNS1",
                     "formatter": 8,
                     "formatOptions": {
                       "min": 0,
@@ -382,7 +396,23 @@
                     }
                   },
                   {
-                    "columnMatch": "Container Registries",
+                    "columnMatch": "K8s (deprecated)",
+                    "formatter": 8,
+                    "formatOptions": {
+                      "min": 0,
+                      "max": 100,
+                      "palette": "lightBlue"
+                    },
+                    "numberFormat": {
+                      "unit": 1,
+                      "options": {
+                        "style": "decimal",
+                        "maximumFractionDigits": 1
+                      }
+                    }
+                  },
+                  {
+                    "columnMatch": "Container Registry (deprecated)",
                     "formatter": 8,
                     "formatOptions": {
                       "min": 0,
@@ -401,18 +431,33 @@
                 "rowLimit": 2,
                 "labelSettings": [
                   {
-                    "columnId": "OSRDB",
-                    "label": "Open-source relational DBs"
+                    "columnId": "Servers1",
+                    "label": "Servers"
+                  },
+                  {
+                    "columnId": "AppSrv1",
+                    "label": "App Services"
+                  },
+                  {
+                    "columnId": "SQL1",
+                    "label": "SQL"
+                  },
+                  {
+                    "columnId": "Storage1",
+                    "label": "Storage"
+                  },
+                  {
+                    "columnId": "Containers1",
+                    "label": "Containers"
+                  },
+                  {
+                    "columnId": "DNS1",
+                    "label": "DNS"
                   }
                 ]
-              },
-              "tileSettings": {
-                "showBorder": false
-              },
-              "graphSettings": {
-                "type": 0
               }
             },
+            "showPin": false,
             "name": "Azure percentage"
           },
           {
@@ -1041,22 +1086,6 @@
               "gridSettings": {
                 "formatters": [
                   {
-                    "columnMatch": "totalConnectors",
-                    "formatter": 5
-                  },
-                  {
-                    "columnMatch": "CSPM",
-                    "formatter": 5
-                  },
-                  {
-                    "columnMatch": "Servers",
-                    "formatter": 5
-                  },
-                  {
-                    "columnMatch": "Containers",
-                    "formatter": 5
-                  },
-                  {
                     "columnMatch": "CSPM1",
                     "formatter": 8,
                     "formatOptions": {
@@ -1103,6 +1132,22 @@
                         "maximumFractionDigits": 1
                       }
                     }
+                  },
+                  {
+                    "columnMatch": "totalConnectors",
+                    "formatter": 5
+                  },
+                  {
+                    "columnMatch": "CSPM",
+                    "formatter": 5
+                  },
+                  {
+                    "columnMatch": "Servers",
+                    "formatter": 5
+                  },
+                  {
+                    "columnMatch": "Containers",
+                    "formatter": 5
                   }
                 ],
                 "rowLimit": 2,
@@ -1113,11 +1158,11 @@
                   },
                   {
                     "columnId": "Servers1",
-                    "label": "Servers"
+                    "label": "Defender for Servers"
                   },
                   {
                     "columnId": "Containers1",
-                    "label": "Containers"
+                    "label": "Defender for Containers"
                   }
                 ]
               }
@@ -1257,6 +1302,10 @@
                   {
                     "columnId": "CSPM",
                     "label": "Cloud Security Posture Management"
+                  },
+                  {
+                    "columnId": "Servers",
+                    "label": "Defender for Servers"
                   },
                   {
                     "columnId": "Containers",
@@ -1409,11 +1458,11 @@
                   },
                   {
                     "columnId": "Servers1",
-                    "label": "Servers"
+                    "label": "Defender for Servers"
                   },
                   {
                     "columnId": "Containers1",
-                    "label": "Containers"
+                    "label": "Defender for Containers"
                   }
                 ]
               }
@@ -1553,6 +1602,10 @@
                   {
                     "columnId": "CSPM",
                     "label": "Cloud Security Posture Management"
+                  },
+                  {
+                    "columnId": "Servers",
+                    "label": "Defender for Servers"
                   },
                   {
                     "columnId": "Containers",


### PR DESCRIPTION
## PR Checklist

* [X] Explain your changes, so people looking at the PR know *what* and *why*, the code changes are the *how*.
This PR fixes the *relative coverage for Azure subscriptions* table as it didn't show Servers coverage.
It also aligns table headings for AWS and GCP to use the same wording.

### If adding or updating templates:
* [x] post a screenshot of templates and/or gallery changes
![coverage4](https://user-images.githubusercontent.com/32520935/163406869-b1b9b73d-d0fc-4b14-ac49-04195302cdf4.png)
![coverage5](https://user-images.githubusercontent.com/32520935/163406891-999a9ed7-72fd-44b2-ada9-748c6797412c.png)
* [x] ensure your template has a corresponding gallery entry in the gallery folder
* [x] If you are adding a new template, add your team and template/gallery file(s) to the CODEOWNERS file. CODEOWNERS entries should be teams, not individuals
* [x] ensure all steps have meaningful names
* [x] ensure all parameters and grid columns have display names set so they can be localized
* [x] ensure that parameters id values are unique __or they will fail PR validation__ (parameter ids are used for localization)
* [x] ensure that steps names are unique __or they will fail PR validation__ (step names are used for localization)
* [x] grep `/subscription/` and ensure that your parameters don't have any hardcoded resourceIds __or they will fail PR validation__
* [x] remove `fallbackResourceIds` and `fromTemplateId` fields from your template workbook __or they will fail PR validation__