### PR TITLE
Add workbook to display Continuos Access Evaluation Insignts per SignIn

### DIFF
--- a/Workbooks/Azure Active Directory Conditional Access/Continuous Access Evaluation Per SignIn/CAEPerSignIn.workbook
+++ b/Workbooks/Azure Active Directory Conditional Access/Continuous Access Evaluation Per SignIn/CAEPerSignIn.workbook
@@ -1,0 +1,179 @@
+{
+  "version": "Notebook/1.0",
+  "items": [
+    {
+      "type": 1,
+      "content": {
+        "json": "## Continuous access evaluation token insights per SignIn"
+      },
+      "name": "text - 2"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "This workbook chains multiple requests from sign-in logs and displays a single request for which CAE token was issued."
+      },
+      "name": "text - 1"
+    },
+    {
+      "type": 12,
+      "content": {
+        "version": "NotebookGroup/1.0",
+        "groupType": "editable",
+        "items": [
+          {
+            "type": 9,
+            "content": {
+              "version": "KqlParameterItem/1.0",
+              "parameters": [
+                {
+                  "id": "b0358364-657a-49f4-8fa6-7327928d80ad",
+                  "version": "KqlParameterItem/1.0",
+                  "name": "TimeRange",
+                  "label": "Time Range",
+                  "type": 4,
+                  "description": "Filter data for specified duration",
+                  "isRequired": true,
+                  "value": {
+                    "durationMs": 3600000
+                  },
+                  "typeSettings": {
+                    "selectableValues": [
+                      {
+                        "durationMs": 300000
+                      },
+                      {
+                        "durationMs": 900000
+                      },
+                      {
+                        "durationMs": 1800000
+                      },
+                      {
+                        "durationMs": 3600000
+                      },
+                      {
+                        "durationMs": 14400000
+                      },
+                      {
+                        "durationMs": 43200000
+                      },
+                      {
+                        "durationMs": 86400000
+                      }
+                    ],
+                    "allowCustom": true
+                  },
+                  "timeContext": {
+                    "durationMs": 86400000
+                  }
+                },
+                {
+                  "id": "eea4af22-cd29-45c0-b877-4808c0d1e557",
+                  "version": "KqlParameterItem/1.0",
+                  "name": "CAETokenValue",
+                  "label": "Is CAE Token",
+                  "type": 2,
+                  "description": "Paramater to determine if the CAE token was issued",
+                  "isRequired": true,
+                  "multiSelect": true,
+                  "quote": "",
+                  "delimiter": ",",
+                  "typeSettings": {
+                    "additionalResourceOptions": [
+                      "value::all"
+                    ],
+                    "selectAllValue": "",
+                    "showDefault": false
+                  },
+                  "jsonData": "[{\"value\": \"1\", \"label\": \"True\", \"selected\": true},{\"value\": \"0\", \"label\": \"False\", \"selected\": false}]",
+                  "value": [
+                    "1"
+                  ]
+                },
+                {
+                  "id": "5f414a83-9dbc-4291-821a-7f72831881f2",
+                  "version": "KqlParameterItem/1.0",
+                  "name": "Application",
+                  "type": 2,
+                  "description": "Select name of application to filter data",
+                  "isRequired": true,
+                  "multiSelect": true,
+                  "quote": "'",
+                  "delimiter": ",",
+                  "query": "SigninLogs\r\n| union AADNonInteractiveUserSignInLogs\r\n| extend compressedvalue = replace_string(AuthenticationProcessingDetails, \" \" , \"\")\r\n| extend compressedvalue = replace_string(compressedvalue, \"\\r\\n\" , \"\")\r\n| parse-where compressedvalue with * \"IsCAEToken\\\",\\\"value\\\":\\\"\" IsTokenCAE\"\\\"\" *\r\n| extend token = iif(IsTokenCAE==true, 1, 0)\r\n| where token in ({CAETokenValue})\r\n| summarize Count = count() by AppDisplayName\r\n| order by Count desc, AppDisplayName asc\r\n| take 10\r\n| project Value = AppDisplayName, Label = AppDisplayName, Selected = false\r\n",
+                  "typeSettings": {
+                    "additionalResourceOptions": [
+                      "value::all"
+                    ],
+                    "selectAllValue": "",
+                    "showDefault": false
+                  },
+                  "timeContext": {
+                    "durationMs": 0
+                  },
+                  "timeContextFromParameter": "TimeRange",
+                  "defaultValue": "value::all",
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "value": [
+                    "value::all"
+                  ]
+                },
+                {
+                  "id": "97f871e7-07cb-4c66-ba24-1222d2b18920",
+                  "version": "KqlParameterItem/1.0",
+                  "name": "Resource",
+                  "type": 2,
+                  "description": "Select name of the resource to filter data",
+                  "isRequired": true,
+                  "multiSelect": true,
+                  "quote": "'",
+                  "delimiter": ",",
+                  "query": "SigninLogs\r\n| union AADNonInteractiveUserSignInLogs\r\n| extend compressedvalue = replace_string(AuthenticationProcessingDetails, \" \" , \"\")\r\n| extend compressedvalue = replace_string(compressedvalue, \"\\r\\n\" , \"\")\r\n| parse-where compressedvalue with * \"IsCAEToken\\\",\\\"value\\\":\\\"\" IsTokenCAE\"\\\"\" *\r\n| extend token = iif(IsTokenCAE==true, 1, 0)\r\n| where token in ({CAETokenValue})\r\n| summarize Count = count() by ResourceDisplayName\r\n| order by Count desc, ResourceDisplayName asc\r\n| take 10\r\n| project Value = ResourceDisplayName, Label = ResourceDisplayName, Selected = false",
+                  "value": [
+                    "value::all"
+                  ],
+                  "typeSettings": {
+                    "additionalResourceOptions": [
+                      "value::all"
+                    ]
+                  },
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces"
+                }
+              ],
+              "style": "pills",
+              "queryType": 0,
+              "resourceType": "microsoft.operationalinsights/workspaces"
+            },
+            "name": "parameters - 1"
+          },
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "SigninLogs\r\n| union (AADNonInteractiveUserSignInLogs)\r\n| where AppDisplayName in ({Application})\r\n| where ResourceDisplayName in ({Resource})\r\n| extend compressedvalue = replace_string(AuthenticationProcessingDetails, \" \" , \"\")\r\n| extend compressedvalue = replace_string(compressedvalue, \"\\r\\n\" , \"\")\r\n| parse-where compressedvalue with * \"IsCAEToken\\\",\\\"value\\\":\\\"\" IsTokenCAE\"\\\"\" *\r\n| extend token = iif(IsTokenCAE==true, 1, 0)\r\n| where token in ({CAETokenValue})\r\n| summarize  arg_max(token, CreatedDateTime, Id, UserDisplayName) by CorrelationId, AppDisplayName, ResourceDisplayName\r\n| project ['User'] = UserDisplayName, ['CorrelationId'] = CorrelationId, ['Is CAE Token'] = token > 0, ['Application'] = AppDisplayName, ['Resource'] = ResourceDisplayName, ['RequestId'] = Id, ['Request DateTime'] = CreatedDateTime\r\n",
+              "size": 3,
+              "showAnalytics": true,
+              "title": "Continuous access evaluation token insights based on CorrelationId",
+              "noDataMessage": "No results found for specified criteria",
+              "timeContextFromParameter": "TimeRange",
+              "showExportToExcel": true,
+              "queryType": 0,
+              "resourceType": "microsoft.operationalinsights/workspaces",
+              "visualization": "table",
+              "gridSettings": {
+                "filter": true
+              },
+              "sortBy": []
+            },
+            "showPin": true,
+            "name": "query - 1"
+          }
+        ]
+      },
+      "name": "group - 0"
+    }
+  ],
+  "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
+}

