### PR TITLE
update all the docs with note + links to the relevant thing in public docs

### DIFF
--- a/Documentation/AutoRefresh.md
+++ b/Documentation/AutoRefresh.md
@@ -1,3 +1,7 @@
+> [!NOTE] 
+> This documentation for Azure workbooks is now located at: https://learn.microsoft.com/en-us/azure/azure-monitor/visualize/workbooks-getting-started#auto-refresh
+> Please **do not** edit this file. All up-to-date information is in the new location and documentation should only be updated there.
+
 ## Auto-Refresh Workbooks
 Clicking on Auto-Refresh button opens a list of intervals to let the user pick up the interval. The Workbook will keep refreshing after the selected time interval. 
 * Auto-Refresh only refreshes when the Workbook is in read mode. If a user sets an interval of say 5 minutes and after 4 minutes switches to edit mode then there is no refreshing when the user is still in edit mode. But if the user comes back to read mode, the interval of 5 minutes resets and the Workbook will be refreshed after 5 minutes. 

--- a/Documentation/BYOS/BringYourOwnStorage.md
+++ b/Documentation/BYOS/BringYourOwnStorage.md
@@ -1,6 +1,8 @@
-> [!NOTE]
-> Customer-facing documentation for Azure workbooks is now located on docs.microsoft.com at: https://docs.microsoft.com/en-us/azure/azure-monitor/visualize/workbooks-overview. Please **do not** edit this file. All up-to-date information is in the new location and documenation should only be updated there.
-> 
+
+> [!NOTE] 
+> This documentation for Azure workbooks is now located at: https://learn.microsoft.com/en-us/azure/azure-monitor/visualize/workbooks-bring-your-own-storage.
+> Please **do not** edit this file. All up-to-date information is in the new location and documentation should only be updated there.
+
 # Bring your own storage to save Workbooks
 
 There are times when you may have a query or some business logic that you want to secure. Workbooks provides an option to secure the workbook by saving the workbook content to your storage. The storage account can then be encrypted with Microsoft-managed keys or you can manage the encryption by supplying your own keys. [See Azure documentation on Storage Service Encryption.](https://docs.microsoft.com/en-us/azure/storage/common/storage-service-encryption)

--- a/Documentation/DataSources/DataSources.md
+++ b/Documentation/DataSources/DataSources.md
@@ -1,3 +1,7 @@
+> [!NOTE] 
+> This documentation for Azure workbooks is now located at: https://learn.microsoft.com/en-us/azure/azure-monitor/visualize/workbooks-data-sources
+> Please **do not** edit this file. All up-to-date information is in the new location and documentation should only be updated there.
+
 # Data Sources in Workbooks
 
 Workbooks can query data from a lot the common sources of telemetry in Azure. Workbook authors can transform this data in interesting way to provide insights into the availability, performance, usage and success of the underlying components. For instance, they could analyze performance logs from virtual machines to identify high CPU or low memory instances and show the results as a grid in an interactive report. 

--- a/Documentation/DataSources/Limits.md
+++ b/Documentation/DataSources/Limits.md
@@ -1,3 +1,7 @@
+> [!NOTE] 
+> This documentation for Azure workbooks is now located at: https://learn.microsoft.com/en-us/azure/azure-monitor/visualize/workbooks-limits
+> Please **do not** edit this file. All up-to-date information is in the new location and documentation should only be updated there.
+
 # Limits
 
 

--- a/Documentation/DataSources/LogsBestPracticesAndHints.md
+++ b/Documentation/DataSources/LogsBestPracticesAndHints.md
@@ -1,3 +1,7 @@
+> [!NOTE] 
+> This documentation for Azure workbooks is now located at: https://learn.microsoft.com/en-us/azure/azure-monitor/visualize/workbooks-data-sources
+> Please **do not** edit this file. All up-to-date information is in the new location and documentation should only be updated there.
+
 # Best Practices and hints for Logs queries
 
 ## Use the smallest possible time ranges by default

--- a/Documentation/DataSources/PrivateWorkbooksDeprecation.md
+++ b/Documentation/DataSources/PrivateWorkbooksDeprecation.md
@@ -1,3 +1,7 @@
+> [!NOTE] 
+> This documentation for Azure workbooks is now located at: https://learn.microsoft.com/en-us/azure/azure-monitor/visualize/workbooks-retrieve-legacy-workbooks
+> Please **do not** edit this file. All up-to-date information is in the new location and documentation should only be updated there.
+
 # Private Workbooks Deprecation
 Workbooks were available in two modes – private and shared. Private workbooks were accessible only to the author and was the default save mode.  
 

--- a/Documentation/DataSources/ResourceCentricLogs.md
+++ b/Documentation/DataSources/ResourceCentricLogs.md
@@ -1,3 +1,7 @@
+> [!NOTE] 
+> This documentation for Azure workbooks is now located at: https://learn.microsoft.com/en-us/azure/azure-monitor/visualize/workbooks-overview
+> Please **do not** edit this file. All up-to-date information is in the new location and documentation should only be updated there.
+
 # Tutorial - resource centric logs queries in workbooks
 This video shows you how to use resource level logs queries in Azure Workbooks. It also has tips and tricks on how to enable advanced scenarios and improve performance.
 

--- a/Documentation/Gallery.md
+++ b/Documentation/Gallery.md
@@ -1,3 +1,7 @@
+> [!NOTE] 
+> This documentation for Azure workbooks is now located at: https://learn.microsoft.com/en-us/azure/azure-monitor/visualize/workbooks-overview#the-gallery.
+> Please **do not** edit this file. All up-to-date information is in the new location and documentation should only be updated there.
+
 ## New Gallery for Workbooks
 
 Here is the new gallery for the workbooks.

--- a/Documentation/Groups/Groups.md
+++ b/Documentation/Groups/Groups.md
@@ -1,3 +1,7 @@
+> [!NOTE] 
+> This documentation for Azure workbooks is now located at: https://learn.microsoft.com/en-us/azure/azure-monitor/visualize/workbooks-create-workbook#add-groups.
+> Please **do not** edit this file. All up-to-date information is in the new location and documentation should only be updated there.
+
 # Using Groups
 
 A group item in a workbook allows you to logically group a set of steps in a workbook. In reading mode, the group itself has no "chrome", only showing the items that are inside the group:

--- a/Documentation/Interactivity.md
+++ b/Documentation/Interactivity.md
@@ -1,3 +1,7 @@
+> [!NOTE] 
+> This documentation for Azure workbooks is now located at: https://learn.microsoft.com/en-us/azure/azure-monitor/visualize/workbooks-configurations#interactivity
+> Please **do not** edit this file. All up-to-date information is in the new location and documentation should only be updated there.
+
 # Interactive Workbooks
 
 Workbooks allow authors to create interactive reports and experiences for their consumers. Interactivity is supported in a number of ways.

--- a/Documentation/Links/LinkActions.md
+++ b/Documentation/Links/LinkActions.md
@@ -1,3 +1,7 @@
+> [!NOTE] 
+> This documentation for Azure workbooks is now located at: https://learn.microsoft.com/en-us/azure/azure-monitor/visualize/workbooks-link-actions
+> Please **do not** edit this file. All up-to-date information is in the new location and documentation should only be updated there.
+
 # Link Actions
 Link actions can be accessed through Workbook [link steps](./Links.md#link-actions), or through column settings of [grids](../Visualizations/Grid.md#link-actions), tiles, or graphs.
 

--- a/Documentation/Links/Links.md
+++ b/Documentation/Links/Links.md
@@ -1,3 +1,7 @@
+> Note: This documentation is now out of date, but exists to preserve any existing links. 
+>
+> For the up to date docs, see: https://learn.microsoft.com/en-us/azure/azure-monitor/visualize/workbooks-create-workbook#add-links
+
 # Using Links Steps
 
 Authors can use the `Links` step to create links to other views, to other workbooks, to other steps inside a workbook, or to create tabbed views within a workbook. Much of the configuration for links is very similar to [using links inside of grids/other visualizations](../Visualizations/Grid.md#link-actions). The links can be styled as hyperlinks, buttons, and tabs.  

--- a/Documentation/Parameters/Criteria.md
+++ b/Documentation/Parameters/Criteria.md
@@ -1,3 +1,7 @@
+> [!NOTE] 
+> This documentation for Azure workbooks is now located at: https://learn.microsoft.com/en-us/azure/azure-monitor/visualize/workbooks-criteria
+> Please **do not** edit this file. All up-to-date information is in the new location and documentation should only be updated there.
+
 # Text Parameter Criteria
 
 When a query depends on many parameters, then the query will be stalled until each of it's parameters have been resolved. Sometimes a parameter could have a simple query that concatenates a string or performs a conditional evaluation. However these queries still make network calls to services that perform these basic operations and that increases the time it takes for a parameter to resolve a value. This results in long load times for complex workbooks.

--- a/Documentation/Parameters/DropDown.md
+++ b/Documentation/Parameters/DropDown.md
@@ -1,3 +1,7 @@
+> [!NOTE] 
+> This documentation for Azure workbooks is now located at: https://learn.microsoft.com/en-us/azure/azure-monitor/visualize/workbooks-dropdowns
+> Please **do not** edit this file. All up-to-date information is in the new location and documentation should only be updated there.
+
 # Drop Down Parameters
 
 Drop downs allow user to collect one or more input values from a known set (e.g. select one of your app’s requests). Drop downs provide user-friendly way to collect arbitrary inputs from users. Drop downs are especially useful in enabling filtering in your interactive reports. 

--- a/Documentation/Parameters/MultiValue.md
+++ b/Documentation/Parameters/MultiValue.md
@@ -1,3 +1,7 @@
+> [!NOTE] 
+> This documentation for Azure workbooks is now located at: https://learn.microsoft.com/en-us/azure/azure-monitor/visualize/workbooks-multi-value
+> Please **do not** edit this file. All up-to-date information is in the new location and documentation should only be updated there.
+
 # Multi-value Parameters
 
 A multi-value parameter allows the user to set one or more arbitrary text values. Multi-value parameters are commonly used for filtering, oftentimes when a drop down control may contain too many values to be useful.

--- a/Documentation/Parameters/OptionsGroup.md
+++ b/Documentation/Parameters/OptionsGroup.md
@@ -1,3 +1,7 @@
+> [!NOTE] 
+> This documentation for Azure workbooks is now located at: https://learn.microsoft.com/en-us/azure/azure-monitor/visualize/workbooks-options-group
+> Please **do not** edit this file. All up-to-date information is in the new location and documentation should only be updated there.
+
 # Options Group Parameters
 
 An options group parameter allows the user to select one values from a known set (e.g. select one of your app’s requests). When there are a small number of values, an options group can be a better choice than a [Drop down](./DropDown.md) parameter, as the user can see all the possible values, and see which one is selected. Options groups are commonly used for yes|no or on|off style choices. When there are large number of possible values, using a drop down is a better choice. Note that unlike drop down parameters, an options group *always* only allows one selected value.

--- a/Documentation/Parameters/Parameters.md
+++ b/Documentation/Parameters/Parameters.md
@@ -1,3 +1,7 @@
+> [!NOTE] 
+> This documentation for Azure workbooks is now located at: https://learn.microsoft.com/en-us/azure/azure-monitor/visualize/workbooks-parameters
+> Please **do not** edit this file. All up-to-date information is in the new location and documentation should only be updated there.
+
 # Workbook Parameters
 
 Parameters allow workbook authors to collect input from the consumers and reference it in other parts of the workbook – usually to scope the result set or setting the right visual. It is a key capability that allows authors to build interactive reports and experiences. 

--- a/Documentation/Parameters/Resources.md
+++ b/Documentation/Parameters/Resources.md
@@ -1,3 +1,7 @@
+> [!NOTE] 
+> This documentation for Azure workbooks is now located at: https://learn.microsoft.com/en-us/azure/azure-monitor/visualize/workbooks-resources
+> Please **do not** edit this file. All up-to-date information is in the new location and documentation should only be updated there.
+
 # Resource Parameters
 
 Resource parameters allow picking of resources in workbooks. This is useful in setting the scope from which to get the data from. An example is allowing users to select the set of VMs which the charts later will use when presenting the data.

--- a/Documentation/Parameters/Text.md
+++ b/Documentation/Parameters/Text.md
@@ -1,3 +1,7 @@
+> [!NOTE] 
+> This documentation for Azure workbooks is now located at: https://learn.microsoft.com/en-us/azure/azure-monitor/visualize/workbooks-text
+> Please **do not** edit this file. All up-to-date information is in the new location and documentation should only be updated there.
+
 # Text Parameters
 
 Textbox parameters provide a simple way to collect text input from workbook users. They are used when it is not practical to use a drop down to collect the input (e.g. an arbitrary threshold or generic filters). Workbooks allow authors to get the default value of the textbox from a query. This allows interesting scenarios like setting the default threshold based on the p95 of the metric.

--- a/Documentation/Parameters/Time.md
+++ b/Documentation/Parameters/Time.md
@@ -1,3 +1,7 @@
+> [!NOTE] 
+> This documentation for Azure workbooks is now located at: https://learn.microsoft.com/en-us/azure/azure-monitor/visualize/workbooks-time
+> Please **do not** edit this file. All up-to-date information is in the new location and documentation should only be updated there.
+
 # Time Parameters
 
 Time parameters allow users to set the time context of analysis and is used by almost all reports. It is relatively simple to setup and use - allowing authors to specify the time ranges to show in the drop down, including the option for custom time ranges. 

--- a/Documentation/Parameters/formatting.md
+++ b/Documentation/Parameters/formatting.md
@@ -1,3 +1,7 @@
+> [!NOTE] 
+> This documentation for Azure workbooks is now located at: https://learn.microsoft.com/en-us/azure/azure-monitor/visualize/workbooks-parameters#parameter-formatting-options
+> Please **do not** edit this file. All up-to-date information is in the new location and documentation should only be updated there.
+
 # Parameter options
 
 The following parameter options are applicable to all parameter types except Time range picker.

--- a/Documentation/Programmatically.md
+++ b/Documentation/Programmatically.md
@@ -1,3 +1,7 @@
+> [!NOTE] 
+> This documentation for Azure workbooks is now located at: https://learn.microsoft.com/en-us/azure/azure-monitor/visualize/workbooks-automate
+> Please **do not** edit this file. All up-to-date information is in the new location and documentation should only be updated there.
+
 # Programmatically Manage Workbooks
 
 Resource owners have the option to create and manage their workbooks programmatically via ARM templates. 
@@ -15,6 +19,7 @@ There are two types of workbook resources that can be managed programmatically:
 ## Deploying a workbook template
 1. Open a workbook whose content you want to deploy programmatically.
 2. Switch the workbook to edit mode by clicking on the _Edit_ toolbar item.
+
 3. Open the _Advanced Editor_ using the _</>_ button on the toolbar.
 4. Ensure you are on the `Gallery Template` tab
 5. Copy the JSON payload to the clipboard for use in the ARM template later.

--- a/Documentation/Samples/AlertDataARM.md
+++ b/Documentation/Samples/AlertDataARM.md
@@ -1,3 +1,7 @@
+> [!NOTE] 
+> This documentation for Azure workbooks is now located at: https://learn.microsoft.com/en-us/azure/azure-monitor/visualize/workbooks-commonly-used-components#use-azure-resource-manager-to-retrieve-alerts-in-a-subscription
+> Please **do not** edit this file. All up-to-date information is in the new location and documentation should only be updated there.
+
 # Using Azure Resource Manager provider to retrieve alerts in a subscription
 
 This sample shows you how to use the Azure Resource Manager (preview) query control to list all existing alerts in a subscription. This guide will also use JSON Path transformations to format the results.

--- a/Documentation/Samples/ODataFilters.md
+++ b/Documentation/Samples/ODataFilters.md
@@ -1,3 +1,7 @@
+> [!NOTE] 
+> This documentation for Azure workbooks is now located at: https://learn.microsoft.com/en-us/azure/azure-monitor/visualize/workbooks-overview
+> Please **do not** edit this file. All up-to-date information is in the new location and documentation should only be updated there.
+
 # Parameter transformation to get OData filters
 
 A common use case in workbooks is to capture user input via drop downs and use the selection in your queries. For instance, you may have a drop down to accept a set of virtual machines and then filter your KQL to include just the selected machines. In most cases, it is as simple as including the parameter's value in the query: 

--- a/Documentation/Samples/ReusingQueryData.md
+++ b/Documentation/Samples/ReusingQueryData.md
@@ -1,3 +1,7 @@
+> [!NOTE] 
+> This documentation for Azure workbooks is now located at: https://learn.microsoft.com/en-us/azure/azure-monitor/visualize/workbooks-commonly-used-components#reuse-query-data-in-different-visualizations
+> Please **do not** edit this file. All up-to-date information is in the new location and documentation should only be updated there.
+
 # Reusing query data in different visualizations
 
 There are times where you want to visualize the underlying data set in different ways without having to pay the cost of the query each time. This sample shows you how to do so using the `Merge` option in the query control.

--- a/Documentation/Samples/Samples.md
+++ b/Documentation/Samples/Samples.md
@@ -1,3 +1,7 @@
+> [!NOTE] 
+> This documentation for Azure workbooks is now located at: https://learn.microsoft.com/en-us/azure/azure-monitor/visualize/workbooks-commonly-used-components
+> Please **do not** edit this file. All up-to-date information is in the new location and documentation should only be updated there.
+
 # Sample Gallery
 
 ### Traffic light status

--- a/Documentation/Samples/TrafficLights.md
+++ b/Documentation/Samples/TrafficLights.md
@@ -1,3 +1,7 @@
+> [!NOTE] 
+> This documentation for Azure workbooks is now located at: https://learn.microsoft.com/en-us/azure/azure-monitor/visualize/workbooks-commonly-used-components#traffic-light-icons
+> Please **do not** edit this file. All up-to-date information is in the new location and documentation should only be updated there.
+
 # Showing traffic lights status in workbooks
 
 It is often desirable to summarize status using a simpler domain instead presenting the full range of values. For example, you may want to categorize your computers by CPU utilization as Cold/Warm/Hot OR user by the performance experienced as Satisfied/Tolerating/Frustrated. This can be as simple as showing an indicator or icon which represents the status next to the underlying metric. 

--- a/Documentation/Settings/Settings.md
+++ b/Documentation/Settings/Settings.md
@@ -1,3 +1,7 @@
+> [!NOTE] 
+> This documentation for Azure workbooks is now located at: https://learn.microsoft.com/en-us/azure/azure-monitor/visualize/workbooks-configurations
+> Please **do not** edit this file. All up-to-date information is in the new location and documentation should only be updated there.
+
 # Workbook Settings
 
 In the workbooks settings context pane, there are a couple of tabs which can be configured for the workbook.

--- a/Documentation/Transformations/JSONPath.md
+++ b/Documentation/Transformations/JSONPath.md
@@ -1,3 +1,7 @@
+> [!NOTE] 
+> This documentation for Azure workbooks is now located at: https://learn.microsoft.com/en-us/azure/azure-monitor/visualize/workbooks-parameters#format-parameters-by-using-jsonpath
+> Please **do not** edit this file. All up-to-date information is in the new location and documentation should only be updated there.
+
 # JSON Path
 
 Workbooks is able to query data from many sources. Some endpoints, such as Azure Resource Manager or custom endpoint, can return results in JSON. If the JSON data returned by the queried endpoint is not configured in a format that you desire, JSONPath can be used to transform the results.

--- a/Documentation/ViewDesigner/AccessPermissions.md
+++ b/Documentation/ViewDesigner/AccessPermissions.md
@@ -1,3 +1,7 @@
+> [!NOTE] 
+> This documentation for Azure workbooks is now located at:https://learn.microsoft.com/en-us/azure/azure-monitor/visualize/workbooks-view-designer-conversion-overview
+> Please **do not** edit this file. All up-to-date information is in the new location and documentation should only be updated there.
+
 # Accessing Workbooks & Viewing Permissions
 
 ### Jump to a section

--- a/Documentation/ViewDesigner/CommonSteps.md
+++ b/Documentation/ViewDesigner/CommonSteps.md
@@ -1,3 +1,7 @@
+> [!NOTE] 
+> This documentation for Azure workbooks is now located at: https://learn.microsoft.com/en-us/azure/azure-monitor/visualize/workbooks-view-designer-conversion-overview
+> Please **do not** edit this file. All up-to-date information is in the new location and documentation should only be updated there.
+
 # Common Steps
 
 ### Jump to a section

--- a/Documentation/ViewDesigner/ConversionOptions.md
+++ b/Documentation/ViewDesigner/ConversionOptions.md
@@ -1,3 +1,7 @@
+> [!NOTE] 
+> This documentation for Azure workbooks is now located at: https://learn.microsoft.com/en-us/azure/azure-monitor/visualize/workbooks-view-designer-conversion-overview
+> Please **do not** edit this file. All up-to-date information is in the new location and documentation should only be updated there.
+
 # <strong>Conversion Options</strong>
 
 View Designer has a fixed static style of representation, while Workbooks enables freedom to include and modify how the data is represented, below depicts a few examples of how one might transform the views within Workbooks.

--- a/Documentation/ViewDesigner/TileConversions.md
+++ b/Documentation/ViewDesigner/TileConversions.md
@@ -1,3 +1,7 @@
+> [!NOTE] 
+> This documentation for Azure workbooks is now located at: https://learn.microsoft.com/en-us/azure/azure-monitor/visualize/workbooks-view-designer-conversion-overview
+> Please **do not** edit this file. All up-to-date information is in the new location and documentation should only be updated there.
+
 # Tile Conversions
 
 ### Jump to a section

--- a/Documentation/ViewDesigner/ViewDesignerOverview.md
+++ b/Documentation/ViewDesigner/ViewDesignerOverview.md
@@ -1,3 +1,7 @@
+> [!NOTE] 
+> This documentation for Azure workbooks is now located at: https://learn.microsoft.com/en-us/azure/azure-monitor/visualize/workbooks-view-designer-conversion-overview
+> Please **do not** edit this file. All up-to-date information is in the new location and documentation should only be updated there.
+
 # View Designer to Workbooks Transition Guide
 
 ## Table of Contents

--- a/Documentation/Visualizations/Chart.md
+++ b/Documentation/Visualizations/Chart.md
@@ -1,3 +1,7 @@
+> [!NOTE] 
+> This documentation for Azure workbooks is now located at: https://learn.microsoft.com/en-us/azure/azure-monitor/visualize/workbooks-chart-visualizations
+> Please **do not** edit this file. All up-to-date information is in the new location and documentation should only be updated there.
+
 # Chart Visualization
 
 Workbooks allow monitoring data to be presented as charts. Supported chart types include line, bar, bar categorical, area, scatter plots, pie and time. Authors can choose to customize the height, width, color palette, legend, titles, no-data message, etc. of the chart, and customize axis types and series colors using chart settings.

--- a/Documentation/Visualizations/CompositeBar.md
+++ b/Documentation/Visualizations/CompositeBar.md
@@ -1,3 +1,7 @@
+> [!NOTE] 
+> This documentation for Azure workbooks is now located at: https://learn.microsoft.com/en-us/azure/azure-monitor/visualize/workbooks-composite-bar
+> Please **do not** edit this file. All up-to-date information is in the new location and documentation should only be updated there.
+
 # Composite Bar Renderer
 
 Workbook allows rendering data using composite bar, a bar made up of multiple bars.

--- a/Documentation/Visualizations/Graph.md
+++ b/Documentation/Visualizations/Graph.md
@@ -1,3 +1,7 @@
+> [!NOTE] 
+> This documentation for Azure workbooks is now located at: https://learn.microsoft.com/en-us/azure/azure-monitor/visualize/workbooks-graph-visualizations
+> Please **do not** edit this file. All up-to-date information is in the new location and documentation should only be updated there.
+
 # Graph Visualization
 
 Workbooks supports visualizing arbitrary graphs based on data from logs to show the relationships between monitoring entities. 

--- a/Documentation/Visualizations/Grid.md
+++ b/Documentation/Visualizations/Grid.md
@@ -1,3 +1,7 @@
+> [!NOTE] 
+> This documentation for Azure workbooks is now located at: https://learn.microsoft.com/en-us/azure/azure-monitor/visualize/workbooks-grid-visualizations
+> Please **do not** edit this file. All up-to-date information is in the new location and documentation should only be updated there.
+
 # Grid Visualization
 
 Grids or tables are a common way to present data to users. Workbooks allow users to individually style the columns of the grid to provide a rich UI for their reports. 

--- a/Documentation/Visualizations/HoneyComb.md
+++ b/Documentation/Visualizations/HoneyComb.md
@@ -1,3 +1,6 @@
+> [!NOTE] 
+> This documentation for Azure workbooks is now located at: https://learn.microsoft.com/en-us/azure/azure-monitor/visualize/workbooks-honey-comb
+> Please **do not** edit this file. All up-to-date information is in the new location and documentation should only be updated there.
 
 # Honey Comb Visualization
 

--- a/Documentation/Visualizations/LogCharts.md
+++ b/Documentation/Visualizations/LogCharts.md
@@ -1,3 +1,7 @@
+> [!NOTE] 
+> This documentation for Azure workbooks is now located at: https://learn.microsoft.com/en-us/azure/azure-monitor/visualize/workbooks-chart-visualizations#log-charts
+> Please **do not** edit this file. All up-to-date information is in the new location and documentation should only be updated there.
+
 # Log Charts
 
 Azure Monitor logs gives resource owners detailed information about the workings of their apps and infrastructure. Unlike metrics, log information is not collected by default and requires some kind of collection on-boarding. However, when present logs provide a lot of information about the state of the resource and data useful for diagnostics. Workbooks allow presenting log data as visual charts for user analysis.

--- a/Documentation/Visualizations/Map.md
+++ b/Documentation/Visualizations/Map.md
@@ -1,3 +1,8 @@
+> [!NOTE] 
+> This documentation for Azure workbooks is now located at: https://learn.microsoft.com/en-us/azure/azure-monitor/visualize/workbooks-map-visualizations
+> Please **do not** edit this file. All up-to-date information is in the new location and documentation should only be updated there.
+
+
 # Map Visualization
 
 Map allows visualizing region specific data, hence aiding in pin-pointing issues with specific regions. This also aids in high level aggregated view of the monitoring data by providing capability to aggregate all the data mapped to each location/country/region.

--- a/Documentation/Visualizations/MetricCharts.md
+++ b/Documentation/Visualizations/MetricCharts.md
@@ -1,3 +1,7 @@
+> [!NOTE] 
+> This documentation for Azure workbooks is now located at: https://learn.microsoft.com/en-us/azure/azure-monitor/visualize/workbooks-chart-visualizations#metric-charts
+> Please **do not** edit this file. All up-to-date information is in the new location and documentation should only be updated there.
+
 # Metric Charts
 
 Most Azure resources emit metric data about state and health (e.g. CPU utilization, storage availability, count of database transactions, failing app requests, etc). Workbooks allow the visualization of this data as time-series charts. 

--- a/Documentation/Visualizations/Text.md
+++ b/Documentation/Visualizations/Text.md
@@ -1,3 +1,7 @@
+> [!NOTE] 
+> This documentation for Azure workbooks is now located at: https://learn.microsoft.com/en-us/azure/azure-monitor/visualize/workbooks-create-workbook#add-text
+> Please **do not** edit this file. All up-to-date information is in the new location and documentation should only be updated there.
+
 # Text Steps
 
 Workbooks allow authors to include text blocks in their workbooks. The text can be human analysis of the telemetry, information to help users interpret the data, section headings, etc. 

--- a/Documentation/Visualizations/TextVisualization.md
+++ b/Documentation/Visualizations/TextVisualization.md
@@ -1,3 +1,7 @@
+> [!NOTE] 
+> This documentation for Azure workbooks is now located at: https://learn.microsoft.com/en-us/azure/azure-monitor/visualize/workbooks-text-visualizations
+> Please **do not** edit this file. All up-to-date information is in the new location and documentation should only be updated there.
+
 # Text Visualization
 
 The text *visualization* in query steps is different from the [text *step*](Text.md). A text step is a top level item in a workbook, and supports replacing parameters in the content, and allows for error/warning styling.

--- a/Documentation/Visualizations/Tiles.md
+++ b/Documentation/Visualizations/Tiles.md
@@ -1,3 +1,7 @@
+> [!NOTE] 
+> This documentation for Azure workbooks is now located at:https://learn.microsoft.com/en-us/azure/azure-monitor/visualize/workbooks-tile-visualizations
+> Please **do not** edit this file. All up-to-date information is in the new location and documentation should only be updated there.
+
 # Tile Visualization
 
 Tiles are a very useful way to present summary data in workbooks. The image below shows a common use case of tiles - app level summary on top of a detailed grid.  

--- a/Documentation/Visualizations/Timebrush.md
+++ b/Documentation/Visualizations/Timebrush.md
@@ -1,3 +1,7 @@
+> [!NOTE] 
+> This documentation for Azure workbooks is now located at: https://learn.microsoft.com/en-us/azure/azure-monitor/visualize/workbooks-configurations#time-brushing
+> Please **do not** edit this file. All up-to-date information is in the new location and documentation should only be updated there.
+
 # Using Time Brushing
 
 When query or metrics steps are displaying time based data, additional options become available in the Advanced settings:

--- a/Documentation/Visualizations/Tree.md
+++ b/Documentation/Visualizations/Tree.md
@@ -1,3 +1,8 @@
+> [!NOTE] 
+> This documentation for Azure workbooks is now located at: https://learn.microsoft.com/en-us/azure/azure-monitor/visualize/workbooks-tree-visualizations
+> Please **do not** edit this file. All up-to-date information is in the new location and documentation should only be updated there.
+
+
 # Tree Visualization
 
 Workbooks support hierarchical views via tree-grids. Trees allow some rows to be expandable into the next level for a drill-down experience.

--- a/Documentation/Visualizations/Visualizations.md
+++ b/Documentation/Visualizations/Visualizations.md
@@ -1,3 +1,8 @@
+> [!NOTE] 
+> This documentation for Azure workbooks is now located at: https://learn.microsoft.com/en-us/azure/azure-monitor/visualize/workbooks-visualizations
+> Please **do not** edit this file. All up-to-date information is in the new location and documentation should only be updated there.
+
+
 # Visualizations in Workbooks
 
 Workbooks provide a rich set of capabilities for visualizing Azure Monitor data. The exact set of capability depends on the data source and result set, but authors can expect them to converge over time. These controls allow authors to present their analysis in rich, interactive reports. 


### PR DESCRIPTION
This is all docs updates, there are no changes to templates or other content.

In general, the only update was to add a note at the top of all of the docs that were moved to public docs at
https://learn.microsoft.com/en-us/azure/azure-monitor/visualize/workbooks-overview

which is now the one true source for public docs.

There are a couple of pages (logs hints, text visualization) that have placeholder links as the real docs haven't been updated there yet.