### PR TITLE
 HANA workbook GA check - fix typos and bugs

### DIFF
--- a/Workbooks/SapMonitor2.0/SapHana/SapHana.workbook
+++ b/Workbooks/SapMonitor2.0/SapHana/SapHana.workbook
@@ -546,7 +546,7 @@
                   "label": "Provider",
                   "type": 2,
                   "isRequired": true,
-                  "query": "SapHana_SystemOverview_CL \r\n| where TimeGenerated > ago(30d)\r\n| extend sid = tostring(VALUE_s)\r\n| extend provider = tostring(PROVIDER_INSTANCE_s)\r\n| where NAME_s == \"Instance ID\"\r\n| distinct provider\r\n| sort by provider asc\r\n;",
+                  "query": "SapHana_SystemOverview_CL \r\n//| where TimeGenerated > ago(30d)\r\n| extend sid = tostring(VALUE_s)\r\n| extend provider = tostring(PROVIDER_INSTANCE_s)\r\n| where NAME_s == \"Instance ID\"\r\n| distinct provider\r\n| sort by provider asc\r\n;",
                   "typeSettings": {
                     "additionalResourceOptions": [],
                     "showDefault": false
@@ -1211,7 +1211,7 @@
                         "type": 3,
                         "content": {
                           "version": "KqlItem/1.0",
-                          "query": "let table_systemoverview = SapHana_SystemOverview_CL \r\n| where TimeGenerated > ago(30d)\r\n| extend sid = tostring(VALUE_s)\r\n| extend provider = tostring(PROVIDER_INSTANCE_s)\r\n| where NAME_s == \"Instance ID\"\r\n| where provider == '{param_provider}'\r\n| project sid, provider\r\n;\r\nSapHana_LoadHistory_CL\r\n| where TimeGenerated {param_timeframe}\r\n| extend cpu = CPU_d\r\n| extend host = HOST_s\r\n| extend provider = PROVIDER_INSTANCE_s\r\n| join kind=leftouter (table_systemoverview) on provider\r\n| where provider == '{param_provider}'\r\n| project TimeGenerated, host, cpu\r\n| summarize max(cpu) by host, bin(TimeGenerated, {param_timeframe:grain})\r\n",
+                          "query": "let table_systemoverview = SapHana_SystemOverview_CL \r\n//| where TimeGenerated > ago(30d)\r\n| extend sid = tostring(VALUE_s)\r\n| extend provider = tostring(PROVIDER_INSTANCE_s)\r\n| where NAME_s == \"Instance ID\"\r\n| where provider == '{param_provider}'\r\n| project sid, provider\r\n;\r\nSapHana_LoadHistory_CL\r\n| where TimeGenerated {param_timeframe}\r\n| extend cpu = CPU_d\r\n| extend host = HOST_s\r\n| extend provider = PROVIDER_INSTANCE_s\r\n| join kind=leftouter (table_systemoverview) on provider\r\n| where provider == '{param_provider}'\r\n| project TimeGenerated, host, cpu\r\n| summarize max(cpu) by host, bin(TimeGenerated, {param_timeframe:grain})\r\n",
                           "size": 4,
                           "aggregation": 3,
                           "title": "CPU Utilization",
@@ -1247,7 +1247,7 @@
                         "type": 3,
                         "content": {
                           "version": "KqlItem/1.0",
-                          "query": "let table_systemoverview = SapHana_SystemOverview_CL \r\n| where TimeGenerated > ago(30d)\r\n| extend sid = tostring(VALUE_s)\r\n| extend provider = tostring(PROVIDER_INSTANCE_s)\r\n| where NAME_s == \"Instance ID\"\r\n| where provider == '{param_provider}'\r\n| project sid, provider\r\n;\r\nSapHana_LoadHistory_CL\r\n| where TimeGenerated {param_timeframe}\r\n| extend memory_used = MEMORY_USED_d\r\n| extend memory_size = MEMORY_SIZE_d\r\n| extend host = HOST_s\r\n| extend provider = PROVIDER_INSTANCE_s\r\n| join kind=leftouter (table_systemoverview) on provider\r\n| where provider == '{param_provider}'\r\n| project TimeGenerated, host, memory_used, memory_size\r\n| summarize max(memory_used / memory_size * 100) by host, bin(TimeGenerated, {param_timeframe:grain})\r\n",
+                          "query": "let table_systemoverview = SapHana_SystemOverview_CL \r\n//| where TimeGenerated > ago(30d)\r\n| extend sid = tostring(VALUE_s)\r\n| extend provider = tostring(PROVIDER_INSTANCE_s)\r\n| where NAME_s == \"Instance ID\"\r\n| where provider == '{param_provider}'\r\n| project sid, provider\r\n;\r\nSapHana_LoadHistory_CL\r\n| where TimeGenerated {param_timeframe}\r\n| extend memory_used = MEMORY_USED_d\r\n| extend memory_size = MEMORY_SIZE_d\r\n| extend host = HOST_s\r\n| extend provider = PROVIDER_INSTANCE_s\r\n| join kind=leftouter (table_systemoverview) on provider\r\n| where provider == '{param_provider}'\r\n| project TimeGenerated, host, memory_used, memory_size\r\n| summarize max(memory_used / memory_size * 100) by host, bin(TimeGenerated, {param_timeframe:grain})\r\n",
                           "size": 4,
                           "title": "Memory Utilization",
                           "queryType": 0,

--- a/Workbooks/SapMonitor2.0/SapHana/SapHana.workbook
+++ b/Workbooks/SapMonitor2.0/SapHana/SapHana.workbook
@@ -641,7 +641,7 @@
                         "type": 3,
                         "content": {
                           "version": "KqlItem/1.0",
-                          "query": "//Query to get SID + Provider from Sys Overview\r\nlet table_systemoverview = SapHana_SystemOverview_CL \r\n| where TimeGenerated > ago(30d)\r\n| extend sid = tostring(VALUE_s)\r\n| extend provider = tostring(PROVIDER_INSTANCE_s)\r\n| where provider in ({param_provider})\r\n| where NAME_s == \"Instance ID\"\r\n| sort by TimeGenerated\r\n| distinct sid, provider\r\n;\r\n//Query to get status and join with System Overview Table\r\nlet systemAvailability = SapHana_SystemAvailability_CL\r\n| sort by EVENT_TIME_t desc \r\n| extend Status = case(EVENT_TIME_t < ago(15m), \"Offline\",\r\n    HOST_ACTIVE_s == 'YES' and HOST_STATUS_s != 'ERROR', 'Available',  \r\n    HOST_ACTIVE_s == 'YES' and HOST_STATUS_s == 'ERROR', 'Non Functional',\r\n    HOST_ACTIVE_s == \"NO\", \"Error\",\r\n    HOST_ACTIVE_s == \"UNKNOWN\", \"Offline\",\r\n    HOST_ACTIVE_s == \"Starting\" and HOST_STATUS_s == 'ERROR', \"Error\",\r\n    HOST_ACTIVE_s == \"Starting\" and HOST_STATUS_s != 'ERROR', \"Non Functional\",\r\n    HOST_ACTIVE_s == \"Stopping\" and HOST_STATUS_s == 'ERROR', \"Error\",\r\n    HOST_ACTIVE_s == \"Stopping\" and HOST_STATUS_s != 'ERROR', \"Non Functional\",\r\n    \"\" )\r\n    //if no updates for more than 3 min say is offline\r\n| extend provider = PROVIDER_INSTANCE_s \r\n| where provider in ({param_provider}) \r\n| extend display =  case({param_availability} == 0 and Status != \"Offline\", \"0\", {param_availability} == \"1\" and Status == \"Offline\", \"0\", \"1\") \r\n| where display == \"1\"\r\n| join kind=leftouter (table_systemoverview) on provider\r\n;\r\n//Get most import details from query by most recent timestamp\r\nlet latestAvail = systemAvailability\r\n| project Status, provider ,sid, EVENT_TIME_t\r\n| summarize arg_max(EVENT_TIME_t, *) by provider\r\n;\r\nlet allHanaProvidersfromSrc =\r\nprint allProviders=parse_json(tostring(\"{param_providers_list:escapejson}\")).value\r\n    | mv-expand allProviders\r\n    | extend type=((parse_json(allProviders).properties).providerSettings).providerType\r\n    | extend state=((allProviders.properties)).provisioningState\r\n    | extend error=(allProviders.properties).errors\r\n//    | where error == \"{}\" or error == \"\"\r\n    | where type == \"SapHana\"\r\n//    | where state != \"Failed\"\r\n    | extend hostname=parse_json(allProviders.properties).providerSettings.hostname\r\n    | extend db=parse_json(allProviders.properties).providerSettings.dbName\r\n    | project allProviders.name, hostname, type, state, db, sysdbprovider=iff(db == \"SYSTEMDB\", 1, 0)\r\n;\r\nlet allHanaProviders = \r\nallHanaProvidersfromSrc\r\n| extend provider=tostring(allProviders_name)\r\n| project provider, allProviders_name, hostname, type, db, state\r\n;\r\n// allHanaProviders;\r\nlet latestAvailTenant = latestAvail \r\n    | join kind=leftouter(allHanaProviders) on provider\r\n    | extend sidten=iff(db == \"\", \"Deleted\", strcat(db, \"@\", sid))\r\n    | project Status = iff(db == \"\", \"Deleted\",  Status), provider, sidten, EVENT_TIME_t, state;\r\nlatestAvailTenant\r\n| project Status, provider, sidten, EVENT_TIME_t, state\r\n| where state != \"Failed\";",
+                          "query": "//Query to get SID + Provider from Sys Overview\r\nlet table_systemoverview = SapHana_SystemOverview_CL \r\n//| where TimeGenerated > ago(30d)\r\n| extend sid = tostring(VALUE_s)\r\n| extend provider = tostring(PROVIDER_INSTANCE_s)\r\n| where provider in ({param_provider})\r\n| where NAME_s == \"Instance ID\"\r\n| sort by TimeGenerated\r\n| distinct sid, provider\r\n;\r\n//Query to get status and join with System Overview Table\r\nlet systemAvailability = SapHana_SystemAvailability_CL\r\n| sort by EVENT_TIME_t desc \r\n| extend Status = case(EVENT_TIME_t < ago(15m), \"Offline\",\r\n    HOST_ACTIVE_s == 'YES' and HOST_STATUS_s != 'ERROR', 'Available',  \r\n    HOST_ACTIVE_s == 'YES' and HOST_STATUS_s == 'ERROR', 'Non Functional',\r\n    HOST_ACTIVE_s == \"NO\", \"Error\",\r\n    HOST_ACTIVE_s == \"UNKNOWN\", \"Offline\",\r\n    HOST_ACTIVE_s == \"Starting\" and HOST_STATUS_s == 'ERROR', \"Error\",\r\n    HOST_ACTIVE_s == \"Starting\" and HOST_STATUS_s != 'ERROR', \"Non Functional\",\r\n    HOST_ACTIVE_s == \"Stopping\" and HOST_STATUS_s == 'ERROR', \"Error\",\r\n    HOST_ACTIVE_s == \"Stopping\" and HOST_STATUS_s != 'ERROR', \"Non Functional\",\r\n    \"\" )\r\n    //if no updates for more than 3 min say is offline\r\n| extend provider = PROVIDER_INSTANCE_s \r\n| where provider in ({param_provider}) \r\n| extend display =  case({param_availability} == 0 and Status != \"Offline\", \"0\", {param_availability} == \"1\" and Status == \"Offline\", \"0\", \"1\") \r\n| where display == \"1\"\r\n| join kind=leftouter (table_systemoverview) on provider\r\n;\r\n//Get most import details from query by most recent timestamp\r\nlet latestAvail = systemAvailability\r\n| project Status, provider ,sid, EVENT_TIME_t\r\n| summarize arg_max(EVENT_TIME_t, *) by provider\r\n;\r\nlet allHanaProvidersfromSrc =\r\nprint allProviders=parse_json(tostring(\"{param_providers_list:escapejson}\")).value\r\n    | mv-expand allProviders\r\n    | extend type=((parse_json(allProviders).properties).providerSettings).providerType\r\n    | extend state=((allProviders.properties)).provisioningState\r\n    | extend error=(allProviders.properties).errors\r\n//    | where error == \"{}\" or error == \"\"\r\n    | where type == \"SapHana\"\r\n//    | where state != \"Failed\"\r\n    | extend hostname=parse_json(allProviders.properties).providerSettings.hostname\r\n    | extend db=parse_json(allProviders.properties).providerSettings.dbName\r\n    | project allProviders.name, hostname, type, state, db, sysdbprovider=iff(db == \"SYSTEMDB\", 1, 0)\r\n;\r\nlet allHanaProviders = \r\nallHanaProvidersfromSrc\r\n| extend provider=tostring(allProviders_name)\r\n| project provider, allProviders_name, hostname, type, db, state\r\n;\r\n// allHanaProviders;\r\nlet latestAvailTenant = latestAvail \r\n    | join kind=leftouter(allHanaProviders) on provider\r\n    | extend sidten=iff(db == \"\", \"Deleted\", strcat(db, \"@\", sid))\r\n    | project Status = iff(db == \"\", \"Deleted\",  Status), provider, sidten, EVENT_TIME_t, state;\r\nlatestAvailTenant\r\n| project Status, provider, sidten, EVENT_TIME_t, state\r\n| where state != \"Failed\";",
                           "size": 0,
                           "queryType": 0,
                           "resourceType": "microsoft.operationalinsights/workspaces",
@@ -712,7 +712,7 @@
                         "type": 3,
                         "content": {
                           "version": "KqlItem/1.0",
-                          "query": "let table_hostconfig = SapHana_HostConfig_CL\r\n| where TimeGenerated > ago(1d)\r\n| extend provider = PROVIDER_INSTANCE_s\r\n| where provider in ({param_provider})\r\n| extend timestamp_hostconfig = TimeGenerated\r\n| extend host = tostring(HOST_s)\r\n| extend role = tolower(INDEXSERVER_ACTUAL_ROLE_s)\r\n| extend active = tolower(HOST_ACTIVE_s)\r\n| summarize arg_max(timestamp_hostconfig, *) by provider, host\r\n| sort by host asc\r\n| project timestamp_hostconfig, host, role, active, provider\r\n;\r\nlet table_load_host = SapHana_LoadHistory_CL\r\n| extend timestamp_load = TimeGenerated\r\n| extend provider = tostring(PROVIDER_INSTANCE_s)\r\n| where provider in ({param_provider})\r\n| extend host = HOST_s\r\n| extend cpu = CPU_d\r\n| extend memory = MEMORY_USED_d / MEMORY_SIZE_d * 100\r\n| extend nw_in = NETWORK_IN_d\r\n| extend nw_out = NETWORK_OUT_d\r\n| join kind=inner (table_hostconfig | where active == \"yes\") on host\r\n| where timestamp_load  > ago(1d)\r\n| project cpu, memory, nw_in, nw_out, provider, host\r\n| summarize cpu=avg(cpu), memory=avg(memory), nw_in=avg(nw_in), nw_out=avg(nw_out) by provider, host\r\n;\r\nlet table_systemavailability = SapHana_SystemAvailability_CL\r\n//| where TimeGenerated  > ago(1d)\r\n| extend timestamp_systemavailability = TimeGenerated\r\n| extend provider = PROVIDER_INSTANCE_s\r\n| extend host = HOST_s\r\n| extend database = DATABASE_NAME_s\r\n| extend service = SERVICE_NAME_s\r\n| extend port = PORT_d\r\n| extend event = tostring(EVENT_NAME_s)\r\n| extend active = tolower(SERVICE_ACTIVE_s)\r\n| join kind=rightouter (table_hostconfig | where active == \"yes\") on provider\r\n| where port != 0\r\n| where service != \"\"\r\n| where provider in ({param_provider})\r\n| summarize arg_max(timestamp_systemavailability, *) by  provider, host, database, service\r\n| project host, provider, database, service, event, port, active\r\n;\r\nlet table_disks = SapHana_Disks_CL\r\n| extend timestamp_disks = TimeGenerated\r\n| extend provider = PROVIDER_INSTANCE_s\r\n| where provider in ({param_provider})\r\n| extend host = HOST_s\r\n| extend type = USAGE_TYPE_s\r\n| extend disk_usage = USED_SIZE_d / TOTAL_SIZE_d * 100\r\n| where type in (\"DATA\", \"LOG\")\r\n| join kind=inner (table_hostconfig | where active == \"yes\") on host\r\n| where timestamp_disks > ago(1d)\r\n| summarize disk_usage=avg(disk_usage) by provider, host, type\r\n;\r\nlet table_license = SapHana_License_Status_CL\r\n| extend provider = PROVIDER_INSTANCE_s\r\n| where provider in ({param_provider})\r\n| extend Status = iff(VALID_s == 'TRUE', \"VALID\", \"INVALID\")\r\n| extend host = HOSTNAME_s\r\n| distinct provider, Status, host;\r\nlet table_stats_server_health = SapHana_StatisticsServerHealth_CL \r\n| extend provider = PROVIDER_INSTANCE_s\r\n| where provider in ({param_provider})\r\n| extend currentStatus = iff(CURRENTSTATUS_s == 'active' and INSTALLATIONSTATUS_s contains \"Done (okay)\", \"Available\", \"Unavailable\")\r\n| distinct provider, currentStatus ;\r\ntable_hostconfig\r\n| extend name = host\r\n| extend id = strcat(provider)\r\n| extend type = \"Host\", parentid = \"\"\r\n| join kind=leftouter (table_load_host | project provider, host, cpu, memory, nw_in, nw_out) on provider, host \r\n| join kind=leftouter (table_disks | project provider,host, disk_usage, type | where type == \"DATA\" | extend disk_data = disk_usage) on provider, host\r\n| join kind=leftouter (table_disks | project provider, host, disk_usage, type | where type == \"LOG\" | extend disk_log = disk_usage) on provider, host\r\n| join kind=leftouter table_license on provider, host\r\n| join kind=leftouter table_stats_server_health on provider\r\n| union (table_systemavailability\r\n    | distinct host, provider, service, database, port, active, event\r\n    | extend type = \"Service\"\r\n    | extend name = strcat(service, \" (:\", tostring(toint(port)), \")\")\r\n    | extend parentid = provider, id = strcat(provider, \"_\", service)\r\n)\r\n| extend provider_name = provider\r\n| distinct provider_name, host, name, type, database, role, active, currentStatus, event, cpu, memory, disk_data, disk_log, nw_in, nw_out,Status, id, parentid\r\n| order by provider_name asc",
+                          "query": "let table_hostconfig = SapHana_HostConfig_CL\r\n| where TimeGenerated > ago(1d)\r\n| extend provider = PROVIDER_INSTANCE_s\r\n| where provider in ({param_provider})\r\n| extend timestamp_hostconfig = TimeGenerated\r\n| extend host = tostring(HOST_s)\r\n| extend role = tolower(INDEXSERVER_ACTUAL_ROLE_s)\r\n| extend active = tolower(HOST_ACTIVE_s)\r\n| summarize arg_max(timestamp_hostconfig, *) by provider, host\r\n| sort by host asc\r\n| project timestamp_hostconfig, host, role, active, provider\r\n;\r\nlet table_load_host = SapHana_LoadHistory_CL\r\n| extend timestamp_load = TimeGenerated\r\n| extend provider = tostring(PROVIDER_INSTANCE_s)\r\n| where provider in ({param_provider})\r\n| extend host = HOST_s\r\n| extend cpu = CPU_d\r\n| extend memory = MEMORY_USED_d / MEMORY_SIZE_d * 100\r\n| extend nw_in = NETWORK_IN_d\r\n| extend nw_out = NETWORK_OUT_d\r\n| join kind=inner (table_hostconfig | where active == \"yes\") on host\r\n| where timestamp_load  > ago(1d)\r\n| project cpu, memory, nw_in, nw_out, provider, host\r\n| summarize cpu=avg(cpu), memory=avg(memory), nw_in=avg(nw_in), nw_out=avg(nw_out) by provider, host\r\n;\r\nlet table_systemavailability = SapHana_SystemAvailability_CL\r\n| where TimeGenerated  > ago(1d)\r\n| extend timestamp_systemavailability = TimeGenerated\r\n| extend provider = PROVIDER_INSTANCE_s\r\n| extend host = HOST_s\r\n| extend database = DATABASE_NAME_s\r\n| extend service = SERVICE_NAME_s\r\n| extend port = PORT_d\r\n| extend event = tostring(EVENT_NAME_s)\r\n| extend active = tolower(SERVICE_ACTIVE_s)\r\n| join kind=rightouter (table_hostconfig | where active == \"yes\") on provider\r\n| where port != 0\r\n| where service != \"\"\r\n| where provider in ({param_provider})\r\n| summarize arg_max(timestamp_systemavailability, *) by  provider, host, database, service\r\n| project host, provider, database, service, event, port, active\r\n;\r\nlet table_disks = SapHana_Disks_CL\r\n| extend timestamp_disks = TimeGenerated\r\n| where TimeGenerated  > ago(1d)\r\n| extend provider = PROVIDER_INSTANCE_s\r\n| where provider in ({param_provider})\r\n| extend host = HOST_s\r\n| extend type = USAGE_TYPE_s\r\n| extend disk_usage = USED_SIZE_d / TOTAL_SIZE_d * 100\r\n| where type in (\"DATA\", \"LOG\")\r\n| join kind=inner (table_hostconfig | where active == \"yes\") on host\r\n| where timestamp_disks > ago(1d)\r\n| summarize disk_usage=avg(disk_usage) by provider, host, type\r\n;\r\nlet table_license = SapHana_License_Status_CL\r\n| extend provider = PROVIDER_INSTANCE_s\r\n| where TimeGenerated  > ago(1d)\r\n| where provider in ({param_provider})\r\n| extend Status = iff(VALID_s == 'TRUE', \"VALID\", \"INVALID\")\r\n| extend host = HOSTNAME_s\r\n| distinct provider, Status, host;\r\nlet table_stats_server_health = SapHana_StatisticsServerHealth_CL \r\n| extend provider = PROVIDER_INSTANCE_s\r\n| where provider in ({param_provider})\r\n| extend currentStatus = iff(CURRENTSTATUS_s == 'active' and INSTALLATIONSTATUS_s contains \"Done (okay)\", \"Available\", \"Unavailable\")\r\n| distinct provider, currentStatus ;\r\ntable_hostconfig\r\n| extend name = host\r\n| extend id = strcat(provider)\r\n| extend type = \"Host\", parentid = \"\"\r\n| join kind=leftouter (table_load_host | project provider, host, cpu, memory, nw_in, nw_out) on provider, host \r\n| join kind=leftouter (table_disks | project provider,host, disk_usage, type | where type == \"DATA\" | extend disk_data = disk_usage) on provider, host\r\n| join kind=leftouter (table_disks | project provider, host, disk_usage, type | where type == \"LOG\" | extend disk_log = disk_usage) on provider, host\r\n| join kind=leftouter table_license on provider, host\r\n| join kind=leftouter table_stats_server_health on provider\r\n| union (table_systemavailability\r\n    | distinct host, provider, service, database, port, active, event\r\n    | extend type = \"Service\"\r\n    | extend name = strcat(service, \" (:\", tostring(toint(port)), \")\")\r\n    | extend parentid = provider, id = strcat(provider, \"_\", service)\r\n)\r\n| extend provider_name = provider\r\n| distinct provider_name, host, name, type, database, role, active, currentStatus, event, cpu, memory, disk_data, disk_log, nw_in, nw_out,Status, id, parentid\r\n| order by provider_name asc",
                           "size": 3,
                           "title": "Instance overview (last 24 hours)",
                           "showRefreshButton": true,
@@ -2016,7 +2016,7 @@
                         "type": 3,
                         "content": {
                           "version": "KqlItem/1.0",
-                          "query": "SapHana_HighMemoryUsageService_CL \r\n| where Time_Generated_t {param_timeframe}\r\n| where PROVIDER_INSTANCE_s == '{param_provider}'\r\n| project DATABASE_NAME_s, SNAPSHOT_TIME_t, SERVICE_NAME_s, PERCENTAGE_USED_MEMORY_d, PERCENTAGE_HEAP_USED_MEMORY_d, PHYSICAL_MEMORY_SIZE_MB_d, LOGICAL_MEMORY_SIZE_MB_d, HEAP_MEMORY_ALLOCATED_SIZE_MB_d, HEAP_MEMORY_USED_SIZE_MB_d, ALLOCATION_LIMIT_MB_d, FREE_MEMORY_SIZE_MB_d, TOTAL_MEMORY_USED_SIZE_MB_d\r\n| order by SNAPSHOT_TIME_t desc\r\n",
+                          "query": "SapHana_HighMemoryUsageService_CL \r\n| where Time_Generated_t {param_timeframe}\r\n| where PROVIDER_INSTANCE_s == '{param_provider}'\r\n| extend DATABASE_NAME = iff(DATABASE_NAME_s == '', \"SYSTEMDB\", DATABASE_NAME_s)\r\n| project DATABASE_NAME, SNAPSHOT_TIME_t, SERVICE_NAME_s, PERCENTAGE_USED_MEMORY_d, PERCENTAGE_HEAP_USED_MEMORY_d, PHYSICAL_MEMORY_SIZE_MB_d, LOGICAL_MEMORY_SIZE_MB_d, HEAP_MEMORY_ALLOCATED_SIZE_MB_d, HEAP_MEMORY_USED_SIZE_MB_d, ALLOCATION_LIMIT_MB_d, FREE_MEMORY_SIZE_MB_d, TOTAL_MEMORY_USED_SIZE_MB_d\r\n| order by SNAPSHOT_TIME_t desc\r\n",
                           "size": 0,
                           "showRefreshButton": true,
                           "showExportToExcel": true,
@@ -2122,15 +2122,9 @@
                               }
                             ],
                             "filter": true,
-                            "sortBy": [
-                              {
-                                "itemKey": "DATABASE_NAME_s",
-                                "sortOrder": 2
-                              }
-                            ],
                             "labelSettings": [
                               {
-                                "columnId": "DATABASE_NAME_s",
+                                "columnId": "DATABASE_NAME",
                                 "label": "Tenant Name"
                               },
                               {
@@ -2181,7 +2175,7 @@
                           },
                           "sortBy": [
                             {
-                              "itemKey": "DATABASE_NAME_s",
+                              "itemKey": "DATABASE_NAME",
                               "sortOrder": 2
                             }
                           ]
@@ -2499,7 +2493,7 @@
                               "type": 3,
                               "content": {
                                 "version": "KqlItem/1.0",
-                                "query": "let nodata = datatable(end_time_utc:datetime,backup_type:string,database:string,backup_size_bytes:real,backup_duration_seconds:real,backup_id:real)\r\n[\r\n'1970-01-01 00:00:00',\"N\\\\A\",\"N\\\\A\",0,0,0,\r\n];\r\nSapHana_BackupCatalog_CL\r\n| where PROVIDER_INSTANCE_s == '{param_provider}'\r\n| where ENTRY_TYPE_NAME_s in ({param_backuptype}) or '*' in ({param_backuptype})\r\n| where STATE_NAME_s in ({param_backupstate}) or '*' in ({param_backupstate})\r\n| extend end_time_utc = UTC_END_TIME_t,\r\n         backup_type = ENTRY_TYPE_NAME_s,\r\n         database = DATABASE_NAME_s,\r\n         backup_size_bytes = BACKUP_SIZE_BYTES_d,\r\n         backup_duration_seconds = TIME_ELAPSED_SECONDS_d,\r\n         backup_id = BACKUP_ID_d\r\n| project end_time_utc, backup_type, database, backup_size_bytes, backup_duration_seconds, backup_id\r\n| distinct *\r\n| union isfuzzy=true nodata | where database <> \"N\\\\A\"",
+                                "query": "let nodata = datatable(end_time_utc:datetime,backup_type:string,database:string,backup_size_bytes:real,backup_duration_seconds:real,backup_id:real)\r\n[\r\n'1970-01-01 00:00:00',\"N\\\\A\",\"N\\\\A\",0,0,0,\r\n];\r\nSapHana_BackupCatalog_CL\r\n| where PROVIDER_INSTANCE_s == '{param_provider}'\r\n| where UTC_END_TIME_t {param_timeframe}\r\n| where ENTRY_TYPE_NAME_s in ({param_backuptype}) or '*' in ({param_backuptype})\r\n| where STATE_NAME_s in ({param_backupstate}) or '*' in ({param_backupstate})\r\n| extend end_time_utc = UTC_END_TIME_t,\r\n         backup_type = ENTRY_TYPE_NAME_s,\r\n         database = DATABASE_NAME_s,\r\n         backup_size_bytes = BACKUP_SIZE_BYTES_d,\r\n         backup_duration_seconds = TIME_ELAPSED_SECONDS_d,\r\n         backup_id = BACKUP_ID_d\r\n| project end_time_utc, backup_type, database, backup_size_bytes, backup_duration_seconds, backup_id\r\n| distinct *\r\n| union isfuzzy=true nodata | where database <> \"N\\\\A\"",
                                 "size": 0,
                                 "aggregation": 4,
                                 "title": "Backup Size",
@@ -2537,7 +2531,7 @@
                               "type": 3,
                               "content": {
                                 "version": "KqlItem/1.0",
-                                "query": "let nodata = datatable(end_time_utc:datetime,backup_type:string,database:string,backup_size_bytes:real,backup_duration_seconds:real,backup_id:real)\r\n[\r\n'1970-01-01 00:00:00',\"N\\\\A\",\"N\\\\A\",0,0,0,\r\n];\r\nSapHana_BackupCatalog_CL\r\n| where PROVIDER_INSTANCE_s == '{param_provider}'\r\n| where ENTRY_TYPE_NAME_s in ({param_backuptype}) or '*' in ({param_backuptype})\r\n| where STATE_NAME_s in ({param_backupstate}) or '*' in ({param_backupstate})\r\n| extend end_time_utc = UTC_END_TIME_t,\r\n         backup_type = ENTRY_TYPE_NAME_s,\r\n         database = DATABASE_NAME_s,\r\n         backup_size_bytes = BACKUP_SIZE_BYTES_d,\r\n         backup_duration_seconds = TIME_ELAPSED_SECONDS_d,\r\n         backup_id = BACKUP_ID_d\r\n| project end_time_utc, backup_type, database, backup_size_bytes, backup_duration_seconds, backup_id\r\n| distinct *\r\n| union isfuzzy=true nodata | where database <> \"N\\\\A\"",
+                                "query": "let nodata = datatable(end_time_utc:datetime,backup_type:string,database:string,backup_size_bytes:real,backup_duration_seconds:real,backup_id:real)\r\n[\r\n'1970-01-01 00:00:00',\"N\\\\A\",\"N\\\\A\",0,0,0,\r\n];\r\nSapHana_BackupCatalog_CL\r\n| where PROVIDER_INSTANCE_s == '{param_provider}'\r\n| where UTC_END_TIME_t {param_timeframe}\r\n| where ENTRY_TYPE_NAME_s in ({param_backuptype}) or '*' in ({param_backuptype})\r\n| where STATE_NAME_s in ({param_backupstate}) or '*' in ({param_backupstate})\r\n| extend end_time_utc = UTC_END_TIME_t,\r\n         backup_type = ENTRY_TYPE_NAME_s,\r\n         database = DATABASE_NAME_s,\r\n         backup_size_bytes = BACKUP_SIZE_BYTES_d,\r\n         backup_duration_seconds = TIME_ELAPSED_SECONDS_d,\r\n         backup_id = BACKUP_ID_d\r\n| project end_time_utc, backup_type, database, backup_size_bytes, backup_duration_seconds, backup_id\r\n| distinct *\r\n| union isfuzzy=true nodata | where database <> \"N\\\\A\"",
                                 "size": 0,
                                 "title": "Backup Duration",
                                 "queryType": 0,
@@ -3724,7 +3718,7 @@
                           "version": "KqlItem/1.0",
                           "query": "SapHana_License_Status_CL\r\n| extend timestamp_load = TimeGenerated\r\n| extend provider = PROVIDER_INSTANCE_s\r\n| where provider == '{param_provider}'\r\n| summarize arg_max(PRODUCT_USAGE_d, *) by SID_s, VALID_s, HARDWARE_KEY_s, PERMANENT_s, INSTALL_NO_s, HOSTNAME_s, PRODUCT_LIMIT_d, SYSTEM_NO_s, START_DATE_t\r\n| extend Status = iff(VALID_s == 'TRUE', \"VALID\", \"INVALID\")\r\n| distinct SID_s, Status, HARDWARE_KEY_s, PERMANENT_s, INSTALL_NO_s, HOSTNAME_s, PRODUCT_LIMIT_d, PRODUCT_USAGE_d, SYSTEM_NO_s, START_DATE_t\r\n| order by START_DATE_t desc\r\n",
                           "size": 0,
-                          "title": "License Status",
+                          "title": "License Status for the whole time",
                           "showRefreshButton": true,
                           "showExportToExcel": true,
                           "queryType": 0,
@@ -3838,7 +3832,7 @@
                           }
                         },
                         "showPin": true,
-                        "name": "License Status"
+                        "name": "License Status for the whole time"
                       },
                       {
                         "type": 1,
@@ -4160,9 +4154,6 @@
                           "version": "KqlItem/1.0",
                           "query": "SapHana_InternodeSendThroughput_CL \r\n| where PROVIDER_INSTANCE_s == '{param_provider}'\r\n| where TimeGenerated {param_timeframe}\r\n| project TimeGenerated, SENDER_s, RECEIVER_s, SIZE_MB_d, DURATION_SECONDS_d, THROUGHPUT_MBPS_d \r\n| order by TimeGenerated desc",
                           "size": 0,
-                          "timeContext": {
-                            "durationMs": 86400000
-                          },
                           "showRefreshButton": true,
                           "showExportToExcel": true,
                           "queryType": 0,
@@ -4391,7 +4382,7 @@
                       {
                         "type": 1,
                         "content": {
-                          "json": "No data avaialble for configuration parameters",
+                          "json": "No data available for configuration parameters.",
                           "style": "info"
                         },
                         "conditionalVisibility": {
@@ -4581,22 +4572,22 @@
                                 "style": "info"
                               },
                               "name": "Long Idling Cursors - table message - no data"
-                            },
-                            {
-                              "type": 1,
-                              "content": {
-                                "json": "<div style=\"float: right\">\r\n\tUpdated every 15 minutes.\r\n</div>"
-                              },
-                              "name": "text - 1"
                             }
                           ]
                         },
                         "conditionalVisibility": {
                           "parameterName": "param_check_longidlingcursor",
-                          "comparison": "isEqualTo",
-                          "value": "2"
+                          "comparison": "isNotEqualTo",
+                          "value": "0"
                         },
                         "name": "Long Idling Cursors  - no data"
+                      },
+                      {
+                        "type": 1,
+                        "content": {
+                          "json": "<div style=\"float: right\">\r\n\tUpdated every 15 minutes.\r\n</div>"
+                        },
+                        "name": "text - 2"
                       }
                     ]
                   },
