### PR TITLE
changes to hide provider dropdown

### DIFF
--- a/Workbooks/SapMonitor2.0/Alerts/Create Alert rule (step 1 of 2)/Create Alert rule (step 1 of 2).workbook
+++ b/Workbooks/SapMonitor2.0/Alerts/Create Alert rule (step 1 of 2)/Create Alert rule (step 1 of 2).workbook
@@ -379,12 +379,20 @@
     {
       "type": 1,
       "content": {
-        "json": "### Choose a name, provider instance and severity for the alert"
+        "json": "### Choose a Name, severity for the alert"
       },
       "name": "text - 5",
       "styleSettings": {
         "margin": "15px 0 0 0 "
       }
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "Please update the alert name by adding a identifier to avoid overiding an existing alert.",
+        "style": "info"
+      },
+      "name": "update-alert-name-info-md"
     },
     {
       "type": 9,
@@ -402,26 +410,7 @@
             "timeContext": {
               "durationMs": 86400000
             },
-            "value": "SAP HANA high memory usage percent"
-          },
-          {
-            "id": "11617d02-e540-45ac-9636-aafcf9fb10a1",
-            "version": "KqlParameterItem/1.0",
-            "name": "ProviderInstance",
-            "label": "Provider instance",
-            "type": 2,
-            "description": "Select a provider instance for this alert rule",
-            "isRequired": true,
-            "query": "{\"version\":\"ARMEndpoint/1.0\",\"data\":null,\"headers\":[],\"method\":\"GET\",\"path\":\"{AmsResource}/providerInstances/\",\"urlParams\":[{\"key\":\"api-version\",\"value\":\"2022-11-01-preview\"}],\"batchDisabled\":false,\"transformers\":[{\"type\":\"jsonpath\",\"settings\":{\"tablePath\":\"$.value[?(@.properties.providerSettings.providerType=='{ProviderType}' && @.properties.provisioningState=='Succeeded')]\",\"columns\":[{\"path\":\"name\",\"columnid\":\"name\"}]}}]}",
-            "value": "SapHana",
-            "typeSettings": {
-              "additionalResourceOptions": [],
-              "showDefault": false
-            },
-            "timeContext": {
-              "durationMs": 86400000
-            },
-            "queryType": 12
+            "value": "Cluster Primary node switched"
           },
           {
             "id": "b16868c1-1463-4edd-8a26-e89c1b282c4d",
@@ -443,10 +432,114 @@
           }
         ],
         "style": "above",
-        "queryType": 12,
-        "resourceType": "microsoft.operationalinsights/workspaces"
+        "queryType": 12
       },
       "name": "parameters - 6"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "### Choose a provider instance for the alert"
