### PR TITLE
Changed isFormComplete Criteria for Alerts

### DIFF
--- a/Workbooks/SapMonitor2.0/Alerts/Create Alert rule (step 1 of 2)/Create Alert rule (step 1 of 2).workbook
+++ b/Workbooks/SapMonitor2.0/Alerts/Create Alert rule (step 1 of 2)/Create Alert rule (step 1 of 2).workbook
@@ -463,7 +463,6 @@
             "label": "Provider instance",
             "type": 2,
             "description": "Select a provider instance for this alert rule",
-            "isRequired": true,
             "query": "{\"version\":\"ARMEndpoint/1.0\",\"data\":null,\"headers\":[],\"method\":\"GET\",\"path\":\"{AmsResource}/providerInstances/\",\"urlParams\":[{\"key\":\"api-version\",\"value\":\"2022-11-01-preview\"}],\"batchDisabled\":false,\"transformers\":[{\"type\":\"jsonpath\",\"settings\":{\"tablePath\":\"$.value[?(@.properties.providerSettings.providerType=='{ProviderType}' && @.properties.provisioningState=='Succeeded')]\",\"columns\":[{\"path\":\"name\",\"columnid\":\"name\"}]}}]}",
             "value": "SapHana",
             "typeSettings": {
@@ -748,6 +747,44 @@
               "version": "KqlParameterItem/1.0",
               "parameters": [
                 {
+                  "id": "e4ec0149-4619-406a-9bb7-475215ed9f38",
+                  "version": "KqlParameterItem/1.0",
+                  "name": "ProviderOrClusterAdded",
+                  "type": 1,
+                  "description": "To check if either Provider Name or HA Cluster is set or not.",
+                  "isHiddenWhenLocked": true,
+                  "criteriaData": [
+                    {
+                      "criteriaContext": {
+                        "leftOperand": "haCluster",
+                        "operator": "isNotNull",
+                        "rightValType": "param",
+                        "resultValType": "static",
+                        "resultVal": "true"
+                      }
+                    },
+                    {
+                      "criteriaContext": {
+                        "leftOperand": "ProviderInstance",
+                        "operator": "isNotNull",
+                        "rightValType": "param",
+                        "resultValType": "static",
+                        "resultVal": "true"
+                      }
+                    },
+                    {
+                      "criteriaContext": {
+                        "operator": "Default",
+                        "resultValType": "static",
+                        "resultVal": "false"
+                      }
+                    }
+                  ],
+                  "timeContext": {
+                    "durationMs": 86400000
+                  }
+                },
+                {
                   "id": "68768512-a9b3-40d5-8c0c-dd95c2a51444",
                   "version": "KqlParameterItem/1.0",
                   "name": "isAggregateComplete",
@@ -812,9 +849,10 @@
                     },
                     {
                       "criteriaContext": {
-                        "leftOperand": "ProviderInstance",
-                        "operator": "is Empty",
-                        "rightValType": "param",
+                        "leftOperand": "ProviderOrClusterAdded",
+                        "operator": "!=",
+                        "rightValType": "static",
+                        "rightVal": "true",
                         "resultValType": "static",
                         "resultVal": "false"
                       }


### PR DESCRIPTION
## PR Checklist

Changed isFormComplete Criteria for alerts, added condition to check if either ProviderInstance or HA Cluster is set.

* [x] Explain your changes, so people looking at the PR know *what* and *why*, the code changes are the *how*.

### If adding or updating templates:
* [ ] post a screenshot of templates and/or gallery changes
* [ ] ensure your template has a corresponding gallery entry in the gallery folder
* [ ] If you are adding a new template, add your team and template/gallery file(s) to the CODEOWNERS file. CODEOWNERS entries should be teams, not individuals
* [ ] ensure all steps have meaningful names
* [ ] ensure all parameters and grid columns have display names set so they can be localized
* [ ] ensure that parameters id values are unique __or they will fail PR validation__ (parameter ids are used for localization)
* [ ] ensure that steps names are unique __or they will fail PR validation__ (step names are used for localization)
* [ ] grep `/subscription/` and ensure that your parameters don't have any hardcoded resourceIds __or they will fail PR validation__
* [ ] remove `fallbackResourceIds` and `fromTemplateId` fields from your template workbook __or they will fail PR validation__