### PR TITLE
updating calculation for Defender for Servers

### DIFF
--- a/Workbooks/Azure Security Center/Price Estimation/PriceEstimation.workbook
+++ b/Workbooks/Azure Security Center/Price Estimation/PriceEstimation.workbook
@@ -85,15 +85,6 @@
         "style": "tabs",
         "links": [
           {
-            "id": "f0901d7f-3e94-4520-a0ba-7c0a1087a7f0",
-            "cellValue": "SelectedView",
-            "linkTarget": "parameter",
-            "linkLabel": "Coverage",
-            "subTarget": "Coverage",
-            "preText": "Overview",
-            "style": "link"
-          },
-          {
             "id": "440616ea-8f0a-473b-a934-a8c33d80b24c",
             "cellValue": "SelectedView",
             "linkTarget": "parameter",
@@ -2273,7 +2264,7 @@
           {
             "type": 1,
             "content": {
-              "json": "This table considers all servers that are on with/without Microsoft Defender for Servers enabled across your selected subscriptions. The results are from the last 7 days. Estimated Monthly Cost takes those 7 days as sample and calculates it for a month.\n\nThe table includes estimations for Azure and hybrid serveres connected through Azure Arc as well as VMSS. If the machine is already connected to a Log Analytics workspace, the workbook takes the total number of hours the machine has been running in the past 7 days. For machines not connected to a workspace, the estimation is based on the machine running 24hrs a day."
+              "json": "This table considers all servers that are on with/without Microsoft Defender for Servers enabled across your selected subscriptions. The results are from the last 7 days. Estimated Monthly Cost takes those 7 days as sample and calculates it for a month.\n\nThe table includes estimations for Azure and hybrid serveres connected through Azure Arc as well as VMSS. If the machine is already connected to a Log Analytics workspace, the workbook takes the total number of hours the machine has been running in the past 7 days. For machines not connected to a workspace, the estimation is based on the machine running 24hrs a day.\n\nThe toggles below let you select Defender for Servers P1 or P2 plans. In addition, the *Containers Plan* toggle lets you select if you want to see Defender for Servers billing in dependency to Defender for Containers. When enabling Defender for Containers, Defender for Servers billing does not apply to Azure Kubernetes Service (AKS) VMSS nodes. Depending on your selection below, AKS VMSS nodes will be exempted from the Defender for Servers calculation below."
             },
             "conditionalVisibility": {
               "parameterName": "info",
@@ -2309,6 +2300,21 @@
                         "timeContext": {
                           "durationMs": 86400000
                         }
+                      },
+                      {
+                        "id": "5deca000-1c93-454a-bc68-dfb6492683c9",
+                        "version": "KqlParameterItem/1.0",
+                        "name": "ContainersPlan",
+                        "label": "Containers Plan",
+                        "type": 10,
+                        "description": "When Defender for Containers is enabled, AKS VMSS nodes won't be charged for Defender for Servers. To get a Defender for Servers estimation depending on Defender for Containers status, make sure to select the appropriate setting.",
+                        "isRequired": true,
+                        "value": "Off",
+                        "typeSettings": {
+                          "additionalResourceOptions": [],
+                          "showDefault": false
+                        },
+                        "jsonData": "[\n { \"value\": \"On\", \"label\": \"Enabled\"},\n { \"value\": \"Off\", \"label\": \"Disabled\"}\n]"
                       }
                     ],
                     "style": "above",
@@ -2334,7 +2340,7 @@
                   "type": 3,
                   "content": {
                     "version": "KqlItem/1.0",
-                    "query": "Resources\r\n| where type =~ 'Microsoft.Compute/virtualMachines' or type == 'microsoft.hybridcompute/machines' or type == \"microsoft.compute/virtualmachinescalesets\"\r\n| summarize by subscriptionId, id, type\r\n",
+                    "query": "Resources | where type =~ 'Microsoft.Compute/virtualMachines' or type == 'microsoft.hybridcompute/machines' or type == \"microsoft.compute/virtualmachinescalesets\"\r\n| summarize by subscriptionId, id, type\r\n",
                     "size": 0,
                     "queryType": 1,
                     "resourceType": "microsoft.resourcegraph/resources",
@@ -2352,6 +2358,29 @@
                     "value": "0"
                   },
                   "name": "ServersP2 query 1"
+                },
+                {
+                  "type": 3,
+                  "content": {
+                    "version": "KqlItem/1.0",
+                    "query": "resources\r\n| where (type =~ 'Microsoft.Compute/virtualMachines' or type == 'microsoft.hybridcompute/machines' or type == \"microsoft.compute/virtualmachinescalesets\")\r\n| project resourceGroup = tolower(resourceGroup),subscriptionId, id, type\r\n| join kind=leftouter  (\r\n    resources\r\n    | where type == \"microsoft.containerservice/managedclusters\"\r\n    | project resourceGroup = tolower(properties.nodeResourceGroup)\r\n)\r\non resourceGroup | where isempty( resourceGroup1)\r\n| summarize by subscriptionId, id, type",
+                    "size": 0,
+                    "queryType": 1,
+                    "resourceType": "microsoft.resourcegraph/resources",
+                    "crossComponentResources": [
+                      "{Subscriptions}"
+                    ],
+                    "visualization": "table",
+                    "gridSettings": {
+                      "rowLimit": 10000
+                    }
+                  },
+                  "conditionalVisibility": {
+                    "parameterName": "{blank}",
+                    "comparison": "isEqualTo",
+                    "value": "0"
+                  },
+                  "name": "Servers Containers on query"
                 },
                 {
                   "type": 3,
@@ -2498,19 +2527,26 @@
                     },
                     "sortBy": []
                   },