@@ -4631,8 +4622,8 @@
                         },
                         "conditionalVisibility": {
                           "parameterName": "param_check_uncommittedwritetransactions",
-                          "comparison": "isEqualTo",
-                          "value": "2"
+                          "comparison": "isNotEqualTo",
+                          "value": "0"
                         },
                         "name": "Uncommitted Write Transactions​ - no data"
                       },
@@ -4815,8 +4806,8 @@
                         },
                         "conditionalVisibility": {
                           "parameterName": "param_check_longrunningtransactions",
-                          "comparison": "isEqualTo",
-                          "value": "2"
+                          "comparison": "isNotEqualTo",
+                          "value": "0"
                         },
                         "name": " Long Running Statement - no data text "
                       },
@@ -4927,8 +4918,8 @@
                         },
                         "conditionalVisibility": {
                           "parameterName": "param_check_blockedtransactions",
-                          "comparison": "isEqualTo",
-                          "value": "2"
+                          "comparison": "isNotEqualTo",
+                          "value": "0"
                         },
                         "name": "Blocked Transactions - no data text "
                       },
@@ -5161,9 +5152,6 @@
                           "size": 0,
                           "aggregation": 2,
                           "title": "Memory statistics (Sum of all nodes in system)",
-                          "timeContext": {
-                            "durationMs": 86400000
-                          },
                           "queryType": 0,
                           "resourceType": "microsoft.operationalinsights/workspaces",
                           "visualization": "linechart",

