### PR TITLE
fixing Defender for App Service calculation

### DIFF
--- a/Workbooks/Azure Security Center/Price Estimation/PriceEstimation.workbook
+++ b/Workbooks/Azure Security Center/Price Estimation/PriceEstimation.workbook
@@ -1624,105 +1624,29 @@
             "name": "AppService banner"
           },
           {
-            "type": 10,
+            "type": 3,
             "content": {
-              "chartId": "workbook111925bd-7b17-4874-8cf3-fe3cf8977589",
-              "version": "MetricsItem/2.0",
+              "version": "KqlItem/1.0",
+              "query": "resources\n| where type == \"microsoft.web/serverfarms\"\n| extend tier = sku.tier, numberOfworkers = properties.numberOfWorkers\n| where tier != \"consumption\"\n| project id, subscriptionId, tier, numberOfworkers",
               "size": 0,
-              "chartType": 0,
-              "resourceType": "microsoft.web/sites",
-              "metricScope": 0,
-              "resourceParameter": "AppService",
-              "resourceIds": [
-                "{AppService}"
-              ],
-              "timeContextFromParameter": "TimeRange",
-              "timeContext": {
-                "durationMs": 604800000
-              },
-              "metrics": [
-                {
-                  "namespace": "microsoft.web/sites",
-                  "metric": "microsoft.web/sites--CpuTime",
-                  "aggregation": 1
-                }
-              ],
-              "gridSettings": {
-                "formatters": [
-                  {
-                    "columnMatch": "Subscription",
-                    "formatter": 5
-                  },
-                  {
-                    "columnMatch": "Name",
-                    "formatter": 13,
-                    "formatOptions": {
-                      "linkTarget": "Resource"
-                    }
-                  },
-                  {
-                    "columnMatch": "microsoft.keyvault/vaults--ServiceApiHit Timeline",
-                    "formatter": 5
-                  },
-                  {
-                    "columnMatch": "microsoft.keyvault/vaults--ServiceApiHit",
-                    "formatter": 1,
-                    "numberFormat": {
-                      "unit": 0,
-                      "options": null
-                    }
-                  },
-                  {
-                    "columnMatch": "microsoft.web/sites--AverageResponseTime Timeline",
-                    "formatter": 5
-                  },
-                  {
-                    "columnMatch": "microsoft.web/sites--AverageResponseTime",
-                    "formatter": 1,
-                    "numberFormat": {
-                      "unit": 24,
-                      "options": null
-                    }
-                  },
-                  {
-                    "columnMatch": "microsoft.web/sites--CpuTime Timeline",
-                    "formatter": 5
-                  },
-                  {
-                    "columnMatch": "microsoft.web/sites--CpuTime",
-                    "formatter": 1,
-                    "numberFormat": {
-                      "unit": 24,
-                      "options": null
-                    }
-                  }
-                ],
-                "rowLimit": 10000,
-                "labelSettings": [
-                  {
-                    "columnId": "microsoft.web/sites--CpuTime",
-                    "label": "CPU Time (Sum)"
-                  },
-                  {
-                    "columnId": "microsoft.web/sites--CpuTime Timeline",
-                    "label": "CPU Time Timeline"
-                  }
-                ]
-              }
+              "queryType": 1,
+              "resourceType": "microsoft.resourcegraph/resources",
+              "crossComponentResources": [
+                "{Subscriptions}"
+              ]
             },
             "conditionalVisibility": {
-              "parameterName": "{blank}",
-              "comparison": "isEqualTo",
-              "value": "0"
+              "parameterName": "blank",
+              "comparison": "isNotEqualTo"
             },
-            "name": "AppService metric"
+            "name": "AppService query"
           },
           {
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "{\"version\":\"Merge/1.0\",\"merges\":[{\"id\":\"5d53c9ab-e18d-4145-83f5-e0f549c18313\",\"mergeType\":\"table\",\"leftTable\":\"AppService metric\"}],\"projectRename\":[{\"originalName\":\"[AppService metric].Name\",\"mergedName\":\"Name\",\"fromId\":\"5d53c9ab-e18d-4145-83f5-e0f549c18313\"},{\"originalName\":\"[Added column]\",\"mergedName\":\"CPU Time\",\"fromId\":null,\"isNewItem\":true,\"newItemData\":[{\"criteriaContext\":{\"leftOperand\":\"CPU Time (Sum)\",\"operator\":\"isNotNull\",\"rightValType\":\"column\",\"resultValType\":\"expression\",\"resultVal\":\"([\\\"CPU Time (Sum)\\\"])/3600\"}},{\"criteriaContext\":{\"operator\":\"Default\",\"rightValType\":\"column\",\"resultValType\":\"static\",\"resultVal\":\"0\"}}]},{\"originalName\":\"[Added column]\",\"mergedName\":\"Estimated Price (7 days)\",\"fromId\":null,\"isNewItem\":true,\"newItemData\":[{\"criteriaContext\":{\"leftOperand\":\"CPU Time\",\"operator\":\"isNotNull\",\"rightValType\":\"column\",\"resultValType\":\"expression\",\"resultVal\":\"[\\\"CPU Time\\\"]*0.02\"}},{\"criteriaContext\":{\"operator\":\"Default\",\"rightValType\":\"column\",\"resultValType\":\"static\",\"resultVal\":\"0\"}}]},{\"originalName\":\"[Added column]\",\"mergedName\":\"Total Estimated Cost\",\"fromId\":null,\"isNewItem\":true,\"newItemData\":[{\"criteriaContext\":{\"operator\":\"Default\",\"rightValType\":\"column\",\"resultValType\":\"static\",\"resultVal\":\"Total Estimated Cost\"}}]},{\"originalName\":\"[Added column]\",\"mergedName\":\"Estimated Monthly Price\",\"fromId\":null,\"isNewItem\":true,\"newItemData\":[{\"criteriaContext\":{\"leftOperand\":\"Estimated Price (7 days)\",\"operator\":\"isNotNull\",\"rightValType\":\"column\",\"resultValType\":\"expression\",\"resultVal\":\"[\\\"Estimated Price (7 days)\\\"]*4.35\"}},{\"criteriaContext\":{\"operator\":\"Default\",\"rightValType\":\"column\",\"resultValType\":\"static\",\"resultVal\":\"0\"}}]},{\"originalName\":\"[AppService metric].Subscription\",\"mergedName\":\"Subscription\",\"fromId\":\"5d53c9ab-e18d-4145-83f5-e0f549c18313\"},{\"originalName\":\"[AppService metric].microsoft.web/sites--CpuTime\",\"mergedName\":\"CPU Time (Sum)\",\"fromId\":\"5d53c9ab-e18d-4145-83f5-e0f549c18313\"},{\"originalName\":\"[AppService metric].microsoft.web/sites--CpuTime Timeline\",\"mergedName\":\"CPU Time Timeline\",\"fromId\":\"5d53c9ab-e18d-4145-83f5-e0f549c18313\"}]}",
-              "size": 3,
+              "query": "{\"version\":\"Merge/1.0\",\"merges\":[{\"id\":\"f71bccb7-6ea5-4098-81fb-57e7c87bf09a\",\"mergeType\":\"table\",\"leftTable\":\"AppService query\"}],\"projectRename\":[{\"originalName\":\"[AppService query].id\",\"mergedName\":\"App service name\",\"fromId\":\"f71bccb7-6ea5-4098-81fb-57e7c87bf09a\"},{\"originalName\":\"[AppService query].subscriptionId\",\"mergedName\":\"subscriptionId\",\"fromId\":\"f71bccb7-6ea5-4098-81fb-57e7c87bf09a\"},{\"originalName\":\"[AppService query].tier\",\"mergedName\":\"tier\",\"fromId\":\"f71bccb7-6ea5-4098-81fb-57e7c87bf09a\"},{\"originalName\":\"[AppService query].numberOfworkers\",\"mergedName\":\"Active worker nodes\",\"fromId\":\"f71bccb7-6ea5-4098-81fb-57e7c87bf09a\"},{\"originalName\":\"[Added column]\",\"mergedName\":\"Estimated monthly price\",\"fromId\":null,\"isNewItem\":true,\"newItemData\":[{\"criteriaContext\":{\"operator\":\"Default\",\"rightValType\":\"column\",\"resultValType\":\"expression\",\"resultVal\":\"[\\\"Active worker nodes\\\"]*15\"}}]},{\"originalName\":\"[Added column]\",\"mergedName\":\"Total Estimated Cost\",\"fromId\":null,\"isNewItem\":true,\"newItemData\":[{\"criteriaContext\":{\"operator\":\"Default\",\"rightValType\":\"column\",\"resultValType\":\"static\",\"resultVal\":\"Total estimated cost\"}}]}]}",
+              "size": 0,
               "queryType": 7,
               "gridSettings": {
                 "formatters": [
@@ -1732,56 +1656,33 @@
                     "formatOptions": {
                       "linkTarget": "Resource",
                       "showIcon": true,
-                      "customColumnWidthSetting": "51ch"
+                      "customColumnWidthSetting": "40ch"
                     }
                   },
                   {
-                    "columnMatch": "Name",
-                    "formatter": 13,
-                    "formatOptions": {
-                      "linkTarget": "Resource",
-                      "showIcon": true
-                    }
-                  },
-                  {
-                    "columnMatch": "CPU Time",
+                    "columnMatch": "App service name",
                     "formatter": 0,
                     "formatOptions": {
-                      "aggregation": "Sum"
-                    },
-                    "numberFormat": {
-                      "unit": 26,
-                      "options": {
-                        "style": "decimal"
-                      }
+                      "customColumnWidthSetting": "46ch"
                     }
                   },
                   {
-                    "columnMatch": "Estimated Price (7 days)",
-                    "formatter": 3,
-                    "formatOptions": {
-                      "palette": "blue",
-                      "aggregation": "Sum"
-                    },
-                    "numberFormat": {
-                      "unit": 0,
-                      "options": {
-                        "currency": "USD",
-                        "style": "currency",
-                        "useGrouping": true,
-                        "minimumFractionDigits": 2,
-                        "maximumFractionDigits": 2
-                      }
-                    }
-                  },
-                  {
-                    "columnMatch": "Total Estimated Cost",
+                    "columnMatch": "subscriptionId",
                     "formatter": 5
                   },
                   {
-                    "columnMatch": "Estimated Monthly Price",
+                    "columnMatch": "tier",
+                    "formatter": 5
+                  },
+                  {
+                    "columnMatch": "Active worker nodes",
+                    "formatter": 5
+                  },
+                  {
+                    "columnMatch": "Estimated monthly price",
                     "formatter": 3,
                     "formatOptions": {
+                      "min": 0,
                       "palette": "yellow",
                       "aggregation": "Sum"
                     },
@@ -1790,21 +1691,12 @@
                       "options": {
                         "currency": "USD",
                         "style": "currency",
-                        "minimumFractionDigits": 2,
                         "maximumFractionDigits": 2
                       }
                     }
                   },
                   {
-                    "columnMatch": "Subscription",
-                    "formatter": 5
-                  },
-                  {
-                    "columnMatch": "CPU Time (Sum)",
-                    "formatter": 5
-                  },
-                  {
-                    "columnMatch": "CPU Time Timeline",
+                    "columnMatch": "Total Estimated Cost",
                     "formatter": 5
                   }
                 ],
