### PR TITLE
[Workbook Change] Remove filtering based on LinkedServer Role

### DIFF
--- a/Workbooks/RedisCache/GeoReplicationDashboard/GeoReplicationMetrics.workbook
+++ b/Workbooks/RedisCache/GeoReplicationDashboard/GeoReplicationMetrics.workbook
@@ -17,7 +17,7 @@
             "type": 5,
             "isRequired": true,
             "isGlobal": true,
-            "query": "where type =~ 'microsoft.cache/redis' and properties.sku.name =~ 'premium' and isnotnull(properties.linkedServers[0])\r\n| project id",
+            "query": "where type =~ 'microsoft.cache/redis' and properties.sku.name =~ 'premium'\n| project id",
             "crossComponentResources": [
               "value::selected"
             ],
@@ -39,7 +39,7 @@
             "type": 5,
             "isRequired": true,
             "isGlobal": true,
-            "query": "where type =~ 'microsoft.cache/redis' and properties.sku.name =~ 'premium' and isnotnull(properties.linkedServers[0])\n| project id",
+            "query": "where type =~ 'microsoft.cache/redis' and properties.sku.name =~ 'premium'\n| project id",
             "crossComponentResources": [
               "value::selected"
             ],


### PR DESCRIPTION
We found a scenario wherein Azure Resource Graph query is not able to sync the linkedserver role post we reverse the roles of caches. Until we figure this out with Azure Resource Graph team, We're removing this filtering based on linkedServer role.

![image](https://user-images.githubusercontent.com/93312257/198997079-92eb5143-7c2e-48aa-b974-f32fdccd2c68.png)

## PR Checklist

* [x] Explain your changes, so people looking at the PR know *what* and *why*, the code changes are the *how*.

### If adding or updating templates:
* [x] post a screenshot of templates and/or gallery changes
* [x] ensure your template has a corresponding gallery entry in the gallery folder
* [x] If you are adding a new template, add your team and template/gallery file(s) to the CODEOWNERS file. CODEOWNERS entries should be teams, not individuals
* [x] ensure all steps have meaningful names
* [x] ensure all parameters and grid columns have display names set so they can be localized
* [x] ensure that parameters id values are unique __or they will fail PR validation__ (parameter ids are used for localization)
* [x] ensure that steps names are unique __or they will fail PR validation__ (step names are used for localization)
* [x] grep `/subscription/` and ensure that your parameters don't have any hardcoded resourceIds __or they will fail PR validation__
* [x] remove `fallbackResourceIds` and `fromTemplateId` fields from your template workbook __or they will fail PR validation__