### PR TITLE
Revised the UI for the Subnet IP usage Workbook

### DIFF
--- a/Workbooks/AKS/Subnet IP Usage/Subnet IP Usage.workbook
+++ b/Workbooks/AKS/Subnet IP Usage/Subnet IP Usage.workbook
@@ -899,7 +899,36 @@
         "json": "## Metrics for IP Usage by Delegated Subnets\n\nThe following metrics depict the IP usage by delegated subnets.\n\nEach of the metrics is organised by Node, and the tallies in the bottom of the metric graph is the latest value of the respective metric count for the selected time range.\n\nFor each metric, you have the ability to select:\n* The *Time Range* i.e. the start time of the metric representation, till the current time. This is required.\n* The *Node* i.e. the Node you wish to see the metrics for. The default is unset, which shows all Nodes.",
         "style": "info"
       },
-      "name": "Information"
+      "conditionalVisibility": {
+        "parameterName": "selTab",
+        "comparison": "isEqualTo",
+        "value": "All IP Usage Metrics"
+      },
+      "name": "Information - All IP Usage Metrics"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "## Metrics for IPs allocated from subnet\r\n\r\nThe following metrics depict the IPs allocated from the subnets.\r\n\r\nIn the current time view, you will see the count of IP's allocated to respective nodes in current time. \r\n\r\nIn the historical view, each of the metrics is organised by Node, and the tallies in the bottom of the metric graph is the latest value of the respective metric count for the selected time range.\r\n\r\n\r\nFor the historical view, you have the ability to select:\r\n* The *Time Range* i.e. the start time of the metric representation, till the current time. This is required.\r\n* The *Node* i.e. the Node you wish to see the metrics for. The default is unset, which shows all Nodes."
+      },
+      "conditionalVisibility": {
+        "parameterName": "selTab",
+        "comparison": "isEqualTo",
+        "value": "IPs allocated from Subnet"
+      },
+      "name": "Information - IPs allocated from Subnet"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "## Metrics for IPs assigned to a pod\r\n\r\nThe following metrics depict the IPs assigned to a pod.\r\n\r\nIn the current time view, you will see the count of IP's assigned to a pod in a given view in current time. \r\n\r\nIn the historical view, each of the metrics is organised by Node, and the tallies in the bottom of the metric graph is the latest value of the respective metric count for the selected time range.\r\n\r\n\r\nFor the historical view, you have the ability to select:\r\n* The *Time Range* i.e. the start time of the metric representation, till the current time. This is required.\r\n* The *Node* i.e. the Node you wish to see the metrics for. The default is unset, which shows all Nodes."
+      },
+      "conditionalVisibility": {
+        "parameterName": "selTab",
+        "comparison": "isEqualTo",
+        "value": "IPs assigned to Pod"
+      },
+      "name": "Information - IPs assigned to Pod"
     }
   ],
   "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"

--- a/Workbooks/AKS/Subnet IP Usage/Subnet IP Usage.workbook
+++ b/Workbooks/AKS/Subnet IP Usage/Subnet IP Usage.workbook
@@ -32,18 +32,308 @@
             "linkLabel": "IPs assigned to Pod",
             "subTarget": "IPs assigned to Pod",
             "style": "link"
-          },
-          {
-            "id": "77ecd681-89bd-40b8-9cf0-86951f3c30eb",
-            "cellValue": "selTab",
-            "linkTarget": "parameter",
-            "linkLabel": "IPs reserved for future Pods",
-            "subTarget": "IPs reserved for future Pods",
-            "style": "link"
           }
         ]
       },
