### PR TITLE
Fix link type in VM

### DIFF
--- a/Workbooks/Azure Stack HCI/SingleCluster/Cluster.workbook
+++ b/Workbooks/Azure Stack HCI/SingleCluster/Cluster.workbook
@@ -1145,7 +1145,7 @@
                           "columnMatch": "Hostname",
                           "formatter": 13,
                           "formatOptions": {
-                            "linkTarget": "WorkbookTemplate",
+                            "linkTarget": "Resource",
                             "showIcon": true,
                             "workbookContext": {
                               "componentIdSource": "workbook",


### PR DESCRIPTION
- Fixed link type in VM tab which should jump into resource page. 
## PR Checklist

* [x] Explain your changes, so people looking at the PR know *what* and *why*, the code changes are the *how*.

### If adding or updating templates:
* [x] post a screenshot of templates and/or gallery changes
* [x] ensure your template has a corresponding gallery entry in the gallery folder
* [x] If you are adding a new template, add your team and template/gallery file(s) to the CODEOWNERS file. CODEOWNERS entries should be teams, not individuals
* [x] ensure all steps have meaningful names
* [x] ensure all parameters and grid columns have display names set so they can be localized
* [x] ensure that parameters id values are unique __or they will fail PR validation__ (parameter ids are used for localization)
* [x] ensure that steps names are unique __or they will fail PR validation__ (step names are used for localization)
* [x] grep `/subscription/` and ensure that your parameters don't have any hardcoded resourceIds __or they will fail PR validation__
* [x] remove `fallbackResourceIds` and `fromTemplateId` fields from your template workbook __or they will fail PR validation__