### PR TITLE
Fix query in win 11 pie chart in feature update

### DIFF
--- a/Workbooks/UpdateCompliance/Feature updates/Feature updates.workbook
+++ b/Workbooks/UpdateCompliance/Feature updates/Feature updates.workbook
@@ -1187,14 +1187,11 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "//let _SnapshotTime = datetime({_SnapshotTime});\r\nUCClientReadinessStatus\r\n//| where TimeGenerated == _SnapshotTime\r\n| summarize count() by ReadinessStatus\r\n",
+              "query": "let _SnapshotTime = datetime({_SnapshotTime});\r\nUCClientReadinessStatus\r\n| where TimeGenerated == _SnapshotTime\r\n| summarize count() by ReadinessStatus\r\n",
               "size": 3,
               "showAnalytics": true,
               "title": "Windows 11 readiness status",
               "noDataMessage": "No devices eligible for Windows 11",
-              "timeContext": {
-                "durationMs": 86400000
-              },
               "showExportToExcel": true,
               "queryType": 0,
               "resourceType": "microsoft.operationalinsights/workspaces",


### PR DESCRIPTION
## PR Checklist

* [x] Fix query in Windows 11 Readiness pie chart under Feature updates > Device status by uncommenting the snapshot time.