--- a/Workbooks/SapMonitor2.0/SapHana/SapHana.workbook
+++ b/Workbooks/SapMonitor2.0/SapHana/SapHana.workbook
@@ -712,7 +712,7 @@
                         "type": 3,
                         "content": {
                           "version": "KqlItem/1.0",
-                          "query": "let table_hostconfig = SapHana_HostConfig_CL\r\n| where TimeGenerated > ago(1d)\r\n| extend provider = PROVIDER_INSTANCE_s\r\n| where provider in ({param_provider})\r\n| extend timestamp_hostconfig = TimeGenerated\r\n| extend host = tostring(HOST_s)\r\n| extend role = tolower(INDEXSERVER_ACTUAL_ROLE_s)\r\n| extend active = tolower(HOST_ACTIVE_s)\r\n| summarize arg_max(timestamp_hostconfig, *) by provider, host\r\n| sort by host asc\r\n| project timestamp_hostconfig, host, role, active, provider\r\n;\r\nlet table_load_host = SapHana_LoadHistory_CL\r\n| extend timestamp_load = TimeGenerated\r\n| extend provider = tostring(PROVIDER_INSTANCE_s)\r\n| where provider in ({param_provider})\r\n| extend host = HOST_s\r\n| extend cpu = CPU_d\r\n| extend memory = MEMORY_USED_d / MEMORY_SIZE_d * 100\r\n| extend nw_in = NETWORK_IN_d\r\n| extend nw_out = NETWORK_OUT_d\r\n| join kind=inner (table_hostconfig | where active == \"yes\") on host\r\n| where timestamp_load  > ago(1d)\r\n| project cpu, memory, nw_in, nw_out, provider, host\r\n| summarize cpu=avg(cpu), memory=avg(memory), nw_in=avg(nw_in), nw_out=avg(nw_out) by provider, host\r\n;\r\nlet table_systemavailability = SapHana_SystemAvailability_CL\r\n| where TimeGenerated  > ago(1d)\r\n| extend timestamp_systemavailability = TimeGenerated\r\n| extend provider = PROVIDER_INSTANCE_s\r\n| extend host = HOST_s\r\n| extend database = DATABASE_NAME_s\r\n| extend service = SERVICE_NAME_s\r\n| extend port = PORT_d\r\n| extend event = tostring(EVENT_NAME_s)\r\n| extend active = tolower(SERVICE_ACTIVE_s)\r\n| join kind=rightouter (table_hostconfig | where active == \"yes\") on provider\r\n| where port != 0\r\n| where service != \"\"\r\n| where provider in ({param_provider})\r\n| summarize arg_max(timestamp_systemavailability, *) by  provider, host, database, service\r\n| project host, provider, database, service, event, port, active\r\n;\r\nlet table_disks = SapHana_Disks_CL\r\n| extend timestamp_disks = TimeGenerated\r\n| where TimeGenerated  > ago(1d)\r\n| extend provider = PROVIDER_INSTANCE_s\r\n| where provider in ({param_provider})\r\n| extend host = HOST_s\r\n| extend type = USAGE_TYPE_s\r\n| extend disk_usage = USED_SIZE_d / TOTAL_SIZE_d * 100\r\n| where type in (\"DATA\", \"LOG\")\r\n| join kind=inner (table_hostconfig | where active == \"yes\") on host\r\n| where timestamp_disks > ago(1d)\r\n| summarize disk_usage=avg(disk_usage) by provider, host, type\r\n;\r\nlet table_license = SapHana_License_Status_CL\r\n| extend provider = PROVIDER_INSTANCE_s\r\n| where TimeGenerated  > ago(1d)\r\n| where provider in ({param_provider})\r\n| extend Status = iff(VALID_s == 'TRUE', \"VALID\", \"INVALID\")\r\n| extend host = HOSTNAME_s\r\n| distinct provider, Status, host;\r\nlet table_stats_server_health = SapHana_StatisticsServerHealth_CL \r\n| extend provider = PROVIDER_INSTANCE_s\r\n| where provider in ({param_provider})\r\n| extend currentStatus = iff(CURRENTSTATUS_s == 'active' and INSTALLATIONSTATUS_s contains \"Done (okay)\", \"Available\", \"Unavailable\")\r\n| distinct provider, currentStatus ;\r\ntable_hostconfig\r\n| extend name = host\r\n| extend id = strcat(provider)\r\n| extend type = \"Host\", parentid = \"\"\r\n| join kind=leftouter (table_load_host | project provider, host, cpu, memory, nw_in, nw_out) on provider, host \r\n| join kind=leftouter (table_disks | project provider,host, disk_usage, type | where type == \"DATA\" | extend disk_data = disk_usage) on provider, host\r\n| join kind=leftouter (table_disks | project provider, host, disk_usage, type | where type == \"LOG\" | extend disk_log = disk_usage) on provider, host\r\n| join kind=leftouter table_license on provider, host\r\n| join kind=leftouter table_stats_server_health on provider\r\n| union (table_systemavailability\r\n    | distinct host, provider, service, database, port, active, event\r\n    | extend type = \"Service\"\r\n    | extend name = strcat(service, \" (:\", tostring(toint(port)), \")\")\r\n    | extend parentid = provider, id = strcat(provider, \"_\", service)\r\n)\r\n| extend provider_name = provider\r\n| distinct provider_name, host, name, type, database, role, active, currentStatus, event, cpu, memory, disk_data, disk_log, nw_in, nw_out,Status, id, parentid\r\n| order by provider_name asc",
+                          "query": "let table_hostconfig = SapHana_HostConfig_CL\r\n| where TimeGenerated > ago(1d)\r\n| extend provider = PROVIDER_INSTANCE_s\r\n| where provider in ({param_provider})\r\n| extend timestamp_hostconfig = TimeGenerated\r\n| extend host = tostring(HOST_s)\r\n| extend role = tolower(INDEXSERVER_ACTUAL_ROLE_s)\r\n| extend active = tolower(HOST_ACTIVE_s)\r\n| summarize arg_max(timestamp_hostconfig, *) by provider, host\r\n| sort by host asc\r\n| project timestamp_hostconfig, host, role, active, provider\r\n;\r\nlet table_load_host = SapHana_LoadHistory_CL\r\n| extend timestamp_load = TimeGenerated\r\n| extend provider = tostring(PROVIDER_INSTANCE_s)\r\n| where provider in ({param_provider})\r\n| extend host = HOST_s\r\n| extend cpu = CPU_d\r\n| extend memory = MEMORY_USED_d / MEMORY_SIZE_d * 100\r\n| extend nw_in = NETWORK_IN_d\r\n| extend nw_out = NETWORK_OUT_d\r\n| join kind=inner (table_hostconfig | where active == \"yes\") on host\r\n| where timestamp_load  > ago(1d)\r\n| project cpu, memory, nw_in, nw_out, provider, host\r\n| summarize cpu=avg(cpu), memory=avg(memory), nw_in=avg(nw_in), nw_out=avg(nw_out) by provider, host\r\n;\r\nlet table_systemavailability = SapHana_SystemAvailability_CL\r\n| where TimeGenerated  > ago(1d)\r\n| extend timestamp_systemavailability = TimeGenerated\r\n| extend provider = PROVIDER_INSTANCE_s\r\n| extend host = HOST_s\r\n| extend database = DATABASE_NAME_s\r\n| extend service = SERVICE_NAME_s\r\n| extend port = PORT_d\r\n| extend event = tostring(EVENT_NAME_s)\r\n| extend active = tolower(SERVICE_ACTIVE_s)\r\n| join kind=rightouter (table_hostconfig | where active == \"yes\") on provider\r\n| where port != 0\r\n| where service != \"\"\r\n| where provider in ({param_provider})\r\n| summarize arg_max(timestamp_systemavailability, *) by  provider, host, database, service\r\n| project host, provider, database, service, event, port, active\r\n;\r\nlet table_disks = SapHana_Disks_CL\r\n| extend timestamp_disks = TimeGenerated\r\n| where TimeGenerated  > ago(1d)\r\n| extend provider = PROVIDER_INSTANCE_s\r\n| where provider in ({param_provider})\r\n| extend host = HOST_s\r\n| extend type = USAGE_TYPE_s\r\n| extend disk_usage = USED_SIZE_d / TOTAL_SIZE_d * 100\r\n| where type in (\"DATA\", \"LOG\")\r\n| join kind=inner (table_hostconfig | where active == \"yes\") on host\r\n| where timestamp_disks > ago(1d)\r\n| summarize disk_usage=avg(disk_usage) by provider, host, type\r\n;\r\nlet table_license = SapHana_License_Status_CL\r\n| extend provider = PROVIDER_INSTANCE_s\r\n| where TimeGenerated  > ago(1d)\r\n| where provider in ({param_provider})\r\n| extend Status = iff(VALID_s == 'TRUE', \"VALID\", \"INVALID\")\r\n| extend host = HOSTNAME_s\r\n| distinct provider, Status, host;\r\nlet table_stats_server_health = SapHana_StatisticsServerHealth_CL \r\n| extend provider = PROVIDER_INSTANCE_s\r\n| where provider in ({param_provider})\r\n| extend currentStatus = iff(CURRENTSTATUS_s == 'active' and INSTALLATIONSTATUS_s contains \"Done (okay)\", \"Available\", \"Unavailable\")\r\n| distinct provider, currentStatus ;\r\ntable_hostconfig\r\n| extend name = host\r\n| extend id = strcat(host,\"_\",provider)\r\n| extend type = \"Host\", parentid = \"\"\r\n| join kind=leftouter (table_load_host | project provider, host, cpu, memory, nw_in, nw_out) on provider, host \r\n| join kind=leftouter (table_disks | project provider,host, disk_usage, type | where type == \"DATA\" | extend disk_data = disk_usage) on provider, host\r\n| join kind=leftouter (table_disks | project provider, host, disk_usage, type | where type == \"LOG\" | extend disk_log = disk_usage) on provider, host\r\n| join kind=leftouter table_license on provider, host\r\n| join kind=leftouter table_stats_server_health on provider\r\n| union (table_systemavailability\r\n    | distinct host, provider, service, database, port, active, event\r\n    | extend type = \"Service\"\r\n    | extend database = iff(database == '', \"SYSTEMDB\", database)\r\n    | extend name = strcat(service, \" (:\", tostring(toint(port)), \")\")\r\n    | extend parentid = strcat(host,\"_\",provider), id = strcat(host,\"_\",provider, \"_\", service)\r\n)\r\n| extend provider_name = provider\r\n| distinct provider_name, host, name, type, database, role, active, currentStatus, event, cpu, memory, disk_data, disk_log, nw_in, nw_out,Status, id, parentid\r\n| order by provider_name asc",
                           "size": 3,
                           "title": "Instance overview (last 24 hours)",
                           "showRefreshButton": true,
@@ -934,6 +934,12 @@
                               "treeType": 0,
                               "expanderColumn": "provider_name"
                             },
