### PR TITLE
Update titles of LA Insights templates

### DIFF
--- a/gallery/workbook/microsoft.operationalinsights-workspaces.json
+++ b/gallery/workbook/microsoft.operationalinsights-workspaces.json
@@ -7,39 +7,39 @@
 			"name": "Log Analytics Workspace Insights",
 			"templates": [
 				{
-					"id": "Workbooks/LogAnalytics Workspace/Usage",
+					"id": "Workbooks/LogAnalytics Workspace/AtResource",
 					"author": "Microsoft",
-					"name": "Log Analytics Workspace Usage"
-				},
-				{
-					"id": "Workbooks/LogAnalytics Workspace/QueryAudit",
-					"author": "Microsoft",
-					"name": "Log Analytics Workspace Query Audit"
+					"name": "Insights"
 				},
 				{
 					"id": "Workbooks/LogAnalytics Workspace/Overview",
 					"author": "Microsoft",
-					"name": "Log Analytics Workspace Overview"
+					"name": "Overview"
+				},
+				{
+					"id": "Workbooks/LogAnalytics Workspace/Usage",
+					"author": "Microsoft",
+					"name": "Usage"
 				},
 				{
 					"id": "Workbooks/LogAnalytics Workspace/Health",
 					"author": "Microsoft",
-					"name": "Log Analytics Workspace Health"
-				},
-				{
-					"id": "Workbooks/LogAnalytics Workspace/ChangeLog",
-					"author": "Microsoft",
-					"name": "Log Analytics Workspace Change Log"
-				},
-				{
-					"id": "Workbooks/LogAnalytics Workspace/AtResource",
-					"author": "Microsoft",
-					"name": "Log Analytics Workspace Insights"
+					"name": "Health"
 				},
 				{
 					"id": "Workbooks/LogAnalytics Workspace/Agents",
 					"author": "Microsoft",
-					"name": "Log Analytics Workspace Agents"
+					"name": "Agents"
+				},
+				{
+					"id": "Workbooks/LogAnalytics Workspace/QueryAudit",
+					"author": "Microsoft",
+					"name": "Query Audit"
+				},
+				{
+					"id": "Workbooks/LogAnalytics Workspace/ChangeLog",
+					"author": "Microsoft",
+					"name": "Change Log"
 				}
 			]
 		},


### PR DESCRIPTION
Update the titles of the LA workspace templates.  Before they all have "Log Analytics Workspace Insights" in the beginning so you can't tell what they are.  I also re-ordered them so the Insights template is first, then they appear in the same order the tabs appear in the Insights template itself.

## Before:
![image](https://github.com/microsoft/Application-Insights-Workbooks/assets/10158007/30942cd0-0157-4477-a7ac-33353ae2949c)


## After:
![image](https://github.com/microsoft/Application-Insights-Workbooks/assets/10158007/2d7894ce-9fde-48fe-add2-557fbca03a80)
