### PR TITLE
Added new template for NSP Access logs insights

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -83,6 +83,8 @@
 /Workbooks/Activity*Log/AtScale/** @microsoft/loganalytics 
 /Workbooks/Activity*Log/Resource/** @microsoft/loganalytics 
 
+/Workbooks/Network*Security*Perimeter/** @microsoft/networking-nsp-portal-workbooks
+
 /Workbooks/UpdateCompliance/** @microsoft/update-compliance-workbooks
 
 /Workbooks/ServiceBus/** @microsoft/service-bus @microsoft/applicationinsights-devtools

--- a/Workbooks/Network Security Perimeter/Access Logs/NSP Access Logs Insights.workbook
+++ b/Workbooks/Network Security Perimeter/Access Logs/NSP Access Logs Insights.workbook
@@ -1,0 +1,98 @@
+{
+  "version": "Notebook/1.0",
+  "items": [
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "parameters": [
+          {
+            "id": "74ba6ba7-94ee-4a5d-9752-a643b2512995",
+            "version": "KqlParameterItem/1.0",
+            "name": "FilterResource",
+            "type": 1,
+            "isHiddenWhenLocked": true,
+            "timeContext": {
+              "durationMs": 2592000000
+            },
+            "value": ""
+          },
+          {
+            "id": "b06d4336-3f0d-44c7-adeb-b2902580ae18",
+            "version": "KqlParameterItem/1.0",
+            "name": "TimeRange",
+            "label": "Time Range",
+            "type": 4,
+            "typeSettings": {
+              "selectableValues": [
+                {
+                  "durationMs": 3600000
+                },
+                {
+                  "durationMs": 14400000
+                },
+                {
+                  "durationMs": 43200000
+                },
+                {
+                  "durationMs": 86400000
+                },
+                {
+                  "durationMs": 172800000
+                },
+                {
+                  "durationMs": 259200000
+                },
+                {
+                  "durationMs": 604800000
+                },
+                {
+                  "durationMs": 1209600000
+                },
+                {
+                  "durationMs": 2419200000
+                },
+                {
+                  "durationMs": 2592000000
+                },
+                {
+                  "durationMs": 5184000000
+                },
+                {
+                  "durationMs": 7776000000
+                }
+              ],
+              "allowCustom": true
+            },
+            "value": {
+              "durationMs": 2592000000
+            }
+          }
+        ],
+        "style": "pills",
+        "queryType": 0,
+        "resourceType": "microsoft.network/networksecurityperimeters"
+      },
+      "name": "parameters - 0"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "NSPAccessLogs \r\n| where ServiceResourceId contains \"{FilterResource}\"",
+        "size": 0,
+        "showAnalytics": true,
+        "title": "Access Logs for the selected paas resource",
+        "timeContextFromParameter": "TimeRange",
+        "showExportToExcel": true,
+        "queryType": 0,
+        "resourceType": "microsoft.network/networksecurityperimeters",
+        "gridSettings": {
+          "filter": true
+        }
+      },
+      "name": "query - 1"
+    }
+  ],
+  "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
+}


### PR DESCRIPTION
Objective: To show NSP(Network Security Perimeter) product access logs insights using workbook, so created new workbook template to show the access logs with time range parameter so that users can access the logs.

## PR Checklist

* [x] Explain your changes, so people looking at the PR know *what* and *why*, the code changes are the *how*.

### If adding or updating templates:
* [x] post a screenshot of templates and/or gallery changes
* [x] ensure your template has a corresponding gallery entry in the gallery folder
* [x] If you are adding a new template, add your team and template/gallery file(s) to the CODEOWNERS file. CODEOWNERS entries should be teams, not individuals
* [x] ensure all steps have meaningful names
* [x] ensure all parameters and grid columns have display names set so they can be localized
* [x] ensure that parameters id values are unique __or they will fail PR validation__ (parameter ids are used for localization)
* [x] ensure that steps names are unique __or they will fail PR validation__ (step names are used for localization)
* [x] grep `/subscription/` and ensure that your parameters don't have any hardcoded resourceIds __or they will fail PR validation__
* [x] remove `fallbackResourceIds` and `fromTemplateId` fields from your template workbook __or they will fail PR validation__


![image](https://user-images.githubusercontent.com/130187819/233209995-706cca94-d91e-4e8b-b40e-c38b25c1109b.png)

![image](https://user-images.githubusercontent.com/130187819/233210013-93d447f3-46f8-4c70-98b0-d8ea8358bfd0.png)

![image](https://user-images.githubusercontent.com/130187819/233209562-34d472e6-7d4e-413b-b480-f6355f1b3cf2.png)