+                            "sortBy": [
+                              {
+                                "itemKey": "$gen_link_name_2",
+                                "sortOrder": 1
+                              }
+                            ],
                             "labelSettings": [
                               {
                                 "columnId": "provider_name",
@@ -1001,7 +1007,12 @@
                               }
                             ]
                           },
-                          "sortBy": []
+                          "sortBy": [
+                            {
+                              "itemKey": "$gen_link_name_2",
+                              "sortOrder": 1
+                            }
+                          ]
                         },
                         "showPin": true,
                         "name": "System_Overview_Dropdown"
@@ -2016,7 +2027,7 @@
                         "type": 3,
                         "content": {
                           "version": "KqlItem/1.0",
-                          "query": "SapHana_HighMemoryUsageService_CL \r\n| where Time_Generated_t {param_timeframe}\r\n| where PROVIDER_INSTANCE_s == '{param_provider}'\r\n| extend DATABASE_NAME = iff(DATABASE_NAME_s == '', \"SYSTEMDB\", DATABASE_NAME_s)\r\n| project DATABASE_NAME, SNAPSHOT_TIME_t, SERVICE_NAME_s, PERCENTAGE_USED_MEMORY_d, PERCENTAGE_HEAP_USED_MEMORY_d, PHYSICAL_MEMORY_SIZE_MB_d, LOGICAL_MEMORY_SIZE_MB_d, HEAP_MEMORY_ALLOCATED_SIZE_MB_d, HEAP_MEMORY_USED_SIZE_MB_d, ALLOCATION_LIMIT_MB_d, FREE_MEMORY_SIZE_MB_d, TOTAL_MEMORY_USED_SIZE_MB_d\r\n| order by SNAPSHOT_TIME_t desc\r\n",
+                          "query": "SapHana_HighMemoryUsageService_CL \r\n| where Time_Generated_t {param_timeframe}\r\n| where PROVIDER_INSTANCE_s == '{param_provider}'\r\n| extend DATABASE_NAME = iff(DATABASE_NAME_s == '', \"SYSTEMDB\", DATABASE_NAME_s)\r\n| project SNAPSHOT_TIME_t, DATABASE_NAME, SERVICE_NAME_s, PERCENTAGE_USED_MEMORY_d, PERCENTAGE_HEAP_USED_MEMORY_d, PHYSICAL_MEMORY_SIZE_MB_d, LOGICAL_MEMORY_SIZE_MB_d, HEAP_MEMORY_ALLOCATED_SIZE_MB_d, HEAP_MEMORY_USED_SIZE_MB_d, ALLOCATION_LIMIT_MB_d, FREE_MEMORY_SIZE_MB_d, TOTAL_MEMORY_USED_SIZE_MB_d\r\n| order by DATABASE_NAME desc, SNAPSHOT_TIME_t desc\r\n",
                           "size": 0,
                           "showRefreshButton": true,
                           "showExportToExcel": true,
@@ -2122,18 +2133,24 @@
                               }
                             ],
                             "filter": true,
