### PR TITLE
Modify the active alerts kpi cards in QU and FU

### DIFF
--- a/Workbooks/UpdateCompliance/Active alerts/Active alerts.workbook
+++ b/Workbooks/UpdateCompliance/Active alerts/Active alerts.workbook
@@ -103,7 +103,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let _SnapshotTime = datetime({_SnapshotTime});\nUCUpdateAlert\n| where TimeGenerated == _SnapshotTime\n| where AlertStatus == \"Active\" and AlertClassification == \"Error\"\n| summarize Devices=count() by AlertSubtype, AlertType, UpdateCategory\n| sort by Devices desc\n| take 3\n| project-reorder AlertSubtype, AlertType, UpdateCategory, Devices",
+        "query": "let _SnapshotTime = datetime({_SnapshotTime});\nlet DeviceAlert = UCDeviceAlert\n| where TimeGenerated == _SnapshotTime\n| where AlertStatus == \"Active\";\nlet UpdateAlert = UCUpdateAlert\n| where TimeGenerated == _SnapshotTime\n| where AlertStatus == \"Active\";\nDeviceAlert\n| union (UpdateAlert)\n| where AlertStatus == \"Active\"\n| summarize Devices=count() by AlertSubtype, AlertType, UpdateCategory, AlertClassification\n| sort by Devices desc\n| take 3\n| project-reorder AlertSubtype, AlertType, AlertClassification, UpdateCategory, Devices",
         "size": 3,
         "showAnalytics": true,
         "title": "Top errors detailed information",

--- a/Workbooks/UpdateCompliance/Feature updates/Feature updates.workbook
+++ b/Workbooks/UpdateCompliance/Feature updates/Feature updates.workbook
@@ -448,7 +448,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "UCUpdateAlert\r\n| where AlertStatus == \"Active\" and UpdateCategory==\"WindowsFeatureUpdate\"\r\n| extend Title=\"Active alerts\", Subtitle = \"Devices having alerts\"\r\n| extend ViewDetails = \"View Details\"\r\n| summarize count() by AlertStatus, Title, Subtitle, ViewDetails",
+        "query": "let _SnapshotTime = datetime({_SnapshotTime});\r\nlet DeviceAlert = UCDeviceAlert\r\n| where TimeGenerated == _SnapshotTime\r\n| where AlertStatus == \"Active\";\r\nlet UpdateAlert = UCUpdateAlert\r\n| where TimeGenerated == _SnapshotTime\r\n| where UpdateCategory==\"WindowsFeatureUpdate\"\r\n| where AlertStatus == \"Active\";\r\nDeviceAlert\r\n| union (UpdateAlert)\r\n| where AlertStatus == \"Active\"\r\n| extend Title=\"Alerts count\", Subtitle = \"Update + Device alerts\"\r\n| extend ViewDetails = \"View details\"\r\n| summarize count() by AlertStatus, Title, Subtitle, ViewDetails",
         "size": 3,
         "title": "Active alerts",
         "noDataMessage": "No alerts",
@@ -1175,7 +1175,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "let _SnapshotTime = datetime({_SnapshotTime});\r\nUCDeviceAlert\r\n| join kind=innerunique UCClientUpdateStatus on AzureADDeviceId, TimeGenerated\r\n| where TimeGenerated == _SnapshotTime\r\n| where UpdateCategory == \"WindowsFeatureUpdate\"\r\n| where AlertStatus == \"Active\"\r\n| summarize count() by AlertClassification",
+              "query": "let _SnapshotTime = datetime({_SnapshotTime});\r\nUCDeviceAlert \r\n| where TimeGenerated == _SnapshotTime\r\n| where AlertStatus == \"Active\"\r\n| summarize count() by AlertClassification\r\n",
               "size": 3,
               "showAnalytics": true,
               "title": "Device alerts",
