### PR TITLE
[Database watcher] Make watcherResourceId settable externally

### DIFF
--- a/Workbooks/Database watcher/watcher.workbook
+++ b/Workbooks/Database watcher/watcher.workbook
@@ -2,6 +2,65 @@
   "version": "Notebook/1.0",
   "items": [
     {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "parameters": [
+          {
+            "id": "a762a2ae-beec-4bf5-9f4a-28bea2d2f737",
+            "version": "KqlParameterItem/1.0",
+            "name": "watcherResourceId",
+            "type": 1,
+            "isHiddenWhenLocked": true,
+            "value": ""
+          },
+          {
+            "id": "83420d36-0646-40aa-9637-d06a3d2a6145",
+            "version": "KqlParameterItem/1.0",
+            "name": "watcherResource",
+            "type": 1,
+            "query": "{\"version\":\"ARMEndpoint/1.0\",\"data\":null,\"headers\":[],\"method\":\"GET\",\"path\":\"{watcherResourceId}?api-version=2023-03-01-preview\",\"urlParams\":[],\"batchDisabled\":false,\"transformers\":null}",
+            "isHiddenWhenLocked": true,
+            "queryType": 12
+          },
+          {
+            "id": "a6cd9521-127a-43bd-9227-6bcd67756456",
+            "version": "KqlParameterItem/1.0",
+            "name": "watcherName",
+            "type": 1,
+            "query": "{\"version\":\"1.0.0\",\"content\":\"{watcherResource}\",\"transformers\":[{\"type\":\"jsonpath\",\"settings\":{\"tablePath\":\"$.name\",\"columns\":[]}}]}",
+            "isHiddenWhenLocked": true,
+            "queryType": 8
+          },
+          {
+            "version": "KqlParameterItem/1.0",
+            "name": "watcherAdxClusterUri",
+            "type": 1,
+            "query": "{\"version\":\"1.0.0\",\"content\":\"{watcherResource}\",\"transformers\":[{\"type\":\"jsonpath\",\"settings\":{\"tablePath\":\"$.properties.datastore.adxClusterUri\",\"columns\":[]}}]}",
+            "isHiddenWhenLocked": true,
+            "queryType": 8,
+            "id": "f0889b5f-3fa4-40a0-838d-443b4c0472b6"
+          },
+          {
+            "id": "0797c608-2ecf-4711-ba9b-6d110f10acd3",
+            "version": "KqlParameterItem/1.0",
+            "name": "watcherAdxDatabase",
+            "type": 1,
+            "query": "{\"version\":\"1.0.0\",\"content\":\"{watcherResource}\",\"transformers\":[{\"type\":\"jsonpath\",\"settings\":{\"tablePath\":\"\",\"columns\":[{\"path\":\"$.properties.datastore.adxDatabaseResourceId\",\"columnid\":\"value\",\"columnType\":\"string\",\"substringRegexMatch\":\".*/(.*)\",\"substringReplace\":\"$1\"}]}}]}",
+            "isHiddenWhenLocked": true,
+            "queryType": 8
+          }
+        ],
+        "style": "above",
+        "queryType": 12
+      },
+      "conditionalVisibility": {
+        "parameterName": "alwaysHidden",
+        "comparison": "isNotEqualTo"
+      },
+      "name": "watcher_adx_parameters"
+    },
+    {
       "type": 12,
       "content": {
         "version": "NotebookGroup/1.0",
@@ -15,51 +74,7 @@
               "version": "KqlParameterItem/1.0",
               "parameters": [
                 {
-                  "id": "a762a2ae-beec-4bf5-9f4a-28bea2d2f737",
-                  "version": "KqlParameterItem/1.0",
-                  "name": "watcherResourceId",
-                  "type": 1,
-                  "isHiddenWhenLocked": true,
-                  "value": ""
-                },
-                {
-                  "id": "83420d36-0646-40aa-9637-d06a3d2a6145",
-                  "version": "KqlParameterItem/1.0",
-                  "name": "watcherResource",
-                  "type": 1,
-                  "query": "{\"version\":\"ARMEndpoint/1.0\",\"data\":null,\"headers\":[],\"method\":\"GET\",\"path\":\"{watcherResourceId}?api-version=2023-03-01-preview\",\"urlParams\":[],\"batchDisabled\":false,\"transformers\":null}",
-                  "isHiddenWhenLocked": true,
-                  "queryType": 12
-                },
-                {
-                  "id": "a6cd9521-127a-43bd-9227-6bcd67756456",
-                  "version": "KqlParameterItem/1.0",
-                  "name": "watcherName",
-                  "type": 1,
-                  "query": "{\"version\":\"1.0.0\",\"content\":\"{watcherResource}\",\"transformers\":[{\"type\":\"jsonpath\",\"settings\":{\"tablePath\":\"$.name\",\"columns\":[]}}]}",
-                  "isHiddenWhenLocked": true,
-                  "queryType": 8
-                },
-                {
-                  "version": "KqlParameterItem/1.0",
-                  "name": "watcherAdxClusterUri",
-                  "type": 1,
-                  "query": "{\"version\":\"1.0.0\",\"content\":\"{watcherResource}\",\"transformers\":[{\"type\":\"jsonpath\",\"settings\":{\"tablePath\":\"$.properties.datastore.adxClusterUri\",\"columns\":[]}}]}",
-                  "isHiddenWhenLocked": true,
-                  "queryType": 8,
-                  "id": "f0889b5f-3fa4-40a0-838d-443b4c0472b6"
-                },
-                {
-                  "id": "0797c608-2ecf-4711-ba9b-6d110f10acd3",
-                  "version": "KqlParameterItem/1.0",
-                  "name": "watcherAdxDatabase",
-                  "type": 1,
-                  "query": "{\"version\":\"1.0.0\",\"content\":\"{watcherResource}\",\"transformers\":[{\"type\":\"jsonpath\",\"settings\":{\"tablePath\":\"\",\"columns\":[{\"path\":\"$.properties.datastore.adxDatabaseResourceId\",\"columnid\":\"value\",\"columnType\":\"string\",\"substringRegexMatch\":\".*/(.*)\",\"substringReplace\":\"$1\"}]}}]}",
-                  "isHiddenWhenLocked": true,
-                  "queryType": 8
-                },
-                {
-                  "id": "1b7d18f3-88a9-40ed-9162-92710b29ba69",
+                  "id": "394a23b6-9786-4e1b-bb03-37ef95dbcb1d",
                   "version": "KqlParameterItem/1.0",
                   "name": "dataStore",
                   "label": "Choose a data store",
@@ -79,7 +94,7 @@
               "queryType": 12
             },
             "customWidth": "30",
-            "name": "watcher_adx_parameters"
+            "name": "data_store_parameters"
           },
           {
             "type": 1,


### PR DESCRIPTION
## PR Checklist

This PR moves a parameter block containing the `watcherResourceId` out of a group so that this parameter can be set by portal when loading the workbook.

* [x] Explain your changes, so people looking at the PR know *what* and *why*, the code changes are the *how*.
* [x] Validate your changes using one or more of the [testing](../Documentation/Testing.md) methods.

### If adding or updating templates:
* [n/a] post a screenshot of templates and/or gallery changes
* [x] ensure your template has a corresponding gallery entry in the gallery folder
* [x] If you are adding a new template, add your team and template/gallery file(s) to the CODEOWNERS file. CODEOWNERS entries should be teams, not individuals
* [x] ensure all steps have meaningful names
* [x] ensure all parameters and grid columns have display names set so they can be localized
* [x] ensure that parameters id values are unique __or they will fail PR validation__ (parameter ids are used for localization)
* [x] ensure that steps names are unique __or they will fail PR validation__ (step names are used for localization)
* [x] grep `/subscription/` and ensure that your parameters don't have any hardcoded resourceIds __or they will fail PR validation__
* [x] remove `fallbackResourceIds` and `fromTemplateId` fields from your template workbook __or they will fail PR validation__