-                            "labelSettings": [
+                            "sortBy": [
                               {
-                                "columnId": "DATABASE_NAME",
-                                "label": "Tenant Name"
-                              },
+                                "itemKey": "DATABASE_NAME",
+                                "sortOrder": 2
+                              }
+                            ],
+                            "labelSettings": [
                               {
                                 "columnId": "SNAPSHOT_TIME_t",
                                 "label": "Time"
                               },
                               {
+                                "columnId": "DATABASE_NAME",
+                                "label": "Tenant Name"
+                              },
+                              {
                                 "columnId": "SERVICE_NAME_s",
-                                "label": "Host Name"
+                                "label": "Service"
                               },
                               {
                                 "columnId": "PERCENTAGE_USED_MEMORY_d",
@@ -2330,8 +2347,8 @@
                                     "name": "param_backuptype",
                                     "label": "Backup Type",
                                     "type": 10,
+                                    "isRequired": true,
                                     "query": "{\"version\":\"1.0.0\",\"content\":\"[\\r\\n    { \\\"value\\\": \\\"'log backup','data'\\\", \\\"label\\\": \\\"All\\\", \\\"selected\\\": true },\\r\\n    { \\\"value\\\": \\\"'log backup'\\\", \\\"label\\\":\\\"Log\\\" },\\r\\n    { \\\"value\\\": \\\"'data','complete data backup'\\\", \\\"label\\\":\\\"Data\\\" }\\r\\n]\",\"transformers\":null}",
-                                    "value": "'log backup'",
                                     "typeSettings": {
                                       "additionalResourceOptions": [],
                                       "showDefault": false
@@ -3413,7 +3430,7 @@
                               "type": 3,
                               "content": {
                                 "version": "KqlItem/1.0",
-                                "query": "// Filter the base data set to only work with the selected Provider\r\nlet table_systemreplication = SapHana_SystemReplication_CL\r\n| where PROVIDER_INSTANCE_s == '{param_provider}'\r\n;\r\n// Find the latest post for this instance\r\nlet table_lastpost = table_systemreplication\r\n| summarize lastpost = max(TimeGenerated)\r\n| project lastpost\r\n;\r\n// Create table of the last posts for this instance\r\nlet table_hsrlastpost = table_systemreplication\r\n| join kind=inner (table_lastpost) on  $left.TimeGenerated == $right.lastpost\r\n;\r\n//create a table with the primary site\r\nlet table_primarysite = table_hsrlastpost \r\n| distinct SITE_NAME_s\r\n| project  \r\n    NodeID = SITE_NAME_s,\r\n    SourceID = '',\r\n    TargetID = '',\r\n    CentreContent = SITE_NAME_s, \r\n    EdgeLabel = '', \r\n    TopContent = 'Primary'\r\n;\r\n// create a table with the secondary sites\r\nlet table_secondarysite = table_hsrlastpost \r\n| summarize\r\n   TIME_DIFF_SECONDS_d = avg(TIME_DIFF_SECONDS_d),\r\n   OPERATION_MODE_s = max(OPERATION_MODE_s),\r\n   REPLICATION_MODE_s = max(REPLICATION_MODE_s),\r\n   SYSTEM_REPLICATION_STATUS_s = max(SYSTEM_REPLICATION_STATUS_s)\r\n  by SITE_NAME_s, SECONDARY_SITE_NAME_s\r\n| project  \r\n   NodeID = SECONDARY_SITE_NAME_s,\r\n   SourceID = SITE_NAME_s,\r\n   TargetID = SECONDARY_SITE_NAME_s,\r\n   CentreContent = SECONDARY_SITE_NAME_s,\r\n   EdgeLabel = strcat( iif(SYSTEM_REPLICATION_STATUS_s == 'ACTIVE', '🟢', '🟥'), ' ', SYSTEM_REPLICATION_STATUS_s, ' - ', REPLICATION_MODE_s, ' with ',OPERATION_MODE_s), \r\n   TopContent = 'Secondary'\r\n;\r\n// join the two together\r\ntable_primarysite\r\n| union table_secondarysite\r\n| order by NodeID asc",
+                                "query": "// Filter the base data set to only work with the selected Provider\r\nlet table_systemreplication = SapHana_SystemReplication_CL\r\n| where PROVIDER_INSTANCE_s == '{param_provider}'\r\n| where TimeGenerated {param_timeframe} \r\n;\r\n// Find the latest post for this instance\r\nlet table_lastpost = table_systemreplication\r\n| summarize lastpost = max(TimeGenerated)\r\n| project lastpost\r\n;\r\n// Create table of the last posts for this instance\r\nlet table_hsrlastpost = table_systemreplication\r\n| join kind=inner (table_lastpost) on  $left.TimeGenerated == $right.lastpost\r\n;\r\n//create a table with the primary site\r\nlet table_primarysite = table_hsrlastpost \r\n| distinct SITE_NAME_s\r\n| project  \r\n    NodeID = SITE_NAME_s,\r\n    SourceID = '',\r\n    TargetID = '',\r\n    CentreContent = SITE_NAME_s, \r\n    EdgeLabel = '', \r\n    TopContent = 'Primary'\r\n;\r\n// create a table with the secondary sites\r\nlet table_secondarysite = table_hsrlastpost \r\n| summarize\r\n   TIME_DIFF_SECONDS_d = avg(TIME_DIFF_SECONDS_d),\r\n   OPERATION_MODE_s = max(OPERATION_MODE_s),\r\n   REPLICATION_MODE_s = max(REPLICATION_MODE_s),\r\n   SYSTEM_REPLICATION_STATUS_s = max(SYSTEM_REPLICATION_STATUS_s)\r\n  by SITE_NAME_s, SECONDARY_SITE_NAME_s\r\n| project  \r\n   NodeID = SECONDARY_SITE_NAME_s,\r\n   SourceID = SITE_NAME_s,\r\n   TargetID = SECONDARY_SITE_NAME_s,\r\n   CentreContent = SECONDARY_SITE_NAME_s,\r\n   EdgeLabel = strcat( iif(SYSTEM_REPLICATION_STATUS_s == 'ACTIVE', '🟢', '🟥'), ' ', SYSTEM_REPLICATION_STATUS_s, ' - ', REPLICATION_MODE_s, ' with ',OPERATION_MODE_s), \r\n   TopContent = 'Secondary'\r\n;\r\n// join the two together\r\ntable_primarysite\r\n| union table_secondarysite\r\n| order by NodeID asc",
                                 "size": 3,
                                 "queryType": 0,
                                 "resourceType": "microsoft.operationalinsights/workspaces",
@@ -3718,7 +3735,7 @@
                           "version": "KqlItem/1.0",
                           "query": "SapHana_License_Status_CL\r\n| extend timestamp_load = TimeGenerated\r\n| extend provider = PROVIDER_INSTANCE_s\r\n| where provider == '{param_provider}'\r\n| summarize arg_max(PRODUCT_USAGE_d, *) by SID_s, VALID_s, HARDWARE_KEY_s, PERMANENT_s, INSTALL_NO_s, HOSTNAME_s, PRODUCT_LIMIT_d, SYSTEM_NO_s, START_DATE_t\r\n| extend Status = iff(VALID_s == 'TRUE', \"VALID\", \"INVALID\")\r\n| distinct SID_s, Status, HARDWARE_KEY_s, PERMANENT_s, INSTALL_NO_s, HOSTNAME_s, PRODUCT_LIMIT_d, PRODUCT_USAGE_d, SYSTEM_NO_s, START_DATE_t\r\n| order by START_DATE_t desc\r\n",
                           "size": 0,
-                          "title": "License Status for the whole time",
+                          "title": "License Status History",
                           "showRefreshButton": true,
                           "showExportToExcel": true,
                           "queryType": 0,
@@ -3832,7 +3849,7 @@
                           }
                         },
                         "showPin": true,
-                        "name": "License Status for the whole time"
+                        "name": "License Status History"
                       },
                       {
                         "type": 1,


### PR DESCRIPTION
## PR Checklist

- fix typos (e.g. avaialble-> available)
- check correct filtering in query for timegenerated depending on user's selection in param_timeframe
- in transaction tab correct displaying of note message if there are no data to be displayed + frequency how often new data are fetched
- in System Utilization tab > Memory Service Usage: for empty field in "Tenant Name" add "SYSTEMDB"
![image](https://user-images.githubusercontent.com/98498799/234034537-f375ff68-e318-4c90-9bc4-bf15f2e5c74d.png)
- System Utilization - sort desc tenant, time (move to left), and Rename the host column to Service

- Landspace overview - don't show duplicates for hosts, and empty database column
Before:
![image](https://user-images.githubusercontent.com/98498799/234680188-fbd6ac8d-5e85-4bff-bacd-d2bb21265d00.png)
Now:
![image](https://user-images.githubusercontent.com/98498799/234680001-ece0906d-0b5d-40b5-b7cd-62b3cc97e562.png)


- Backup tab shows error if the Backup Type filter is set to "Unset"
![image](https://user-images.githubusercontent.com/98498799/234679097-be76f078-763f-42da-a926-595965cd4728.png)
- Update Replication site to be filtered based on user's time frame selection


### If adding or updating templates:
* [x] post a screenshot of templates and/or gallery changes
* [x] ensure your template has a corresponding gallery entry in the gallery folder
* [x] If you are adding a new template, add your team and template/gallery file(s) to the CODEOWNERS file. CODEOWNERS entries should be teams, not individuals
* [x] ensure all steps have meaningful names
* [x] ensure all parameters and grid columns have display names set so they can be localized
* [x] ensure that parameters id values are unique __or they will fail PR validation__ (parameter ids are used for localization)
* [x] ensure that steps names are unique __or they will fail PR validation__ (step names are used for localization)
* [x] grep `/subscription/` and ensure that your parameters don't have any hardcoded resourceIds __or they will fail PR validation__
* [x] remove `fallbackResourceIds` and `fromTemplateId` fields from your template workbook __or they will fail PR validation__