@@ -1814,30 +1706,14 @@
                   "treeType": 1,
                   "groupBy": [
                     "Total Estimated Cost",
-                    "Subscription"
+                    "subscriptionId"
                   ],
                   "expandTopLevel": true
                 },
                 "labelSettings": [
                   {
-                    "columnId": "Name",
-                    "label": "App service name"
-                  },
-                  {
-                    "columnId": "CPU Time",
-                    "label": "Weekly runtime"
-                  },
-                  {
-                    "columnId": "Estimated Price (7 days)",
-                    "label": "Estimated price (7 days)"
-                  },
-                  {
                     "columnId": "Total Estimated Cost",
                     "label": "Subscription"
-                  },
-                  {
-                    "columnId": "Estimated Monthly Price",
-                    "label": "Estimated monthly price"
                   }
                 ]
               }
@@ -1846,7 +1722,8 @@
               "parameterName": "AppService",
               "comparison": "isNotEqualTo"
             },
-            "name": "AppService result"
+            "showPin": false,
+            "name": "App Service result"
           }
         ]
       },


### PR DESCRIPTION
## PR Checklist

* [X] Explain your changes, so people looking at the PR know *what* and *why*, the code changes are the *how*.
Defender for App Service calculation was reported to be incorrect. This change fixes calculation to align with actual billing as it is being used in Defender for Cloud's backend.

### If adding or updating templates:
* [x] post a screenshot of templates and/or gallery changes
![priceEstimation](https://user-images.githubusercontent.com/32520935/166479741-1371d3a2-5f14-45a2-8c7f-daf674baf14e.png)

* [x] ensure your template has a corresponding gallery entry in the gallery folder
* [x] If you are adding a new template, add your team and template/gallery file(s) to the CODEOWNERS file. CODEOWNERS entries should be teams, not individuals
* [x] ensure all steps have meaningful names
* [x] ensure all parameters and grid columns have display names set so they can be localized
* [x] ensure that parameters id values are unique __or they will fail PR validation__ (parameter ids are used for localization)
* [x] ensure that steps names are unique __or they will fail PR validation__ (step names are used for localization)
* [x] grep `/subscription/` and ensure that your parameters don't have any hardcoded resourceIds __or they will fail PR validation__
* [x] remove `fallbackResourceIds` and `fromTemplateId` fields from your template workbook __or they will fail PR validation__