### PR TITLE
Fix RDMA chart in HCI Insights

### DIFF
--- a/Workbooks/Azure Stack HCI/AtScale/Insights.workbook
+++ b/Workbooks/Azure Stack HCI/AtScale/Insights.workbook
@@ -272,8 +272,8 @@
           }
         ],
         "style": "pills",
-        "queryType": 1,
-        "resourceType": "microsoft.resourcegraph/resources"
+        "queryType": 0,
+        "resourceType": "microsoft.resources/subscriptions"
       },
       "name": "HCI Parameters",
       "styleSettings": {
@@ -1008,7 +1008,7 @@
                 {
                   "type": 1,
                   "content": {
-                    "json": "View the health of volumes accross monitored clusters—expand a cluster to see the state of individual volumes."
+                    "json": "View the health of volumes across monitored clusters—expand a cluster to see the state of individual volumes."
                   },
                   "name": "storage text"
                 },

--- a/Workbooks/Azure Stack HCI/SingleCluster/Cluster.workbook
+++ b/Workbooks/Azure Stack HCI/SingleCluster/Cluster.workbook
@@ -479,7 +479,7 @@
                   "type": 3,
                   "content": {
                     "version": "KqlItem/1.0",
-                    "query": "let Health = Event\r\n| where EventLog =~ \"Microsoft-Windows-Health/Operational\"\r\n| extend description = parse_json(RenderedDescription)\r\n| extend CorrelationId = tostring(description.CorrelationId)\r\n| where CorrelationId =~ '{lastCorrelationId}'\r\n| where tostring(description.Fault.ObjectType) == 'Microsoft.Health.EntityType.Server'\r\n| extend NodeId = tolower(tostring(description.Fault.ObjectId))\r\n| extend Severity = toint(description.Fault.Severity)\r\n| extend Severity = iff(Severity > 2, -1, Severity)\r\n| summarize Status = max(Severity) by NodeId;\r\n\r\nEvent\r\n| where EventLog =~ \"Microsoft-Windows-SDDC-Management/Operational\" and EventID == \"3000\"\r\n| extend ClsuterData = parse_xml(EventData)\r\n| extend ClusterName = tostring(ClsuterData.DataItem.UserData.EventData[\"ClusterName\"])\r\n| extend ClusterArmId = tostring(ClsuterData.DataItem.UserData.EventData[\"ArmId\"])\r\n| where ClusterArmId =~ '{resource}'\r\n| summarize arg_max(TimeGenerated,*) by ClusterArmId\r\n| extend ArmPrefix = extract(@'(.+/)[^/]+$', 1, _ResourceId)\r\n| extend servers_information = parse_json(RenderedDescription).m_servers\r\n| mv-expand servers_information\r\n| extend Nodename = tostring(servers_information.m_name)\r\n| extend NodeId = tolower(Nodename)\r\n| join kind=leftouter Health on NodeId\r\n| extend serverArmId = strcat(ArmPrefix, Nodename)\r\n| extend UsedCpu = toint(servers_information.m_totalProcessorsUsedPercentage)\r\n| extend AvailableCpu = 100 - UsedCpu\r\n| extend UsedMemory = todecimal(servers_information.m_usedPhysicalMemoryInBytes)\r\n| extend TotalMemory = todecimal(servers_information.m_totalPhysicalMemoryInBytes)\r\n| extend TotalMemory = iff(TotalMemory == 0.0, todecimal(1), TotalMemory)\r\n| extend AvailableMemory = TotalMemory - UsedMemory\r\n| extend MemoryUsage = round(UsedMemory/TotalMemory*100, 0)\r\n| extend LogicalProcessors = toint(servers_information.m_totalLogicalProcessors)\r\n| extend PhysicalProcessors = toint(servers_information.m_totalPhysicalProcessors)\r\n| extend Site = tostring(servers_information.m_site)\r\n| extend Uptime = tolong(servers_information.m_uptimeInSeconds)\r\n| extend DomainGroup = extract(@'[^\\.]+\\.(.+)', 1, Computer)\r\n| order by tolower(Nodename) asc\r\n| project serverArmId, Nodename, LastUpdated = TimeGenerated, Status, UsedCpu, AvailableCpu, MemoryUsage, UsedMemory, AvailableMemory, LogicalProcessors, PhysicalProcessors, Uptime, Site, DomainGroup",
+                    "query": "let Health = Event\r\n| where EventLog =~ \"Microsoft-Windows-Health/Operational\"\r\n| extend description = parse_json(RenderedDescription)\r\n| extend CorrelationId = tostring(description.CorrelationId)\r\n| where CorrelationId =~ '{lastCorrelationId}'\r\n| where tostring(description.Fault.ObjectType) == 'Microsoft.Health.EntityType.Server'\r\n| extend NodeId = tolower(tostring(description.Fault.ObjectId))\r\n| extend Severity = toint(description.Fault.Severity)\r\n| extend Severity = iff(Severity > 2, -1, Severity)\r\n| summarize Status = max(Severity) by NodeId;\r\n\r\nEvent\r\n| where EventLog =~ \"Microsoft-Windows-SDDC-Management/Operational\" and EventID == \"3000\"\r\n| extend ClsuterData = parse_xml(EventData)\r\n| extend ClusterName = tostring(ClsuterData.DataItem.UserData.EventData[\"ClusterName\"])\r\n| extend ClusterArmId = tostring(ClsuterData.DataItem.UserData.EventData[\"ArmId\"])\r\n| where ClusterArmId =~ '{resource}'\r\n| summarize arg_max(TimeGenerated,*) by ClusterArmId\r\n| extend ArmPrefix = extract(@'(.+/)[^/]+$', 1, _ResourceId)\r\n| extend servers_information = parse_json(RenderedDescription).m_servers\r\n| mv-expand servers_information\r\n| extend Nodename = tostring(servers_information.m_name)\r\n| extend NodeId = tolower(Nodename)\r\n| join kind=leftouter Health on NodeId\r\n| extend serverArmId = strcat(ArmPrefix, Nodename)\r\n| extend UsedCpu = toint(servers_information.m_totalProcessorsUsedPercentage)\r\n| extend AvailableCpu = 100 - UsedCpu\r\n| extend TotalMemory = todecimal(servers_information.m_totalPhysicalMemoryInBytes)\r\n| extend UsedMemory = iff(TotalMemory == 0.0, todecimal(0.0), todecimal(servers_information.m_usedPhysicalMemoryInBytes))\r\n| extend AvailableMemory = iff(TotalMemory == 0.0, todecimal(1.0), todecimal(TotalMemory - UsedMemory))\r\n| extend MemoryUsage = iff(TotalMemory == 0.0, todecimal(0.0), todecimal(round(UsedMemory/TotalMemory*100, 0)))\r\n| extend LogicalProcessors = toint(servers_information.m_totalLogicalProcessors)\r\n| extend PhysicalProcessors = toint(servers_information.m_totalPhysicalProcessors)\r\n| extend Site = tostring(servers_information.m_site)\r\n| extend Uptime = tolong(servers_information.m_uptimeInSeconds)\r\n| extend DomainGroup = extract(@'[^\\.]+\\.(.+)', 1, Computer)\r\n| order by tolower(Nodename) asc\r\n| project serverArmId, Nodename, LastUpdated = TimeGenerated, Status, UsedCpu, AvailableCpu, MemoryUsage, UsedMemory, AvailableMemory, LogicalProcessors, PhysicalProcessors, Uptime, Site, DomainGroup",
                     "size": 3,
                     "showAnalytics": true,
                     "timeContextFromParameter": "timeRange",
@@ -607,22 +607,7 @@
                         },
                         {
                           "columnMatch": "UsedMemory",
-                          "formatter": 5,
-                          "formatOptions": {
-                            "compositeBarSettings": {
-                              "labelText": "",
-                              "columnSettings": [
-                                {
-                                  "columnName": "UsedMemory",
-                                  "color": "blue"
-                                },
-                                {
-                                  "columnName": "AvailableMemory",
-                                  "color": "gray"
-                                }
-                              ]
-                            }
-                          }
+                          "formatter": 5
                         },
                         {
                           "columnMatch": "AvailableMemory",
@@ -914,7 +899,7 @@
                           "visualization": "linechart",
                           "chartSettings": {
                             "yAxis": [
-                              "TotalRdmaUsage"
+                              "RdmaUsage"
                             ],
                             "ySettings": {
                               "numberFormatSettings": {
@@ -1757,7 +1742,7 @@
                           "query": "let Health = Event\r\n| where EventLog =~ \"Microsoft-Windows-Health/Operational\"\r\n| extend description = parse_json(RenderedDescription)\r\n| extend CorrelationId = tostring(description.CorrelationId)\r\n| where CorrelationId =~ '{lastCorrelationId}'\r\n| where tostring(description.Fault.RootObjectType) == 'Microsoft.Health.EntityType.PhysicalDisk'\r\n| extend driveId = tostring(description.Fault.RootObjectId)\r\n| extend Severity = toint(description.Fault.Severity)\r\n| extend Severity = iff(Severity > 2, -1, Severity)\r\n| summarize Status = max(Severity) by driveId;\r\n\r\nEvent\r\n| where EventLog =~ \"Microsoft-Windows-SDDC-Management/Operational\" and EventID == \"3001\"\r\n| extend ClsuterData = parse_xml(EventData)\r\n| extend ClusterName = tostring(ClsuterData.DataItem.UserData.EventData[\"ClusterName\"])\r\n| extend ClusterArmId = tostring(ClsuterData.DataItem.UserData.EventData[\"ArmId\"])\r\n| where ClusterArmId =~ '{resource}'\r\n| extend Description = parse_json(RenderedDescription)\r\n| extend CorrelationId = tostring(Description.m_correlationId)\r\n| where CorrelationId =~ '{lastCorrelationId}'\r\n| extend drives_information = Description.m_drives\r\n| where array_length(drives_information) > 0\r\n| mv-expand drives_information\r\n| extend driveId = tostring(drives_information.m_uniqueId)\r\n| join kind=leftouter Health on driveId\r\n| extend TotalCapacity = tolong(drives_information.m_sizeInBytes)\r\n| extend AvailableCapacity = TotalCapacity - tolong(drives_information.m_sizeUsedInBytes)\r\n| project Drives = driveId, LastUpdated = TimeGenerated, Status, AvailableCapacity, TotalCapacity, CanPool = iff(tobool(drives_information.m_canPool), \"Yes\", \"No\")",
                           "size": 0,
                           "showAnalytics": true,
-                          "noDataMessage": "Install the latest OS update on this cluster to show complete drive info.",
+                          "noDataMessage": "Install the latest OS update on this cluster to show complete drive info. Learn more: https://docs.microsoft.com/en-us/azure-stack/hci/manage/update-cluster",
                           "noDataMessageStyle": 4,
                           "timeContextFromParameter": "timeRange",
                           "showRefreshButton": true,


### PR DESCRIPTION
## PR Checklist

* [x] Explain your changes, so people looking at the PR know *what* and *why*, the code changes are the *how*.
- RDMA was not shown in the chart as the name of parameter was not correct.
- Added a link of HCI update instructions to drive error message.
- Fix memory column in server tab for 0 total memory

### If adding or updating templates:
* [x] post a screenshot of templates and/or gallery changes
* [x] ensure your template has a corresponding gallery entry in the gallery folder
* [x] If you are adding a new template, add your team and template/gallery file(s) to the CODEOWNERS file. CODEOWNERS entries should be teams, not individuals
* [x] ensure all steps have meaningful names
* [x] ensure all parameters and grid columns have display names set so they can be localized
* [x] ensure that parameters id values are unique __or they will fail PR validation__ (parameter ids are used for localization)
* [x] ensure that steps names are unique __or they will fail PR validation__ (step names are used for localization)
* [x] grep `/subscription/` and ensure that your parameters don't have any hardcoded resourceIds __or they will fail PR validation__
* [x] remove `fallbackResourceIds` and `fromTemplateId` fields from your template workbook __or they will fail PR validation__