-      "name": "Navigation Bar"
+      "name": "Navigation Bar",
+      "styleSettings": {
+        "padding": "-10"
+      }
+    },
+    {
+      "type": 12,
+      "content": {
+        "version": "NotebookGroup/1.0",
+        "groupType": "editable",
+        "items": [
+          {
+            "type": 11,
+            "content": {
+              "version": "LinkItem/1.0",
+              "style": "tabs",
+              "links": [
+                {
+                  "id": "3a4d001b-b312-4a48-aa52-ac7bd55ba5c4",
+                  "cellValue": "selTab",
+                  "linkTarget": "parameter",
+                  "linkLabel": "Current Time View",
+                  "subTarget": "Current Time View - Allocated IPs",
+                  "preText": "Current Time View",
+                  "style": "link"
+                },
+                {
+                  "id": "465bdaa1-1485-448c-b87e-a0f03aadaff9",
+                  "cellValue": "selTab",
+                  "linkTarget": "parameter",
+                  "linkLabel": "Historical View",
+                  "subTarget": "Historical View - Allocated IPs",
+                  "style": "link"
+                }
+              ]
+            },
+            "name": "links - 3"
+          },
+          {
+            "type": 12,
+            "content": {
+              "version": "NotebookGroup/1.0",
+              "groupType": "editable",
+              "items": [
+                {
+                  "type": 9,
+                  "content": {
+                    "version": "KqlParameterItem/1.0",
+                    "parameters": [
+                      {
+                        "id": "86213344-4b4a-4962-9b79-3bc231fbdc74",
+                        "version": "KqlParameterItem/1.0",
+                        "name": "hostname",
+                        "label": "Node",
+                        "type": 2,
+                        "query": "InsightsMetrics\r\n| where TimeGenerated < now() and TimeGenerated >= now(-120s)\r\n| where Name contains \"cx_ipam_total_ips\"\r\n| where Namespace == \"prometheus\"\r\n| extend jsonprop = parse_json(Tags)\r\n| extend hostname = tostring(jsonprop.hostName)\r\n| distinct hostname\r\n| project hostname",
+                        "value": null,
+                        "typeSettings": {
+                          "additionalResourceOptions": [],
+                          "showDefault": false
+                        },
+                        "queryType": 0,
+                        "resourceType": "microsoft.containerservice/managedclusters"
+                      },
+                      {
+                        "id": "a774557d-9191-4bc1-aa04-19321beb0e8c",
+                        "version": "KqlParameterItem/1.0",
+                        "name": "hostwhereclause",
+                        "type": 1,
+                        "isHiddenWhenLocked": true,
+                        "criteriaData": [
+                          {
+                            "criteriaContext": {
+                              "leftOperand": "hostname",
+                              "operator": "is Empty",
+                              "rightValType": "param",
+                              "resultValType": "static",
+                              "resultVal": "| where 1 == 1"
+                            }
+                          },
+                          {
+                            "criteriaContext": {
+                              "operator": "Default",
+                              "resultValType": "static",
+                              "resultVal": "| where HostName == '{hostname}'"
+                            }
+                          }
+                        ]
+                      }
+                    ],
+                    "style": "pills",
+                    "queryType": 0,
+                    "resourceType": "microsoft.containerservice/managedclusters"
+                  },
+                  "name": "parameters - 6"
+                },
+                {
+                  "type": 3,
+                  "content": {
+                    "version": "KqlItem/1.0",
+                    "query": "InsightsMetrics\r\n| where TimeGenerated < now() and TimeGenerated >= now(-120s)\r\n| where Name == \"cx_ipam_total_ips\"\r\n| where Namespace == \"prometheus\"\r\n| extend jsonprop = parse_json(Tags)\r\n| extend HostName = jsonprop.hostName\r\n{hostwhereclause}\r\n| project Val, HostName\r\n| summarize Val=avg(Val) by tostring(HostName)",
+                    "size": 3,
+                    "queryType": 0,
+                    "resourceType": "microsoft.containerservice/managedclusters",
+                    "visualization": "table",
+                    "chartSettings": {
+                      "showLegend": true,
+                      "ySettings": {
+                        "numberFormatSettings": {
+                          "unit": 0,
+                          "options": {
+                            "style": "decimal",
+                            "useGrouping": true
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "name": "IPs allocated from Subnet - Summary"
+                }
+              ]
+            },
+            "conditionalVisibility": {
+              "parameterName": "selTab",
+              "comparison": "isEqualTo",
+              "value": "Current Time View - Allocated IPs"
+            },
+            "name": "IPs allocated from Subnet - Current Time View"
+          },
+          {
+            "type": 12,
+            "content": {
+              "version": "NotebookGroup/1.0",
+              "groupType": "editable",
+              "items": [
+                {
+                  "type": 9,
+                  "content": {
+                    "version": "KqlParameterItem/1.0",
+                    "parameters": [
+                      {
+                        "id": "eb2e0cdb-1de8-4eb4-a20a-6c862082f3e5",
+                        "version": "KqlParameterItem/1.0",
+                        "name": "timeRange",
+                        "label": "Time Range",
+                        "type": 4,
+                        "isRequired": true,
+                        "value": {
+                          "durationMs": 300000
+                        },
+                        "typeSettings": {
+                          "selectableValues": [
+                            {
+                              "durationMs": 300000
+                            },
+                            {
+                              "durationMs": 900000
+                            },
+                            {
+                              "durationMs": 1800000
+                            },
+                            {
+                              "durationMs": 3600000
+                            },
+                            {
+                              "durationMs": 14400000
+                            },
+                            {
+                              "durationMs": 43200000
+                            },
+                            {
+                              "durationMs": 86400000
+                            },
+                            {
+                              "durationMs": 172800000
+                            },
+                            {
+                              "durationMs": 259200000
+                            },
+                            {
+                              "durationMs": 604800000
+                            },
+                            {
+                              "durationMs": 1209600000
+                            },
+                            {
+                              "durationMs": 2419200000
+                            },
+                            {
+                              "durationMs": 2592000000
+                            },
+                            {
+                              "durationMs": 5184000000
+                            },
+                            {
+                              "durationMs": 7776000000
+                            }
+                          ],
+                          "allowCustom": true
+                        },
+                        "timeContext": {
+                          "durationMs": 86400000
+                        }
+                      },
+                      {
+                        "id": "bfb869d8-d9d2-4ef3-81a3-83bab1566982",
+                        "version": "KqlParameterItem/1.0",
+                        "name": "hostname",
+                        "label": "Node",
+                        "type": 2,
+                        "query": "InsightsMetrics\n| where Name contains \"cx_ipam_total_ips\"\n| where Namespace == \"prometheus\"\n| extend jsonprop = parse_json(Tags)\n| extend hostname = tostring(jsonprop.hostName)\n| distinct hostname\n| project hostname",
+                        "value": null,
+                        "typeSettings": {
+                          "additionalResourceOptions": [],
+                          "showDefault": false
+                        },
+                        "timeContext": {
+                          "durationMs": 0
+                        },
+                        "timeContextFromParameter": "timeRange",
+                        "queryType": 0,
+                        "resourceType": "microsoft.containerservice/managedclusters"
+                      },
+                      {
+                        "id": "38268eb9-1729-4ef7-91e7-74320263ec17",
+                        "version": "KqlParameterItem/1.0",
+                        "name": "hostwhereclause",
+                        "type": 1,
+                        "isHiddenWhenLocked": true,
+                        "criteriaData": [
+                          {
+                            "criteriaContext": {
+                              "leftOperand": "hostname",
+                              "operator": "is Empty",
+                              "rightValType": "static",
+                              "rightVal": "''",
+                              "resultValType": "static",
+                              "resultVal": "| where 1 == 1"
+                            }
+                          },
+                          {
+                            "criteriaContext": {
+                              "operator": "Default",
+                              "resultValType": "static",
+                              "resultVal": "| where HostName == '{hostname}'"
+                            }
+                          }
+                        ],
+                        "timeContext": {
+                          "durationMs": 86400000
+                        }
+                      }
+                    ],
+                    "style": "pills",
+                    "queryType": 0,
+                    "resourceType": "microsoft.containerservice/managedclusters"
+                  },
+                  "name": "parameters - IPs allocated from Subnet"
+                },
+                {
+                  "type": 3,
+                  "content": {
+                    "version": "KqlItem/1.0",
+                    "query": "InsightsMetrics\n| where TimeGenerated < {timeRange:end} and TimeGenerated >= {timeRange:start}\n| where Name == \"cx_ipam_total_ips\"\n| where Namespace == \"prometheus\"\n| extend jsonprop = parse_json(Tags)\n| extend HostName = jsonprop.hostName\n{hostwhereclause}\n| project TimeGenerated, Val, HostName\n| summarize Val=avg(Val) by bin(TimeGenerated, {timeRange:grain}), tostring(HostName)\n\n\n",
+                    "size": 0,
+                    "aggregation": 5,
+                    "timeContextFromParameter": "timeRange",
+                    "queryType": 0,
+                    "resourceType": "microsoft.containerservice/managedclusters",
+                    "visualization": "barchart",
+                    "chartSettings": {
+                      "xAxis": "TimeGenerated",
+                      "yAxis": [
+                        "Val"
+                      ],
+                      "group": "HostName",
+                      "createOtherGroup": null,
+                      "showLegend": true
+                    }
+                  },
+                  "name": "IPs allocated from Subnet - Historical View"
+                }
+              ]
+            },
+            "conditionalVisibility": {
+              "parameterName": "selTab",
+              "comparison": "isEqualTo",
+              "value": "Historical View - Allocated IPs"
+            },
+            "name": "IPs allocated from Subnet - Historical View"
+          }
+        ]
+      },
+      "conditionalVisibility": {
+        "parameterName": "selTab",
+        "comparison": "isEqualTo",
+        "value": "IPs allocated from Subnet"
+      },
+      "name": "IPs allocated from Subnet"
     },
     {
       "type": 12,
@@ -64,7 +354,7 @@
                   "type": 4,
                   "isRequired": true,
                   "value": {
-                    "durationMs": 259200000
+                    "durationMs": 2419200000
                   },
                   "typeSettings": {
                     "selectableValues": [
@@ -128,14 +418,15 @@
                   "type": 2,
                   "isRequired": true,
                   "query": "InsightsMetrics\n| where Name contains \"cx_ipam_total_ips\"\n| where Namespace == \"prometheus\"\n| extend jsonprop = parse_json(Tags)\n| extend hostname = tostring(jsonprop.hostName)\n| distinct hostname\n| project hostname",
-                  "value": "aks-nodepool1-41155402-vmss000001",
+                  "value": "aks-nodepool1-25254241-vmss000003",
                   "typeSettings": {
                     "additionalResourceOptions": [],
                     "showDefault": false
                   },
                   "timeContext": {
-                    "durationMs": 86400000
+                    "durationMs": 0
                   },
+                  "timeContextFromParameter": "timeRange",
                   "queryType": 0,
                   "resourceType": "microsoft.containerservice/managedclusters"
                 },
@@ -179,11 +470,10 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "InsightsMetrics\n| where TimeGenerated < {timeRange:end} and TimeGenerated >= {timeRange:start}\n| where Namespace == \"prometheus\"\n| extend MetricName = case(Name == \"cx_ipam_pod_allocated_ips\", \"Assigned to Pod\", \n    Name == \"cx_ipam_available_ips\", \"Reserved for future Pods\", \n    Name == \"cx_ipam_total_ips\", \"Allocated from Subnet\",\n    \"\")\n| extend jsonprop = parse_json(Tags)\n| extend HostName = jsonprop.hostName\n| where HostName == '{hostname}'\n| where MetricName != \"\"\n| project TimeGenerated, Val, MetricName\n| summarize by bin(TimeGenerated, {timeRange:grain}), MetricName, Val",
+              "query": "InsightsMetrics\n| where TimeGenerated < {timeRange:end} and TimeGenerated >= {timeRange:start}\n| where Namespace == \"prometheus\"\n| extend MetricName = case(Name == \"cx_ipam_pod_allocated_ips\", \"Assigned to Pod\",\n    Name == \"cx_ipam_total_ips\", \"Allocated from Subnet\",\n    \"\")\n| extend jsonprop = parse_json(Tags)\n| extend HostName = jsonprop.hostName\n| where HostName == '{hostname}'\n| where MetricName != \"\"\n| project TimeGenerated, Val, MetricName\n| summarize Val=avg(Val) by bin(TimeGenerated, {timeRange:grain}), MetricName",
               "size": 0,
-              "timeContext": {
-                "durationMs": 2592000000
-              },
+              "aggregation": 5,
+              "timeContextFromParameter": "timeRange",
               "queryType": 0,
               "resourceType": "microsoft.containerservice/managedclusters",
               "visualization": "unstackedbar",
@@ -289,310 +579,310 @@
         "groupType": "editable",
         "items": [
           {
-            "type": 9,
+            "type": 11,
             "content": {
-              "version": "KqlParameterItem/1.0",
-              "parameters": [
+              "version": "LinkItem/1.0",
+              "style": "tabs",
+              "links": [
                 {
-                  "id": "eb2e0cdb-1de8-4eb4-a20a-6c862082f3e5",
-                  "version": "KqlParameterItem/1.0",
-                  "name": "timeRange",
-                  "label": "Time Range",
-                  "type": 4,
-                  "isRequired": true,
-                  "value": {
-                    "durationMs": 259200000
-                  },
-                  "typeSettings": {
-                    "selectableValues": [
-                      {
-                        "durationMs": 300000
-                      },
-                      {
-                        "durationMs": 900000
-                      },
-                      {
-                        "durationMs": 1800000
-                      },
-                      {
-                        "durationMs": 3600000
-                      },
-                      {
-                        "durationMs": 14400000
-                      },
-                      {
-                        "durationMs": 43200000
-                      },
-                      {
-                        "durationMs": 86400000
-                      },
-                      {
-                        "durationMs": 172800000
-                      },
-                      {
-                        "durationMs": 259200000
-                      },
-                      {
-                        "durationMs": 604800000
-                      },
-                      {
-                        "durationMs": 1209600000
-                      },
-                      {
-                        "durationMs": 2419200000
-                      },
-                      {
-                        "durationMs": 2592000000
-                      },
-                      {
-                        "durationMs": 5184000000
-                      },
-                      {
-                        "durationMs": 7776000000
-                      }
-                    ],
-                    "allowCustom": true
-                  },
-                  "timeContext": {
-                    "durationMs": 86400000
-                  }
+                  "id": "913ae181-60d8-4bdd-afa3-5128f4ab3cbe",
+                  "cellValue": "selTab",
+                  "linkTarget": "parameter",
+                  "linkLabel": "Current Time View",
+                  "subTarget": "Current Time Data",
+                  "preText": "CurrentTime Data",
+                  "style": "link"
                 },
                 {
-                  "id": "bfb869d8-d9d2-4ef3-81a3-83bab1566982",
-                  "version": "KqlParameterItem/1.0",
-                  "name": "hostname",
-                  "label": "Node",
-                  "type": 2,
-                  "query": "InsightsMetrics\n| where Name contains \"cx_ipam_total_ips\"\n| where Namespace == \"prometheus\"\n| extend jsonprop = parse_json(Tags)\n| extend hostname = tostring(jsonprop.hostName)\n| distinct hostname\n| project hostname",
-                  "value": null,
-                  "typeSettings": {
-                    "additionalResourceOptions": [],
-                    "showDefault": false
-                  },
-                  "timeContext": {
-                    "durationMs": 86400000
-                  },
-                  "queryType": 0,
-                  "resourceType": "microsoft.containerservice/managedclusters"
-                },
-                {
-                  "id": "38268eb9-1729-4ef7-91e7-74320263ec17",
-                  "version": "KqlParameterItem/1.0",
-                  "name": "hostwhereclause",
-                  "type": 1,
-                  "isHiddenWhenLocked": true,
-                  "criteriaData": [
-                    {
-                      "criteriaContext": {
-                        "leftOperand": "hostname",
-                        "operator": "is Empty",
-                        "rightValType": "static",
-                        "rightVal": "''",
-                        "resultValType": "static",
-                        "resultVal": "| where 1 == 1"
-                      }
-                    },
-                    {
-                      "criteriaContext": {
-                        "operator": "Default",
-                        "resultValType": "static",
-                        "resultVal": "| where HostName == '{hostname}'"
-                      }
-                    }
-                  ],
-                  "timeContext": {
-                    "durationMs": 86400000
-                  }
+                  "id": "873efcc6-8200-4b3b-bae0-ade83550790c",
+                  "cellValue": "selTab",
+                  "linkTarget": "parameter",
+                  "linkLabel": "Historical View",
+                  "subTarget": "Historical Data",
+                  "preText": "Historical Data",
+                  "style": "link"
                 }
-              ],
-              "style": "pills",
-              "queryType": 0,
-              "resourceType": "microsoft.containerservice/managedclusters"
+              ]
             },
-            "name": "parameters - IPs allocated from Subnet"
+            "name": "links - 3"
           },
           {
-            "type": 3,
+            "type": 12,
             "content": {
-              "version": "KqlItem/1.0",
-              "query": "InsightsMetrics\n| where TimeGenerated < {timeRange:end} and TimeGenerated >= {timeRange:start}\n| where Name == \"cx_ipam_total_ips\"\n| where Namespace == \"prometheus\"\n| extend jsonprop = parse_json(Tags)\n| extend HostName = jsonprop.hostName\n{hostwhereclause}\n| project TimeGenerated, Val, HostName\n| summarize by bin(TimeGenerated, {timeRange:grain}), tostring(HostName), Val\n\n",
-              "size": 0,
-              "timeContext": {
-                "durationMs": 2592000000
-              },
-              "queryType": 0,
-              "resourceType": "microsoft.containerservice/managedclusters",
-              "visualization": "categoricalbar",
-              "chartSettings": {
-                "xAxis": "TimeGenerated",
-                "yAxis": [
-                  "Val"
-                ],
-                "group": "HostName",
-                "createOtherGroup": null,
-                "showLegend": true
-              }
-            },
-            "name": "IPs allocated from Subnet"
-          }
-        ]
-      },
-      "conditionalVisibility": {
-        "parameterName": "selTab",
-        "comparison": "isEqualTo",
-        "value": "IPs allocated from Subnet"
-      },
-      "name": "IPs allocated from Subnet"
-    },
-    {
-      "type": 12,
-      "content": {
-        "version": "NotebookGroup/1.0",
-        "groupType": "editable",
-        "items": [
-          {
-            "type": 9,
-            "content": {
-              "version": "KqlParameterItem/1.0",
-              "parameters": [
+              "version": "NotebookGroup/1.0",
+              "groupType": "editable",
+              "items": [
                 {
-                  "id": "eb2e0cdb-1de8-4eb4-a20a-6c862082f3e5",
-                  "version": "KqlParameterItem/1.0",
-                  "name": "timeRange",
-                  "label": "Time Range",
-                  "type": 4,
-                  "isRequired": true,
-                  "value": {
-                    "durationMs": 259200000
-                  },
-                  "typeSettings": {
-                    "selectableValues": [
+                  "type": 9,
+                  "content": {
+                    "version": "KqlParameterItem/1.0",
+                    "parameters": [
                       {
-                        "durationMs": 300000
+                        "id": "56fc3741-1281-4a21-8866-1d0530eeff81",
+                        "version": "KqlParameterItem/1.0",
+                        "name": "hostname",
+                        "label": "Node",
+                        "type": 2,
+                        "query": "InsightsMetrics\r\n| where TimeGenerated < now() and TimeGenerated >= now(-120s)\r\n| where Name contains \"cx_ipam_available_ips\"\r\n| where Namespace == \"prometheus\"\r\n| extend jsonprop = parse_json(Tags)\r\n| extend hostname = tostring(jsonprop.hostName)\r\n| distinct hostname\r\n| project hostname",
+                        "value": null,
+                        "typeSettings": {
+                          "additionalResourceOptions": [],
+                          "showDefault": false
+                        },
+                        "queryType": 0,
+                        "resourceType": "microsoft.containerservice/managedclusters"
                       },
                       {
-                        "durationMs": 900000
-                      },
-                      {
-                        "durationMs": 1800000
-                      },
-                      {
-                        "durationMs": 3600000
-                      },
-                      {
-                        "durationMs": 14400000
-                      },
-                      {
-                        "durationMs": 43200000
-                      },
-                      {
-                        "durationMs": 86400000
-                      },
-                      {
-                        "durationMs": 172800000
-                      },
-                      {
-                        "durationMs": 259200000
-                      },
-                      {
-                        "durationMs": 604800000
-                      },
-                      {
-                        "durationMs": 1209600000
-                      },
-                      {
-                        "durationMs": 2419200000
-                      },
-                      {
-                        "durationMs": 2592000000
-                      },
-                      {
-                        "durationMs": 5184000000
-                      },
-                      {
-                        "durationMs": 7776000000
+                        "id": "25a3a87e-f5ef-4bfe-ae58-a4cccd8424ea",
+                        "version": "KqlParameterItem/1.0",
+                        "name": "hostwhereclause",
+                        "type": 1,
+                        "isHiddenWhenLocked": true,
+                        "criteriaData": [
+                          {
+                            "criteriaContext": {
+                              "leftOperand": "hostname",
+                              "operator": "is Empty",
+                              "rightValType": "param",
+                              "resultValType": "static",
+                              "resultVal": "| where 1 == 1"
+                            }
+                          },
+                          {
+                            "criteriaContext": {
+                              "operator": "Default",
+                              "resultValType": "static",
+                              "resultVal": "| where HostName == '{hostname}'"
+                            }
+                          }
+                        ],
+                        "timeContext": {
+                          "durationMs": 1800000
+                        }
                       }
                     ],
-                    "allowCustom": true
+                    "style": "pills",
+                    "queryType": 0,
+                    "resourceType": "microsoft.containerservice/managedclusters"
                   },
-                  "timeContext": {
-                    "durationMs": 86400000
-                  }
+                  "name": "parameters - IPs assigned to Pod - Current Time View"
                 },
                 {
-                  "id": "bfb869d8-d9d2-4ef3-81a3-83bab1566982",
-                  "version": "KqlParameterItem/1.0",
-                  "name": "hostname",
-                  "label": "Node",
-                  "type": 2,
-                  "query": "InsightsMetrics\n| where Name contains \"cx_ipam_available_ips\"\n| where Namespace == \"prometheus\"\n| extend jsonprop = parse_json(Tags)\n| extend hostname = tostring(jsonprop.hostName)\n| distinct hostname\n| project hostname",
-                  "value": null,
-                  "typeSettings": {
-                    "additionalResourceOptions": [],
-                    "showDefault": false
-                  },
-                  "timeContext": {
-                    "durationMs": 86400000
-                  },
-                  "queryType": 0,
-                  "resourceType": "microsoft.containerservice/managedclusters"
-                },
-                {
-                  "id": "38268eb9-1729-4ef7-91e7-74320263ec17",
-                  "version": "KqlParameterItem/1.0",
-                  "name": "hostwhereclause",
-                  "type": 1,
-                  "isHiddenWhenLocked": true,
-                  "criteriaData": [
-                    {
-                      "criteriaContext": {
-                        "leftOperand": "hostname",
-                        "operator": "is Empty",
-                        "rightValType": "static",
-                        "rightVal": "''",
-                        "resultValType": "static",
-                        "resultVal": "| where 1 == 1"
+                  "type": 3,
+                  "content": {
+                    "version": "KqlItem/1.0",
+                    "query": "InsightsMetrics\r\n| where TimeGenerated < now() and TimeGenerated >= now(-120s)\r\n| where Name == \"cx_ipam_pod_allocated_ips\"\r\n| where Namespace == \"prometheus\"\r\n| extend jsonprop = parse_json(Tags)\r\n| extend HostName = jsonprop.hostName\r\n{hostwhereclause}\r\n| project Val, HostName\r\n| summarize Val=avg(Val) by tostring(HostName)",
+                    "size": 3,
+                    "queryType": 0,
+                    "resourceType": "microsoft.containerservice/managedclusters",
+                    "visualization": "table",
+                    "tileSettings": {
+                      "showBorder": false,
+                      "titleContent": {
+                        "columnMatch": "HostName",
+                        "formatter": 1
+                      },
+                      "leftContent": {
+                        "columnMatch": "Val",
+                        "formatter": 12,
+                        "formatOptions": {
+                          "palette": "auto"
+                        },
+                        "numberFormat": {
+                          "unit": 17,
+                          "options": {
+                            "maximumSignificantDigits": 3,
+                            "maximumFractionDigits": 2
+                          }
+                        }
                       }
                     },
-                    {
-                      "criteriaContext": {
-                        "operator": "Default",
-                        "resultValType": "static",
-                        "resultVal": "| where HostName == '{hostname}'"
+                    "chartSettings": {
+                      "group": "HostName",
+                      "createOtherGroup": null,
+                      "showLegend": true,
+                      "ySettings": {
+                        "numberFormatSettings": {
+                          "unit": 0,
+                          "options": {
+                            "style": "decimal",
+                            "useGrouping": true
+                          }
+                        }
                       }
                     }
-                  ],
-                  "timeContext": {
-                    "durationMs": 86400000
-                  }
+                  },
+                  "name": "IPs assigned to Pod - Current Time View"
                 }
-              ],
-              "style": "pills",
-              "queryType": 0,
-              "resourceType": "microsoft.containerservice/managedclusters"
+              ]
             },
-            "name": "parameters - IPs assigned to Pod"
+            "conditionalVisibility": {
+              "parameterName": "selTab",
+              "comparison": "isEqualTo",
+              "value": "Current Time Data"
+            },
+            "name": "IPs assigned to Pod - Current Time View"
           },
           {
-            "type": 3,
+            "type": 12,
             "content": {
-              "version": "KqlItem/1.0",
-              "query": "InsightsMetrics\n| where TimeGenerated < {timeRange:end} and TimeGenerated >= {timeRange:start}\n| where Name == \"cx_ipam_pod_allocated_ips\"\n| where Namespace == \"prometheus\"\n| extend jsonprop = parse_json(Tags)\n| extend HostName = jsonprop.hostName\n{hostwhereclause}\n| project TimeGenerated, Val, HostName\n| summarize count = count(Val) by bin(TimeGenerated, {timeRange:grain}), tostring(HostName), Val\n\n",
-              "size": 0,
-              "queryType": 0,
-              "resourceType": "microsoft.containerservice/managedclusters",
-              "visualization": "categoricalbar",
-              "chartSettings": {
-                "xAxis": "TimeGenerated",
-                "yAxis": [
-                  "Val"
-                ],
-                "group": "HostName",
-                "createOtherGroup": null,
-                "showLegend": true
-              }
+              "version": "NotebookGroup/1.0",
+              "groupType": "editable",
+              "items": [
+                {
+                  "type": 9,
+                  "content": {
+                    "version": "KqlParameterItem/1.0",
+                    "parameters": [
+                      {
+                        "id": "eb2e0cdb-1de8-4eb4-a20a-6c862082f3e5",
+                        "version": "KqlParameterItem/1.0",
+                        "name": "timeRange",
+                        "label": "Time Range",
+                        "type": 4,
+                        "isRequired": true,
+                        "value": {
+                          "durationMs": 2419200000
+                        },
+                        "typeSettings": {
+                          "selectableValues": [
+                            {
+                              "durationMs": 300000
+                            },
+                            {
+                              "durationMs": 900000
+                            },
+                            {
+                              "durationMs": 1800000
+                            },
+                            {
+                              "durationMs": 3600000
+                            },
+                            {
+                              "durationMs": 14400000
+                            },
+                            {
+                              "durationMs": 43200000
+                            },
+                            {
+                              "durationMs": 86400000
+                            },
+                            {
+                              "durationMs": 172800000
+                            },
+                            {
+                              "durationMs": 259200000
+                            },
+                            {
+                              "durationMs": 604800000
+                            },
+                            {
+                              "durationMs": 1209600000
+                            },
+                            {
+                              "durationMs": 2419200000
+                            },
+                            {
+                              "durationMs": 2592000000
+                            },
+                            {
+                              "durationMs": 5184000000
+                            },
+                            {
+                              "durationMs": 7776000000
+                            }
+                          ],
+                          "allowCustom": true
+                        },
+                        "timeContext": {
+                          "durationMs": 86400000
+                        }
+                      },
+                      {
+                        "id": "bfb869d8-d9d2-4ef3-81a3-83bab1566982",
+                        "version": "KqlParameterItem/1.0",
+                        "name": "hostname",
+                        "label": "Node",
+                        "type": 2,
+                        "query": "InsightsMetrics\n| where Name contains \"cx_ipam_available_ips\"\n| where Namespace == \"prometheus\"\n| extend jsonprop = parse_json(Tags)\n| extend hostname = tostring(jsonprop.hostName)\n| distinct hostname\n| project hostname",
+                        "value": "aks-nodepool1-25254241-vmss000006",
+                        "typeSettings": {
+                          "additionalResourceOptions": [],
+                          "showDefault": false
+                        },
+                        "timeContext": {
+                          "durationMs": 259200000
+                        },
+                        "timeContextFromParameter": "timeRange",
+                        "queryType": 0,
+                        "resourceType": "microsoft.containerservice/managedclusters"
+                      },
+                      {
+                        "id": "38268eb9-1729-4ef7-91e7-74320263ec17",
+                        "version": "KqlParameterItem/1.0",
+                        "name": "hostwhereclause",
+                        "type": 1,
+                        "isHiddenWhenLocked": true,
+                        "criteriaData": [
+                          {
+                            "criteriaContext": {
+                              "leftOperand": "hostname",
+                              "operator": "is Empty",
+                              "rightValType": "static",
+                              "rightVal": "''",
+                              "resultValType": "static",
+                              "resultVal": "| where 1 == 1"
+                            }
+                          },
+                          {
+                            "criteriaContext": {
+                              "operator": "Default",
+                              "resultValType": "static",
+                              "resultVal": "| where HostName == '{hostname}'"
+                            }
+                          }
+                        ],
+                        "timeContext": {
+                          "durationMs": 86400000
+                        }
+                      }
+                    ],
+                    "style": "pills",
+                    "queryType": 0,
+                    "resourceType": "microsoft.containerservice/managedclusters"
+                  },
+                  "name": "parameters - IPs assigned to Pod - Historical View"
+                },
+                {
+                  "type": 3,
+                  "content": {
+                    "version": "KqlItem/1.0",
+                    "query": "InsightsMetrics\n| where TimeGenerated < {timeRange:end} and TimeGenerated >= {timeRange:start}\n| where Name == \"cx_ipam_pod_allocated_ips\"\n| where Namespace == \"prometheus\"\n| extend jsonprop = parse_json(Tags)\n| extend HostName = jsonprop.hostName\n{hostwhereclause}\n| project TimeGenerated, Val, HostName\n| summarize Val=avg(Val) by bin(TimeGenerated, {timeRange:grain}), tostring(HostName)\n\n",
+                    "size": 0,
+                    "aggregation": 5,
+                    "queryType": 0,
+                    "resourceType": "microsoft.containerservice/managedclusters",
+                    "visualization": "barchart",
+                    "chartSettings": {
+                      "xAxis": "TimeGenerated",
+                      "yAxis": [
+                        "Val"
+                      ],
+                      "group": "HostName",
+                      "createOtherGroup": null,
+                      "showLegend": true
+                    }
+                  },
+                  "name": "IPs assigned to Pod"
+                }
+              ]
             },
-            "name": "IPs assigned to Pod"
+            "conditionalVisibility": {
+              "parameterName": "selTab",
+              "comparison": "isEqualTo",
+              "value": "Historical Data"
+            },
+            "name": "IPs assigned to Pod - Historical View"
           }
         ]
       },
@@ -604,171 +894,12 @@
       "name": "IPs assigned to Pod"
     },
     {
-      "type": 12,
-      "content": {
-        "version": "NotebookGroup/1.0",
-        "groupType": "editable",
-        "items": [
-          {
-            "type": 9,
-            "content": {
-              "version": "KqlParameterItem/1.0",
-              "parameters": [
-                {
-                  "id": "eb2e0cdb-1de8-4eb4-a20a-6c862082f3e5",
-                  "version": "KqlParameterItem/1.0",
-                  "name": "timeRange",
-                  "label": "Time Range",
-                  "type": 4,
-                  "isRequired": true,
-                  "value": {
-                    "durationMs": 259200000
-                  },
-                  "typeSettings": {
-                    "selectableValues": [
-                      {
-                        "durationMs": 300000
-                      },
-                      {
-                        "durationMs": 900000
-                      },
-                      {
-                        "durationMs": 1800000
-                      },
-                      {
-                        "durationMs": 3600000
-                      },
-                      {
-                        "durationMs": 14400000
-                      },
-                      {
-                        "durationMs": 43200000
-                      },
-                      {
-                        "durationMs": 86400000
-                      },
-                      {
-                        "durationMs": 172800000
-                      },
-                      {
-                        "durationMs": 259200000
-                      },
-                      {
-                        "durationMs": 604800000
-                      },
-                      {
-                        "durationMs": 1209600000
-                      },
-                      {
-                        "durationMs": 2419200000
-                      },
-                      {
-                        "durationMs": 2592000000
-                      },
-                      {
-                        "durationMs": 5184000000
-                      },
-                      {
-                        "durationMs": 7776000000
-                      }
-                    ],
-                    "allowCustom": true
-                  },
-                  "timeContext": {
-                    "durationMs": 86400000
-                  }
-                },
-                {
-                  "id": "bfb869d8-d9d2-4ef3-81a3-83bab1566982",
-                  "version": "KqlParameterItem/1.0",
-                  "name": "hostname",
-                  "label": "Node",
-                  "type": 2,
-                  "query": "InsightsMetrics\n| where Name contains \"cx_ipam_pod_allocated_ips\"\n| where Namespace == \"prometheus\"\n| extend jsonprop = parse_json(Tags)\n| extend hostname = tostring(jsonprop.hostName)\n| distinct hostname\n| project hostname",
-                  "value": null,
-                  "typeSettings": {
-                    "additionalResourceOptions": [],
-                    "showDefault": false
-                  },
-                  "timeContext": {
-                    "durationMs": 86400000
-                  },
-                  "queryType": 0,
-                  "resourceType": "microsoft.containerservice/managedclusters"
-                },
-                {
-                  "id": "38268eb9-1729-4ef7-91e7-74320263ec17",
-                  "version": "KqlParameterItem/1.0",
-                  "name": "hostwhereclause",
-                  "type": 1,
-                  "isHiddenWhenLocked": true,
-                  "criteriaData": [
-                    {
-                      "criteriaContext": {
-                        "leftOperand": "hostname",
-                        "operator": "is Empty",
-                        "rightValType": "static",
-                        "rightVal": "''",
-                        "resultValType": "static",
-                        "resultVal": "| where 1 == 1"
-                      }
-                    },
-                    {
-                      "criteriaContext": {
-                        "operator": "Default",
-                        "resultValType": "static",
-                        "resultVal": "| where HostName == '{hostname}'"
-                      }
-                    }
-                  ],
-                  "timeContext": {
-                    "durationMs": 86400000
-                  }
-                }
-              ],
-              "style": "pills",
-              "queryType": 0,
-              "resourceType": "microsoft.containerservice/managedclusters"
-            },
-            "name": "parameters - IPs reserved for future Pods"
-          },
-          {
-            "type": 3,
-            "content": {
-              "version": "KqlItem/1.0",
-              "query": "InsightsMetrics\n| where TimeGenerated < {timeRange:end} and TimeGenerated >= {timeRange:start}\n| where Name == \"cx_ipam_available_ips\"\n| where Namespace == \"prometheus\"\n| extend jsonprop = parse_json(Tags)\n| extend HostName = jsonprop.hostName\n{hostwhereclause}\n| project TimeGenerated, Val, HostName\n| summarize count = count(Val) by bin(TimeGenerated, {timeRange:grain}), tostring(HostName), Val\n\n",
-              "size": 0,
-              "queryType": 0,
-              "resourceType": "microsoft.containerservice/managedclusters",
-              "visualization": "categoricalbar",
-              "chartSettings": {
-                "xAxis": "TimeGenerated",
-                "yAxis": [
-                  "Val"
-                ],
-                "group": "HostName",
-                "createOtherGroup": null,
-                "showLegend": true
-              }
-            },
-            "name": "IPs reserved for future Pods"
-          }
-        ]
-      },
-      "conditionalVisibility": {
-        "parameterName": "selTab",
-        "comparison": "isEqualTo",
-        "value": "IPs reserved for future Pods"
-      },
-      "name": "IPs reserved for future Pods"
-    },
-    {
       "type": 1,
       "content": {
-        "json": "## Metrics for IP Usage by Delegated Subnets\n\nThe following metrics depict the IP usage by delegated subnets.\n\nEach of the metrics is organised by Node, and the tallies in the bottom of the metric graph is sum of the respective metric count for the selected time range.\n\nFor each metric, you have the ability to select:\n* The *Time Range* i.e. the start time of the metric representation, till the current time. This is required.\n* The *Node* i.e. the Node you wish to see the metrics for. The default is unset, which shows all Nodes.",
+        "json": "## Metrics for IP Usage by Delegated Subnets\n\nThe following metrics depict the IP usage by delegated subnets.\n\nEach of the metrics is organised by Node, and the tallies in the bottom of the metric graph is the latest value of the respective metric count for the selected time range.\n\nFor each metric, you have the ability to select:\n* The *Time Range* i.e. the start time of the metric representation, till the current time. This is required.\n* The *Node* i.e. the Node you wish to see the metrics for. The default is unset, which shows all Nodes.",
         "style": "info"
       },
-      "name": "text - 5"
+      "name": "Information"
     }
   ],
   "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"

--- a/Workbooks/AKS/Subnet IP Usage/Subnet IP Usage.workbook
+++ b/Workbooks/AKS/Subnet IP Usage/Subnet IP Usage.workbook
@@ -909,7 +909,8 @@
     {
       "type": 1,
       "content": {
-        "json": "## Metrics for IPs allocated from subnet\r\n\r\nThe following metrics depict the IPs allocated from the subnets.\r\n\r\nIn the current time view, you will see the count of IP's allocated to respective nodes in current time. \r\n\r\nIn the historical view, each of the metrics is organised by Node, and the tallies in the bottom of the metric graph is the latest value of the respective metric count for the selected time range.\r\n\r\n\r\nFor the historical view, you have the ability to select:\r\n* The *Time Range* i.e. the start time of the metric representation, till the current time. This is required.\r\n* The *Node* i.e. the Node you wish to see the metrics for. The default is unset, which shows all Nodes."
+        "json": "## Metrics for IPs allocated from the Subnets\r\n\r\nThe following metrics depict the IPs allocated from the subnets.\r\n\r\nIn the current time view, you will see the count of IP's allocated to respective pod in current time. \r\n\r\nIn the historical view, each of the metrics is organised by Node, and the tallies in the bottom of the metric graph is the latest value of the respective metric count for the selected time range.\r\n\r\n\r\nFor the historical view, you have the ability to select:\r\n* The *Time Range* i.e. the start time of the metric representation, till the current time. This is required.\r\n* The *Node* i.e. the Node you wish to see the metrics for. The default is unset, which shows all Nodes.",
+        "style": "info"
       },
       "conditionalVisibility": {
         "parameterName": "selTab",
@@ -921,7 +922,8 @@
     {
       "type": 1,
       "content": {
-        "json": "## Metrics for IPs assigned to a pod\r\n\r\nThe following metrics depict the IPs assigned to a pod.\r\n\r\nIn the current time view, you will see the count of IP's assigned to a pod in a given view in current time. \r\n\r\nIn the historical view, each of the metrics is organised by Node, and the tallies in the bottom of the metric graph is the latest value of the respective metric count for the selected time range.\r\n\r\n\r\nFor the historical view, you have the ability to select:\r\n* The *Time Range* i.e. the start time of the metric representation, till the current time. This is required.\r\n* The *Node* i.e. the Node you wish to see the metrics for. The default is unset, which shows all Nodes."
+        "json": "## Metrics for IPs assigned to Pod\r\n\r\nThe following metrics depict the IPs assigned to Pod.\r\n\r\nIn the current time view, you will see the count of IP's assigned to pod on respective nodes in current time. \r\n\r\nIn the historical view, each of the metrics is organised by Node, and the tallies in the bottom of the metric graph is the latest value of the respective metric count for the selected time range.\r\n\r\n\r\nFor the historical view, you have the ability to select:\r\n* The *Time Range* i.e. the start time of the metric representation, till the current time. This is required.\r\n* The *Node* i.e. the Node you wish to see the metrics for. The default is unset, which shows all Nodes.",
+        "style": "info"
       },
       "conditionalVisibility": {
         "parameterName": "selTab",


### PR DESCRIPTION
## PR Checklist

In the Subnet IP usage Workbook we made the following changes
- Removed the IP usage reserved for future to avoid any confusion to the user.
- For the IPs allocated from Subnet and IPs assigned to Pod, we are currently using bar to show historical view. We added a section to show current time view on the same section 
- We improved the query  
- Below are the screenshot of the changes:

### If adding or updating templates:
1) Removed "IPs reserved for future Pods" from the list
![image](https://user-images.githubusercontent.com/110055433/200048159-dbc74cbe-2352-49d5-a8f6-53cb4386d19f.png)

<img width="927" alt="image" src="https://user-images.githubusercontent.com/110055433/201216069-ac0e88c6-880a-4bc0-ab97-22dae872db8b.png">

2) For IPs allocated from Subnet we created two views:
* Current Time view 
![image](https://user-images.githubusercontent.com/110055433/200048615-210846a5-b64f-4bc0-a01f-66eabbb1cc09.png)
* Historical view 
![image](https://user-images.githubusercontent.com/110055433/200048529-0bddc63e-7fbf-49f0-84a1-f9e1fad1372f.png)

<img width="949" alt="image" src="https://user-images.githubusercontent.com/110055433/201216267-a2fd03f6-d2b2-4774-85f8-f9890f38300d.png">

3) For IPs assigned to Pod from Subnet we created two views:
* Current Time view
![image](https://user-images.githubusercontent.com/110055433/200049191-68ebb923-214c-4c47-afc8-58208816b756.png)

* Historical view 
![image](https://user-images.githubusercontent.com/110055433/200049264-1b059bdc-851d-4c06-92b8-b12c8474c91a.png)

<img width="938" alt="image" src="https://user-images.githubusercontent.com/110055433/201216514-b8ca8ddc-91f0-4cb4-81ed-56dd508643db.png">