### PR TITLE
Create ConditionalAccessInsightsAndReporting.workbook

### DIFF
--- a/Workbooks/Azure Active Directory Conditional Access/Conditional Access Insights and Reporting/ConditionalAccessInsightsAndReporting.workbook
+++ b/Workbooks/Azure Active Directory Conditional Access/Conditional Access Insights and Reporting/ConditionalAccessInsightsAndReporting.workbook
@@ -409,7 +409,7 @@
               "comparison": "isEqualTo",
               "value": "All"
             },
-            "name": "query - 21"
+            "name": "All Policies Summary"
           },
           {
             "type": 1,
@@ -482,7 +482,7 @@
               "comparison": "isNotEqualTo",
               "value": "All"
             },
-            "name": "query - 56"
+            "name": "Individual Policies Summary"
           },
           {
             "type": 1,
@@ -1383,12 +1383,12 @@
             "type": 2,
             "description": "Show result for all enabled policies. Cannot select individual policies that apply to service principals.",
             "isRequired": true,
-            "value": "All",
+            "query": "{\"version\":\"Merge/1.0\",\"merges\":[{\"id\":\"579accbb-074e-44de-91ec-13a63f39508b\",\"mergeType\":\"union\",\"leftTable\":\"Static all enabled policies\",\"rightTable\":\"Graph call enabled\"},{\"id\":\"579accbb-074e-44de-91ec-13a63f39508c\",\"mergeType\":\"union\",\"leftTable\":\"Graph call enabled\",\"rightTable\":\"Graph call report-only\"}],\"projectRename\":[{\"originalName\":\"id\",\"mergedName\":\"id\",\"fromId\":\"unknown\"},{\"originalName\":\"name\",\"mergedName\":\"name\",\"fromId\":\"unknown\"},{\"originalName\":\"group\",\"mergedName\":\"group\",\"fromId\":\"unknown\"},{\"originalName\":\"[Static all enabled policies].id\",\"mergedName\":\"id1\",\"fromId\":\"579accbb-074e-44de-91ec-13a63f39508b\"},{\"originalName\":\"[Static all enabled policies].name\",\"mergedName\":\"name1\",\"fromId\":\"579accbb-074e-44de-91ec-13a63f39508b\"},{\"originalName\":\"[Static all enabled policies].group\",\"mergedName\":\"group1\",\"fromId\":\"579accbb-074e-44de-91ec-13a63f39508b\"}]}",
             "typeSettings": {
               "additionalResourceOptions": [],
               "showDefault": false
             },
-            "jsonData": "[\r\n    {\"value\": \"All\", \"label\": \"All enabled policies\"}\r\n]"
+            "queryType": 7
           },
           {
             "id": "dfa8db4a-0f30-479b-9f11-70ad8d619a1e",
@@ -1497,7 +1497,7 @@
           }
         ],
         "style": "pills",
-        "queryType": 0,
+        "queryType": 7,
         "resourceType": "microsoft.operationalinsights/workspaces"
       },
       "conditionalVisibility": {
@@ -1573,12 +1573,12 @@
               "comparison": "isEqualTo",
               "value": "All"
             },
