### PR TITLE
BareMetal added with HANA Large Instances

### DIFF
--- a/Workbooks/Workloads/SAP/Inventory Checks for SAP/Inventory Checks for SAP.workbook
+++ b/Workbooks/Workloads/SAP/Inventory Checks for SAP/Inventory Checks for SAP.workbook
@@ -2337,10 +2337,34 @@
                   }
                 },
                 {
+                  "type": 1,
+                  "content": {
+                    "json": " List of available Azure Large Instances (also known as BareMetal Infrastructure instances)."
+                  },
+                  "conditionalVisibilities": [
+                    {
+                      "parameterName": "SelectedTab",
+                      "comparison": "isEqualTo",
+                      "value": "compute"
+                    },
+                    {
+                      "parameterName": "Report_check",
+                      "comparison": "isEqualTo",
+                      "value": "No"
+                    },
+                    {
+                      "parameterName": "compute",
+                      "comparison": "isEqualTo",
+                      "value": "computehli"
+                    }
+                  ],
+                  "name": "text - HLI Overview"
+                },
+                {
                   "type": 3,
                   "content": {
                     "version": "KqlItem/1.0",
-                    "query": "resources\r\n| where type == \"microsoft.hanaonazure/hanainstances\"\r\n| where resourceGroup in ({Resource_Group}) or '*' in ({Resource_Group})\r\n| mv-expand hanasid=properties.storageProfile.hanaSids\r\n| mv-expand ntwork=properties.networkProfile.networkInterfaces\r\n| project id, name, ipaddress=tostring(ntwork.ipAddress), SID=tostring(hanasid.sid), HLI=tostring(properties.hardwareProfile.hanaInstanceSize), memory=tostring(hanasid.memoryAllocation),HLR_Revision=tostring(properties.hwRevision),OS= tostring(properties.osProfile.osType), state=tostring(properties.powerState),resourceGroup, location",
+                    "query": "resources\r\n| where type == \"microsoft.hanaonazure/hanainstances\" or type == \"microsoft.baremetalinfrastructure/baremetalinstances\"\r\n| where resourceGroup in ({Resource_Group}) or '*' in ({Resource_Group})\r\n| mv-expand hanasid=properties.storageProfile.hanaSids\r\n| mv-expand ntwork=properties.networkProfile.networkInterfaces\r\n| extend HLI = iff(properties.hardwareProfile.hanaInstanceSize == '',properties.hardwareProfile.azureBareMetalInstanceSize, properties.hardwareProfile.hanaInstanceSize)\r\n| project id, name, ipaddress=tostring(ntwork.ipAddress), SID=tostring(hanasid.sid), HLI, memory=tostring(hanasid.memoryAllocation),HLR_Revision=tostring(properties.hwRevision),OS= tostring(properties.osProfile.osType), state=tostring(properties.powerState),resourceGroup, location",
                     "size": 2,
                     "title": "HANA Large Instance Overview",
                     "noDataMessage": "No HLI nodes found!",
@@ -10881,5 +10905,6 @@
   "fallbackResourceIds": [
     "Azure Monitor"
   ],
+  "fromTemplateId": "community-Workbooks/Workloads/SAP/Inventory Checks for SAP",
   "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
 }


### PR DESCRIPTION
Only microsoft.hanaonazure/hanainstances was picked for SAP customers, now we are adding microsoft.baremetalinfrastructure/baremetalinstances as well.

## PR Checklist

Adding below code
resources
| where type == "microsoft.hanaonazure/hanainstances" or type == "microsoft.baremetalinfrastructure/baremetalinstances"
| where resourceGroup in ({Resource_Group}) or '*' in ({Resource_Group})
| mv-expand hanasid=properties.storageProfile.hanaSids
| mv-expand ntwork=properties.networkProfile.networkInterfaces
| extend HLI = iff(properties.hardwareProfile.hanaInstanceSize == '',properties.hardwareProfile.azureBareMetalInstanceSize, properties.hardwareProfile.hanaInstanceSize)
| project id, name, ipaddress=tostring(ntwork.ipAddress), SID=tostring(hanasid.sid), HLI, memory=tostring(hanasid.memoryAllocation),HLR_Revision=tostring(properties.hwRevision),OS= tostring(properties.osProfile.osType), state=tostring(properties.powerState),resourceGroup, location