### PR TITLE
GPU metrics deprecation

### DIFF
--- a/Workbooks/AKS/Node GPU/Node GPU.workbook
+++ b/Workbooks/AKS/Node GPU/Node GPU.workbook
@@ -176,448 +176,493 @@
       "name": "pills"
     },
     {
-      "type": 3,
+      "type": 11,
       "content": {
-        "version": "KqlItem/1.0",
-        "query": "union\r\n(InsightsMetrics \r\n| where Name == \"nodeGpuCapacity\" \r\n| where Namespace == \"container.azm.ms/gpu\" \r\n| where Origin == \"container.azm.ms\"\r\n| where TimeGenerated >= {timeRange:start}\r\n| where TimeGenerated < {timeRange:end}\r\n| where '*' in ({selectedNodes}) or Computer in ({selectedNodes})\r\n| extend Tags = todynamic(Tags)\r\n| extend clusterId = tostring(Tags['container.azm.ms/clusterId'])\r\n{clusterIdWhereClause}\r\n| where Val > 0\r\n//add cluster filter\r\n| summarize GPUsPerComputer=arg_max(Val,*) by Computer, bin(TimeGenerated, {timeRange:grain})\r\n| make-series ['Total GPUs'] = toint(sum(GPUsPerComputer)) default = 0 on TimeGenerated from {timeRange:start} to {timeRange:end} step {timeRange:grain} \r\n),\r\n(\r\nInsightsMetrics \r\n| where Name == \"containerGpuDutyCycle\" \r\n| where Namespace == \"container.azm.ms/gpu\" \r\n| where Origin == \"container.azm.ms\"\r\n| where TimeGenerated >= {timeRange:start}\r\n| where TimeGenerated < {timeRange:end}\r\n| where '*' in ({selectedNodes}) or Computer in ({selectedNodes})\r\n| extend Tags = todynamic(Tags)\r\n| extend clusterId = tostring(Tags['container.azm.ms/clusterId'])\r\n{clusterIdWhereClause}\r\n| where Val > 0\r\n| extend gpuId = tostring(Tags.gpuId)\r\n| summarize count() by bin(TimeGenerated, {timeRange:grain}), gpuId\r\n| make-series ['Busy GPUs'] = count() default = 0 on TimeGenerated from {timeRange:start} to {timeRange:end} step {timeRange:grain} \r\n)",
-        "size": 0,
-        "aggregation": 5,
-        "showAnnotations": true,
-        "showAnalytics": true,
-        "title": "GPU Usage",
-        "color": "turquoise",
-        "queryType": 0,
-        "resourceType": "{ResourceType}",
-        "crossComponentResources": [
-          "{Resource}"
-        ],
-        "visualization": "linechart",
-        "tileSettings": {
-          "showBorder": false,
-          "titleContent": {
-            "columnMatch": "gpuVendor",
-            "formatter": 1
+        "version": "LinkItem/1.0",
+        "style": "tabs",
+        "links": [
+          {
+            "id": "5c20ad89-4167-418b-ba12-5aa6fc298614",
+            "cellValue": "selectedTab",
+            "linkTarget": "parameter",
+            "linkLabel": "Overview",
+            "subTarget": "Overview",
+            "style": "link"
           },
-          "leftContent": {
-            "columnMatch": "gpuCount",
-            "formatter": 12,
-            "formatOptions": {
-              "palette": "auto"
-            },
-            "numberFormat": {
-              "unit": 17,
-              "options": {
-                "maximumSignificantDigits": 3,
-                "maximumFractionDigits": 2
-              }
-            }
+          {
+            "id": "45f8e6cb-8638-41b9-9304-7abfcf4ef129",
+            "cellValue": "selectedTab",
+            "linkTarget": "parameter",
+            "linkLabel": "GPU",
+            "subTarget": "GPU",
+            "style": "link"
           }
-        },
-        "graphSettings": {
-          "type": 0,
-          "topContent": {
-            "columnMatch": "gpuVendor",
-            "formatter": 1
-          },
-          "centerContent": {
-            "columnMatch": "gpuCount",
-            "formatter": 1,
-            "numberFormat": {
-              "unit": 17,
-              "options": {
-                "maximumSignificantDigits": 3,
-                "maximumFractionDigits": 2
-              }
-            }
-          }
-        },
-        "chartSettings": {
-          "showLegend": true,
-          "seriesLabelSettings": [
-            {
-              "seriesName": "Busy Gpus",
-              "color": "redBright"
-            }
-          ],
-          "xSettings": {
-            "unit": 17,
-            "min": null,
-            "max": null
-          },
-          "ySettings": {
-            "min": 0,
-            "max": null
-          }
-        }
+        ]
       },
-      "customWidth": "50",
-      "showPin": true,
-      "name": "GPU-Usage",
-      "styleSettings": {
-        "maxWidth": "50",
-        "showBorder": true
-      }
+      "name": "links - 3"
     },
     {
-      "type": 3,
+      "type": 12,
       "content": {
-        "version": "KqlItem/1.0",
-        "query": "union\r\n(InsightsMetrics \r\n| where Name == \"containerGpumemoryTotalBytes\" \r\n| where Namespace == \"container.azm.ms/gpu\" \r\n| where Origin == \"container.azm.ms\"\r\n| where TimeGenerated >= {timeRange:start}\r\n| where TimeGenerated < {timeRange:end}\r\n| where '*' in ({selectedNodes}) or Computer in ({selectedNodes})\r\n| extend Tags = todynamic(Tags)\r\n| extend clusterId = tostring(Tags['container.azm.ms/clusterId'])\r\n{clusterIdWhereClause}\r\n//| extend tags=parse_json(Tags) \r\n| extend gpuVendor=tostring(Tags.gpuVendor)\r\n| extend gpuId = tostring(Tags.gpuId)\r\n| extend gpuModel = tostring(Tags.gpuModel)\r\n| extend gpu=strcat(gpuVendor, \"/\", gpuModel)\r\n| summarize GpuMemoryBytes=max(Val) by bin(TimeGenerated,  {timeRange:grain}), gpu, gpuId, Computer//, metricname\r\n| make-series ['Total-GPUMemory'] = sum(GpuMemoryBytes) default = 0 on TimeGenerated from {timeRange:start} to {timeRange:end} step {timeRange:grain} //by status\r\n),\r\n(InsightsMetrics \r\n| where Name == \"containerGpumemoryUsedBytes\" \r\n| where Namespace == \"container.azm.ms/gpu\" \r\n| where Origin == \"container.azm.ms\"\r\n| where TimeGenerated >= {timeRange:start}\r\n| where TimeGenerated < {timeRange:end}\r\n| where '*' in ({selectedNodes}) or Computer in ({selectedNodes})\r\n| extend Tags = todynamic(Tags)\r\n| extend clusterId = tostring(Tags['container.azm.ms/clusterId'])\r\n{clusterIdWhereClause}\r\n| extend gpuVendor=tostring(Tags.gpuVendor)\r\n| extend gpuId = tostring(Tags.gpuId)\r\n| extend gpuModel = tostring(Tags.gpuModel)\r\n| extend gpu=strcat(gpuVendor, \"/\", gpuModel)\r\n| summarize maxused=max(Val) by bin(TimeGenerated, {timeRange:grain}), gpu, gpuId, Computer\r\n| make-series ['Max-Used'] = sum(maxused) default = 0 on TimeGenerated from {timeRange:start} to {timeRange:end} step {timeRange:grain}\r\n),\r\n(InsightsMetrics \r\n| where Name == \"containerGpumemoryUsedBytes\" \r\n| where Namespace == \"container.azm.ms/gpu\" \r\n| where Origin == \"container.azm.ms\"\r\n| where TimeGenerated >= {timeRange:start}\r\n| where TimeGenerated < {timeRange:end}\r\n| where '*' in ({selectedNodes}) or Computer in ({selectedNodes})\r\n| extend Tags = todynamic(Tags)\r\n| extend clusterId = tostring(Tags['container.azm.ms/clusterId'])\r\n{clusterIdWhereClause}\r\n| extend gpuVendor=tostring(Tags.gpuVendor)\r\n| extend gpuId = tostring(Tags.gpuId)\r\n| extend gpuModel = tostring(Tags.gpuModel)\r\n| extend gpu=strcat(gpuVendor, \"/\", gpuModel)\r\n| summarize ptile95used=percentile(Val,95) by bin(TimeGenerated, {timeRange:grain}), gpu, gpuId, Computer\r\n| make-series ['95th-ptile-Used'] = sum(ptile95used) default = 0 on TimeGenerated from {timeRange:start} to {timeRange:end} step {timeRange:grain}\r\n),\r\n(InsightsMetrics \r\n| where Name == \"containerGpumemoryUsedBytes\" \r\n| where Namespace == \"container.azm.ms/gpu\" \r\n| where Origin == \"container.azm.ms\"\r\n| where TimeGenerated >= {timeRange:start}\r\n| where TimeGenerated < {timeRange:end}\r\n| where '*' in ({selectedNodes}) or Computer in ({selectedNodes})\r\n| extend Tags = todynamic(Tags)\r\n| extend clusterId = tostring(Tags['container.azm.ms/clusterId'])\r\n{clusterIdWhereClause}\r\n| extend gpuVendor=tostring(Tags.gpuVendor)\r\n| extend gpuId = tostring(Tags.gpuId)\r\n| extend gpuModel = tostring(Tags.gpuModel)\r\n| extend gpu=strcat(gpuVendor, \"/\", gpuModel)\r\n| summarize ptile99used=percentile(Val,99) by bin(TimeGenerated, {timeRange:grain}), gpu, gpuId, Computer\r\n| make-series ['99th-ptile-Used'] = sum(ptile99used) default = 0 on TimeGenerated from {timeRange:start} to {timeRange:end} step {timeRange:grain}\r\n)\r\n",
-        "size": 0,
-        "aggregation": 5,
-        "showAnnotations": true,
-        "showAnalytics": true,
-        "title": "GPU Memory Usage",
-        "timeContext": {
-          "durationMs": 21600000
-        },
-        "timeContextFromParameter": "timeRange",
-        "queryType": 0,
-        "resourceType": "{ResourceType}",
-        "crossComponentResources": [
-          "{Resource}"
-        ],
-        "visualization": "linechart",
-        "chartSettings": {
-          "showLegend": true,
-          "ySettings": {
-            "unit": 2,
-            "min": 0,
-            "max": null
+        "version": "NotebookGroup/1.0",
+        "groupType": "editable",
+        "items": [
+          {
+            "type": 1,
+            "content": {
+              "json": "As per the Kubernetes [upstream announcement](https://kubernetes.io/blog/2020/12/16/third-party-device-metrics-reaches-ga/#nvidia-gpu-metrics-deprecated), Kubernetes is deprecating GPU metrics that are being reported by the kubelet, for Kubernetes ver. 1.20+. This means Container Insights will no longer be able to collect the following metrics out of the box:\r\n* containerGpuDutyCycle\r\n* containerGpumemoryTotalBytes\r\n* containerGpumemoryUsedBytes\r\n\r\nTo continue collecting GPU metrics through Container Insights, please migrate by December 31, 2022 to your GPU vendor specific metrics exporter and configure [Prometheus scraping](https://docs.microsoft.com/azure/azure-monitor/containers/container-insights-prometheus-integration) to scrape metrics from the deployed vendor specific exporter.\r\n\r\nAs a temporary hotfix, for AKS, upgrade your GPU Node pool to the latest version or \\*-2022.06.08 or higher. For Arc enabled Kubernetes, enable feature gate DisableAcceleratorUsageMetrics=false in Kubelet configuration of the node and restart the Kubelet. Once the upstream changes reach GA, this fix will not longer work, make plans to migrate to using your GPU vendor specific metrics exporter by December 31, 2022.\r\n\r\nFor additional information visit [GPU monitoring](https://docs.microsoft.com/azure/azure-monitor/containers/container-insights-gpu-monitoring) in Container Insights.\r\n",
+              "style": "warning"
+            },
+            "name": "text - 0"
           }
-        }
+        ]
       },
-      "customWidth": "50",
-      "showPin": true,
-      "name": "GPU-MemoryUsage",
-      "styleSettings": {
-        "maxWidth": "50",
-        "showBorder": true
-      }
+      "conditionalVisibility": {
+        "parameterName": "selectedTab",
+        "comparison": "isEqualTo",
+        "value": "Overview"
+      },
+      "name": "Overview"
     },
     {
-      "type": 3,
+      "type": 12,
       "content": {
-        "version": "KqlItem/1.0",
-        "query": "let im  = InsightsMetrics\r\n| where Name == \"nodeGpuCapacity\"\r\n| where Namespace == \"container.azm.ms/gpu\" \r\n| where Origin == \"container.azm.ms\"\r\n| where TimeGenerated >= {timeRange:start}\r\n| where TimeGenerated < {timeRange:end}\r\n| where '*' in ({selectedNodes}) or Computer in ({selectedNodes})\r\n| extend Tags = todynamic(Tags)\r\n| extend clusterId = tostring(Tags['container.azm.ms/clusterId'])\r\n{clusterIdWhereClause}\r\n| where Val >= 1\r\n| distinct Computer;\r\nKubeNodeInventory\r\n| extend clusterId = ClusterId\r\n{clusterIdWhereClause}\r\n| where Computer in (im)\r\n| extend status=iif(strlen(Status) == 0 ,\"Unknown\", Status)\r\n| summarize count() by Computer, status, bin(TimeGenerated, {timeRange:grain})\r\n| summarize val=count() by status, bin(TimeGenerated, {timeRange:grain})\r\n| make-series ['Node Count by status'] = sum(val) default = 0 on TimeGenerated from {timeRange:start} to {timeRange:end} step {timeRange:grain} by status\r\n\r\n",
-        "size": 0,
-        "aggregation": 5,
-        "showAnnotations": true,
-        "showAnalytics": true,
-        "title": "GPU Node Count by Node Status",
-        "timeContext": {
-          "durationMs": 21600000
-        },
-        "timeContextFromParameter": "timeRange",
-        "queryType": 0,
-        "resourceType": "{ResourceType}",
-        "crossComponentResources": [
-          "{Resource}"
-        ],
-        "visualization": "linechart",
-        "tileSettings": {
-          "titleContent": {
-            "columnMatch": "status",
-            "formatter": 1,
-            "formatOptions": {
-              "showIcon": true
-            }
-          },
-          "leftContent": {
-            "columnMatch": "Node Count by State",
-            "formatter": 12,
-            "formatOptions": {
-              "palette": "auto",
-              "showIcon": true
-            },
-            "numberFormat": {
-              "unit": 17,
-              "options": {
-                "style": "decimal",
-                "maximumFractionDigits": 2,
-                "maximumSignificantDigits": 3
-              }
-            }
-          },
-          "showBorder": false
-        },
-        "chartSettings": {
-          "showLegend": true,
-          "seriesLabelSettings": [
-            {
-              "seriesName": "Ready",
-              "color": "green"
-            },
-            {
-              "seriesName": "Unknown",
-              "color": "blue"
-            }
-          ],
-          "ySettings": {
-            "min": 0,
-            "max": null
-          }
-        }
-      },
-      "customWidth": "50",
-      "showPin": true,
-      "name": "GPU-NodeCountByNodeStatus",
-      "styleSettings": {
-        "maxWidth": "50",
-        "showBorder": true
-      }
-    },
-    {
-      "type": 3,
-      "content": {
-        "version": "KqlItem/1.0",
-        "query": "let im  = InsightsMetrics\r\n| where Name in (\"containerGpuRequests\", \"containerGpuLimits\")\r\n| where Namespace == \"container.azm.ms/gpu\" \r\n| where Origin == \"container.azm.ms\"\r\n| where TimeGenerated >= {timeRange:start}\r\n| where TimeGenerated < {timeRange:end}\r\n| extend selectedNodes = {selectedNodes}\r\n| extend nodeList = iif(selectedNodes == \"*\", \",*\", selectedNodes) \r\n| where '*' in (selectedNodes) or Computer in (selectedNodes)\r\n| extend Tags = todynamic(Tags)\r\n| extend clusterId = tostring(Tags['container.azm.ms/clusterId'])\r\n{clusterIdWhereClause}\r\n//| extend tags=parse_json(Tags)\r\n| extend containerName = tostring(Tags.containerName)\r\n| extend poduidArray = split(containerName, \"/\")\r\n| extend podUid = iif(array_length(poduidArray) == 2, poduidArray[0], \"\")\r\n| where Val >= 1\r\n| where podUid != \"\"\r\n| distinct podUid;\r\nKubePodInventory\r\n| where PodUid in (im)\r\n| extend clusterId = ClusterId\r\n{clusterIdWhereClause}\r\n| where TimeGenerated >= {timeRange:start}\r\n| where TimeGenerated < {timeRange:end}\r\n| extend selectedNodes = {selectedNodes}\r\n| extend nodeList = iif(selectedNodes == \"*\", \",*\", selectedNodes) \r\n| where '*' in (selectedNodes) or Computer in (selectedNodes)\r\n| summarize count() by PodUid, PodStatus, bin(TimeGenerated, {timeRange:grain})\r\n| make-series ['GPU Pod Count by status'] = count() default = 0 on TimeGenerated from {timeRange:start} to {timeRange:end} step {timeRange:grain} by PodStatus",
-        "size": 0,
-        "aggregation": 5,
-        "showAnnotations": true,
-        "showAnalytics": true,
-        "title": "GPU Pod Count by Pod Status",
-        "timeContext": {
-          "durationMs": 21600000
-        },
-        "timeContextFromParameter": "timeRange",
-        "queryType": 0,
-        "resourceType": "{ResourceType}",
-        "crossComponentResources": [
-          "{Resource}"
-        ],
-        "visualization": "timechart",
-        "chartSettings": {
-          "showLegend": true,
-          "seriesLabelSettings": [
-            {
-              "seriesName": "Succeeded",
-              "color": "greenDark"
-            },
-            {
-              "seriesName": "Running",
-              "color": "green"
-            }
-          ],
-          "ySettings": {
-            "min": 0,
-            "max": null
-          }
-        }
-      },
-      "customWidth": "50",
-      "showPin": true,
-      "name": "GPU-PodCountByPodStatus",
-      "styleSettings": {
-        "maxWidth": "50",
-        "showBorder": true
-      }
-    },
-    {
-      "type": 3,
-      "content": {
-        "version": "KqlItem/1.0",
-        "query": "let im  = InsightsMetrics\r\n| where Name in (\"containerGpuRequests\", \"containerGpuLimits\")\r\n| where Namespace == \"container.azm.ms/gpu\" \r\n| where Origin == \"container.azm.ms\"\r\n| where TimeGenerated >= {timeRange:start}\r\n| where TimeGenerated < {timeRange:end}\r\n| extend selectedNodes = {selectedNodes}\r\n| extend nodeList = iif(selectedNodes == \"*\", \",*\", selectedNodes)\r\n| where '*' in (selectedNodes) or Computer in (selectedNodes)\r\n| extend Tags = todynamic(Tags)\r\n| extend clusterId = tostring(Tags['container.azm.ms/clusterId'])\r\n{clusterIdWhereClause}\r\n//| extend tags=parse_json(Tags)\r\n| extend containerName = tostring(Tags.containerName)\r\n| extend poduidArray = split(containerName, \"/\")\r\n| extend podUid = iif(array_length(poduidArray) == 2, poduidArray[0], \"\")\r\n| where Val >= 1\r\n| where podUid != \"\"\r\n| distinct podUid;\r\nKubePodInventory\r\n| where PodUid in (im)\r\n| extend clusterId = ClusterId\r\n{clusterIdWhereClause}\r\n| where TimeGenerated >= {timeRange:start}\r\n| where TimeGenerated < {timeRange:end}\r\n| summarize count() by PodUid, Namespace, PodStatus, bin(TimeGenerated, {timeRange:grain})\r\n| make-series ['GPU Pods by namespace'] = count() default = 0 on TimeGenerated from {timeRange:start} to {timeRange:end} step {timeRange:grain} by Namespace, PodStatus\r\n",
-        "size": 0,
-        "aggregation": 5,
-        "showAnnotations": true,
-        "showAnalytics": true,
-        "title": "GPU Pod Count by Kubernetes Namespace",
-        "timeContext": {
-          "durationMs": 21600000
-        },
-        "timeContextFromParameter": "timeRange",
-        "queryType": 0,
-        "resourceType": "{ResourceType}",
-        "crossComponentResources": [
-          "{Resource}"
-        ],
-        "visualization": "linechart",
-        "tileSettings": {
-          "titleContent": {
-            "columnMatch": "Namespace",
-            "formatOptions": {
-              "showIcon": true
-            }
-          },
-          "subtitleContent": {
-            "columnMatch": "PodStatus",
-            "formatOptions": {
-              "showIcon": true
-            }
-          },
-          "rightContent": {
-            "columnMatch": "GPU Pods by namespace",
-            "formatter": 10,
-            "formatOptions": {
-              "palette": "red",
-              "showIcon": true
-            },
-            "tooltipFormat": {
-              "tooltip": "hello {0}"
-            }
-          },
-          "showBorder": false,
-          "sortCriteriaField": "Namespace"
-        },
-        "graphSettings": {
-          "type": 0,
-          "topContent": {
-            "columnMatch": "Namespace",
-            "formatter": 1,
-            "formatOptions": {
-              "showIcon": true
-            }
-          },
-          "leftContent": {
-            "columnMatch": "PodStatus",
-            "formatOptions": {
-              "showIcon": true
-            }
-          },
-          "centerContent": {
-            "columnMatch": "podcount",
-            "formatter": 1,
-            "formatOptions": {
-              "showIcon": true
-            },
-            "numberFormat": {
-              "unit": 17,
-              "options": {
-                "maximumSignificantDigits": 3,
-                "maximumFractionDigits": 2
-              }
-            }
-          },
-          "nodeIdField": "Namespace",
-          "nodeSize": null,
-          "staticNodeSize": 100,
-          "colorSettings": null,
-          "hivesMargin": 5
-        },
-        "chartSettings": {
-          "showLegend": true,
-          "ySettings": {
-            "unit": 17,
-            "min": 0,
-            "max": null
-          }
-        }
-      },
-      "customWidth": "50",
-      "showPin": true,
-      "name": "GPU-PodCountByK8SNamespace",
-      "styleSettings": {
-        "maxWidth": "50",
-        "showBorder": true
-      }
-    },
-    {
-      "type": 3,
-      "content": {
-        "version": "KqlItem/1.0",
-        "query": "InsightsMetrics \r\n| where Name == \"nodeGpuCapacity\" \r\n| where Namespace == \"container.azm.ms/gpu\" \r\n| where Origin == \"container.azm.ms\"\r\n| where TimeGenerated >= {timeRange:start}\r\n| where TimeGenerated < {timeRange:end}\r\n| where '*' in ({selectedNodes}) or Computer in ({selectedNodes})\r\n| extend Tags = todynamic(Tags)\r\n| extend clusterId = tostring(Tags['container.azm.ms/clusterId'])\r\n{clusterIdWhereClause}\r\n| extend gpuVendor=strcat ('🔹 ',tostring(Tags.gpuVendor))\r\n| summarize gpuCountPerComputer=max(Val) by gpuVendor, Computer , bin(TimeGenerated, {timeRange:grain})\r\n| make-series ['GPU count by make'] =sum(gpuCountPerComputer) default = 0 on TimeGenerated from {timeRange:start} to {timeRange:end} step {timeRange:grain} by gpuVendor\r\n\r\n\r\n\r\n\r\n\r\n\r\n",
-        "size": 0,
-        "aggregation": 5,
-        "showAnnotations": true,
-        "showAnalytics": true,
-        "title": "GPU Count by Make",
-        "color": "blue",
-        "timeContext": {
-          "durationMs": 21600000
-        },
-        "timeContextFromParameter": "timeRange",
-        "queryType": 0,
-        "resourceType": "{ResourceType}",
-        "crossComponentResources": [
-          "{Resource}"
-        ],
-        "visualization": "table",
-        "gridSettings": {
-          "formatters": [
-            {
-              "columnMatch": "gpuVendor",
-              "formatter": 1,
-              "formatOptions": {
-                "showIcon": true
-              }
-            },
-            {
-              "columnMatch": "GPU count by make",
-              "formatter": 10,
-              "formatOptions": {
-                "showIcon": true
-              },
-              "numberFormat": {
-                "unit": 17,
-                "options": {
-                  "style": "decimal"
+        "version": "NotebookGroup/1.0",
+        "groupType": "editable",
+        "items": [
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "union\r\n(InsightsMetrics \r\n| where Name == \"nodeGpuCapacity\" \r\n| where Namespace == \"container.azm.ms/gpu\" \r\n| where Origin == \"container.azm.ms\"\r\n| where TimeGenerated >= {timeRange:start}\r\n| where TimeGenerated < {timeRange:end}\r\n| where '*' in ({selectedNodes}) or Computer in ({selectedNodes})\r\n| extend Tags = todynamic(Tags)\r\n| extend clusterId = tostring(Tags['container.azm.ms/clusterId'])\r\n{clusterIdWhereClause}\r\n| where Val > 0\r\n//add cluster filter\r\n| summarize GPUsPerComputer=arg_max(Val,*) by Computer, bin(TimeGenerated, {timeRange:grain})\r\n| make-series ['Total GPUs'] = toint(sum(GPUsPerComputer)) default = 0 on TimeGenerated from {timeRange:start} to {timeRange:end} step {timeRange:grain} \r\n),\r\n(\r\nInsightsMetrics \r\n| where Name == \"containerGpuDutyCycle\" \r\n| where Namespace == \"container.azm.ms/gpu\" \r\n| where Origin == \"container.azm.ms\"\r\n| where TimeGenerated >= {timeRange:start}\r\n| where TimeGenerated < {timeRange:end}\r\n| where '*' in ({selectedNodes}) or Computer in ({selectedNodes})\r\n| extend Tags = todynamic(Tags)\r\n| extend clusterId = tostring(Tags['container.azm.ms/clusterId'])\r\n{clusterIdWhereClause}\r\n| where Val > 0\r\n| extend gpuId = tostring(Tags.gpuId)\r\n| summarize count() by bin(TimeGenerated, {timeRange:grain}), gpuId\r\n| make-series ['Busy GPUs'] = count() default = 0 on TimeGenerated from {timeRange:start} to {timeRange:end} step {timeRange:grain} \r\n)",
+              "size": 0,
+              "aggregation": 5,
+              "showAnnotations": true,
+              "showAnalytics": true,
+              "title": "GPU Usage",
+              "color": "turquoise",
+              "queryType": 0,
+              "resourceType": "{ResourceType}",
+              "crossComponentResources": [
+                "{Resource}"
+              ],
+              "visualization": "linechart",
+              "tileSettings": {
+                "showBorder": false,
+                "titleContent": {
+                  "columnMatch": "gpuVendor",
+                  "formatter": 1
+                },
+                "leftContent": {
+                  "columnMatch": "gpuCount",
+                  "formatter": 12,
+                  "formatOptions": {
+                    "palette": "auto"
+                  },
+                  "numberFormat": {
+                    "unit": 17,
+                    "options": {
+                      "maximumSignificantDigits": 3,
+                      "maximumFractionDigits": 2
+                    }
+                  }
                 }
               },
-              "tooltipFormat": {
-                "tooltip": "{0}"
+              "graphSettings": {
+                "type": 0,
+                "topContent": {
+                  "columnMatch": "gpuVendor",
+                  "formatter": 1
+                },
+                "centerContent": {
+                  "columnMatch": "gpuCount",
+                  "formatter": 1,
+                  "numberFormat": {
+                    "unit": 17,
+                    "options": {
+                      "maximumSignificantDigits": 3,
+                      "maximumFractionDigits": 2
+                    }
+                  }
+                }
+              },
+              "chartSettings": {
+                "showLegend": true,
+                "seriesLabelSettings": [
+                  {
+                    "seriesName": "Busy Gpus",
+                    "color": "redBright"
+                  }
+                ],
+                "xSettings": {
+                  "unit": 17,
+                  "min": null,
+                  "max": null
+                },
+                "ySettings": {
+                  "min": 0,
+                  "max": null
+                }
               }
             },
-            {
-              "columnMatch": "TimeGenerated",
-              "formatter": 5,
-              "formatOptions": {
-                "showIcon": true
+            "customWidth": "50",
+            "showPin": true,
+            "name": "GPU-Usage",
+            "styleSettings": {
+              "maxWidth": "50",
+              "showBorder": true
+            }
+          },
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "union\r\n(InsightsMetrics \r\n| where Name == \"containerGpumemoryTotalBytes\" \r\n| where Namespace == \"container.azm.ms/gpu\" \r\n| where Origin == \"container.azm.ms\"\r\n| where TimeGenerated >= {timeRange:start}\r\n| where TimeGenerated < {timeRange:end}\r\n| where '*' in ({selectedNodes}) or Computer in ({selectedNodes})\r\n| extend Tags = todynamic(Tags)\r\n| extend clusterId = tostring(Tags['container.azm.ms/clusterId'])\r\n{clusterIdWhereClause}\r\n//| extend tags=parse_json(Tags) \r\n| extend gpuVendor=tostring(Tags.gpuVendor)\r\n| extend gpuId = tostring(Tags.gpuId)\r\n| extend gpuModel = tostring(Tags.gpuModel)\r\n| extend gpu=strcat(gpuVendor, \"/\", gpuModel)\r\n| summarize GpuMemoryBytes=max(Val) by bin(TimeGenerated,  {timeRange:grain}), gpu, gpuId, Computer//, metricname\r\n| make-series ['Total-GPUMemory'] = sum(GpuMemoryBytes) default = 0 on TimeGenerated from {timeRange:start} to {timeRange:end} step {timeRange:grain} //by status\r\n),\r\n(InsightsMetrics \r\n| where Name == \"containerGpumemoryUsedBytes\" \r\n| where Namespace == \"container.azm.ms/gpu\" \r\n| where Origin == \"container.azm.ms\"\r\n| where TimeGenerated >= {timeRange:start}\r\n| where TimeGenerated < {timeRange:end}\r\n| where '*' in ({selectedNodes}) or Computer in ({selectedNodes})\r\n| extend Tags = todynamic(Tags)\r\n| extend clusterId = tostring(Tags['container.azm.ms/clusterId'])\r\n{clusterIdWhereClause}\r\n| extend gpuVendor=tostring(Tags.gpuVendor)\r\n| extend gpuId = tostring(Tags.gpuId)\r\n| extend gpuModel = tostring(Tags.gpuModel)\r\n| extend gpu=strcat(gpuVendor, \"/\", gpuModel)\r\n| summarize maxused=max(Val) by bin(TimeGenerated, {timeRange:grain}), gpu, gpuId, Computer\r\n| make-series ['Max-Used'] = sum(maxused) default = 0 on TimeGenerated from {timeRange:start} to {timeRange:end} step {timeRange:grain}\r\n),\r\n(InsightsMetrics \r\n| where Name == \"containerGpumemoryUsedBytes\" \r\n| where Namespace == \"container.azm.ms/gpu\" \r\n| where Origin == \"container.azm.ms\"\r\n| where TimeGenerated >= {timeRange:start}\r\n| where TimeGenerated < {timeRange:end}\r\n| where '*' in ({selectedNodes}) or Computer in ({selectedNodes})\r\n| extend Tags = todynamic(Tags)\r\n| extend clusterId = tostring(Tags['container.azm.ms/clusterId'])\r\n{clusterIdWhereClause}\r\n| extend gpuVendor=tostring(Tags.gpuVendor)\r\n| extend gpuId = tostring(Tags.gpuId)\r\n| extend gpuModel = tostring(Tags.gpuModel)\r\n| extend gpu=strcat(gpuVendor, \"/\", gpuModel)\r\n| summarize ptile95used=percentile(Val,95) by bin(TimeGenerated, {timeRange:grain}), gpu, gpuId, Computer\r\n| make-series ['95th-ptile-Used'] = sum(ptile95used) default = 0 on TimeGenerated from {timeRange:start} to {timeRange:end} step {timeRange:grain}\r\n),\r\n(InsightsMetrics \r\n| where Name == \"containerGpumemoryUsedBytes\" \r\n| where Namespace == \"container.azm.ms/gpu\" \r\n| where Origin == \"container.azm.ms\"\r\n| where TimeGenerated >= {timeRange:start}\r\n| where TimeGenerated < {timeRange:end}\r\n| where '*' in ({selectedNodes}) or Computer in ({selectedNodes})\r\n| extend Tags = todynamic(Tags)\r\n| extend clusterId = tostring(Tags['container.azm.ms/clusterId'])\r\n{clusterIdWhereClause}\r\n| extend gpuVendor=tostring(Tags.gpuVendor)\r\n| extend gpuId = tostring(Tags.gpuId)\r\n| extend gpuModel = tostring(Tags.gpuModel)\r\n| extend gpu=strcat(gpuVendor, \"/\", gpuModel)\r\n| summarize ptile99used=percentile(Val,99) by bin(TimeGenerated, {timeRange:grain}), gpu, gpuId, Computer\r\n| make-series ['99th-ptile-Used'] = sum(ptile99used) default = 0 on TimeGenerated from {timeRange:start} to {timeRange:end} step {timeRange:grain}\r\n)\r\n",
+              "size": 0,
+              "aggregation": 5,
+              "showAnnotations": true,
+              "showAnalytics": true,
+              "title": "GPU Memory Usage",
+              "queryType": 0,
+              "resourceType": "{ResourceType}",
+              "crossComponentResources": [
+                "{Resource}"
+              ],
+              "visualization": "linechart",
+              "chartSettings": {
+                "showLegend": true,
+                "ySettings": {
+                  "unit": 2,
+                  "min": 0,
+                  "max": null
+                }
               }
-            }
-          ],
-          "labelSettings": [
-            {
-              "columnId": "gpuVendor",
-              "label": "Make",
-              "comment": ""
             },
-            {
-              "columnId": "GPU count by make",
-              "label": "Count"
-            },
-            {
-              "columnId": "TimeGenerated"
-            }
-          ]
-        },
-        "tileSettings": {
-          "titleContent": {
-            "columnMatch": "gpuVendor",
-            "formatOptions": {
-              "showIcon": true
+            "customWidth": "50",
+            "showPin": true,
+            "name": "GPU-MemoryUsage",
+            "styleSettings": {
+              "maxWidth": "50",
+              "showBorder": true
             }
           },
-          "rightContent": {
-            "columnMatch": "GPU count by make",
-            "formatter": 10,
-            "formatOptions": {
-              "palette": "blue",
-              "showIcon": true
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "let im  = InsightsMetrics\r\n| where Name == \"nodeGpuCapacity\"\r\n| where Namespace == \"container.azm.ms/gpu\" \r\n| where Origin == \"container.azm.ms\"\r\n| where TimeGenerated >= {timeRange:start}\r\n| where TimeGenerated < {timeRange:end}\r\n| where '*' in ({selectedNodes}) or Computer in ({selectedNodes})\r\n| extend Tags = todynamic(Tags)\r\n| extend clusterId = tostring(Tags['container.azm.ms/clusterId'])\r\n{clusterIdWhereClause}\r\n| where Val >= 1\r\n| distinct Computer;\r\nKubeNodeInventory\r\n| extend clusterId = ClusterId\r\n{clusterIdWhereClause}\r\n| where Computer in (im)\r\n| extend status=iif(strlen(Status) == 0 ,\"Unknown\", Status)\r\n| summarize count() by Computer, status, bin(TimeGenerated, {timeRange:grain})\r\n| summarize val=count() by status, bin(TimeGenerated, {timeRange:grain})\r\n| make-series ['Node Count by status'] = sum(val) default = 0 on TimeGenerated from {timeRange:start} to {timeRange:end} step {timeRange:grain} by status\r\n\r\n",
+              "size": 0,
+              "aggregation": 5,
+              "showAnnotations": true,
+              "showAnalytics": true,
+              "title": "GPU Node Count by Node Status",
+              "timeContextFromParameter": "timeRange",
+              "queryType": 0,
+              "resourceType": "{ResourceType}",
+              "crossComponentResources": [
+                "{Resource}"
+              ],
+              "visualization": "linechart",
+              "tileSettings": {
+                "titleContent": {
+                  "columnMatch": "status",
+                  "formatter": 1,
+                  "formatOptions": {
+                    "showIcon": true
+                  }
+                },
+                "leftContent": {
+                  "columnMatch": "Node Count by State",
+                  "formatter": 12,
+                  "formatOptions": {
+                    "palette": "auto",
+                    "showIcon": true
+                  },
+                  "numberFormat": {
+                    "unit": 17,
+                    "options": {
+                      "style": "decimal",
+                      "maximumFractionDigits": 2,
+                      "maximumSignificantDigits": 3
+                    }
+                  }
+                },
+                "showBorder": false
+              },
+              "chartSettings": {
+                "showLegend": true,
+                "seriesLabelSettings": [
+                  {
+                    "seriesName": "Ready",
+                    "color": "green"
+                  },
+                  {
+                    "seriesName": "Unknown",
+                    "color": "blue"
+                  }
+                ],
+                "ySettings": {
+                  "min": 0,
+                  "max": null
+                }
+              }
             },
-            "tooltipFormat": {
-              "tooltip": "{0}"
+            "customWidth": "50",
+            "showPin": true,
+            "name": "GPU-NodeCountByNodeStatus",
+            "styleSettings": {
+              "maxWidth": "50",
+              "showBorder": true
             }
           },
-          "showBorder": true,
-          "sortCriteriaField": "TimeGenerated",
-          "sortOrderField": 1
-        },
-        "chartSettings": {
-          "ySettings": {
-            "unit": 17,
-            "min": 0,
-            "max": null
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "let im  = InsightsMetrics\r\n| where Name in (\"containerGpuRequests\", \"containerGpuLimits\")\r\n| where Namespace == \"container.azm.ms/gpu\" \r\n| where Origin == \"container.azm.ms\"\r\n| where TimeGenerated >= {timeRange:start}\r\n| where TimeGenerated < {timeRange:end}\r\n| extend selectedNodes = {selectedNodes}\r\n| extend nodeList = iif(selectedNodes == \"*\", \",*\", selectedNodes) \r\n| where '*' in (selectedNodes) or Computer in (selectedNodes)\r\n| extend Tags = todynamic(Tags)\r\n| extend clusterId = tostring(Tags['container.azm.ms/clusterId'])\r\n{clusterIdWhereClause}\r\n//| extend tags=parse_json(Tags)\r\n| extend containerName = tostring(Tags.containerName)\r\n| extend poduidArray = split(containerName, \"/\")\r\n| extend podUid = iif(array_length(poduidArray) == 2, poduidArray[0], \"\")\r\n| where Val >= 1\r\n| where podUid != \"\"\r\n| distinct podUid;\r\nKubePodInventory\r\n| where PodUid in (im)\r\n| extend clusterId = ClusterId\r\n{clusterIdWhereClause}\r\n| where TimeGenerated >= {timeRange:start}\r\n| where TimeGenerated < {timeRange:end}\r\n| extend selectedNodes = {selectedNodes}\r\n| extend nodeList = iif(selectedNodes == \"*\", \",*\", selectedNodes) \r\n| where '*' in (selectedNodes) or Computer in (selectedNodes)\r\n| summarize count() by PodUid, PodStatus, bin(TimeGenerated, {timeRange:grain})\r\n| make-series ['GPU Pod Count by status'] = count() default = 0 on TimeGenerated from {timeRange:start} to {timeRange:end} step {timeRange:grain} by PodStatus",
+              "size": 0,
+              "aggregation": 5,
+              "showAnnotations": true,
+              "showAnalytics": true,
+              "title": "GPU Pod Count by Pod Status",
+              "timeContextFromParameter": "timeRange",
+              "queryType": 0,
+              "resourceType": "{ResourceType}",
+              "crossComponentResources": [
+                "{Resource}"
+              ],
+              "visualization": "timechart",
+              "chartSettings": {
+                "showLegend": true,
+                "seriesLabelSettings": [
+                  {
+                    "seriesName": "Succeeded",
+                    "color": "greenDark"
+                  },
+                  {
+                    "seriesName": "Running",
+                    "color": "green"
+                  }
+                ],
+                "ySettings": {
+                  "min": 0,
+                  "max": null
+                }
+              }
+            },
+            "customWidth": "50",
+            "showPin": true,
+            "name": "GPU-PodCountByPodStatus",
+            "styleSettings": {
+              "maxWidth": "50",
+              "showBorder": true
+            }
+          },
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "let im  = InsightsMetrics\r\n| where Name in (\"containerGpuRequests\", \"containerGpuLimits\")\r\n| where Namespace == \"container.azm.ms/gpu\" \r\n| where Origin == \"container.azm.ms\"\r\n| where TimeGenerated >= {timeRange:start}\r\n| where TimeGenerated < {timeRange:end}\r\n| extend selectedNodes = {selectedNodes}\r\n| extend nodeList = iif(selectedNodes == \"*\", \",*\", selectedNodes)\r\n| where '*' in (selectedNodes) or Computer in (selectedNodes)\r\n| extend Tags = todynamic(Tags)\r\n| extend clusterId = tostring(Tags['container.azm.ms/clusterId'])\r\n{clusterIdWhereClause}\r\n//| extend tags=parse_json(Tags)\r\n| extend containerName = tostring(Tags.containerName)\r\n| extend poduidArray = split(containerName, \"/\")\r\n| extend podUid = iif(array_length(poduidArray) == 2, poduidArray[0], \"\")\r\n| where Val >= 1\r\n| where podUid != \"\"\r\n| distinct podUid;\r\nKubePodInventory\r\n| where PodUid in (im)\r\n| extend clusterId = ClusterId\r\n{clusterIdWhereClause}\r\n| where TimeGenerated >= {timeRange:start}\r\n| where TimeGenerated < {timeRange:end}\r\n| summarize count() by PodUid, Namespace, PodStatus, bin(TimeGenerated, {timeRange:grain})\r\n| make-series ['GPU Pods by namespace'] = count() default = 0 on TimeGenerated from {timeRange:start} to {timeRange:end} step {timeRange:grain} by Namespace, PodStatus\r\n",
+              "size": 0,
+              "aggregation": 5,
+              "showAnnotations": true,
+              "showAnalytics": true,
+              "title": "GPU Pod Count by Kubernetes Namespace",
+              "timeContextFromParameter": "timeRange",
+              "queryType": 0,
+              "resourceType": "{ResourceType}",
+              "crossComponentResources": [
+                "{Resource}"
+              ],
+              "visualization": "linechart",
+              "tileSettings": {
+                "titleContent": {
+                  "columnMatch": "Namespace",
+                  "formatOptions": {
+                    "showIcon": true
+                  }
+                },
+                "subtitleContent": {
+                  "columnMatch": "PodStatus",
+                  "formatOptions": {
+                    "showIcon": true
+                  }
+                },
+                "rightContent": {
+                  "columnMatch": "GPU Pods by namespace",
+                  "formatter": 10,
+                  "formatOptions": {
+                    "palette": "red",
+                    "showIcon": true
+                  },
+                  "tooltipFormat": {
+                    "tooltip": "hello {0}"
+                  }
+                },
+                "showBorder": false,
+                "sortCriteriaField": "Namespace"
+              },
+              "graphSettings": {
+                "type": 0,
+                "topContent": {
+                  "columnMatch": "Namespace",
+                  "formatter": 1,
+                  "formatOptions": {
+                    "showIcon": true
+                  }
+                },
+                "leftContent": {
+                  "columnMatch": "PodStatus",
+                  "formatOptions": {
+                    "showIcon": true
+                  }
+                },
+                "centerContent": {
+                  "columnMatch": "podcount",
+                  "formatter": 1,
+                  "formatOptions": {
+                    "showIcon": true
+                  },
+                  "numberFormat": {
+                    "unit": 17,
+                    "options": {
+                      "maximumSignificantDigits": 3,
+                      "maximumFractionDigits": 2
+                    }
+                  }
+                },
+                "nodeIdField": "Namespace",
+                "nodeSize": null,
+                "staticNodeSize": 100,
+                "colorSettings": null,
+                "hivesMargin": 5
+              },
+              "chartSettings": {
+                "showLegend": true,
+                "ySettings": {
+                  "unit": 17,
+                  "min": 0,
+                  "max": null
+                }
+              }
+            },
+            "customWidth": "50",
+            "showPin": true,
+            "name": "GPU-PodCountByK8SNamespace",
+            "styleSettings": {
+              "maxWidth": "50",
+              "showBorder": true
+            }
+          },
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "InsightsMetrics \r\n| where Name == \"nodeGpuCapacity\" \r\n| where Namespace == \"container.azm.ms/gpu\" \r\n| where Origin == \"container.azm.ms\"\r\n| where TimeGenerated >= {timeRange:start}\r\n| where TimeGenerated < {timeRange:end}\r\n| where '*' in ({selectedNodes}) or Computer in ({selectedNodes})\r\n| extend Tags = todynamic(Tags)\r\n| extend clusterId = tostring(Tags['container.azm.ms/clusterId'])\r\n{clusterIdWhereClause}\r\n| extend gpuVendor=strcat ('🔹 ',tostring(Tags.gpuVendor))\r\n| summarize gpuCountPerComputer=max(Val) by gpuVendor, Computer , bin(TimeGenerated, {timeRange:grain})\r\n| make-series ['GPU count by make'] =sum(gpuCountPerComputer) default = 0 on TimeGenerated from {timeRange:start} to {timeRange:end} step {timeRange:grain} by gpuVendor\r\n\r\n\r\n\r\n\r\n\r\n\r\n",
+              "size": 0,
+              "aggregation": 5,
+              "showAnnotations": true,
+              "showAnalytics": true,
+              "title": "GPU Count by Make",
+              "color": "blue",
+              "timeContextFromParameter": "timeRange",
+              "queryType": 0,
+              "resourceType": "{ResourceType}",
+              "crossComponentResources": [
+                "{Resource}"
+              ],
+              "visualization": "table",
+              "gridSettings": {
+                "formatters": [
+                  {
+                    "columnMatch": "gpuVendor",
+                    "formatter": 1,
+                    "formatOptions": {
+                      "showIcon": true
+                    }
+                  },
+                  {
+                    "columnMatch": "GPU count by make",
+                    "formatter": 10,
+                    "formatOptions": {
+                      "showIcon": true
+                    },
+                    "numberFormat": {
+                      "unit": 17,
+                      "options": {
+                        "style": "decimal"
+                      }
+                    },
+                    "tooltipFormat": {
+                      "tooltip": "{0}"
+                    }
+                  },
+                  {
+                    "columnMatch": "TimeGenerated",
+                    "formatter": 5,
+                    "formatOptions": {
+                      "showIcon": true
+                    }
+                  }
+                ],
+                "labelSettings": [
+                  {
+                    "columnId": "gpuVendor",
+                    "label": "Make",
+                    "comment": ""
+                  },
+                  {
+                    "columnId": "GPU count by make",
+                    "label": "Count"
+                  }
+                ]
+              },
+              "tileSettings": {
+                "titleContent": {
+                  "columnMatch": "gpuVendor",
+                  "formatOptions": {
+                    "showIcon": true
+                  }
+                },
+                "rightContent": {
+                  "columnMatch": "GPU count by make",
+                  "formatter": 10,
+                  "formatOptions": {
+                    "palette": "blue",
+                    "showIcon": true
+                  },
+                  "tooltipFormat": {
+                    "tooltip": "{0}"
+                  }
+                },
+                "showBorder": true,
+                "sortCriteriaField": "TimeGenerated",
+                "sortOrderField": 1
+              },
+              "chartSettings": {
+                "ySettings": {
+                  "unit": 17,
+                  "min": 0,
+                  "max": null
+                }
+              }
+            },
+            "customWidth": "50",
+            "showPin": true,
+            "name": "GPU-GpuCountByMake",
+            "styleSettings": {
+              "maxWidth": "50",
+              "showBorder": true
+            }
           }
-        }
+        ]
       },
-      "customWidth": "50",
-      "showPin": true,
-      "name": "GPU-GpuCountByMake",
-      "styleSettings": {
-        "maxWidth": "50",
-        "showBorder": true
-      }
+      "conditionalVisibility": {
+        "parameterName": "selectedTab",
+        "comparison": "isEqualTo",
+        "value": "GPU"
+      },
+      "name": "GPU-tab"
     }
   ],
   "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"


### PR DESCRIPTION
Moving to a tab structure, adding note on GPU migration

## PR Checklist

* [x] Explain your changes, so people looking at the PR know *what* and *why*, the code changes are the *how*.
GPU metrics collection are being deprecated from the Kubernetes upstream. Added a note in the template to redirect to Container Insights documentation.

### If adding or updating templates:
* [x] post a screenshot of templates and/or gallery changes
![image](https://user-images.githubusercontent.com/22860422/176554485-c8e7a8b6-0995-4dde-b6db-18dbddc6e7a8.png)

* [x] ensure your template has a corresponding gallery entry in the gallery folder
* [ ] If you are adding a new template, add your team and template/gallery file(s) to the CODEOWNERS file. CODEOWNERS entries should be teams, not individuals
* [x] ensure all steps have meaningful names
* [x] ensure all parameters and grid columns have display names set so they can be localized
* [x] ensure that parameters id values are unique __or they will fail PR validation__ (parameter ids are used for localization)
* [x] ensure that steps names are unique __or they will fail PR validation__ (step names are used for localization)
* [x] grep `/subscription/` and ensure that your parameters don't have any hardcoded resourceIds __or they will fail PR validation__
* [x] remove `fallbackResourceIds` and `fromTemplateId` fields from your template workbook __or they will fail PR validation__