--- a/gallery/workbook/microsoft.aadiam-tenant.json
+++ b/gallery/workbook/microsoft.aadiam-tenant.json
@@ -93,6 +93,11 @@
 					"name": "Continuous access evaluation insights"
 				},
 				{
+					"id": "Workbooks/Azure Active Directory Conditional Access/Continuous Access Evaluation Per SignIn",
+					"author": "Microsoft",
+					"name": "Continuous Access Evaluation Per SignIn"
+				},
+				{
 					"id": "Workbooks/Azure Active Directory Conditional Access/By conditional access status",
 					"author": "Microsoft",
 					"name": "Sign-ins by Conditional Access Status (Deprecated)"


### PR DESCRIPTION
## Description:
Add new workbbok template to display CAE insights per Sign In.

## Validation:
Verified the workbook in woodgrove tenant.

## Screenshot:
![image](https://user-images.githubusercontent.com/99998257/169382682-e0aa92e7-f24f-4f4d-9ce8-655b9d761c45.png)







## PR Checklist

* [x] Explain your changes, so people looking at the PR know *what* and *why*, the code changes are the *how*.

### If adding or updating templates:
* [x] post a screenshot of templates and/or gallery changes
* [x] ensure your template has a corresponding gallery entry in the gallery folder
* [ ] If you are adding a new template, add your team and template/gallery file(s) to the CODEOWNERS file. CODEOWNERS entries should be teams, not individuals
* [x] ensure all steps have meaningful names
* [x] ensure all parameters and grid columns have display names set so they can be localized
* [x] ensure that parameters id values are unique __or they will fail PR validation__ (parameter ids are used for localization)
* [x] ensure that steps names are unique __or they will fail PR validation__ (step names are used for localization)
* [x] grep `/subscription/` and ensure that your parameters don't have any hardcoded resourceIds __or they will fail PR validation__
* [x] remove `fallbackResourceIds` and `fromTemplateId` fields from your template workbook __or they will fail PR validation__