### PR TITLE
adding coverage for Defender for Databases

### DIFF
--- a/Workbooks/Azure Security Center/Coverage/Coverage.workbook
+++ b/Workbooks/Azure Security Center/Coverage/Coverage.workbook
@@ -59,7 +59,7 @@
     {
       "type": 1,
       "content": {
-        "json": "## Release notes\n\n|Version|Description|Date|\n|---|---|---|\n|v1.0|initial release, public availability of Defender for Cloud Coverage Workbook|1/20/2022|\n|v1.1|adding navigation menu and coverage for AWS connectors|2/21/2022|\n|v1.2|Updating AWS query and adding coverage for GCP connectors after API update|3/23/2022|\n|v1.3|adding Defender for Servers P1/P2|4/7/2022|\n|v1.4|adding relative coverage|4/14/2022|"
+        "json": "## Release notes\n\n|Version|Description|Date|\n|---|---|---|\n|v1.0|initial release, public availability of Defender for Cloud Coverage Workbook|1/20/2022|\n|v1.1|adding navigation menu and coverage for AWS connectors|2/21/2022|\n|v1.2|Updating AWS query and adding coverage for GCP connectors after API update|3/23/2022|\n|v1.3|adding Defender for Servers P1/P2|4/7/2022|\n|v1.4|adding relative coverage|4/14/2022|\n|v1.5|adding coverage for Defender for Databases on multicloud connectors|6/27/2022|"
       },
       "conditionalVisibility": {
         "parameterName": "info",
@@ -1057,7 +1057,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "resources\n| where type == \"microsoft.security/securityconnectors\" and properties.environmentName == \"AWS\"\n| extend offerings = properties.offerings\n| project id,\n    CSPM = case(offerings has \"CspmMonitorAws\",\"on\",\"off\"),\n    Servers = case(\n        offerings has \"DefenderForServersAws\" and offerings has \"P1\",\"Plan 1 on\",\n        offerings has \"DefenderForServersAws\" and offerings has \"P2\", \"Plan 2 on\",\n        \"off\"\n    ),\n    Containers = case(offerings has \"DefenderForContainersAws\",\"on\",\"off\")\n| summarize totalConnectors = count(), CSPM = countif(CSPM == \"on\"), Servers = countif(Servers has \"on\"), Containers = countif(Containers == \"on\")",
+              "query": "resources\n| where type == \"microsoft.security/securityconnectors\" and properties.environmentName == \"AWS\"\n| extend offerings = properties.offerings\n| project id,\n    CSPM = case(offerings has \"CspmMonitorAws\",\"on\",\"off\"),\n    Servers = case(\n        offerings has \"DefenderForServersAws\" and offerings has \"P1\",\"Plan 1 on\",\n        offerings has \"DefenderForServersAws\" and offerings has \"P2\", \"Plan 2 on\",\n        \"off\"\n    ),\n    Databases = case (offerings has \"DefenderForDatabasesAws\",\"on\",\"off\"),\n    Containers = case(offerings has \"DefenderForContainersAws\",\"on\",\"off\")\n| summarize totalConnectors = count(), CSPM = countif(CSPM == \"on\"), Servers = countif(Servers has \"on\"), Databases = countif(Databases == \"on\"), Containers = countif(Containers == \"on\")",
               "size": 3,
               "queryType": 1,
               "resourceType": "microsoft.resourcegraph/resources",
@@ -1079,7 +1079,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "{\"version\":\"Merge/1.0\",\"merges\":[{\"id\":\"f0f7f6bc-6bf8-4dac-bbb9-f8458a71404b\",\"mergeType\":\"table\",\"leftTable\":\"AWS numbers\"}],\"projectRename\":[{\"originalName\":\"[Added column]\",\"mergedName\":\"CSPM1\",\"fromId\":null,\"isNewItem\":true,\"newItemData\":[{\"criteriaContext\":{\"operator\":\"Default\",\"rightValType\":\"column\",\"resultValType\":\"expression\",\"resultVal\":\"[\\\"CSPM\\\"]/[\\\"totalConnectors\\\"]*100\"}}]},{\"originalName\":\"[Added column]\",\"mergedName\":\"Servers1\",\"fromId\":null,\"isNewItem\":true,\"newItemData\":[{\"criteriaContext\":{\"operator\":\"Default\",\"rightValType\":\"column\",\"resultValType\":\"expression\",\"resultVal\":\"[\\\"Servers\\\"]/[\\\"totalConnectors\\\"]*100\"}}]},{\"originalName\":\"[Added column]\",\"mergedName\":\"Containers1\",\"fromId\":null,\"isNewItem\":true,\"newItemData\":[{\"criteriaContext\":{\"operator\":\"Default\",\"rightValType\":\"column\",\"resultValType\":\"expression\",\"resultVal\":\"[\\\"Containers\\\"]/[\\\"totalConnectors\\\"]*100\"}}]},{\"originalName\":\"[AWS numbers].totalConnectors\",\"mergedName\":\"totalConnectors\",\"fromId\":\"f0f7f6bc-6bf8-4dac-bbb9-f8458a71404b\"},{\"originalName\":\"[AWS numbers].CSPM\",\"mergedName\":\"CSPM\",\"fromId\":\"f0f7f6bc-6bf8-4dac-bbb9-f8458a71404b\"},{\"originalName\":\"[AWS numbers].Servers\",\"mergedName\":\"Servers\",\"fromId\":\"f0f7f6bc-6bf8-4dac-bbb9-f8458a71404b\"},{\"originalName\":\"[AWS numbers].Containers\",\"mergedName\":\"Containers\",\"fromId\":\"f0f7f6bc-6bf8-4dac-bbb9-f8458a71404b\"}]}",
+              "query": "{\"version\":\"Merge/1.0\",\"merges\":[{\"id\":\"f0f7f6bc-6bf8-4dac-bbb9-f8458a71404b\",\"mergeType\":\"table\",\"leftTable\":\"AWS numbers\"}],\"projectRename\":[{\"originalName\":\"[Added column]\",\"mergedName\":\"CSPM1\",\"fromId\":null,\"isNewItem\":true,\"newItemData\":[{\"criteriaContext\":{\"operator\":\"Default\",\"rightValType\":\"column\",\"resultValType\":\"expression\",\"resultVal\":\"[\\\"CSPM\\\"]/[\\\"totalConnectors\\\"]*100\"}}]},{\"originalName\":\"[Added column]\",\"mergedName\":\"Servers1\",\"fromId\":null,\"isNewItem\":true,\"newItemData\":[{\"criteriaContext\":{\"operator\":\"Default\",\"rightValType\":\"column\",\"resultValType\":\"expression\",\"resultVal\":\"[\\\"Servers\\\"]/[\\\"totalConnectors\\\"]*100\"}}]},{\"originalName\":\"[Added column]\",\"mergedName\":\"Databases1\",\"fromId\":null,\"isNewItem\":true,\"newItemData\":[{\"criteriaContext\":{\"operator\":\"Default\",\"rightValType\":\"column\",\"resultValType\":\"expression\",\"resultVal\":\"[\\\"Databases\\\"]/[\\\"totalConnectors\\\"]*100\"}}]},{\"originalName\":\"[Added column]\",\"mergedName\":\"Containers1\",\"fromId\":null,\"isNewItem\":true,\"newItemData\":[{\"criteriaContext\":{\"operator\":\"Default\",\"rightValType\":\"column\",\"resultValType\":\"expression\",\"resultVal\":\"[\\\"Containers\\\"]/[\\\"totalConnectors\\\"]*100\"}}]},{\"originalName\":\"[AWS numbers].totalConnectors\",\"mergedName\":\"totalConnectors\",\"fromId\":\"f0f7f6bc-6bf8-4dac-bbb9-f8458a71404b\"},{\"originalName\":\"[AWS numbers].CSPM\",\"mergedName\":\"CSPM\",\"fromId\":\"f0f7f6bc-6bf8-4dac-bbb9-f8458a71404b\"},{\"originalName\":\"[AWS numbers].Servers\",\"mergedName\":\"Servers\",\"fromId\":\"f0f7f6bc-6bf8-4dac-bbb9-f8458a71404b\"},{\"originalName\":\"[AWS numbers].Containers\",\"mergedName\":\"Containers\",\"fromId\":\"f0f7f6bc-6bf8-4dac-bbb9-f8458a71404b\"},{\"originalName\":\"[AWS numbers].Databases\",\"mergedName\":\"Databases\",\"fromId\":\"unknown\"}]}",
               "size": 3,
               "title": "Relative coverage across AWS connectors",
               "noDataMessage": "No AWS connectors found in your selected subscriptions.",
@@ -1104,6 +1104,22 @@
                   },
                   {
                     "columnMatch": "Servers1",
+                    "formatter": 8,
+                    "formatOptions": {
+                      "min": 0,
+                      "max": 100,
+                      "palette": "yellow"
+                    },
+                    "numberFormat": {
+                      "unit": 1,
+                      "options": {
+                        "style": "decimal",
+                        "maximumFractionDigits": 1
+                      }
+                    }
+                  },
+                  {
+                    "columnMatch": "Databases1",
                     "formatter": 8,
                     "formatOptions": {
                       "min": 0,
@@ -1149,6 +1165,10 @@
                   {
                     "columnMatch": "Containers",
                     "formatter": 5
+                  },
+                  {
+                    "columnMatch": "Databases",
+                    "formatter": 5
                   }
                 ],
                 "rowLimit": 2,
@@ -1160,6 +1180,10 @@
                   {
                     "columnId": "Servers1",
                     "label": "Defender for Servers"
+                  },
+                  {
+                    "columnId": "Databases1",
+                    "label": "Defender for Databases"
                   },
                   {
                     "columnId": "Containers1",
@@ -1175,7 +1199,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "resources\n| where type == \"microsoft.security/securityconnectors\" and properties.environmentName == \"AWS\"\n| extend offerings = properties.offerings\n| project id,\n    CSPM = case(offerings has \"CspmMonitorAws\",\"on\",\"off\"),\n    Servers = case(\n        offerings has \"DefenderForServersAws\" and offerings has \"P1\",\"Plan 1 on\",\n        offerings has \"DefenderForServersAws\" and offerings has \"P2\", \"Plan 2 on\",\n        \"off\"\n    ),\n    Containers = case(offerings has \"DefenderForContainersAws\",\"on\",\"off\")",
+              "query": "resources\n| where type == \"microsoft.security/securityconnectors\" and properties.environmentName == \"AWS\"\n| extend offerings = properties.offerings\n| project id,\n    CSPM = case(offerings has \"CspmMonitorAws\",\"on\",\"off\"),\n    Servers = case(\n        offerings has \"DefenderForServersAws\" and offerings has \"P1\",\"Plan 1 on\",\n        offerings has \"DefenderForServersAws\" and offerings has \"P2\", \"Plan 2 on\",\n        \"off\"\n    ),\n    Databases = case(offerings has \"DefenderForDatabasesAws\",\"on\",\"off\"),\n    Containers = case(offerings has \"DefenderForContainersAws\",\"on\",\"off\")",
               "size": 3,
               "showAnalytics": true,
               "title": "Absolute coverage across AWS connectors",
@@ -1260,6 +1284,27 @@
                     }
                   },
                   {
+                    "columnMatch": "Databases",
+                    "formatter": 18,
+                    "formatOptions": {
+                      "thresholdsOptions": "colors",
+                      "thresholdsGrid": [
+                        {
+                          "operator": "==",
+                          "thresholdValue": "on",
+                          "representation": "yellow",
+                          "text": "{0}{1}"
+                        },
+                        {
+                          "operator": "Default",
+                          "thresholdValue": null,
+                          "representation": "orange",
+                          "text": "{0}{1}"
+                        }
+                      ]
+                    }
+                  },
+                  {
                     "columnMatch": "Containers",
                     "formatter": 18,
                     "formatOptions": {
@@ -1276,7 +1321,7 @@
                           "operator": "Default",
                           "thresholdValue": null,
                           "representation": "orange",
-                          "text": "off"
+                          "text": "{0}{1}"
                         }
                       ],
                       "bladeOpenContext": {
@@ -1307,6 +1352,10 @@
                   {
                     "columnId": "Servers",
                     "label": "Defender for Servers"
+                  },
+                  {
+                    "columnId": "Databases",
+                    "label": "Defender for Databases"
                   },
                   {
                     "columnId": "Containers",
@@ -1360,7 +1409,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "resources\n| where type == \"microsoft.security/securityconnectors\" and properties.environmentName == \"GCP\"\n| extend offerings = properties.offerings\n| project id,\n    CSPM = case(offerings has \"CspmMonitorGcp\",\"on\",\"off\"),\n    Servers = case(\n        offerings has \"DefenderForServersGcp\" and offerings has \"P1\",\"Plan 1 on\",\n        offerings has \"DefenderForServersGcp\" and offerings has \"P2\", \"Plan 2 on\",\n        \"off\"\n    ),\n    Containers = case(offerings has \"DefenderForContainersGcp\",\"on\",\"off\")\n| summarize totalConnectors = count(), CSPM = countif(CSPM == \"on\"), Servers = countif(Servers has \"on\"), Containers = countif(Containers == \"on\")",
+              "query": "resources\n| where type == \"microsoft.security/securityconnectors\" and properties.environmentName == \"GCP\"\n| extend offerings = properties.offerings\n| project id,\n    CSPM = case(offerings has \"CspmMonitorGcp\",\"on\",\"off\"),\n    Servers = case(\n        offerings has \"DefenderForServersGcp\" and offerings has \"P1\",\"Plan 1 on\",\n        offerings has \"DefenderForServersGcp\" and offerings has \"P2\", \"Plan 2 on\",\n        \"off\"\n    ),\n    Databases = case(offerings has \"DefenderForDatabasesGcp\",\"on\",\"off\"),\n    Containers = case(offerings has \"DefenderForContainersGcp\",\"on\",\"off\")\n| summarize totalConnectors = count(), CSPM = countif(CSPM == \"on\"), Servers = countif(Servers has \"on\"), Databases = countif(Databases == \"on\"), Containers = countif(Containers == \"on\")",
               "size": 3,
               "queryType": 1,
               "resourceType": "microsoft.resourcegraph/resources",
@@ -1379,7 +1428,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "{\"version\":\"Merge/1.0\",\"merges\":[{\"id\":\"f0f7f6bc-6bf8-4dac-bbb9-f8458a71406b\",\"mergeType\":\"table\",\"leftTable\":\"GCP numbers\"}],\"projectRename\":[{\"originalName\":\"[GCP numbers].totalConnectors\",\"mergedName\":\"totalConnectors\",\"fromId\":\"f0f7f6bc-6bf8-4dac-bbb9-f8458a71406b\"},{\"originalName\":\"[GCP numbers].CSPM\",\"mergedName\":\"CSPM\",\"fromId\":\"f0f7f6bc-6bf8-4dac-bbb9-f8458a71406b\"},{\"originalName\":\"[GCP numbers].Servers\",\"mergedName\":\"Servers\",\"fromId\":\"f0f7f6bc-6bf8-4dac-bbb9-f8458a71406b\"},{\"originalName\":\"[GCP numbers].Containers\",\"mergedName\":\"Containers\",\"fromId\":\"f0f7f6bc-6bf8-4dac-bbb9-f8458a71406b\"},{\"originalName\":\"[Added column]\",\"mergedName\":\"CSPM1\",\"fromId\":null,\"isNewItem\":true,\"newItemData\":[{\"criteriaContext\":{\"operator\":\"Default\",\"rightValType\":\"column\",\"resultValType\":\"expression\",\"resultVal\":\"[\\\"CSPM\\\"]/[\\\"totalConnectors\\\"]*100\"}}]},{\"originalName\":\"[Added column]\",\"mergedName\":\"Servers1\",\"fromId\":null,\"isNewItem\":true,\"newItemData\":[{\"criteriaContext\":{\"operator\":\"Default\",\"rightValType\":\"column\",\"resultValType\":\"expression\",\"resultVal\":\"[\\\"Servers\\\"]/[\\\"totalConnectors\\\"]*100\"}}]},{\"originalName\":\"[Added column]\",\"mergedName\":\"Containers1\",\"fromId\":null,\"isNewItem\":true,\"newItemData\":[{\"criteriaContext\":{\"operator\":\"Default\",\"rightValType\":\"column\",\"resultValType\":\"expression\",\"resultVal\":\"[\\\"Containers\\\"]/[\\\"totalConnectors\\\"]*100\"}}]}]}",
+              "query": "{\"version\":\"Merge/1.0\",\"merges\":[{\"id\":\"f0f7f6bc-6bf8-4dac-bbb9-f8458a71406b\",\"mergeType\":\"table\",\"leftTable\":\"GCP numbers\"}],\"projectRename\":[{\"originalName\":\"[GCP numbers].totalConnectors\",\"mergedName\":\"totalConnectors\",\"fromId\":\"f0f7f6bc-6bf8-4dac-bbb9-f8458a71406b\"},{\"originalName\":\"[GCP numbers].CSPM\",\"mergedName\":\"CSPM\",\"fromId\":\"f0f7f6bc-6bf8-4dac-bbb9-f8458a71406b\"},{\"originalName\":\"[GCP numbers].Servers\",\"mergedName\":\"Servers\",\"fromId\":\"f0f7f6bc-6bf8-4dac-bbb9-f8458a71406b\"},{\"originalName\":\"[GCP numbers].Containers\",\"mergedName\":\"Containers\",\"fromId\":\"f0f7f6bc-6bf8-4dac-bbb9-f8458a71406b\"},{\"originalName\":\"[Added column]\",\"mergedName\":\"CSPM1\",\"fromId\":null,\"isNewItem\":true,\"newItemData\":[{\"criteriaContext\":{\"operator\":\"Default\",\"rightValType\":\"column\",\"resultValType\":\"expression\",\"resultVal\":\"[\\\"CSPM\\\"]/[\\\"totalConnectors\\\"]*100\"}}]},{\"originalName\":\"[Added column]\",\"mergedName\":\"Servers1\",\"fromId\":null,\"isNewItem\":true,\"newItemData\":[{\"criteriaContext\":{\"operator\":\"Default\",\"rightValType\":\"column\",\"resultValType\":\"expression\",\"resultVal\":\"[\\\"Servers\\\"]/[\\\"totalConnectors\\\"]*100\"}}]},{\"originalName\":\"[Added column]\",\"mergedName\":\"Databases1\",\"fromId\":null,\"isNewItem\":true,\"newItemData\":[{\"criteriaContext\":{\"operator\":\"Default\",\"rightValType\":\"column\",\"resultValType\":\"expression\",\"resultVal\":\"[\\\"Databases\\\"]/[\\\"totalConnectors\\\"]*100\"}}]},{\"originalName\":\"[Added column]\",\"mergedName\":\"Containers1\",\"fromId\":null,\"isNewItem\":true,\"newItemData\":[{\"criteriaContext\":{\"operator\":\"Default\",\"rightValType\":\"column\",\"resultValType\":\"expression\",\"resultVal\":\"[\\\"Containers\\\"]/[\\\"totalConnectors\\\"]*100\"}}]},{\"originalName\":\"[GCP numbers].Databases\",\"mergedName\":\"Databases\",\"fromId\":\"unknown\"}]}",
               "size": 3,
               "title": "Relative coverage across GCP connectors",
               "noDataMessage": "No GCP connectors found in your selected subscriptions.",
@@ -1435,6 +1484,22 @@
                     }
                   },
                   {
+                    "columnMatch": "Databases1",
+                    "formatter": 8,
+                    "formatOptions": {
+                      "min": 0,
+                      "max": 100,
+                      "palette": "turquoise"
+                    },
+                    "numberFormat": {
+                      "unit": 1,
+                      "options": {
+                        "style": "decimal",
+                        "maximumFractionDigits": 1
+                      }
+                    }
+                  },
+                  {
                     "columnMatch": "Containers1",
                     "formatter": 8,
                     "formatOptions": {
@@ -1449,6 +1514,10 @@
                         "maximumFractionDigits": 1
                       }
                     }
+                  },
+                  {
+                    "columnMatch": "Databases",
+                    "formatter": 5
                   }
                 ],
                 "rowLimit": 2,
