### PR TITLE
Update ownership of LA Gallery to include workbooks team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -157,7 +157,7 @@
 /gallery/laws-insights/** @microsoft/loganalytics
 /gallery/updatecenter-insights/** @microsoft/azure-update-center
 /gallery/workbook/Azure*Update*Manage*Center.json @microsoft/azure-update-center
-/gallery/workbook/microsoft.operationalinsights*workspaces.json @microsoft/loganalytics
+/gallery/workbook/microsoft.operationalinsights*workspaces.json @microsoft/loganalytics @microsoft/applicationinsights-devtools
 /gallery/usage/microsoft.insights-components.json @microsoft/applicationinsights-heart @microsoft/ApplicationInsights-PortalExperiences @microsoft/applicationinsights-devtools
 /gallery/workbook/microsoft.insights-components.json @microsoft/applicationinsights-heart @microsoft/ApplicationInsights-PortalExperiences @microsoft/applicationinsights-devtools
 /gallery/all-resource-types/** @microsoft/applicationinsights-devtools


### PR DESCRIPTION
Update ownership of LA Gallery to include workbooks team so we can unblock changes to the LA Gallery