-            "name": "query - 21"
+            "name": "SPs - All Policies Summary"
           },
           {
             "type": 1,
             "content": {
-              "json": "**Total**: Number of {unit:label} in the {TimeRange}</br>\r\n**Success**: Number of {unit:label} where the selected polic(ies) granted access and the required controls were satisifed</br>\r\n**Failure**: Number of {unit:label} where the selected polic(ies) denied access and the required controls were not satisfied</br>\r\n**User action required**: Number of {unit:label} where the selected report-only policy applied but user action (e.g. MFA or Terms of Use) would be required if the policy were enabled.</br>\r\n**Not applied**: Number of {unit:label} that are bypassing the selected polic(ies) because the sign-in did not match at least one of the assignments or conditions. "
+              "json": "**Total**: Number of {unit:label} in the {TimeRange}</br>\r\n**Success**: Number of {unit:label} where the selected polic(ies) granted access and the required controls were satisifed</br>\r\n**Failure**: Number of {unit:label} where the selected polic(ies) denied access and the required controls were not satisfied</br>\r\n**Not applied**: Number of {unit:label} that are bypassing the selected polic(ies) because the sign-in did not match at least one of the assignments or conditions. "
             },
             "conditionalVisibility": {
               "parameterName": "Guide",
@@ -1591,7 +1591,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "// Total\r\nSigninLogs\r\n| where TimeGenerated {TimeRange:value}\r\n| project ConditionalAccessPolicies, UserPrincipalName, AppDisplayName\r\n| where ConditionalAccessPolicies != \"[]\"\r\n| where \"{User:escape}\" == \"All users\" or UserPrincipalName has \"{User:escape}\"\r\n| where \"{App:escape}\" == \"All apps\" or AppDisplayName has \"{App:escape}\"\r\n| project-away AppDisplayName\r\n| mv-expand ConditionalAccessPolicies\r\n| where ConditionalAccessPolicies[\"id\"] == \"{policy:escape}\"\r\n| project-away ConditionalAccessPolicies\r\n{unit} summarize count() by UserPrincipalName\r\n| summarize count()\r\n| extend resultName = \"Total\", unit = case(\"{unit}\" == \"//\", \"sign-ins\",\"users\"), statusCode = 1\r\n//\r\n//\r\n// Number of success/failure/user action required/not applied\r\n| union (\r\nSigninLogs\r\n| where TimeGenerated {TimeRange:value}\r\n| project ConditionalAccessPolicies, UserPrincipalName, AppDisplayName\r\n| where ConditionalAccessPolicies != \"[]\"\r\n| where \"{User:escape}\" == \"All users\" or UserPrincipalName has \"{User:escape}\"\r\n| where \"{App:escape}\" == \"All apps\" or AppDisplayName has \"{App:escape}\"\r\n| project-away AppDisplayName\r\n| mv-expand ConditionalAccessPolicies\r\n| where ConditionalAccessPolicies[\"id\"] == \"{policy:escape}\"\r\n| extend result = ConditionalAccessPolicies[\"result\"]\r\n| project-away ConditionalAccessPolicies\r\n| extend resultName = case(result == \"success\" or result == \"reportOnlySuccess\", \"Success\", result == \"failure\" or result == \"reportOnlyFailure\", \"Failure\", result == \"interrupt\" or result == \"reportOnlyInterrupted\", \"User action required\", \"Not applied\")\r\n| extend statusCode = case(resultName == \"Success\", 2, resultName == \"Failure\", 3, resultName == \"User action required\", 4, 5)\r\n{unit} summarize count() by resultName, UserPrincipalName, statusCode\r\n| summarize count() by resultName, statusCode\r\n| extend unit = case(\"{unit}\" == \"//\", \"sign-ins\",\"users\")\r\n)\r\n//\r\n// Case if result count is 0\r\n| join kind = fullouter (\r\n    datatable (resultName:string,statusCode1:string)\r\n    [\"Total\", 1,\r\n     \"Success\", 2,\r\n     \"Failure\", 3,\r\n     \"User action required\", 4,\r\n     \"Not applied\", 5]\r\n) on resultName\r\n| extend resultName = iff(resultName == '', resultName1, resultName), count_ = iff(resultName == '', 0, count_), unit = \"{unit:label}\", statusCode1\r\n| project-away resultName1\r\n| sort by statusCode1 asc",
+              "query": "// Total\r\nAADServicePrincipalSignInLogs\r\n| where TimeGenerated {TimeRange:value}\r\n| project ConditionalAccessPolicies, ServicePrincipalId, ResourceDisplayName\r\n| where ConditionalAccessPolicies != \"[]\"\r\n| where \"{spid:escape}\" == \"All service principals\" or ServicePrincipalId has \"{spid:escape}\"\r\n| where \"{App:escape}\" == \"All apps\" or ResourceDisplayName has \"{App:escape}\"\r\n| project-away ResourceDisplayName\r\n| extend test15 = parse_json(ConditionalAccessPolicies)\r\n| mv-expand test15\r\n| where test15[\"id\"] == \"{policy:escape}\"\r\n| project-away test15\r\n{unit} summarize count() by ServicePrincipalId\r\n| summarize count()\r\n| extend resultName = \"Total\", unit = case(\"{unit}\" == \"//\", \"sign-ins\",\"Service Principals\"), statusCode = 1\r\n//\r\n//\r\n// Number of success/failure/user action required/not applied\r\n| union (\r\nAADServicePrincipalSignInLogs\r\n| where TimeGenerated {TimeRange:value}\r\n| project ConditionalAccessPolicies, ServicePrincipalId, ResourceDisplayName\r\n| where ConditionalAccessPolicies != \"[]\"\r\n| where \"{spid:escape}\" == \"All service principals\" or ServicePrincipalId has \"{spid:escape}\"\r\n| where \"{App:escape}\" == \"All apps\" or ResourceDisplayName has \"{App:escape}\"\r\n| project-away ResourceDisplayName\r\n| extend test15 = parse_json(ConditionalAccessPolicies)\r\n| mv-expand test15\r\n| where test15[\"id\"] == \"{policy:escape}\"\r\n| extend result = test15[\"result\"]\r\n| project-away test15\r\n| extend resultName = case(result == \"success\" or result == \"reportOnlySuccess\", \"Success\", result == \"failure\" or result == \"reportOnlyFailure\", \"Failure\", \"Not applied\")\r\n| extend statusCode = case(resultName == \"Success\", 2, resultName == \"Failure\", 3, 4)\r\n{unit} summarize count() by resultName, ServicePrincipalId, statusCode\r\n| summarize count() by resultName, statusCode\r\n| extend unit = case(\"{unit}\" == \"//\", \"sign-ins\",\"Service Principals\")\r\n)\r\n//\r\n// Case if result count is 0\r\n| join kind = fullouter (\r\n    datatable (resultName:string,statusCode1:string)\r\n    [\"Total\", 1,\r\n     \"Success\", 2,\r\n     \"Failure\", 3,\r\n     \"Not applied\", 4]\r\n) on resultName\r\n| extend resultName = iff(resultName == '', resultName1, resultName), count_ = iff(resultName == '', 0, count_), unit = \"{unit:label}\", statusCode1\r\n| project-away resultName1\r\n| sort by statusCode1 asc",
               "size": 3,
               "showAnalytics": true,
               "timeContext": {
@@ -1646,7 +1646,7 @@
               "comparison": "isNotEqualTo",
               "value": "All"
             },
-            "name": "query - 56"
+            "name": "SPs - Individual Policy Summary"
           },
           {
             "type": 1,
@@ -1664,7 +1664,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "AADServicePrincipalSignInLogs\r\n| where TimeGenerated {TimeRange:value}\r\n| project ConditionalAccessPolicies, ServicePrincipalId, ResourceDisplayName, Location\r\n| where ConditionalAccessPolicies != \"\"\r\n| where \"{spid:escape}\" == \"All service principals\" or ServicePrincipalId has \"{spid:escape}\"\r\n| where \"{App:escape}\" == \"All apps\" or ResourceDisplayName has \"{App:escape}\"\r\n| project-away ResourceDisplayName\r\n| mv-expand ConditionalAccessPolicies\r\n| where ConditionalAccessPolicies[\"id\"] == \"{policy:escape}\"\r\n| extend result = ConditionalAccessPolicies[\"result\"]\r\n| project-away ConditionalAccessPolicies\r\n// filter by the result type selected\r\n// Total = any result type (the result type will contain the empty string \"\")\r\n// Success = result types containing \"uccess\" (includes \"success\" and \"reportOnlySuccess\")\r\n// Failure = result types containing \"ailure\" (includes \"failure\" and \"reportOnlyFailure\")\r\n// User action required = result types containing \"nterrupt\" (includes \"interrupt\" and \"reportOnlyInterrupted\")\r\n// Not applied = result types containing \"ot\" (includes \"notApplied\", \"reportOnlyNotApplied\", and \"notEnabled\")\r\n| extend filterResult = case(\"{resultName}\" == \"Total\",\"\", \"{resultName}\" == \"Success\", \"uccess\", \"{resultName}\" == \"Failure\", \"ailure\", \"{resultName}\" == \"User action required\", \"nterrupted\",\"ot\")\r\n| where result contains filterResult\r\n{unit} summarize count() by ServicePrincipalId, Location\r\n| summarize Count = count() by Location\r\n| sort by Count desc",
+              "query": "AADServicePrincipalSignInLogs\r\n| where TimeGenerated {TimeRange:value}\r\n| project ConditionalAccessPolicies, ServicePrincipalId, ResourceDisplayName, Location\r\n| where ConditionalAccessPolicies != \"\"\r\n| where \"{spid:escape}\" == \"All service principals\" or ServicePrincipalId has \"{spid:escape}\"\r\n| where \"{App:escape}\" == \"All apps\" or ResourceDisplayName has \"{App:escape}\"\r\n| project-away ResourceDisplayName\r\n| extend test15 = parse_json(ConditionalAccessPolicies)\r\n| mv-expand test15\r\n| where test15[\"id\"] == \"{policy:escape}\"\r\n| extend result = test15[\"result\"]\r\n| project-away test15\r\n// filter by the result type selected\r\n// Total = any result type (the result type will contain the empty string \"\")\r\n// Success = result types containing \"uccess\" (includes \"success\" and \"reportOnlySuccess\")\r\n// Failure = result types containing \"ailure\" (includes \"failure\" and \"reportOnlyFailure\")\r\n// User action required = result types containing \"nterrupt\" (includes \"interrupt\" and \"reportOnlyInterrupted\")\r\n// Not applied = result types containing \"ot\" (includes \"notApplied\", \"reportOnlyNotApplied\", and \"notEnabled\")\r\n| extend filterResult = case(\"{resultName}\" == \"Total\",\"\", \"{resultName}\" == \"Success\", \"uccess\", \"{resultName}\" == \"Failure\", \"ailure\", \"{resultName}\" == \"User action required\", \"nterrupted\",\"ot\")\r\n| where result contains filterResult\r\n{unit} summarize count() by ServicePrincipalId, Location\r\n| summarize Count = count() by Location\r\n| sort by Count desc",
               "size": 0,
               "showAnalytics": true,
               "title": "Location - {resultName}",
@@ -1811,7 +1811,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "AADServicePrincipalSignInLogs\r\n| where TimeGenerated {TimeRange:value}\r\n| project ConditionalAccessPolicies, ServicePrincipalId, ResourceDisplayName\r\n| where ConditionalAccessPolicies != \"[]\"\r\n| where \"{spid:escape}\" == \"All service principals\" or ServicePrincipalId has \"{spid:escape}\"\r\n| where \"{App:escape}\" == \"All apps\" or ResourceDisplayName has \"{App:escape}\"\r\n| mv-expand ConditionalAccessPolicies\r\n| where ConditionalAccessPolicies[\"id\"] == \"{policy:escape}\"\r\n| extend result = ConditionalAccessPolicies[\"result\"]\r\n| project-away ConditionalAccessPolicies\r\n// filter by the result type selected\r\n// Total = any result type (the result type will contain the empty string \"\")\r\n// Success = result types containing \"uccess\" (includes \"success\" and \"reportOnlySuccess\")\r\n// Failure = result types containing \"ailure\" (includes \"failure\" and \"reportOnlyFailure\")\r\n// User action required = result types containing \"nterrupt\" (includes \"interrupt\" and \"reportOnlyInterrupted\")\r\n// Not applied = result types containing \"ot\" (includes \"notApplied\", \"reportOnlyNotApplied\", and \"notEnabled\")\r\n| extend filterResult = case(\"{resultName}\" == \"Total\",\"\", \"{resultName}\" == \"Success\", \"uccess\", \"{resultName}\" == \"Failure\", \"ailure\", \"{resultName}\" == \"User action required\", \"nterrupted\",\"ot\")\r\n| where result contains filterResult\r\n{unit} summarize count() by ServicePrincipalId, ResourceDisplayName\r\n| summarize Count = count() by ResourceDisplayName\r\n| sort by Count desc",
+              "query": "AADServicePrincipalSignInLogs\r\n| where TimeGenerated {TimeRange:value}\r\n| project ConditionalAccessPolicies, ServicePrincipalId, ResourceDisplayName\r\n| where ConditionalAccessPolicies != \"[]\"\r\n| where \"{spid:escape}\" == \"All service principals\" or ServicePrincipalId has \"{spid:escape}\"\r\n| where \"{App:escape}\" == \"All apps\" or ResourceDisplayName has \"{App:escape}\"\r\n| extend test15 = parse_json(ConditionalAccessPolicies)\r\n| mv-expand test15\r\n| where test15[\"id\"] == \"{policy:escape}\"\r\n| extend result = test15[\"result\"]\r\n| project-away test15\r\n// filter by the result type selected\r\n// Total = any result type (the result type will contain the empty string \"\")\r\n// Success = result types containing \"uccess\" (includes \"success\" and \"reportOnlySuccess\")\r\n// Failure = result types containing \"ailure\" (includes \"failure\" and \"reportOnlyFailure\")\r\n// User action required = result types containing \"nterrupt\" (includes \"interrupt\" and \"reportOnlyInterrupted\")\r\n// Not applied = result types containing \"ot\" (includes \"notApplied\", \"reportOnlyNotApplied\", and \"notEnabled\")\r\n| extend filterResult = case(\"{resultName}\" == \"Total\",\"\", \"{resultName}\" == \"Success\", \"uccess\", \"{resultName}\" == \"Failure\", \"ailure\", \"{resultName}\" == \"User action required\", \"nterrupted\",\"ot\")\r\n| where result contains filterResult\r\n{unit} summarize count() by ServicePrincipalId, ResourceDisplayName\r\n| summarize Count = count() by ResourceDisplayName\r\n| sort by Count desc",
               "size": 1,
               "showAnalytics": true,
               "title": "Resources - {resultName}",
@@ -1939,10 +1939,10 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "SigninLogs\r\n| where TimeGenerated {TimeRange:value}\r\n| project ConditionalAccessPolicies, UserPrincipalName, AppDisplayName\r\n| where ConditionalAccessPolicies != \"[]\"\r\n| where \"{User:escape}\" == \"All users\" or UserPrincipalName has \"{User:escape}\"\r\n| where \"{App:escape}\" == \"All apps\" or AppDisplayName has \"{App:escape}\"\r\n| project-away AppDisplayName\r\n| mv-expand ConditionalAccessPolicies\r\n| where ConditionalAccessPolicies[\"id\"] == \"{policy:escape}\"\r\n| extend result = ConditionalAccessPolicies[\"result\"]\r\n| project-away ConditionalAccessPolicies\r\n// filter by the result type selected\r\n// Total = any result type (the result type will contain the empty string \"\")\r\n// Success = result types containing \"uccess\" (includes \"success\" and \"reportOnlySuccess\")\r\n// Failure = result types containing \"ailure\" (includes \"failure\" and \"reportOnlyFailure\")\r\n// User action required = result types containing \"nterrupt\" (includes \"interrupt\" and \"reportOnlyInterrupted\")\r\n// Not applied = result types containing \"ot\" (includes \"notApplied\", \"reportOnlyNotApplied\", and \"notEnabled\")\r\n| extend filterResult = case(\"{resultName}\" == \"Total\",\"\", \"{resultName}\" == \"Success\", \"uccess\", \"{resultName}\" == \"Failure\", \"ailure\", \"{resultName}\" == \"User action required\", \"nterrupted\",\"ot\")\r\n| where result contains filterResult\r\n| summarize Count = count() by UserPrincipalName\r\n| sort by Count desc",
+              "query": "AADServicePrincipalSignInLogs\r\n| where TimeGenerated {TimeRange:value}\r\n| project ConditionalAccessPolicies, ServicePrincipalId, ResourceDisplayName\r\n| where ConditionalAccessPolicies != \"[]\"\r\n| where \"{spid:escape}\" == \"All service principals\" or ServicePrincipalId has \"{spid:escape}\"\r\n| where \"{App:escape}\" == \"All apps\" or ResourceDisplayName has \"{App:escape}\"\r\n| project-away ResourceDisplayName\r\n| extend test15 = parse_json(ConditionalAccessPolicies)\r\n| mv-expand test15\r\n| where test15[\"id\"] == \"{policy:escape}\"\r\n| extend result = test15[\"result\"]\r\n| project-away test15\r\n// filter by the result type selected\r\n// Total = any result type (the result type will contain the empty string \"\")\r\n// Success = result types containing \"uccess\" (includes \"success\" and \"reportOnlySuccess\")\r\n// Failure = result types containing \"ailure\" (includes \"failure\" and \"reportOnlyFailure\")\r\n// User action required = result types containing \"nterrupt\" (includes \"interrupt\" and \"reportOnlyInterrupted\")\r\n// Not applied = result types containing \"ot\" (includes \"notApplied\", \"reportOnlyNotApplied\", and \"notEnabled\")\r\n| extend filterResult = case(\"{resultName}\" == \"Total\",\"\", \"{resultName}\" == \"Success\", \"uccess\", \"{resultName}\" == \"Failure\", \"ailure\", \"{resultName}\" == \"User action required\", \"nterrupted\",\"ot\")\r\n| where result contains filterResult\r\n| summarize Count = count() by ServicePrincipalId\r\n| sort by Count desc",
               "size": 0,
               "showAnalytics": true,
-              "title": "User sign-in count - {resultName}",
+              "title": "Service Principal sign-in count - {resultName}",
               "timeContext": {
                 "durationMs": 86400000
               },
@@ -2039,7 +2039,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "SigninLogs\r\n| where TimeGenerated {TimeRange:value}\r\n| project ConditionalAccessPolicies, TimeGenerated, UserPrincipalName, AppDisplayName, CorrelationId, Status\r\n| where ConditionalAccessPolicies != \"[]\"\r\n| where '{user:escape}' == '*' or '{user:escape}' == UserPrincipalName\r\n| where \"{User:escape}\" == \"All users\" or UserPrincipalName has \"{User:escape}\"\r\n| where \"{App:escape}\" == \"All apps\" or AppDisplayName has \"{App:escape}\"\r\n| mv-expand ConditionalAccessPolicies\r\n| where ConditionalAccessPolicies[\"id\"] == \"{policy:escape}\"\r\n| extend result = ConditionalAccessPolicies[\"result\"], failureReason = tostring(Status[\"failureReason\"])\r\n| project-away ConditionalAccessPolicies\r\n// filter by the result type selected\r\n// Total = any result type (the result type will contain the empty string \"\")\r\n// Success = result types containing \"uccess\" (includes \"success\" and \"reportOnlySuccess\")\r\n// Failure = result types containing \"ailure\" (includes \"failure\" and \"reportOnlyFailure\")\r\n// User action required = result types containing \"nterrupt\" (includes \"interrupt\" and \"reportOnlyInterrupted\")\r\n// Not applied = result types containing \"ot\" (includes \"notApplied\", \"reportOnlyNotApplied\", and \"notEnabled\")\r\n| extend filterResult = case(\"{resultName}\" == \"Total\",\"\", \"{resultName}\" == \"Success\", \"uccess\", \"{resultName}\" == \"Failure\", \"ailure\", \"{resultName}\" == \"User action required\", \"nterrupted\",\"ot\")\r\n| where result contains filterResult\r\n| project TimeGenerated, UserPrincipalName, AppDisplayName, result, CorrelationId\r\n| sort by TimeGenerated desc",
+              "query": "AADServicePrincipalSignInLogs\r\n| where TimeGenerated {TimeRange:value}\r\n| project ConditionalAccessPolicies, TimeGenerated, ServicePrincipalId, ResourceDisplayName, CorrelationId\r\n| where ConditionalAccessPolicies != \"[]\"\r\n| where \"{spid:escape}\" == \"All service principals\" or ServicePrincipalId has \"{spid:escape}\"\r\n| where \"{App:escape}\" == \"All apps\" or ResourceDisplayName has \"{App:escape}\"\r\n| extend test15 = parse_json(ConditionalAccessPolicies)\r\n| mv-expand test15\r\n| where test15[\"id\"] == \"{policy:escape}\"\r\n| extend result = test15[\"result\"]//, failureReason = tostring(Status[\"failureReason\"])\r\n| project-away test15\r\n| extend filterResult = case(\"{resultName}\" == \"Total\",\"\", \"{resultName}\" == \"Success\", \"success\", \"{resultName}\" == \"Failure\", \"failure\", \"notApplied\")\r\n| where result contains filterResult\r\n| project TimeGenerated, ServicePrincipalId, ResourceDisplayName, result, CorrelationId\r\n| sort by TimeGenerated desc",
               "size": 0,
               "showAnalytics": true,
               "title": "Sign-in events - {resultName}",


### PR DESCRIPTION
Making the following changes to the CA Insights workbook:
1. Added ability to select individual policies for Service Principals
2. Introduced a few new queries so as to be able to obtain results accurately for CA Summary, Sign-in etc. This includes using the parse_json queries to be able to filter out data from the AADServicePrincipalSignInLogs approppriately

Change were tested successfully in the Woodgrove tenant. Please look at the workbook titled 'CA Insights - Krishna test' to view the test workbook that contains these changes.