@@ -1191,6 +1191,10 @@
                   {
                     "seriesName": "",
                     "label": "Unknown"
+                  },
+                  {
+                    "seriesName": "Warning",
+                    "color": "orange"
                   }
                 ],
                 "ySettings": {

--- a/Workbooks/UpdateCompliance/Quality updates/Quality Updates.workbook
+++ b/Workbooks/UpdateCompliance/Quality updates/Quality Updates.workbook
@@ -446,13 +446,10 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "UCUpdateAlert\r\n| where AlertStatus == \"Active\" and UpdateCategory==\"WindowsQualityUpdate\"  \r\n| extend Title=\"Active alerts\", Subtitle = \"Devices having alerts\"\r\n| extend ViewDetails = \"View details\"\r\n| summarize count() by AlertStatus, Title, Subtitle, ViewDetails",
+        "query": "let _SnapshotTime = datetime({_SnapshotTime});\r\nlet DeviceAlert = UCDeviceAlert\r\n| where TimeGenerated == _SnapshotTime\r\n| where AlertStatus == \"Active\";\r\nlet UpdateAlert = UCUpdateAlert\r\n| where TimeGenerated == _SnapshotTime\r\n| where UpdateCategory==\"WindowsQualityUpdate\"\r\n| where AlertStatus == \"Active\";\r\nDeviceAlert\r\n| union (UpdateAlert)\r\n| where AlertStatus == \"Active\"\r\n| extend Title=\"Alerts count\", Subtitle = \"Update + Device alerts\"\r\n| extend ViewDetails = \"View details\"\r\n| summarize count() by AlertStatus, Title, Subtitle, ViewDetails",
         "size": 3,
-        "title": "Active alerts",
+        "title": "Active alerts count",
         "noDataMessage": "No alerts",
-        "timeContext": {
-          "durationMs": 604800000
-        },
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
         "crossComponentResources": [
@@ -1286,6 +1283,47 @@
             },
             "customWidth": "33",
             "name": "TargetOSVersionChart"
+          },
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "let _SnapshotTime = datetime({_SnapshotTime});\r\nUCDeviceAlert \r\n| where TimeGenerated == _SnapshotTime\r\n| where AlertStatus == \"Active\"\r\n| summarize count() by AlertClassification\r\n",
+              "size": 3,
+              "showAnalytics": true,
+              "title": "Device alerts",
+              "showExportToExcel": true,
+              "queryType": 0,
+              "resourceType": "microsoft.operationalinsights/workspaces",
+              "crossComponentResources": [
+                "{mappedWorkspace}"
+              ],
+              "visualization": "piechart",
+              "chartSettings": {
+                "seriesLabelSettings": [
+                  {
+                    "seriesName": "",
+                    "label": "Unknown"
+                  },
+                  {
+                    "seriesName": "Warning",
+                    "color": "orange"
+                  }
+                ],
+                "ySettings": {
+                  "numberFormatSettings": {
+                    "unit": 17,
+                    "options": {
+                      "style": "decimal",
+                      "useGrouping": true,
+                      "maximumFractionDigits": 1
+                    }
+                  }
+                }
+              }
+            },
+            "customWidth": "33",
+            "name": "DeviceAlertsChart"
           },
           {
             "type": 3,


### PR DESCRIPTION
## PR Checklist

* [x] Changed the active alerts KPI cards in QU and FU to show both Device and Update alerts
* [x] Added a Device Alerts pie chart under the Device Status tab in both QU and FU.
* [x] Updated the header text on the alerts KPI cards
![image](https://user-images.githubusercontent.com/98173238/197007997-8cc45ab3-3b8c-4d20-ad29-5e8bd868da15.png)
![image](https://user-images.githubusercontent.com/98173238/197008336-d7a8c59c-0fb4-4aae-9331-331486a7f78f.png)
![image](https://user-images.githubusercontent.com/98173238/197008258-1d0d9ed1-b97f-4f53-b1d4-1d4995e83a0e.png)
