### PR TITLE
Updated custom width for alert filters

### DIFF
--- a/Workbooks/SapMonitor2.0/SapLandscapeMonitor/SapLandscapeMonitor.workbook
+++ b/Workbooks/SapMonitor2.0/SapLandscapeMonitor/SapLandscapeMonitor.workbook
@@ -636,7 +636,7 @@
               "style": "pills",
               "queryType": 8
             },
-            "customWidth": "15",
+            "customWidth": "25",
             "conditionalVisibility": {
               "parameterName": "SelectedGroup",
               "comparison": "isEqualTo",
@@ -683,7 +683,7 @@
               "style": "pills",
               "queryType": 0
             },
-            "customWidth": "15",
+            "customWidth": "25",
             "conditionalVisibility": {
               "parameterName": "SelectedSID",
               "comparison": "isEqualTo",
@@ -725,7 +725,7 @@
               "style": "pills",
               "queryType": 8
             },
-            "customWidth": "15",
+            "customWidth": "25",
             "name": "CategoryFilter"
           },
           {
@@ -762,7 +762,7 @@
               "style": "pills",
               "queryType": 8
             },
-            "customWidth": "15",
+            "customWidth": "25",
             "name": "SeverityFilter"
           },
           {


### PR DESCRIPTION
Increased custom width for alert filters in SAP Landscape monitor workbook.

![image](https://user-images.githubusercontent.com/115653217/226249825-ac3d9f87-4d97-4ba8-8b21-351f5102f13a.png)

## PR Checklist

* [X] Explain your changes, so people looking at the PR know *what* and *why*, the code changes are the *how*.

### If adding or updating templates:
* [X] post a screenshot of templates and/or gallery changes
* [ ] ensure your template has a corresponding gallery entry in the gallery folder
* [ ] If you are adding a new template, add your team and template/gallery file(s) to the CODEOWNERS file. CODEOWNERS entries should be teams, not individuals
* [ ] ensure all steps have meaningful names
* [ ] ensure all parameters and grid columns have display names set so they can be localized
* [ ] ensure that parameters id values are unique __or they will fail PR validation__ (parameter ids are used for localization)
* [ ] ensure that steps names are unique __or they will fail PR validation__ (step names are used for localization)
* [ ] grep `/subscription/` and ensure that your parameters don't have any hardcoded resourceIds __or they will fail PR validation__
* [ ] remove `fallbackResourceIds` and `fromTemplateId` fields from your template workbook __or they will fail PR validation__