@@ -1460,6 +1529,10 @@
                   {
                     "columnId": "Servers1",
                     "label": "Defender for Servers"
+                  },
+                  {
+                    "columnId": "Databases1",
+                    "label": "Defender for Databases"
                   },
                   {
                     "columnId": "Containers1",
@@ -1475,7 +1548,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "resources\n| where type == \"microsoft.security/securityconnectors\" and properties.environmentName == \"GCP\"\n| extend offerings = properties.offerings\n| project id,\n    CSPM = case(offerings has \"CspmMonitorGcp\",\"on\",\"off\"),\n    Servers = case(\n        offerings has \"DefenderForServersGcp\" and offerings has \"P1\",\"Plan 1 on\",\n        offerings has \"DefenderForServersGcp\" and offerings has \"P2\", \"Plan 2 on\",\n        \"off\"\n    ),\n    Containers = case(offerings has \"DefenderForContainersGcp\",\"on\",\"off\")",
+              "query": "resources\n| where type == \"microsoft.security/securityconnectors\" and properties.environmentName == \"GCP\"\n| extend offerings = properties.offerings\n| project id,\n    CSPM = case(offerings has \"CspmMonitorGcp\",\"on\",\"off\"),\n    Servers = case(\n        offerings has \"DefenderForServersGcp\" and offerings has \"P1\",\"Plan 1 on\",\n        offerings has \"DefenderForServersGcp\" and offerings has \"P2\", \"Plan 2 on\",\n        \"off\"\n    ),\n    Databases = case(offerings has \"DefenderForDatabasesGcp\",\"on\",\"off\"),\n    Containers = case(offerings has \"DefenderForContainersGcp\",\"on\",\"off\")",
               "size": 3,
               "showAnalytics": true,
               "title": "Absolute coverage across GCP connectors",
@@ -1560,6 +1633,27 @@
                     }
                   },
                   {
+                    "columnMatch": "Databases",
+                    "formatter": 18,
+                    "formatOptions": {
+                      "thresholdsOptions": "colors",
+                      "thresholdsGrid": [
+                        {
+                          "operator": "==",
+                          "thresholdValue": "on",
+                          "representation": "turquoise",
+                          "text": "{0}{1}"
+                        },
+                        {
+                          "operator": "Default",
+                          "thresholdValue": null,
+                          "representation": "grayBlue",
+                          "text": "{0}{1}"
+                        }
+                      ]
+                    }
+                  },
+                  {
                     "columnMatch": "Containers",
                     "formatter": 18,
                     "formatOptions": {
@@ -1607,6 +1701,10 @@
                   {
                     "columnId": "Servers",
                     "label": "Defender for Servers"
+                  },
+                  {
+                    "columnId": "Databases",
+                    "label": "Defender for Databases"
                   },
                   {
                     "columnId": "Containers",


### PR DESCRIPTION
## PR Checklist

* [x] Explain your changes, so people looking at the PR know *what* and *why*, the code changes are the *how*.
This update adds coverage information for Defender for Databases for AWS and GCP multicloud connectors.

### If adding or updating templates:
* [x] post a screenshot of templates and/or gallery changes
![aws](https://user-images.githubusercontent.com/32520935/175886792-aa59ad4e-70bf-4ed0-923d-5632ef1ebd7c.png)
![aws1](https://user-images.githubusercontent.com/32520935/175886802-4d5f7cbc-17a4-40e3-95d0-ff7992a3d842.png)
![gcp](https://user-images.githubusercontent.com/32520935/175886806-419be55b-d17e-47dc-a20a-a42e771e6629.png)



* [x] ensure your template has a corresponding gallery entry in the gallery folder
* [x] If you are adding a new template, add your team and template/gallery file(s) to the CODEOWNERS file. CODEOWNERS entries should be teams, not individuals
* [x] ensure all steps have meaningful names
* [x] ensure all parameters and grid columns have display names set so they can be localized
* [x] ensure that parameters id values are unique __or they will fail PR validation__ (parameter ids are used for localization)
* [x] ensure that steps names are unique __or they will fail PR validation__ (step names are used for localization)
* [x] grep `/subscription/` and ensure that your parameters don't have any hardcoded resourceIds __or they will fail PR validation__
* [x] remove `fallbackResourceIds` and `fromTemplateId` fields from your template workbook __or they will fail PR validation__