### PR TITLE
Fix Virtual WAN Hub level Status and Capacities bug

### DIFF
--- a/Workbooks/Network Insights/VirtualWANWorkbooks/NetworkInsights-VirtualWANMetrics/NetworkInsights-VirtualWANMetrics.workbook
+++ b/Workbooks/Network Insights/VirtualWANWorkbooks/NetworkInsights-VirtualWANMetrics/NetworkInsights-VirtualWANMetrics.workbook
@@ -258,626 +258,378 @@
       "name": "Virtual WAN Regional Status and Hub Capacities (Gbps)"
     },
     {
-      "type": 3,
+      "type": 12,
       "content": {
-        "version": "KqlItem/1.0",
-        "query": "resources\r\n| where type =~ \"microsoft.network/virtualhubs\"\r\n| where properties.virtualWan.id =~ '{virtualWAN}'\r\n| project hubId = tolower(id), hubStatus = properties.provisioningState\r\n| join kind=leftouter (\r\nresources\r\n| where type =~ \"microsoft.network/vpngateways\"\r\n| project hubId = tolower(properties.virtualHub.id), vpnGWStatus = properties.provisioningState, vpnGWScaleUnit = properties.vpnGatewayScaleUnit\r\n) on hubId\r\n| join kind=leftouter (\r\nresources\r\n| where type =~ \"microsoft.network/p2svpngateways\"\r\n| project hubId = tolower(properties.virtualHub.id), p2sGWStatus = properties.provisioningState, p2sGWScaleUnit = properties.vpnGatewayScaleUnit\r\n) on hubId\r\n| join kind=leftouter (\r\nresources\r\n| where type =~ \"microsoft.network/expressroutegateways\"\r\n| project hubId = tolower(properties.virtualHub.id), erGWStatus = properties.provisioningState, erGWMinScaleUnit = properties.autoScaleConfiguration.bounds.min\r\n) on hubId\r\n| extend totalHubCapacityInGbps = (iff(isnotempty(vpnGWScaleUnit), vpnGWScaleUnit, 0) + iff(isnotempty(p2sGWScaleUnit), p2sGWScaleUnit, 0) + iff(isnotempty(erGWMinScaleUnit), 2 * erGWMinScaleUnit, 0))*0.5\r\n| project hubId, hubStatus, vpnGWStatus, vpnGWScaleUnit, p2sGWStatus, p2sGWScaleUnit, erGWStatus, erGWMinScaleUnit, totalHubCapacityInGbps",
-        "size": 3,
-        "title": "Hub level status and capacities without firewall",
-        "queryType": 1,
-        "resourceType": "microsoft.resourcegraph/resources",
-        "crossComponentResources": [
-          "value::all"
-        ],
-        "visualization": "table",
-        "gridSettings": {
-          "formatters": [
-            {
-              "columnMatch": "hubId",
-              "formatter": 13,
-              "formatOptions": {
-                "linkTarget": "OpenBlade",
-                "showIcon": true,
-                "bladeOpenContext": {
-                  "bladeName": "VirtualHubManagementViewModel",
-                  "extensionName": "Microsoft_Azure_HybridNetworking",
-                  "bladeParameters": [
-                    {
-                      "name": "virtualHubId",
-                      "source": "cell",
-                      "value": ""
-                    }
-                  ]
-                }
-              }
-            },
-            {
-              "columnMatch": "hubStatus",
-              "formatter": 1
-            },
-            {
-              "columnMatch": "vpnGWStatus",
-              "formatter": 1,
-              "numberFormat": {
-                "unit": 0,
-                "options": {
-                  "style": "decimal"
-                },
-                "emptyValCustomText": "-"
-              }
-            },
-            {
-              "columnMatch": "vpnGWScaleUnit",
-              "formatter": 1,
-              "numberFormat": {
-                "unit": 0,
-                "options": {
-                  "style": "decimal"
-                },
-                "emptyValCustomText": "-"
-              }
-            },
-            {
-              "columnMatch": "p2sGWStatus",
-              "formatter": 1,
-              "numberFormat": {
-                "unit": 0,
-                "options": {
-                  "style": "decimal"
-                },
-                "emptyValCustomText": "-"
-              }
-            },
-            {
-              "columnMatch": "p2sGWScaleUnit",
-              "formatter": 1,
-              "numberFormat": {
-                "unit": 0,
-                "options": {
-                  "style": "decimal"
-                },
-                "emptyValCustomText": "-"
-              }
-            },
-            {
-              "columnMatch": "erGWStatus",
-              "formatter": 1,
-              "numberFormat": {
-                "unit": 0,
-                "options": {
-                  "style": "decimal"
-                },
-                "emptyValCustomText": "-"
-              }
-            },
-            {
-              "columnMatch": "erGWMinScaleUnit",
-              "formatter": 1,
-              "numberFormat": {
-                "unit": 0,
-                "options": {
-                  "style": "decimal"
-                },
-                "emptyValCustomText": "-"
-              }
-            },
-            {
-              "columnMatch": "totalHubCapacityInGbps",
-              "formatter": 1,
-              "numberFormat": {
-                "unit": 0,
-                "options": {
-                  "style": "decimal"
-                },
-                "emptyValCustomText": "0"
-              }
-            }
-          ],
-          "labelSettings": [
-            {
-              "columnId": "hubId",
-              "label": "Virtual Hub"
-            },
-            {
-              "columnId": "hubStatus",
-              "label": "Hub Deployment Status"
-            },
-            {
-              "columnId": "vpnGWStatus",
-              "label": "VPN Gateway Status"
-            },
-            {
-              "columnId": "vpnGWScaleUnit",
-              "label": "VPN Gateway Scale Units"
-            },
-            {
-              "columnId": "p2sGWStatus",
-              "label": "P2S Gateway Status"
-            },
-            {
-              "columnId": "p2sGWScaleUnit",
-              "label": "P2S Gateway Scale Units"
-            },
-            {
-              "columnId": "erGWStatus",
-              "label": "ER Gateway Status"
-            },
-            {
-              "columnId": "erGWMinScaleUnit",
-              "label": "ER Gateway Scale Units"
-            },
-            {
-              "columnId": "totalHubCapacityInGbps",
-              "label": "Provisioned Hub Capacity (Gbps)"
-            }
-          ]
-        }
-      },
-      "conditionalVisibility": {
-        "parameterName": "tab",
-        "comparison": "isEqualTo",
-        "value": "-1"
-      },
-      "name": "Hub level status and capacities without firewall"
-    },
-    {
-      "type": 3,
-      "content": {
-        "version": "KqlItem/1.0",
-        "query": "resources\r\n| where type =~ \"microsoft.network/virtualhubs\"\r\n| where properties.virtualWan.id =~ '{virtualWAN}'\r\n| project hubId = tolower(id), hubStatus = properties.provisioningState\r\n| join kind=leftouter (\r\nresources\r\n| where type =~ \"microsoft.network/vpngateways\"\r\n| project vpngwId = tolower(id), hubId = tolower(properties.virtualHub.id), vpnGWStatus = properties.provisioningState, vpnGWScaleUnit = properties.vpnGatewayScaleUnit\r\n) on hubId\r\n| project hubId, vpngwId",
-        "size": 3,
-        "title": "vpn gateway to hubs matching",
-        "queryType": 1,
-        "resourceType": "microsoft.resourcegraph/resources",
-        "crossComponentResources": [
-          "value::all"
-        ],
-        "visualization": "table",
-        "gridSettings": {
-          "formatters": [
-            {
-              "columnMatch": "hubId",
-              "formatter": 13,
-              "formatOptions": {
-                "linkTarget": "OpenBlade",
-                "showIcon": true,
-                "bladeOpenContext": {
-                  "bladeName": "VirtualHubManagementViewModel",
-                  "extensionName": "Microsoft_Azure_HybridNetworking",
-                  "bladeParameters": [
-                    {
-                      "name": "virtualHubId",
-                      "source": "cell",
-                      "value": ""
-                    }
-                  ]
-                }
-              }
-            },
-            {
-              "columnMatch": "hubStatus",
-              "formatter": 1
-            },
-            {
-              "columnMatch": "vpnGWStatus",
-              "formatter": 1,
-              "numberFormat": {
-                "unit": 0,
-                "options": {
-                  "style": "decimal"
-                },
-                "emptyValCustomText": "-"
-              }
-            },
-            {
-              "columnMatch": "vpnGWScaleUnit",
-              "formatter": 1,
-              "numberFormat": {
-                "unit": 0,
-                "options": {
-                  "style": "decimal"
-                },
-                "emptyValCustomText": "-"
-              }
-            },
-            {
-              "columnMatch": "p2sGWStatus",
-              "formatter": 1,
-              "numberFormat": {
-                "unit": 0,
-                "options": {
-                  "style": "decimal"
-                },
-                "emptyValCustomText": "-"
-              }
-            },
-            {
-              "columnMatch": "p2sGWScaleUnit",
-              "formatter": 1,
-              "numberFormat": {
-                "unit": 0,
-                "options": {
-                  "style": "decimal"
-                },
-                "emptyValCustomText": "-"
-              }
-            },
-            {
-              "columnMatch": "erGWStatus",
-              "formatter": 1,
-              "numberFormat": {
-                "unit": 0,
-                "options": {
-                  "style": "decimal"
-                },
-                "emptyValCustomText": "-"
-              }
-            },
-            {
-              "columnMatch": "erGWMinScaleUnit",
-              "formatter": 1,
-              "numberFormat": {
-                "unit": 0,
-                "options": {
-                  "style": "decimal"
-                },
-                "emptyValCustomText": "-"
-              }
-            },
-            {
-              "columnMatch": "totalHubCapacityInGbps",
-              "formatter": 1,
-              "numberFormat": {
-                "unit": 0,
-                "options": {
-                  "style": "decimal"
-                },
-                "emptyValCustomText": "0"
-              }
-            }
-          ],
-          "labelSettings": [
-            {
-              "columnId": "hubId",
-              "label": "Virtual Hub"
-            }
-          ]
-        }
-      },
-      "conditionalVisibility": {
-        "parameterName": "tab",
-        "comparison": "isEqualTo",
-        "value": "-1"
-      },
-      "name": "vpn gateway to hubs matching"
-    },
-    {
-      "type": 3,
-      "content": {
-        "version": "KqlItem/1.0",
-        "query": "resources\r\n| where type =~ \"microsoft.network/virtualwans\" and id =~ '{virtualWAN}'\r\n| mv-expand virtualHub = properties.virtualHubs\r\n| project hubId = tolower(virtualHub.id)\r\n| join kind=inner (\r\nresources\r\n| where type =~ \"microsoft.network/azurefirewalls\"\r\n| project hubId = tolower(properties.virtualHub.id), firewallStatus = properties.provisioningState\r\n) on hubId\r\n| project hubId, firewallStatus",
-        "size": 3,
-        "title": "Firewall Status",
-        "queryType": 1,
-        "resourceType": "microsoft.resourcegraph/resources",
-        "crossComponentResources": [
-          "value::all"
-        ],
-        "visualization": "table"
-      },
-      "conditionalVisibility": {
-        "parameterName": "tab",
-        "comparison": "isEqualTo",
-        "value": "-1"
-      },
-      "name": "Firewall Status"
-    },
-    {
-      "type": 10,
-      "content": {
-        "chartId": "workbook1b5f06fe-6eb8-4352-97f3-3e0da75b23b0",
-        "version": "MetricsItem/2.0",
-        "size": 0,
-        "chartType": 0,
-        "resourceType": "microsoft.network/vpngateways",
-        "metricScope": 0,
-        "resourceParameter": "vpnGateway",
-        "resourceIds": [
-          "{vpnGateway}"
-        ],
-        "timeContextFromParameter": "TimeRange",
-        "timeContext": {
-          "durationMs": 86400000
-        },
-        "metrics": [
+        "version": "NotebookGroup/1.0",
+        "groupType": "editable",
+        "loadType": "always",
+        "items": [
           {
-            "namespace": "microsoft.network/vpngateways",
-            "metric": "microsoft.network/vpngateways-Traffic-AverageBandwidth",
-            "aggregation": 4
-          }
-        ],
-        "title": "Consumed capacity metric",
-        "gridSettings": {
-          "formatters": [
-            {
-              "columnMatch": "Subscription",
-              "formatter": 5
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "resources\r\n| where type =~ \"microsoft.network/virtualhubs\"\r\n| where properties.virtualWan.id =~ '{virtualWAN}'\r\n| project hubId = tolower(id), hubStatus = properties.provisioningState\r\n| join kind=leftouter (\r\nresources\r\n| where type =~ \"microsoft.network/vpngateways\"\r\n| project hubId = tolower(properties.virtualHub.id), vpnGWStatus = properties.provisioningState, vpnGWScaleUnit = properties.vpnGatewayScaleUnit, vpngwId = tolower(id)\r\n) on hubId\r\n| join kind=leftouter (\r\nresources\r\n| where type =~ \"microsoft.network/p2svpngateways\"\r\n| project hubId = tolower(properties.virtualHub.id), p2sGWStatus = properties.provisioningState, p2sGWScaleUnit = properties.vpnGatewayScaleUnit\r\n) on hubId\r\n| join kind=leftouter (\r\n    resources\r\n    | where type =~ \"microsoft.network/expressroutegateways\"\r\n    | project hubId = tolower(properties.virtualHub.id), erGWStatus = properties.provisioningState, erGWMinScaleUnit = properties.autoScaleConfiguration.bounds.min\r\n) on hubId\r\n| extend totalHubCapacityInGbps = (iff(isnotempty(vpnGWScaleUnit), vpnGWScaleUnit, 0) + iff(isnotempty(p2sGWScaleUnit), p2sGWScaleUnit, 0) + iff(isnotempty(erGWMinScaleUnit), 2 * erGWMinScaleUnit, 0))*0.5\r\n| project hubId, vpngwId, hubStatus, vpnGWStatus, vpnGWScaleUnit, p2sGWStatus, p2sGWScaleUnit, erGWStatus, erGWMinScaleUnit, totalHubCapacityInGbps",
+              "size": 0,
+              "queryType": 1,
+              "resourceType": "microsoft.resourcegraph/resources"
             },
-            {
-              "columnMatch": "Name",
-              "formatter": 13,
-              "formatOptions": {
-                "linkTarget": "Resource",
-                "showIcon": true
-              }
+            "conditionalVisibility": {
+              "parameterName": "show",
+              "comparison": "isEqualTo",
+              "value": "1"
             },
-            {
-              "columnMatch": "microsoft.network/vpngateways-Traffic-AverageBandwidth",
-              "formatter": 1,
-              "numberFormat": {
-                "unit": 11,
-                "options": {
-                  "style": "decimal"
-                }
-              }
+            "name": " Hub level status and capacities without firewall + vpn gateway to hubs matching"
+          },
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "resources\r\n| where type =~ \"microsoft.network/virtualwans\" and id =~ '{virtualWAN}'\r\n| mv-expand virtualHub = properties.virtualHubs\r\n| project hubId = tolower(virtualHub.id)\r\n| join kind=leftouter (\r\nresources\r\n| where type =~ \"microsoft.network/azurefirewalls\"\r\n| project hubId = tolower(properties.virtualHub.id), firewallStatus = properties.provisioningState\r\n) on hubId\r\n| join kind=leftouter (\r\nresources\r\n| where type =~ \"microsoft.network/vpngateways\"\r\n| project hubId = tolower(properties.virtualHub.id), vpngwId = tolower(id)\r\n) on hubId\r\n| project hubId, vpngwId, firewallStatus",
+              "size": 0,
+              "queryType": 1,
+              "resourceType": "microsoft.resourcegraph/resources"
             },
-            {
-              "columnMatch": "Timeline",
-              "formatter": 9
+            "conditionalVisibility": {
+              "parameterName": "show",
+              "comparison": "isEqualTo",
+              "value": "1"
             },
-            {
-              "columnMatch": "Metric",
-              "formatter": 1
-            },
-            {
-              "columnMatch": "Aggregation",
-              "formatter": 5
-            },
-            {
-              "columnMatch": "Value",
-              "formatter": 1
-            }
-          ],
-          "rowLimit": 10000,
-          "labelSettings": [
-            {
-              "columnId": "microsoft.network/vpngateways-Traffic-AverageBandwidth",
-              "label": "Gateway S2S Bandwidth (Average)"
-            },
-            {
-              "columnId": "microsoft.network/vpngateways-Traffic-AverageBandwidth Timeline",
-              "label": "Gateway S2S Bandwidth Timeline"
-            }
-          ]
-        }
-      },
-      "conditionalVisibility": {
-        "parameterName": "tab",
-        "comparison": "isEqualTo",
-        "value": "-1"
-      },
-      "name": "metric - 21"
-    },
-    {
-      "type": 3,
-      "content": {
-        "version": "KqlItem/1.0",
-        "query": "{\"version\":\"Merge/1.0\",\"merges\":[{\"id\":\"ea8985d5-4294-407e-946a-d4e030c8e066\",\"mergeType\":\"innerunique\",\"leftTable\":\"metric - 21\",\"rightTable\":\"vpn gateway to hubs matching\",\"leftColumn\":\"Name\",\"rightColumn\":\"vpngwId\"}],\"projectRename\":[{\"originalName\":\"[metric - 21].Subscription\",\"mergedName\":\"Subscription\",\"fromId\":\"ea8985d5-4294-407e-946a-d4e030c8e066\"},{\"originalName\":\"[metric - 21].Name\",\"mergedName\":\"VPN Gateway\",\"fromId\":\"ea8985d5-4294-407e-946a-d4e030c8e066\"},{\"originalName\":\"[metric - 21].microsoft.network/vpngateways-Traffic-AverageBandwidth\",\"mergedName\":\"Gateway S2S Bandwidth (Average)\",\"fromId\":\"ea8985d5-4294-407e-946a-d4e030c8e066\"},{\"originalName\":\"[metric - 21].microsoft.network/vpngateways-Traffic-AverageBandwidth Timeline\",\"mergedName\":\"Gateway S2S Bandwidth Timeline\",\"fromId\":\"ea8985d5-4294-407e-946a-d4e030c8e066\"},{\"originalName\":\"[vpn gateway to hubs matching].hubId\",\"mergedName\":\"Virtual Hub\",\"fromId\":\"ea8985d5-4294-407e-946a-d4e030c8e066\"},{\"originalName\":\"[vpn gateway to hubs matching].vpngwId\",\"mergedName\":\"vpngwId\",\"fromId\":\"ea8985d5-4294-407e-946a-d4e030c8e066\"},{\"originalName\":\"[metric - 21].Subscription\"},{\"originalName\":\"[metric - 21].microsoft.network/vpngateways-Traffic-AverageBandwidth Timeline\"}]}",
-        "size": 0,
-        "title": "Hub to VPN and Consumed cap",
-        "exportToExcelOptions": "all",
-        "queryType": 7,
-        "visualization": "table",
-        "gridSettings": {
-          "formatters": [
-            {
-              "columnMatch": "Gateway S2S Bandwidth (Average)",
-              "formatter": 0,
-              "numberFormat": {
-                "unit": 11,
-                "options": {
-                  "style": "decimal"
-                }
-              }
-            }
-          ]
-        }
-      },
-      "conditionalVisibility": {
-        "parameterName": "tab",
-        "comparison": "isEqualTo",
-        "value": "-1"
-      },
-      "name": "query - 23"
-    },
-    {
-      "type": 3,
-      "content": {
-        "version": "KqlItem/1.0",
-        "query": "{\"version\":\"Merge/1.0\",\"merges\":[{\"id\":\"ea8985d5-4294-407e-946a-d4e030c8e06f\",\"mergeType\":\"innerunique\",\"leftTable\":\"Hub level status and capacities without firewall\",\"rightTable\":\"query - 23\",\"leftColumn\":\"hubId\",\"rightColumn\":\"Virtual Hub\"}],\"projectRename\":[{\"originalName\":\"[Hub level status and capacities without firewall].hubId\",\"mergedName\":\"Virtual Hub\",\"fromId\":\"ea8985d5-4294-407e-946a-d4e030c8e06f\"},{\"originalName\":\"[query - 23].Gateway S2S Bandwidth (Average)\",\"mergedName\":\"Gateway S2S Bandwidth (Average)\",\"fromId\":\"ea8985d5-4294-407e-946a-d4e030c8e06f\"},{\"originalName\":\"[query - 23].VPN Gateway\"},{\"originalName\":\"[query - 23].Virtual Hub\"},{\"originalName\":\"[Hub level status and capacities without firewall].hubStatus\"},{\"originalName\":\"[Hub level status and capacities without firewall].vpnGWStatus\"},{\"originalName\":\"[Hub level status and capacities without firewall].vpnGWScaleUnit\"},{\"originalName\":\"[Hub level status and capacities without firewall].p2sGWStatus\"},{\"originalName\":\"[Hub level status and capacities without firewall].p2sGWScaleUnit\"},{\"originalName\":\"[Hub level status and capacities without firewall].erGWStatus\"},{\"originalName\":\"[Hub level status and capacities without firewall].erGWMinScaleUnit\"},{\"originalName\":\"[Hub level status and capacities without firewall].totalHubCapacityInGbps\"},{\"originalName\":\"[query - 23].vpngwId\"},{\"originalName\":\"[query - 23].Subscription\"},{\"originalName\":\"[query - 23].Gateway S2S Bandwidth Timeline\"}]}",
-        "size": 0,
-        "queryType": 7,
-        "gridSettings": {
-          "formatters": [
-            {
-              "columnMatch": "Gateway S2S Bandwidth (Average)",
-              "formatter": 0,
-              "formatOptions": {
-                "aggregation": "Sum"
+            "name": "Firewall Status V2"
+          },
+          {
+            "type": 10,
+            "content": {
+              "chartId": "workbook873e27c2-5708-42b1-bf86-80c1278ce0cf",
+              "version": "MetricsItem/2.0",
+              "size": 0,
+              "chartType": 0,
+              "resourceType": "microsoft.network/vpngateways",
+              "metricScope": 0,
+              "resourceParameter": "vpnGateway",
+              "resourceIds": [
+                "{vpnGateway}"
+              ],
+              "timeContext": {
+                "durationMs": 3600000
               },
-              "numberFormat": {
-                "unit": 11,
-                "options": {
-                  "style": "decimal"
+              "metrics": [
+                {
+                  "namespace": "microsoft.network/vpngateways",
+                  "metric": "microsoft.network/vpngateways-Traffic-AverageBandwidth",
+                  "aggregation": 4
                 }
-              }
-            },
-            {
-              "columnMatch": "vpngwId",
-              "formatter": 0,
-              "formatOptions": {
-                "aggregation": "Unique"
-              }
-            }
-          ],
-          "hierarchySettings": {
-            "treeType": 1,
-            "groupBy": [
-              "Virtual Hub"
-            ],
-            "expandTopLevel": true
-          }
-        }
-      },
-      "conditionalVisibility": {
-        "parameterName": "tab",
-        "comparison": "isEqualTo",
-        "value": "-1"
-      },
-      "name": "query - 24"
-    },
-    {
-      "type": 3,
-      "content": {
-        "version": "KqlItem/1.0",
-        "query": "{\"version\":\"Merge/1.0\",\"merges\":[{\"id\":\"8a47059f-c364-47ed-b3ec-f2b15f063071\",\"mergeType\":\"leftouter\",\"leftTable\":\"Hub level status and capacities without firewall\",\"rightTable\":\"Firewall Status\",\"leftColumn\":\"hubId\",\"rightColumn\":\"hubId\"},{\"id\":\"ea8985d5-4294-407e-946a-d4e030c8e080\",\"mergeType\":\"innerunique\",\"leftTable\":\"Hub level status and capacities without firewall\",\"rightTable\":\"query - 24\",\"leftColumn\":\"hubId\",\"rightColumn\":\"Virtual Hub\"}],\"projectRename\":[{\"originalName\":\"[Hub level status and capacities without firewall].hubId\",\"mergedName\":\"Virtual Hub\",\"fromId\":\"8a47059f-c364-47ed-b3ec-f2b15f063071\"},{\"originalName\":\"[Hub level status and capacities without firewall].hubStatus\",\"mergedName\":\"Hub Deployment Status\",\"fromId\":\"8a47059f-c364-47ed-b3ec-f2b15f063071\"},{\"originalName\":\"[Hub level status and capacities without firewall].vpnGWStatus\",\"mergedName\":\"VPN Gateway Status\",\"fromId\":\"8a47059f-c364-47ed-b3ec-f2b15f063071\"},{\"originalName\":\"[Hub level status and capacities without firewall].vpnGWScaleUnit\",\"mergedName\":\"VPN Gateway Scale Units\",\"fromId\":\"8a47059f-c364-47ed-b3ec-f2b15f063071\"},{\"originalName\":\"[Hub level status and capacities without firewall].p2sGWStatus\",\"mergedName\":\"P2S Gateway Status\",\"fromId\":\"8a47059f-c364-47ed-b3ec-f2b15f063071\"},{\"originalName\":\"[Hub level status and capacities without firewall].p2sGWScaleUnit\",\"mergedName\":\"P2S Gateway Scale Units\",\"fromId\":\"8a47059f-c364-47ed-b3ec-f2b15f063071\"},{\"originalName\":\"[Hub level status and capacities without firewall].erGWStatus\",\"mergedName\":\"ER Gateway Status\",\"fromId\":\"8a47059f-c364-47ed-b3ec-f2b15f063071\"},{\"originalName\":\"[Hub level status and capacities without firewall].erGWMinScaleUnit\",\"mergedName\":\"ER Gateway Scale Units\",\"fromId\":\"8a47059f-c364-47ed-b3ec-f2b15f063071\"},{\"originalName\":\"[Firewall Status].firewallStatus\",\"mergedName\":\"firewallStatus\",\"fromId\":\"8a47059f-c364-47ed-b3ec-f2b15f063071\"},{\"originalName\":\"[Hub level status and capacities without firewall].totalHubCapacityInGbps\",\"mergedName\":\"Total Hub Capacity (Gbps)\",\"fromId\":\"8a47059f-c364-47ed-b3ec-f2b15f063071\"},{\"originalName\":\"[query - 24].Gateway S2S Bandwidth Timeline\",\"mergedName\":\"Gateway S2S Bandwidth Timeline\",\"fromId\":\"unknown\"},{\"originalName\":\"[query - 24].hubStatus\",\"mergedName\":\"hubStatus\",\"fromId\":\"unknown\"},{\"originalName\":\"[query - 24].vpnGWStatus\",\"mergedName\":\"vpnGWStatus\",\"fromId\":\"unknown\"},{\"originalName\":\"[query - 24].vpnGWScaleUnit\",\"mergedName\":\"vpnGWScaleUnit\",\"fromId\":\"unknown\"},{\"originalName\":\"[query - 24].p2sGWStatus\",\"mergedName\":\"p2sGWStatus\",\"fromId\":\"unknown\"},{\"originalName\":\"[query - 24].p2sGWScaleUnit\",\"mergedName\":\"p2sGWScaleUnit\",\"fromId\":\"unknown\"},{\"originalName\":\"[query - 24].erGWStatus\",\"mergedName\":\"erGWStatus\",\"fromId\":\"unknown\"},{\"originalName\":\"[query - 24].erGWMinScaleUnit\",\"mergedName\":\"erGWMinScaleUnit\",\"fromId\":\"unknown\"},{\"originalName\":\"[query - 24].totalHubCapacityInGbps\",\"mergedName\":\"totalHubCapacityInGbps\",\"fromId\":\"unknown\"},{\"originalName\":\"[query - 24].VPN Gateway\",\"mergedName\":\"VPN Gateway\",\"fromId\":\"unknown\"},{\"originalName\":\"[query - 24].vpngwId\",\"mergedName\":\"vpngwId\",\"fromId\":\"unknown\"},{\"originalName\":\"[query - 24].Gateway S2S Bandwidth (Average)\",\"mergedName\":\"Gateway S2S Bandwidth (Average)\",\"fromId\":\"ea8985d5-4294-407e-946a-d4e030c8e080\"},{\"originalName\":\"[Firewall Status].hubId\"},{\"originalName\":\"[query - 24].Virtual Hub\"},{\"originalName\":\"[query - 24].Subscription\"},{\"originalName\":\"[query - 24].hubId\"}]}",
-        "size": 3,
-        "title": "Virtual WAN Hub level Status and Capacities",
-        "noDataMessage": "No virtual hubs found",
-        "showExportToExcel": true,
-        "queryType": 7,
-        "visualization": "table",
-        "gridSettings": {
-          "formatters": [
-            {
-              "columnMatch": "Virtual Hub",
-              "formatter": 13,
-              "formatOptions": {
-                "linkTarget": "OpenBlade",
-                "showIcon": true,
-                "bladeOpenContext": {
-                  "bladeName": "VirtualHubManagementViewModel",
-                  "extensionName": "Microsoft_Azure_HybridNetworking",
-                  "bladeParameters": [
-                    {
-                      "name": "virtualHubId",
-                      "source": "cell",
-                      "value": ""
+              ],
+              "gridSettings": {
+                "formatters": [
+                  {
+                    "columnMatch": "Subscription",
+                    "formatter": 5
+                  },
+                  {
+                    "columnMatch": "Name",
+                    "formatter": 13,
+                    "formatOptions": {
+                      "linkTarget": "Resource",
+                      "showIcon": true
                     }
-                  ]
-                }
+                  },
+                  {
+                    "columnMatch": "microsoft.network/vpngateways-Traffic-AverageBandwidth",
+                    "formatter": 1,
+                    "numberFormat": {
+                      "unit": 11,
+                      "options": {
+                        "style": "decimal"
+                      }
+                    }
+                  },
+                  {
+                    "columnMatch": "microsoft.network/vpngateways-Traffic-AverageBandwidth Timeline",
+                    "formatter": 1
+                  },
+                  {
+                    "columnMatch": ".*\\/Gateway S2S Bandwidth$",
+                    "formatter": 1
+                  }
+                ],
+                "rowLimit": 10000,
+                "labelSettings": [
+                  {
+                    "columnId": "Name",
+                    "label": "VPN Gateway"
+                  },
+                  {
+                    "columnId": "microsoft.network/vpngateways-Traffic-AverageBandwidth",
+                    "label": "Gateway S2S Bandwidth (Average)"
+                  },
+                  {
+                    "columnId": "microsoft.network/vpngateways-Traffic-AverageBandwidth Timeline",
+                    "label": "Gateway S2S Bandwidth Timeline"
+                  }
+                ]
+              },
+              "sortBy": []
+            },
+            "conditionalVisibility": {
+              "parameterName": "show",
+              "comparison": "isEqualTo",
+              "value": "1"
+            },
+            "name": "Consumed capacity metric V2"
+          },
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "{\"version\":\"Merge/1.0\",\"merges\":[{\"id\":\"5a4488b9-55b4-4b06-b7d5-ea3e2a2970a4\",\"mergeType\":\"innerunique\",\"leftTable\":\"Consumed capacity metric V2\",\"rightTable\":\" Hub level status and capacities without firewall + vpn gateway to hubs matching\",\"leftColumn\":\"Name\",\"rightColumn\":\"vpngwId\"},{\"id\":\"5a4488b9-55b4-4b06-b7d5-ea3e2a2970a6\",\"mergeType\":\"innerunique\",\"leftTable\":\" Hub level status and capacities without firewall + vpn gateway to hubs matching\",\"rightTable\":\"Firewall Status V2\",\"leftColumn\":\"hubId\",\"rightColumn\":\"hubId\"}],\"projectRename\":[{\"originalName\":\"[Firewall Status V2].hubId\",\"mergedName\":\"Virtual Hub\",\"fromId\":\"5a4488b9-55b4-4b06-b7d5-ea3e2a2970a6\"},{\"originalName\":\"[ Hub level status and capacities without firewall + vpn gateway to hubs matching].hubStatus\",\"mergedName\":\"Hub Deployment Status\",\"fromId\":\"5a4488b9-55b4-4b06-b7d5-ea3e2a2970a4\"},{\"originalName\":\"[ Hub level status and capacities without firewall + vpn gateway to hubs matching].vpnGWStatus\",\"mergedName\":\"VPN Gateway Status\",\"fromId\":\"5a4488b9-55b4-4b06-b7d5-ea3e2a2970a4\"},{\"originalName\":\"[ Hub level status and capacities without firewall + vpn gateway to hubs matching].vpnGWScaleUnit\",\"mergedName\":\"VPN Gateway Scale Units\",\"fromId\":\"5a4488b9-55b4-4b06-b7d5-ea3e2a2970a4\"},{\"originalName\":\"[ Hub level status and capacities without firewall + vpn gateway to hubs matching].p2sGWStatus\",\"mergedName\":\"P2S Gateway Status\",\"fromId\":\"5a4488b9-55b4-4b06-b7d5-ea3e2a2970a4\"},{\"originalName\":\"[ Hub level status and capacities without firewall + vpn gateway to hubs matching].p2sGWScaleUnit\",\"mergedName\":\"P2S Gateway Scale Units\",\"fromId\":\"5a4488b9-55b4-4b06-b7d5-ea3e2a2970a4\"},{\"originalName\":\"[ Hub level status and capacities without firewall + vpn gateway to hubs matching].erGWStatus\",\"mergedName\":\"ER Gateway Status\",\"fromId\":\"5a4488b9-55b4-4b06-b7d5-ea3e2a2970a4\"},{\"originalName\":\"[ Hub level status and capacities without firewall + vpn gateway to hubs matching].erGWMinScaleUnit\",\"mergedName\":\"ER Gateway Scale Units\",\"fromId\":\"5a4488b9-55b4-4b06-b7d5-ea3e2a2970a4\"},{\"originalName\":\"[Firewall Status V2].firewallStatus\",\"mergedName\":\"Firewall Status\",\"fromId\":\"5a4488b9-55b4-4b06-b7d5-ea3e2a2970a6\"},{\"originalName\":\"[ Hub level status and capacities without firewall + vpn gateway to hubs matching].totalHubCapacityInGbps\",\"mergedName\":\"Provisioned Hub Capacity (Gbps)\",\"fromId\":\"5a4488b9-55b4-4b06-b7d5-ea3e2a2970a4\"},{\"originalName\":\"[Consumed capacity metric V2].microsoft.network/vpngateways-Traffic-AverageBandwidth\",\"mergedName\":\"Consumed Capacity\",\"fromId\":\"5a4488b9-55b4-4b06-b7d5-ea3e2a2970a4\"},{\"originalName\":\"[Consumed capacity metric V2].Name\"},{\"originalName\":\"[Consumed capacity metric V2].Subscription\"},{\"originalName\":\"[ Hub level status and capacities without firewall + vpn gateway to hubs matching].vpngwId\"},{\"originalName\":\"[ Hub level status and capacities without firewall + vpn gateway to hubs matching].hubId\"},{\"originalName\":\"[Firewall Status V2].vpngwId\"},{\"originalName\":\"[Consumed capacity metric V2].microsoft.network/vpngateways-Traffic-AverageBandwidth Timeline\"}]}",
+              "size": 3,
+              "title": "Virtual WAN Hub level Status and Capacities",
+              "queryType": 7,
+              "visualization": "table",
+              "gridSettings": {
+                "formatters": [
+                  {
+                    "columnMatch": "Virtual Hub",
+                    "formatter": 13,
+                    "formatOptions": {
+                      "linkTarget": "OpenBlade",
+                      "showIcon": true,
+                      "bladeOpenContext": {
+                        "bladeName": "VirtualHubManagementViewModel",
+                        "extensionName": "Microsoft_Azure_HybridNetworking",
+                        "bladeParameters": []
+                      }
+                    }
+                  },
+                  {
+                    "columnMatch": "Hub Deployment Status",
+                    "formatter": 1
+                  },
+                  {
+                    "columnMatch": "VPN Gateway Status",
+                    "formatter": 1,
+                    "numberFormat": {
+                      "unit": 0,
+                      "options": {
+                        "style": "decimal"
+                      },
+                      "emptyValCustomText": "-"
+                    }
+                  },
+                  {
+                    "columnMatch": "VPN Gateway Scale Units",
+                    "formatter": 1,
+                    "numberFormat": {
+                      "unit": 0,
+                      "options": {
+                        "style": "decimal"
+                      },
+                      "emptyValCustomText": "-"
+                    }
+                  },
+                  {
+                    "columnMatch": "P2S Gateway Status",
+                    "formatter": 1,
+                    "numberFormat": {
+                      "unit": 0,
+                      "options": {
+                        "style": "decimal"
+                      },
+                      "emptyValCustomText": "-"
+                    }
+                  },
+                  {
+                    "columnMatch": "P2S Gateway Scale Units",
+                    "formatter": 1,
+                    "numberFormat": {
+                      "unit": 0,
+                      "options": {
+                        "style": "decimal"
+                      },
+                      "emptyValCustomText": "-"
+                    }
+                  },
+                  {
+                    "columnMatch": "ER Gateway Status",
+                    "formatter": 1,
+                    "numberFormat": {
+                      "unit": 0,
+                      "options": {
+                        "style": "decimal"
+                      },
+                      "emptyValCustomText": "-"
+                    }
+                  },
+                  {
+                    "columnMatch": "ER Gateway Scale Units",
+                    "formatter": 1,
+                    "numberFormat": {
+                      "unit": 0,
+                      "options": {
+                        "style": "decimal"
+                      },
+                      "emptyValCustomText": "-"
+                    }
+                  },
+                  {
+                    "columnMatch": "Firewall Status",
+                    "formatter": 1,
+                    "numberFormat": {
+                      "unit": 0,
+                      "options": {
+                        "style": "decimal"
+                      },
+                      "emptyValCustomText": "-"
+                    }
+                  },
+                  {
+                    "columnMatch": "Consumed Capacity",
+                    "formatter": 0,
+                    "numberFormat": {
+                      "unit": 11,
+                      "options": {
+                        "style": "decimal"
+                      }
+                    }
+                  }
+                ]
               }
             },
-            {
-              "columnMatch": "Hub Deployment Status",
-              "formatter": 1
+            "conditionalVisibility": {
+              "parameterName": "vpnGateway",
+              "comparison": "isNotEqualTo"
             },
-            {
-              "columnMatch": "VPN Gateway Status",
-              "formatter": 1,
-              "numberFormat": {
-                "unit": 0,
-                "options": {
-                  "style": "decimal"
-                },
-                "emptyValCustomText": "-"
+            "showPin": false,
+            "name": "Virtual WAN Hub level Status and Capacities With VPN Gateway"
+          },
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "{\"version\":\"Merge/1.0\",\"merges\":[{\"id\":\"5a4488b9-55b4-4b06-b7d5-ea3e2a2970a6\",\"mergeType\":\"innerunique\",\"leftTable\":\" Hub level status and capacities without firewall + vpn gateway to hubs matching\",\"rightTable\":\"Firewall Status V2\",\"leftColumn\":\"hubId\",\"rightColumn\":\"hubId\"}],\"projectRename\":[{\"originalName\":\"[Firewall Status V2].hubId\",\"mergedName\":\"Virtual Hub\",\"fromId\":\"5a4488b9-55b4-4b06-b7d5-ea3e2a2970a6\"},{\"originalName\":\"[ Hub level status and capacities without firewall + vpn gateway to hubs matching].hubStatus\",\"mergedName\":\"Hub Deployment Status\",\"fromId\":\"unknown\"},{\"originalName\":\"[ Hub level status and capacities without firewall + vpn gateway to hubs matching].vpnGWStatus\",\"mergedName\":\"VPN Gateway Status\",\"fromId\":\"unknown\"},{\"originalName\":\"[ Hub level status and capacities without firewall + vpn gateway to hubs matching].vpnGWScaleUnit\",\"mergedName\":\"VPN Gateway Scale Units\",\"fromId\":\"unknown\"},{\"originalName\":\"[ Hub level status and capacities without firewall + vpn gateway to hubs matching].p2sGWStatus\",\"mergedName\":\"P2S Gateway Status\",\"fromId\":\"unknown\"},{\"originalName\":\"[ Hub level status and capacities without firewall + vpn gateway to hubs matching].p2sGWScaleUnit\",\"mergedName\":\"P2S Gateway Scale Units\",\"fromId\":\"unknown\"},{\"originalName\":\"[ Hub level status and capacities without firewall + vpn gateway to hubs matching].erGWStatus\",\"mergedName\":\"ER Gateway Status\",\"fromId\":\"unknown\"},{\"originalName\":\"[ Hub level status and capacities without firewall + vpn gateway to hubs matching].erGWMinScaleUnit\",\"mergedName\":\"ER Gateway Scale Units\",\"fromId\":\"unknown\"},{\"originalName\":\"[Firewall Status V2].firewallStatus\",\"mergedName\":\"Firewall Status\",\"fromId\":\"5a4488b9-55b4-4b06-b7d5-ea3e2a2970a6\"},{\"originalName\":\"[ Hub level status and capacities without firewall + vpn gateway to hubs matching].totalHubCapacityInGbps\",\"mergedName\":\"Provisioned Hub Capacity (Gbps)\",\"fromId\":\"unknown\"},{\"originalName\":\"[Consumed capacity metric V2].Name\"},{\"originalName\":\"[Consumed capacity metric V2].Subscription\"},{\"originalName\":\"[ Hub level status and capacities without firewall + vpn gateway to hubs matching].vpngwId\"},{\"originalName\":\"[ Hub level status and capacities without firewall + vpn gateway to hubs matching].hubId\"},{\"originalName\":\"[Firewall Status V2].vpngwId\"},{\"originalName\":\"[Consumed capacity metric V2].microsoft.network/vpngateways-Traffic-AverageBandwidth Timeline\"}]}",
+              "size": 3,
+              "title": "Virtual WAN Hub level Status and Capacities",
+              "queryType": 7,
+              "visualization": "table",
+              "gridSettings": {
+                "formatters": [
+                  {
+                    "columnMatch": "Virtual Hub",
+                    "formatter": 13,
+                    "formatOptions": {
+                      "linkTarget": "OpenBlade",
+                      "showIcon": true,
+                      "bladeOpenContext": {
+                        "bladeName": "VirtualHubManagementViewModel",
+                        "extensionName": "Microsoft_Azure_HybridNetworking",
+                        "bladeParameters": []
+                      }
+                    }
+                  },
+                  {
+                    "columnMatch": "Hub Deployment Status",
+                    "formatter": 1
+                  },
+                  {
+                    "columnMatch": "VPN Gateway Status",
+                    "formatter": 1,
+                    "numberFormat": {
+                      "unit": 0,
+                      "options": {
+                        "style": "decimal"
+                      },
+                      "emptyValCustomText": "-"
+                    }
+                  },
+                  {
+                    "columnMatch": "VPN Gateway Scale Units",
+                    "formatter": 1,
+                    "numberFormat": {
+                      "unit": 0,
+                      "options": {
+                        "style": "decimal"
+                      },
+                      "emptyValCustomText": "-"
+                    }
+                  },
+                  {
+                    "columnMatch": "P2S Gateway Status",
+                    "formatter": 1,
+                    "numberFormat": {
+                      "unit": 0,
+                      "options": {
+                        "style": "decimal"
+                      },
+                      "emptyValCustomText": "-"
+                    }
+                  },
+                  {
+                    "columnMatch": "P2S Gateway Scale Units",
+                    "formatter": 1,
+                    "numberFormat": {
+                      "unit": 0,
+                      "options": {
+                        "style": "decimal"
+                      },
+                      "emptyValCustomText": "-"
+                    }
+                  },
+                  {
+                    "columnMatch": "ER Gateway Status",
+                    "formatter": 1,
+                    "numberFormat": {
+                      "unit": 0,
+                      "options": {
+                        "style": "decimal"
+                      },
+                      "emptyValCustomText": "-"
+                    }
+                  },
+                  {
+                    "columnMatch": "ER Gateway Scale Units",
+                    "formatter": 1,
+                    "numberFormat": {
+                      "unit": 0,
+                      "options": {
+                        "style": "decimal"
+                      },
+                      "emptyValCustomText": "-"
+                    }
+                  },
+                  {
+                    "columnMatch": "Firewall Status",
+                    "formatter": 1,
+                    "numberFormat": {
+                      "unit": 0,
+                      "options": {
+                        "style": "decimal"
+                      },
+                      "emptyValCustomText": "-"
+                    }
+                  },
+                  {
+                    "columnMatch": "Consumed Capacity",
+                    "formatter": 0,
+                    "numberFormat": {
+                      "unit": 11,
+                      "options": {
+                        "style": "decimal"
+                      }
+                    }
+                  }
+                ]
               }
             },
-            {
-              "columnMatch": "VPN Gateway Scale Units",
-              "formatter": 1,
-              "numberFormat": {
-                "unit": 0,
-                "options": {
-                  "style": "decimal"
-                },
-                "emptyValCustomText": "-"
-              }
+            "conditionalVisibility": {
+              "parameterName": "vpnGateway",
+              "comparison": "isEqualTo"
             },
-            {
-              "columnMatch": "P2S Gateway Status",
-              "formatter": 1,
-              "numberFormat": {
-                "unit": 0,
-                "options": {
-                  "style": "decimal"
-                },
-                "emptyValCustomText": "-"
-              }
-            },
-            {
-              "columnMatch": "P2S Gateway Scale Units",
-              "formatter": 1,
-              "numberFormat": {
-                "unit": 0,
-                "options": {
-                  "style": "decimal"
-                },
-                "emptyValCustomText": "-"
-              }
-            },
-            {
-              "columnMatch": "ER Gateway Status",
-              "formatter": 1,
-              "numberFormat": {
-                "unit": 0,
-                "options": {
-                  "style": "decimal"
-                },
-                "emptyValCustomText": "-"
-              }
-            },
-            {
-              "columnMatch": "ER Gateway Scale Units",
-              "formatter": 1,
-              "numberFormat": {
-                "unit": 0,
-                "options": {
-                  "style": "decimal"
-                },
-                "emptyValCustomText": "-"
-              }
-            },
-            {
-              "columnMatch": "firewallStatus",
-              "formatter": 1,
-              "numberFormat": {
-                "unit": 0,
-                "options": {
-                  "style": "decimal"
-                },
-                "emptyValCustomText": "-"
-              }
-            },
-            {
-              "columnMatch": "Gateway S2S Bandwidth (Average)",
-              "formatter": 0,
-              "numberFormat": {
-                "unit": 11,
-                "options": {
-                  "style": "decimal"
-                }
-              }
-            }
-          ],
-          "filter": true,
-          "labelSettings": [
-            {
-              "columnId": "firewallStatus",
-              "label": "Firewall Status"
-            },
-            {
-              "columnId": "Total Hub Capacity (Gbps)",
-              "label": "Provisioned Hub Capacity (Gbps)"
-            },
-            {
-              "columnId": "Gateway S2S Bandwidth (Average)",
-              "label": "Consumed Capacity"
-            }
-          ]
-        }
+            "showPin": false,
+            "name": "Virtual WAN Hub level Status and Capacities Without VPN Gateway"
+          }
+        ]
       },
-      "name": "Virtual WAN Hub level Status and Capacities"
+      "name": "Hidden Group"
     },
     {
       "type": 1,
@@ -1070,7 +822,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "{\"version\":\"ARMEndpoint/1.0\",\"data\":\"{{virtualHubQuery:escapejson}}\",\"headers\":[],\"method\":\"POST\",\"path\":\"/batch\",\"urlParams\":[{\"key\":\"api-version\",\"value\":\"2020-06-01\"}],\"batchDisabled\":false,\"transformers\":[{\"type\":\"jsonpath\",\"settings\":{\"tablePath\":\"$.responses[*].content.value\",\"columns\":[{\"path\":\"$.length\",\"columnid\":\"Vnet_Count\"},{\"path\":\"$[0].id\",\"columnid\":\"HubName\",\"substringRegexMatch\":\"(.*)/(.*)/(.*)/(.*).*\",\"substringReplace\":\"$2\"}]}}]}",
+              "query": "{\"version\":\"ARMEndpoint/1.0\",\"data\":\"{{virtualHubQuery:escapejson}}\",\"headers\":[],\"method\":\"POST\",\"path\":\"/batch\",\"urlParams\":[{\"key\":\"api-version\",\"value\":\"2020-06-01\"}],\"batchDisabled\":false,\"transformers\":[{\"type\":\"jsonpath\",\"settings\":{\"tablePath\":\"$.responses[*].content\",\"columns\":[{\"path\":\"$.value.length\",\"columnid\":\"Vnet_Count\"},{\"path\":\"$.value[0].id\",\"columnid\":\"HubName\",\"substringRegexMatch\":\"(.*)/(.*)/(.*)/(.*).*\",\"substringReplace\":\"$2\"}]}}]}",
               "size": 0,
               "queryType": 12,
               "sortBy": []
@@ -1086,7 +838,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "{\"version\":\"Merge/1.0\",\"merges\":[{\"id\":\"f2aecb87-affc-469c-9818-c16135e3f1c3\",\"mergeType\":\"leftouter\",\"leftTable\":\"Virtual WAN Connection Counts\",\"rightTable\":\"Virtual WAN VNet Connection Count\",\"leftColumn\":\"hubName\",\"rightColumn\":\"HubName\"}],\"projectRename\":[{\"originalName\":\"[Virtual WAN Connection Counts].hubId\",\"mergedName\":\"Virtual Hub\",\"fromId\":\"f2aecb87-affc-469c-9818-c16135e3f1c3\"},{\"originalName\":\"[Virtual WAN Connection Counts].vpnConnectionCount\",\"mergedName\":\"VPN Connection Count\",\"fromId\":\"f2aecb87-affc-469c-9818-c16135e3f1c3\"},{\"originalName\":\"[Virtual WAN Connection Counts].p2sConnectionCount\",\"mergedName\":\"P2S Connection Configuration Count\",\"fromId\":\"f2aecb87-affc-469c-9818-c16135e3f1c3\"},{\"originalName\":\"[Virtual WAN Connection Counts].erConnectionCount\",\"mergedName\":\"ER Connection Count\",\"fromId\":\"f2aecb87-affc-469c-9818-c16135e3f1c3\"},{\"originalName\":\"[Virtual WAN VNet Connection Count].Vnet_Count\",\"mergedName\":\"Virtual Network Connection Count\",\"fromId\":\"f2aecb87-affc-469c-9818-c16135e3f1c3\"},{\"originalName\":\"[Virtual WAN VNet Connection Count].HubName\",\"mergedName\":\"HubName\",\"fromId\":\"f2aecb87-affc-469c-9818-c16135e3f1c3\"},{\"originalName\":\"[Total Connection Count]\",\"mergedName\":\"Total Connection Count\",\"fromId\":null,\"isNewItem\":true,\"newItemData\":[{\"criteriaContext\":{\"operator\":\"Default\",\"rightValType\":\"column\",\"resultValType\":\"expression\",\"resultVal\":\"[\\\"Virtual Network Connection Count\\\"] + [\\\"VPN Connection Count\\\"] + [\\\"P2S Connection Configuration Count\\\"] + [\\\"ER Connection Count\\\"]\"}}]},{\"originalName\":\"[Virtual WAN Connection Counts].hubName\"}]}",
+              "query": "{\"version\":\"Merge/1.0\",\"merges\":[{\"id\":\"f2aecb87-affc-469c-9818-c16135e3f1c3\",\"mergeType\":\"leftouter\",\"leftTable\":\"Virtual WAN Connection Counts\",\"rightTable\":\"Virtual WAN VNet Connection Count\",\"leftColumn\":\"hubName\",\"rightColumn\":\"HubName\"}],\"projectRename\":[{\"originalName\":\"[Virtual WAN Connection Counts].hubId\",\"mergedName\":\"Virtual Hub\",\"fromId\":\"f2aecb87-affc-469c-9818-c16135e3f1c3\"},{\"originalName\":\"[Virtual WAN Connection Counts].vpnConnectionCount\",\"mergedName\":\"VPN Connection Count\",\"fromId\":\"f2aecb87-affc-469c-9818-c16135e3f1c3\"},{\"originalName\":\"[Virtual WAN Connection Counts].p2sConnectionCount\",\"mergedName\":\"P2S Connection Configuration Count\",\"fromId\":\"f2aecb87-affc-469c-9818-c16135e3f1c3\"},{\"originalName\":\"[Virtual WAN Connection Counts].erConnectionCount\",\"mergedName\":\"ER Connection Count\",\"fromId\":\"f2aecb87-affc-469c-9818-c16135e3f1c3\"},{\"originalName\":\"[Virtual WAN VNet Connection Count].Vnet_Count\",\"mergedName\":\"Virtual Network Connection Count\",\"fromId\":\"f2aecb87-affc-469c-9818-c16135e3f1c3\"},{\"originalName\":\"[Virtual WAN VNet Connection Count].HubName\",\"mergedName\":\"HubName\",\"fromId\":\"f2aecb87-affc-469c-9818-c16135e3f1c3\"},{\"originalName\":\"[Total Connection Count]\",\"mergedName\":\"Total Connection Count\",\"fromId\":null,\"isNewItem\":true,\"newItemData\":[{\"criteriaContext\":{\"operator\":\"Default\",\"rightValType\":\"column\",\"resultValType\":\"expression\",\"resultVal\":\"[\\\"Virtual Network Connection Count\\\"] + [\\\"VPN Connection Count\\\"] + [\\\"P2S Connection Configuration Count\\\"] + [\\\"ER Connection Count\\\"]\"}}]},{\"originalName\":\"[Virtual WAN VNet Connection Count].wtf\",\"mergedName\":\"wtf\",\"fromId\":\"unknown\"},{\"originalName\":\"[Virtual WAN Connection Counts].hubName\"}]}",
               "size": 0,
               "queryType": 7,
               "gridSettings": {


### PR DESCRIPTION
## PR Checklist

* [X] Explain your changes, so people looking at the PR know *what* and *why*, the code changes are the *how*.

### If adding or updating templates:
* [X] post a screenshot of templates and/or gallery changes
* [X] ensure your template has a corresponding gallery entry in the gallery folder
* [X] If you are adding a new template, add your team and template/gallery file(s) to the CODEOWNERS file. CODEOWNERS entries should be teams, not individuals
* [X] ensure all steps have meaningful names
* [X] ensure all parameters and grid columns have display names set so they can be localized
* [X] ensure that parameters id values are unique __or they will fail PR validation__ (parameter ids are used for localization)
* [X] ensure that steps names are unique __or they will fail PR validation__ (step names are used for localization)
* [X] grep `/subscription/` and ensure that your parameters don't have any hardcoded resourceIds __or they will fail PR validation__
* [X] remove `fallbackResourceIds` and `fromTemplateId` fields from your template workbook __or they will fail PR validation__

Fix bug in "Virtual WAN Hub level Status and Capacities" section where the output was not showing due to multiple hidden merge steps.
![image](https://user-images.githubusercontent.com/95475229/176869644-ac7af9eb-ebe2-4e79-8a81-f4c04060daa3.png)
![image](https://user-images.githubusercontent.com/95475229/176869674-95c7012f-9381-4b8c-8b12-a6966313e789.png)