-                  "conditionalVisibility": {
-                    "parameterName": "ServersPlan",
-                    "comparison": "isEqualTo",
-                    "value": "P2"
-                  },
+                  "conditionalVisibilities": [
+                    {
+                      "parameterName": "ServersPlan",
+                      "comparison": "isEqualTo",
+                      "value": "P2"
+                    },
+                    {
+                      "parameterName": "ContainersPlan",
+                      "comparison": "isEqualTo",
+                      "value": "Off"
+                    }
+                  ],
                   "showPin": false,
-                  "name": "ServersP2 result"
+                  "name": "ServersP2 Containers off result"
                 },
                 {
                   "type": 3,
                   "content": {
                     "version": "KqlItem/1.0",
-                    "query": "{\"version\":\"Merge/1.0\",\"merges\":[{\"id\":\"70774d0c-4d25-4bae-9d9b-bcbcf8a39057\",\"mergeType\":\"outer\",\"leftTable\":\"ServersP2 query 1\",\"rightTable\":\"ServersP2 query 2\",\"leftColumn\":\"id\",\"rightColumn\":\"Computer\"}],\"projectRename\":[{\"originalName\":\"[Added column]\",\"mergedName\":\"Total estimated Defender cost\",\"fromId\":null,\"isNewItem\":true,\"newItemData\":[{\"criteriaContext\":{\"operator\":\"Default\",\"rightValType\":\"column\",\"resultValType\":\"expression\",\"resultVal\":\"\\\"Total estimated Defender cost\\\"\"}}]},{\"originalName\":\"[Added column]\",\"mergedName\":\"SubId\",\"fromId\":null,\"isNewItem\":true,\"newItemData\":[{\"criteriaContext\":{\"leftOperand\":\"subscriptionId\",\"operator\":\"isNotNull\",\"rightValType\":\"column\",\"resultValType\":\"column\",\"resultVal\":\"subscriptionId\"}},{\"criteriaContext\":{\"operator\":\"Default\",\"rightValType\":\"column\",\"resultValType\":\"column\",\"resultVal\":\"SubscriptionId\"}}]},{\"originalName\":\"[Added column]\",\"mergedName\":\"machineName\",\"fromId\":null,\"isNewItem\":true,\"newItemData\":[{\"criteriaContext\":{\"leftOperand\":\"id\",\"operator\":\"isNotNull\",\"rightValType\":\"column\",\"resultValType\":\"column\",\"resultVal\":\"id\"}},{\"criteriaContext\":{\"operator\":\"Default\",\"rightValType\":\"column\",\"resultValType\":\"column\",\"resultVal\":\"Computer\"}}]},{\"originalName\":\"[Added column]\",\"mergedName\":\"weeklyRuntime\",\"fromId\":null,\"isNewItem\":true,\"newItemData\":[{\"criteriaContext\":{\"leftOperand\":\"total_running_hours\",\"operator\":\">\",\"rightValType\":\"static\",\"rightVal\":\"168\",\"resultValType\":\"expression\",\"resultVal\":\"24*7\"}},{\"criteriaContext\":{\"leftOperand\":\"total_running_hours\",\"operator\":\"isNotNull\",\"rightValType\":\"column\",\"resultValType\":\"column\",\"resultVal\":\"total_running_hours\"}},{\"criteriaContext\":{\"operator\":\"Default\",\"rightValType\":\"column\",\"resultValType\":\"expression\",\"resultVal\":\"24*7\"}}]},{\"originalName\":\"[Added column]\",\"mergedName\":\"Estimated price (7 days)\",\"fromId\":null,\"isNewItem\":true,\"newItemData\":[{\"criteriaContext\":{\"operator\":\"Default\",\"rightValType\":\"column\",\"resultValType\":\"expression\",\"resultVal\":\"[\\\"weeklyRuntime\\\"] * 0.00672\"}}]},{\"originalName\":\"[Added column]\",\"mergedName\":\"Estimated monthly price\",\"fromId\":null,\"isNewItem\":true,\"newItemData\":[{\"criteriaContext\":{\"leftOperand\":\"Estimated price (7 days)\",\"operator\":\"isNotNull\",\"rightValType\":\"column\",\"resultValType\":\"expression\",\"resultVal\":\"[\\\"Estimated price (7 days)\\\"]*4.345\"}},{\"criteriaContext\":{\"operator\":\"Default\",\"rightValType\":\"column\",\"resultValType\":\"column\"}}]},{\"originalName\":\"[query - 3].TimeGenerated\",\"mergedName\":\"TimeGenerated\",\"fromId\":\"unknown\"},{\"originalName\":\"[query - 3].heartbeats_per_hour\",\"mergedName\":\"heartbeats_per_hour\",\"fromId\":\"unknown\"},{\"originalName\":\"[ServersP2 query 1].subscriptionId\",\"mergedName\":\"subscriptionId\",\"fromId\":\"70774d0c-4d25-4bae-9d9b-bcbcf8a39057\"},{\"originalName\":\"[ServersP2 query 1].id\",\"mergedName\":\"id\",\"fromId\":\"70774d0c-4d25-4bae-9d9b-bcbcf8a39057\"},{\"originalName\":\"[ServersP2 query 1].type\",\"mergedName\":\"type\",\"fromId\":\"70774d0c-4d25-4bae-9d9b-bcbcf8a39057\"},{\"originalName\":\"[ServersP2 query 2].Computer\",\"mergedName\":\"Computer\",\"fromId\":\"70774d0c-4d25-4bae-9d9b-bcbcf8a39057\"},{\"originalName\":\"[ServersP2 query 2].SubscriptionId\",\"mergedName\":\"SubscriptionId\",\"fromId\":\"70774d0c-4d25-4bae-9d9b-bcbcf8a39057\"},{\"originalName\":\"[ServersP2 query 2].total_running_hours\",\"mergedName\":\"total_running_hours\",\"fromId\":\"70774d0c-4d25-4bae-9d9b-bcbcf8a39057\"}]}",
+                    "query": "{\"version\":\"Merge/1.0\",\"merges\":[{\"id\":\"70774d0c-4d25-4bae-9d9b-bcbcf8a39057\",\"mergeType\":\"outer\",\"leftTable\":\"Servers Containers on query\",\"rightTable\":\"ServersP2 query 2\",\"leftColumn\":\"id\",\"rightColumn\":\"Computer\"}],\"projectRename\":[{\"originalName\":\"[Added column]\",\"mergedName\":\"Total estimated Defender cost\",\"fromId\":null,\"isNewItem\":true,\"newItemData\":[{\"criteriaContext\":{\"operator\":\"Default\",\"rightValType\":\"column\",\"resultValType\":\"expression\",\"resultVal\":\"\\\"Total estimated Defender cost\\\"\"}}]},{\"originalName\":\"[Added column]\",\"mergedName\":\"SubId\",\"fromId\":null,\"isNewItem\":true,\"newItemData\":[{\"criteriaContext\":{\"leftOperand\":\"subscriptionId\",\"operator\":\"isNotNull\",\"rightValType\":\"column\",\"resultValType\":\"column\",\"resultVal\":\"subscriptionId\"}},{\"criteriaContext\":{\"operator\":\"Default\",\"rightValType\":\"column\",\"resultValType\":\"column\",\"resultVal\":\"SubscriptionId\"}}]},{\"originalName\":\"[Added column]\",\"mergedName\":\"machineName\",\"fromId\":null,\"isNewItem\":true,\"newItemData\":[{\"criteriaContext\":{\"leftOperand\":\"id\",\"operator\":\"isNotNull\",\"rightValType\":\"column\",\"resultValType\":\"column\",\"resultVal\":\"id\"}},{\"criteriaContext\":{\"operator\":\"Default\",\"rightValType\":\"column\",\"resultValType\":\"column\",\"resultVal\":\"Computer\"}}]},{\"originalName\":\"[Added column]\",\"mergedName\":\"weeklyRuntime\",\"fromId\":null,\"isNewItem\":true,\"newItemData\":[{\"criteriaContext\":{\"leftOperand\":\"total_running_hours\",\"operator\":\">\",\"rightValType\":\"static\",\"rightVal\":\"168\",\"resultValType\":\"expression\",\"resultVal\":\"24*7\"}},{\"criteriaContext\":{\"leftOperand\":\"total_running_hours\",\"operator\":\"isNotNull\",\"rightValType\":\"column\",\"resultValType\":\"column\",\"resultVal\":\"total_running_hours\"}},{\"criteriaContext\":{\"operator\":\"Default\",\"rightValType\":\"column\",\"resultValType\":\"expression\",\"resultVal\":\"24*7\"}}]},{\"originalName\":\"[Added column]\",\"mergedName\":\"Estimated price (7 days)\",\"fromId\":null,\"isNewItem\":true,\"newItemData\":[{\"criteriaContext\":{\"operator\":\"Default\",\"rightValType\":\"column\",\"resultValType\":\"expression\",\"resultVal\":\"[\\\"weeklyRuntime\\\"] * 0.02\"}}]},{\"originalName\":\"[Added column]\",\"mergedName\":\"Estimated monthly price\",\"fromId\":null,\"isNewItem\":true,\"newItemData\":[{\"criteriaContext\":{\"leftOperand\":\"Estimated price (7 days)\",\"operator\":\"isNotNull\",\"rightValType\":\"column\",\"resultValType\":\"expression\",\"resultVal\":\"[\\\"Estimated price (7 days)\\\"]*4.345\"}},{\"criteriaContext\":{\"operator\":\"Default\",\"rightValType\":\"column\",\"resultValType\":\"column\"}}]},{\"originalName\":\"[query - 3].TimeGenerated\",\"mergedName\":\"TimeGenerated\",\"fromId\":\"unknown\"},{\"originalName\":\"[query - 3].heartbeats_per_hour\",\"mergedName\":\"heartbeats_per_hour\",\"fromId\":\"unknown\"},{\"originalName\":\"[Servers Containers on query].subscriptionId\",\"mergedName\":\"subscriptionId\",\"fromId\":\"70774d0c-4d25-4bae-9d9b-bcbcf8a39057\"},{\"originalName\":\"[Servers Containers on query].id\",\"mergedName\":\"id\",\"fromId\":\"70774d0c-4d25-4bae-9d9b-bcbcf8a39057\"},{\"originalName\":\"[Servers Containers on query].type\",\"mergedName\":\"type\",\"fromId\":\"70774d0c-4d25-4bae-9d9b-bcbcf8a39057\"},{\"originalName\":\"[ServersP2 query 2].Computer\",\"mergedName\":\"Computer\",\"fromId\":\"70774d0c-4d25-4bae-9d9b-bcbcf8a39057\"},{\"originalName\":\"[ServersP2 query 2].SubscriptionId\",\"mergedName\":\"SubscriptionId\",\"fromId\":\"70774d0c-4d25-4bae-9d9b-bcbcf8a39057\"},{\"originalName\":\"[ServersP2 query 2].total_running_hours\",\"mergedName\":\"total_running_hours\",\"fromId\":\"70774d0c-4d25-4bae-9d9b-bcbcf8a39057\"}]}",
                     "size": 3,
                     "queryType": 7,
                     "gridSettings": {
@@ -2538,7 +2574,7 @@
                           "formatter": 13,
                           "formatOptions": {
                             "linkTarget": "Resource",
-                            "showIcon": false
+                            "showIcon": true
                           }
                         },
                         {
@@ -2629,13 +2665,296 @@
                     },
                     "sortBy": []
                   },
-                  "conditionalVisibility": {
-                    "parameterName": "ServersPlan",
-                    "comparison": "isEqualTo",
-                    "value": "P1"
-                  },
+                  "conditionalVisibilities": [
+                    {
+                      "parameterName": "ServersPlan",
+                      "comparison": "isEqualTo",
+                      "value": "P2"
+                    },
+                    {
+                      "parameterName": "ContainersPlan",
+                      "comparison": "isEqualTo",
+                      "value": "On"
+                    }
+                  ],
                   "showPin": false,
-                  "name": "ServersP1 result"
+                  "name": "ServersP2 Containers on result"
+                },
+                {
+                  "type": 3,
+                  "content": {
+                    "version": "KqlItem/1.0",
+                    "query": "{\"version\":\"Merge/1.0\",\"merges\":[{\"id\":\"70774d0c-4d25-4bae-9d9b-bcbcf8a39057\",\"mergeType\":\"outer\",\"leftTable\":\"ServersP2 query 1\",\"rightTable\":\"ServersP2 query 2\",\"leftColumn\":\"id\",\"rightColumn\":\"Computer\"}],\"projectRename\":[{\"originalName\":\"[Added column]\",\"mergedName\":\"Total estimated Defender cost\",\"fromId\":null,\"isNewItem\":true,\"newItemData\":[{\"criteriaContext\":{\"operator\":\"Default\",\"rightValType\":\"column\",\"resultValType\":\"expression\",\"resultVal\":\"\\\"Total estimated Defender cost\\\"\"}}]},{\"originalName\":\"[Added column]\",\"mergedName\":\"SubId\",\"fromId\":null,\"isNewItem\":true,\"newItemData\":[{\"criteriaContext\":{\"leftOperand\":\"subscriptionId\",\"operator\":\"isNotNull\",\"rightValType\":\"column\",\"resultValType\":\"column\",\"resultVal\":\"subscriptionId\"}},{\"criteriaContext\":{\"operator\":\"Default\",\"rightValType\":\"column\",\"resultValType\":\"column\",\"resultVal\":\"SubscriptionId\"}}]},{\"originalName\":\"[Added column]\",\"mergedName\":\"machineName\",\"fromId\":null,\"isNewItem\":true,\"newItemData\":[{\"criteriaContext\":{\"leftOperand\":\"id\",\"operator\":\"isNotNull\",\"rightValType\":\"column\",\"resultValType\":\"column\",\"resultVal\":\"id\"}},{\"criteriaContext\":{\"operator\":\"Default\",\"rightValType\":\"column\",\"resultValType\":\"column\",\"resultVal\":\"Computer\"}}]},{\"originalName\":\"[Added column]\",\"mergedName\":\"weeklyRuntime\",\"fromId\":null,\"isNewItem\":true,\"newItemData\":[{\"criteriaContext\":{\"leftOperand\":\"total_running_hours\",\"operator\":\">\",\"rightValType\":\"static\",\"rightVal\":\"168\",\"resultValType\":\"expression\",\"resultVal\":\"24*7\"}},{\"criteriaContext\":{\"leftOperand\":\"total_running_hours\",\"operator\":\"isNotNull\",\"rightValType\":\"column\",\"resultValType\":\"column\",\"resultVal\":\"total_running_hours\"}},{\"criteriaContext\":{\"operator\":\"Default\",\"rightValType\":\"column\",\"resultValType\":\"expression\",\"resultVal\":\"24*7\"}}]},{\"originalName\":\"[Added column]\",\"mergedName\":\"Estimated price (7 days)\",\"fromId\":null,\"isNewItem\":true,\"newItemData\":[{\"criteriaContext\":{\"operator\":\"Default\",\"rightValType\":\"column\",\"resultValType\":\"expression\",\"resultVal\":\"[\\\"weeklyRuntime\\\"] * 0.00672\"}}]},{\"originalName\":\"[Added column]\",\"mergedName\":\"Estimated monthly price\",\"fromId\":null,\"isNewItem\":true,\"newItemData\":[{\"criteriaContext\":{\"leftOperand\":\"Estimated price (7 days)\",\"operator\":\"isNotNull\",\"rightValType\":\"column\",\"resultValType\":\"expression\",\"resultVal\":\"[\\\"Estimated price (7 days)\\\"]*4.345\"}},{\"criteriaContext\":{\"operator\":\"Default\",\"rightValType\":\"column\",\"resultValType\":\"column\"}}]},{\"originalName\":\"[query - 3].TimeGenerated\",\"mergedName\":\"TimeGenerated\",\"fromId\":\"unknown\"},{\"originalName\":\"[query - 3].heartbeats_per_hour\",\"mergedName\":\"heartbeats_per_hour\",\"fromId\":\"unknown\"},{\"originalName\":\"[ServersP2 query 1].subscriptionId\",\"mergedName\":\"subscriptionId\",\"fromId\":\"70774d0c-4d25-4bae-9d9b-bcbcf8a39057\"},{\"originalName\":\"[ServersP2 query 1].id\",\"mergedName\":\"id\",\"fromId\":\"70774d0c-4d25-4bae-9d9b-bcbcf8a39057\"},{\"originalName\":\"[ServersP2 query 1].type\",\"mergedName\":\"type\",\"fromId\":\"70774d0c-4d25-4bae-9d9b-bcbcf8a39057\"},{\"originalName\":\"[ServersP2 query 2].Computer\",\"mergedName\":\"Computer\",\"fromId\":\"70774d0c-4d25-4bae-9d9b-bcbcf8a39057\"},{\"originalName\":\"[ServersP2 query 2].SubscriptionId\",\"mergedName\":\"SubscriptionId\",\"fromId\":\"70774d0c-4d25-4bae-9d9b-bcbcf8a39057\"},{\"originalName\":\"[ServersP2 query 2].total_running_hours\",\"mergedName\":\"total_running_hours\",\"fromId\":\"70774d0c-4d25-4bae-9d9b-bcbcf8a39057\"},{\"originalName\":\"[ServersP2 query 1].resourceGroup\",\"mergedName\":\"resourceGroup\",\"fromId\":\"unknown\"}]}",
+                    "size": 3,
+                    "queryType": 7,
+                    "gridSettings": {
+                      "formatters": [
+                        {
+                          "columnMatch": "$gen_group",
+                          "formatter": 15,
+                          "formatOptions": {
+                            "linkTarget": "Resource",
+                            "linkIsContextBlade": true,
+                            "showIcon": true,
+                            "customColumnWidthSetting": "51ch"
+                          }
+                        },
+                        {
+                          "columnMatch": "Total estimated Defender cost",
+                          "formatter": 5
+                        },
+                        {
+                          "columnMatch": "SubId",
+                          "formatter": 5
+                        },
+                        {
+                          "columnMatch": "machineName",
+                          "formatter": 13,
+                          "formatOptions": {
+                            "linkTarget": "Resource",
+                            "showIcon": true
+                          }
+                        },
+                        {
+                          "columnMatch": "Estimated price (7 days)",
+                          "formatter": 3,
+                          "formatOptions": {
+                            "palette": "blue",
+                            "aggregation": "Sum"
+                          },
+                          "numberFormat": {
+                            "unit": 0,
+                            "options": {
+                              "currency": "USD",
+                              "style": "currency",
+                              "maximumFractionDigits": 2
+                            }
+                          }
+                        },
+                        {
+                          "columnMatch": "Estimated monthly price",
+                          "formatter": 3,
+                          "formatOptions": {
+                            "palette": "yellow",
+                            "aggregation": "Sum"
+                          },
+                          "numberFormat": {
+                            "unit": 0,
+                            "options": {
+                              "currency": "USD",
+                              "style": "currency",
+                              "maximumFractionDigits": 2
+                            }
+                          }
+                        },
+                        {
+                          "columnMatch": "subscriptionId",
+                          "formatter": 5
+                        },
+                        {
+                          "columnMatch": "id",
+                          "formatter": 5
+                        },
+                        {
+                          "columnMatch": "type",
+                          "formatter": 5
+                        },
+                        {
+                          "columnMatch": "Computer",
+                          "formatter": 5
+                        },
+                        {
+                          "columnMatch": "SubscriptionId",
+                          "formatter": 5
+                        },
+                        {
+                          "columnMatch": "total_running_hours",
+                          "formatter": 5
+                        },
+                        {
+                          "columnMatch": "name",
+                          "formatter": 5
+                        }
+                      ],
+                      "rowLimit": 10000,
+                      "filter": true,
+                      "hierarchySettings": {
+                        "treeType": 1,
+                        "groupBy": [
+                          "Total estimated Defender cost",
+                          "SubId"
+                        ],
+                        "expandTopLevel": true
+                      },
+                      "labelSettings": [
+                        {
+                          "columnId": "Total estimated Defender cost",
+                          "label": "Subscription"
+                        },
+                        {
+                          "columnId": "machineName",
+                          "label": "Machine name"
+                        },
+                        {
+                          "columnId": "weeklyRuntime",
+                          "label": "Weekly runtime"
+                        }
+                      ]
+                    },
+                    "sortBy": []
+                  },
+                  "conditionalVisibilities": [
+                    {
+                      "parameterName": "ServersPlan",
+                      "comparison": "isEqualTo",
+                      "value": "P1"
+                    },
+                    {
+                      "parameterName": "ContainersPlan",
+                      "comparison": "isEqualTo",
+                      "value": "Off"
+                    }
+                  ],
+                  "showPin": false,
+                  "name": "ServersP1 Containers off result"
+                },
+                {
+                  "type": 3,
+                  "content": {
+                    "version": "KqlItem/1.0",
+                    "query": "{\"version\":\"Merge/1.0\",\"merges\":[{\"id\":\"70774d0c-4d25-4bae-9d9b-bcbcf8a39057\",\"mergeType\":\"outer\",\"leftTable\":\"Servers Containers on query\",\"rightTable\":\"ServersP2 query 2\",\"leftColumn\":\"id\",\"rightColumn\":\"Computer\"}],\"projectRename\":[{\"originalName\":\"[Added column]\",\"mergedName\":\"Total estimated Defender cost\",\"fromId\":null,\"isNewItem\":true,\"newItemData\":[{\"criteriaContext\":{\"operator\":\"Default\",\"rightValType\":\"column\",\"resultValType\":\"expression\",\"resultVal\":\"\\\"Total estimated Defender cost\\\"\"}}]},{\"originalName\":\"[Added column]\",\"mergedName\":\"SubId\",\"fromId\":null,\"isNewItem\":true,\"newItemData\":[{\"criteriaContext\":{\"leftOperand\":\"subscriptionId\",\"operator\":\"isNotNull\",\"rightValType\":\"column\",\"resultValType\":\"column\",\"resultVal\":\"subscriptionId\"}},{\"criteriaContext\":{\"operator\":\"Default\",\"rightValType\":\"column\",\"resultValType\":\"column\",\"resultVal\":\"SubscriptionId\"}}]},{\"originalName\":\"[Added column]\",\"mergedName\":\"machineName\",\"fromId\":null,\"isNewItem\":true,\"newItemData\":[{\"criteriaContext\":{\"leftOperand\":\"id\",\"operator\":\"isNotNull\",\"rightValType\":\"column\",\"resultValType\":\"column\",\"resultVal\":\"id\"}},{\"criteriaContext\":{\"operator\":\"Default\",\"rightValType\":\"column\",\"resultValType\":\"column\",\"resultVal\":\"Computer\"}}]},{\"originalName\":\"[Added column]\",\"mergedName\":\"weeklyRuntime\",\"fromId\":null,\"isNewItem\":true,\"newItemData\":[{\"criteriaContext\":{\"leftOperand\":\"total_running_hours\",\"operator\":\">\",\"rightValType\":\"static\",\"rightVal\":\"168\",\"resultValType\":\"expression\",\"resultVal\":\"24*7\"}},{\"criteriaContext\":{\"leftOperand\":\"total_running_hours\",\"operator\":\"isNotNull\",\"rightValType\":\"column\",\"resultValType\":\"column\",\"resultVal\":\"total_running_hours\"}},{\"criteriaContext\":{\"operator\":\"Default\",\"rightValType\":\"column\",\"resultValType\":\"expression\",\"resultVal\":\"24*7\"}}]},{\"originalName\":\"[Added column]\",\"mergedName\":\"Estimated price (7 days)\",\"fromId\":null,\"isNewItem\":true,\"newItemData\":[{\"criteriaContext\":{\"operator\":\"Default\",\"rightValType\":\"column\",\"resultValType\":\"expression\",\"resultVal\":\"[\\\"weeklyRuntime\\\"] * 0.00672\"}}]},{\"originalName\":\"[Added column]\",\"mergedName\":\"Estimated monthly price\",\"fromId\":null,\"isNewItem\":true,\"newItemData\":[{\"criteriaContext\":{\"leftOperand\":\"Estimated price (7 days)\",\"operator\":\"isNotNull\",\"rightValType\":\"column\",\"resultValType\":\"expression\",\"resultVal\":\"[\\\"Estimated price (7 days)\\\"]*4.345\"}},{\"criteriaContext\":{\"operator\":\"Default\",\"rightValType\":\"column\",\"resultValType\":\"column\"}}]},{\"originalName\":\"[query - 3].TimeGenerated\",\"mergedName\":\"TimeGenerated\",\"fromId\":\"unknown\"},{\"originalName\":\"[query - 3].heartbeats_per_hour\",\"mergedName\":\"heartbeats_per_hour\",\"fromId\":\"unknown\"},{\"originalName\":\"[ServersP2 query 1].resourceGroup\",\"mergedName\":\"resourceGroup\",\"fromId\":\"unknown\"},{\"originalName\":\"[Servers Containers on query].subscriptionId\",\"mergedName\":\"subscriptionId\",\"fromId\":\"70774d0c-4d25-4bae-9d9b-bcbcf8a39057\"},{\"originalName\":\"[Servers Containers on query].id\",\"mergedName\":\"id\",\"fromId\":\"70774d0c-4d25-4bae-9d9b-bcbcf8a39057\"},{\"originalName\":\"[Servers Containers on query].type\",\"mergedName\":\"type\",\"fromId\":\"70774d0c-4d25-4bae-9d9b-bcbcf8a39057\"},{\"originalName\":\"[ServersP2 query 2].Computer\",\"mergedName\":\"Computer\",\"fromId\":\"70774d0c-4d25-4bae-9d9b-bcbcf8a39057\"},{\"originalName\":\"[ServersP2 query 2].SubscriptionId\",\"mergedName\":\"SubscriptionId\",\"fromId\":\"70774d0c-4d25-4bae-9d9b-bcbcf8a39057\"},{\"originalName\":\"[ServersP2 query 2].total_running_hours\",\"mergedName\":\"total_running_hours\",\"fromId\":\"70774d0c-4d25-4bae-9d9b-bcbcf8a39057\"}]}",
+                    "size": 3,
+                    "queryType": 7,
+                    "gridSettings": {
+                      "formatters": [
+                        {
+                          "columnMatch": "$gen_group",
+                          "formatter": 15,
+                          "formatOptions": {
+                            "linkTarget": "Resource",
+                            "linkIsContextBlade": true,
+                            "showIcon": true,
+                            "customColumnWidthSetting": "51ch"
+                          }
+                        },
+                        {
+                          "columnMatch": "Total estimated Defender cost",
+                          "formatter": 5
+                        },
+                        {
+                          "columnMatch": "SubId",
+                          "formatter": 5
+                        },
+                        {
+                          "columnMatch": "machineName",
+                          "formatter": 13,
+                          "formatOptions": {
+                            "linkTarget": "Resource",
+                            "showIcon": true
+                          }
+                        },
+                        {
+                          "columnMatch": "Estimated price (7 days)",
+                          "formatter": 3,
+                          "formatOptions": {
+                            "palette": "blue",
+                            "aggregation": "Sum"
+                          },
+                          "numberFormat": {
+                            "unit": 0,
+                            "options": {
+                              "currency": "USD",
+                              "style": "currency",
+                              "maximumFractionDigits": 2
+                            }
+                          }
+                        },
+                        {
+                          "columnMatch": "Estimated monthly price",
+                          "formatter": 3,
+                          "formatOptions": {
+                            "palette": "yellow",
+                            "aggregation": "Sum"
+                          },
+                          "numberFormat": {
+                            "unit": 0,
+                            "options": {
+                              "currency": "USD",
+                              "style": "currency",
+                              "maximumFractionDigits": 2
+                            }
+                          }
+                        },
+                        {
+                          "columnMatch": "subscriptionId",
+                          "formatter": 5
+                        },
+                        {
+                          "columnMatch": "id",
+                          "formatter": 5
+                        },
+                        {
+                          "columnMatch": "type",
+                          "formatter": 5
+                        },
+                        {
+                          "columnMatch": "Computer",
+                          "formatter": 5
+                        },
+                        {
+                          "columnMatch": "SubscriptionId",
+                          "formatter": 5
+                        },
+                        {
+                          "columnMatch": "total_running_hours",
+                          "formatter": 5
+                        },
+                        {
+                          "columnMatch": "name",
+                          "formatter": 5
+                        }
+                      ],
+                      "rowLimit": 10000,
+                      "filter": true,
+                      "hierarchySettings": {
+                        "treeType": 1,
+                        "groupBy": [
+                          "Total estimated Defender cost",
+                          "SubId"
+                        ],
+                        "expandTopLevel": true
+                      },
+                      "labelSettings": [
+                        {
+                          "columnId": "Total estimated Defender cost",
+                          "label": "Subscription"
+                        },
+                        {
+                          "columnId": "machineName",
+                          "label": "Machine name"
+                        },
+                        {
+                          "columnId": "weeklyRuntime",
+                          "label": "Weekly runtime"
+                        }
+                      ]
+                    },
+                    "sortBy": []
+                  },
+                  "conditionalVisibilities": [
+                    {
+                      "parameterName": "ServersPlan",
+                      "comparison": "isEqualTo",
+                      "value": "P1"
+                    },
+                    {
+                      "parameterName": "ContainersPlan",
+                      "comparison": "isEqualTo",
+                      "value": "On"
+                    }
+                  ],
+                  "showPin": false,
+                  "name": "ServersP1 Containers on result"
                 }
               ]
             },