+      },
+      "conditionalVisibility": {
+        "parameterName": "ProviderType",
+        "comparison": "isNotEqualTo",
+        "value": "PrometheusHaCluster"
+      },
+      "name": "choose-provider-instance-md",
+      "styleSettings": {
+        "margin": "15px 0 0 0 "
+      }
+    },
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "parameters": [
+          {
+            "id": "9c69800e-b0aa-4678-801b-01a6891b6df8",
+            "version": "KqlParameterItem/1.0",
+            "name": "ProviderInstance",
+            "label": "Provider instance",
+            "type": 2,
+            "description": "Select a provider instance for this alert rule",
+            "isRequired": true,
+            "query": "{\"version\":\"ARMEndpoint/1.0\",\"data\":null,\"headers\":[],\"method\":\"GET\",\"path\":\"{AmsResource}/providerInstances/\",\"urlParams\":[{\"key\":\"api-version\",\"value\":\"2022-11-01-preview\"}],\"batchDisabled\":false,\"transformers\":[{\"type\":\"jsonpath\",\"settings\":{\"tablePath\":\"$.value[?(@.properties.providerSettings.providerType=='{ProviderType}' && @.properties.provisioningState=='Succeeded')]\",\"columns\":[{\"path\":\"name\",\"columnid\":\"name\"}]}}]}",
+            "value": "SapHana",
+            "typeSettings": {
+              "additionalResourceOptions": [],
+              "showDefault": false
+            },
+            "timeContext": {
+              "durationMs": 86400000
+            },
+            "queryType": 12
+          }
+        ],
+        "style": "above",
+        "queryType": 12
+      },
+      "conditionalVisibility": {
+        "parameterName": "ProviderType",
+        "comparison": "isNotEqualTo",
+        "value": "PrometheusHaCluster"
+      },
+      "name": "select-provider-instance"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "### Choose a HA cluster for the alert"
+      },
+      "conditionalVisibility": {
+        "parameterName": "ProviderType",
+        "comparison": "isEqualTo",
+        "value": "PrometheusHaCluster"
+      },
+      "name": "choose-ha-cluster-md",
+      "styleSettings": {
+        "margin": "15px 0 0 0 "
+      }
+    },
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "parameters": [
+          {
+            "id": "1c5a3631-31cb-4a39-bc2a-f87a71e4a2c3",
+            "version": "KqlParameterItem/1.0",
+            "name": "haCluster",
+            "label": "HA Cluster",
+            "type": 2,
+            "description": "Select a provider instance for this alert rule",
+            "isRequired": true,
+            "multiSelect": true,
+            "quote": "'",
+            "delimiter": ",",
+            "query": "{\"version\":\"ARMEndpoint/1.0\",\"data\":null,\"headers\":[],\"method\":\"GET\",\"path\":\"{AmsResource}/providerInstances/\",\"urlParams\":[{\"key\":\"api-version\",\"value\":\"2022-11-01-preview\"}],\"batchDisabled\":false,\"transformers\":[{\"type\":\"jsonpath\",\"settings\":{\"tablePath\":\"$.value[?(@.properties.providerSettings.providerType=='{ProviderType}' && @.properties.provisioningState=='Succeeded')]\",\"columns\":[{\"path\":\"$.properties.providerSettings.clusterName\",\"columnid\":\"clusterName\",\"columnType\":\"string\"}]}}]}",
+            "typeSettings": {
+              "additionalResourceOptions": [
+                "value::all"
+              ],
+              "showDefault": false
+            },
+            "timeContext": {
+              "durationMs": 86400000
+            },
+            "defaultValue": "value::all",
+            "queryType": 12
+          }
+        ],
+        "style": "above",
+        "queryType": 12
+      },
+      "conditionalVisibility": {
+        "parameterName": "ProviderType",
+        "comparison": "isEqualTo",
+        "value": "PrometheusHaCluster"
+      },
+      "name": "select-ha-cluster"
     },
     {
       "type": 1,

--- a/Workbooks/SapMonitor2.0/Alerts/Create Alert rule (step 1 of 2)/Create Alert rule (step 1 of 2).workbook
+++ b/Workbooks/SapMonitor2.0/Alerts/Create Alert rule (step 1 of 2)/Create Alert rule (step 1 of 2).workbook
@@ -379,7 +379,7 @@
     {
       "type": 1,
       "content": {
-        "json": "### Choose a name, severity for the alert"
+        "json": "### Choose a name and severity for the alert"
       },
       "name": "text - 5",
       "styleSettings": {

--- a/Workbooks/SapMonitor2.0/Alerts/Create Alert rule (step 1 of 2)/Create Alert rule (step 1 of 2).workbook
+++ b/Workbooks/SapMonitor2.0/Alerts/Create Alert rule (step 1 of 2)/Create Alert rule (step 1 of 2).workbook
@@ -379,7 +379,7 @@
     {
       "type": 1,
       "content": {
-        "json": "### Choose a Name, severity for the alert"
+        "json": "### Choose a name, severity for the alert"
       },
       "name": "text - 5",
       "styleSettings": {
@@ -410,7 +410,7 @@
             "timeContext": {
               "durationMs": 86400000
             },
-            "value": "Cluster Primary node switched"
+            "value": "SAP HANA high memory usage percent"
           },
           {
             "id": "b16868c1-1463-4edd-8a26-e89c1b282c4d",
@@ -434,7 +434,7 @@
         "style": "above",
         "queryType": 12
       },
-      "name": "parameters - 6"
+      "name": "param-alert-name-severity"
     },
     {
       "type": 1,


### PR DESCRIPTION
## PR Checklist

* [x] Explain your changes, so people looking at the PR know *what* and *why*, the code changes are the *how*.

Moved Provider Instance dropdown outside the current dropdown group.
Made the Provider instance dropdown conditionally visible, hide the dropdown when provider type is HA Cluster.
Updated Headers above the dropdowns.

Alerts Page for HA Alerts 
![ha cluster select](https://user-images.githubusercontent.com/17769418/227870553-48f4bc4a-e4f2-42e3-9d4b-f3696f5c76fd.png)


Alerts Page For other Provider Types
![For other Alerts](https://user-images.githubusercontent.com/17769418/225235957-f2800bb2-eb6e-40f5-9418-f27227de12b2.png)


### If adding or updating templates:
* [x] post a screenshot of templates and/or gallery changes
* [x] ensure your template has a corresponding gallery entry in the gallery folder
* [ ] If you are adding a new template, add your team and template/gallery file(s) to the CODEOWNERS file. CODEOWNERS entries should be teams, not individuals
* [x] ensure all steps have meaningful names
* [x] ensure all parameters and grid columns have display names set so they can be localized
* [x] ensure that parameters id values are unique __or they will fail PR validation__ (parameter ids are used for localization)
* [x] ensure that steps names are unique __or they will fail PR validation__ (step names are used for localization)
* [x] grep `/subscription/` and ensure that your parameters don't have any hardcoded resourceIds __or they will fail PR validation__
* [x] remove `fallbackResourceIds` and `fromTemplateId` fields from your template workbook __or they will fail PR validation__