### PR TITLE
24185180: update prom explorer template in AMW to use this all string columns setting, high limit for max series

### DIFF
--- a/Workbooks/Azure Monitor - Workspaces/Prometheus Explorer/Prometheus Explorer.workbook
+++ b/Workbooks/Azure Monitor - Workspaces/Prometheus Explorer/Prometheus Explorer.workbook
@@ -243,6 +243,8 @@
               ],
               "visualization": "timechart",
               "chartSettings": {
+                "group": "*",
+                "createOtherGroup": 50,
                 "ySettings": {
                   "numberFormatSettings": {
                     "unit": 0,


### PR DESCRIPTION
## Before
the chart just uses the default setting and shows 1 series:

![image](https://github.com/microsoft/Application-Insights-Workbooks/assets/10158007/1436e660-033e-494a-9eb9-82bbba6e0b8c)

## After
use all string columns, split to first 50+others

![image](https://github.com/microsoft/Application-Insights-Workbooks/assets/10158007/ca9b1750-9905-4d14-ba66-bd90f31f0945)