### PR DESCRIPTION
## PR Checklist

* [x] Explain your changes, so people looking at the PR know *what* and *why*, the code changes are the *how*.
In case Defender for Containers is enabled, AKS VMSS nodes are exempted from Defender for Servers billing. This change will add a toggle switch to allow setting Defender for Containers on/off when estimating Defender for Servers cost. In addition, we removed the coverage table as this is part of a separate workbook.
### If adding or updating templates:
* [x] post a screenshot of templates and/or gallery changes
![priceEstimation](https://user-images.githubusercontent.com/32520935/165303665-efb8d984-8c13-4b30-8bb0-4bf566f20cba.png)
* [x] ensure your template has a corresponding gallery entry in the gallery folder
* [x] If you are adding a new template, add your team and template/gallery file(s) to the CODEOWNERS file. CODEOWNERS entries should be teams, not individuals
* [x] ensure all steps have meaningful names
* [x] ensure all parameters and grid columns have display names set so they can be localized
* [x] ensure that parameters id values are unique __or they will fail PR validation__ (parameter ids are used for localization)
* [x] ensure that steps names are unique __or they will fail PR validation__ (step names are used for localization)
* [x] grep `/subscription/` and ensure that your parameters don't have any hardcoded resourceIds __or they will fail PR validation__
* [x] remove `fallbackResourceIds` and `fromTemplateId` fields from your template workbook __or they will fail PR validation__