### PR TITLE
NetWeaver Workbook - Add appropriate param check name for outbound queue tiles and updated logic to show sub menu for queue statistics tab

### DIFF
--- a/Workbooks/SapMonitor2.0/SapNetWeaver/SapNetWeaver.workbook
+++ b/Workbooks/SapMonitor2.0/SapNetWeaver/SapNetWeaver.workbook
@@ -7928,7 +7928,7 @@
                     "comparison": "isEqualTo",
                     "value": "0"
                   },
-                  "name": "Total Inbound Queue Items - Copy"
+                  "name": "Total outbound Queue"
                 },
                 {
                   "type": 3,
@@ -7982,7 +7982,7 @@
                     "comparison": "isEqualTo",
                     "value": "0"
                   },
-                  "name": "Total Inbound Queue Items - Copy - Copy"
+                  "name": "Total outbound Queue Items"
                 },
                 {
                   "type": 3,
@@ -8077,7 +8077,7 @@
                   },
                   "customWidth": "50",
                   "conditionalVisibility": {
-                    "parameterName": "param_check_inbound_queue",
+                    "parameterName": "param_check_outbound_queue",
                     "comparison": "isEqualTo",
                     "value": "0"
                   },

--- a/Workbooks/SapMonitor2.0/SapNetWeaver/SapNetWeaver.workbook
+++ b/Workbooks/SapMonitor2.0/SapNetWeaver/SapNetWeaver.workbook
@@ -7485,18 +7485,11 @@
                 }
               ]
             },
-            "conditionalVisibilities": [
-              {
-                "parameterName": "SelectedTab",
-                "comparison": "isEqualTo",
-                "value": "QueueStatistics"
-              },
-              {
-                "parameterName": "param_check_rfc_metrics",
-                "comparison": "isEqualTo",
-                "value": "0"
-              }
-            ],
+            "conditionalVisibility": {
+              "parameterName": "SelectedTab",
+              "comparison": "isEqualTo",
+              "value": "QueueStatistics"
+            },
             "name": "queueStatisticsTab"
           },
           {
@@ -8017,11 +8010,18 @@
                       }
                     }
                   },
-                  "conditionalVisibility": {
-                    "parameterName": "param_check_inbound_queue",
-                    "comparison": "isEqualTo",
-                    "value": "0"
-                  },
+                  "conditionalVisibilities": [
+                    {
+                      "parameterName": "param_check_inbound_queue",
+                      "comparison": "isEqualTo",
+                      "value": "0"
+                    },
+                    {
+                      "parameterName": "param_check_outbound_queue",
+                      "comparison": "isEqualTo",
+                      "value": "0"
+                    }
+                  ],
                   "name": "Queued Remote Function"
                 },
                 {


### PR DESCRIPTION
## PR Checklist

* [x] Explain your changes, so people looking at the PR know *what* and *why*, the code changes are the *how*.
* [x] Validate your changes using one or more of the [testing](../Documentation/Testing.md) methods.

### If adding or updating templates:
* [x] post a screenshot of templates and/or gallery changes
* [ ] ensure your template has a corresponding gallery entry in the gallery folder
* [ ] If you are adding a new template, add your team and template/gallery file(s) to the CODEOWNERS file. CODEOWNERS entries should be teams, not individuals
* [x] ensure all steps have meaningful names
* [ ] ensure all parameters and grid columns have display names set so they can be localized
* [ ] ensure that parameters id values are unique __or they will fail PR validation__ (parameter ids are used for localization)
* [ ] ensure that steps names are unique __or they will fail PR validation__ (step names are used for localization)
* [ ] grep `/subscription/` and ensure that your parameters don't have any hardcoded resourceIds __or they will fail PR validation__
* [ ] remove `fallbackResourceIds` and `fromTemplateId` fields from your template workbook __or they will fail PR validation__

Description:

1. This PR is a minor bug fix for outbound queue tiles. Ideally to show/hide the outbound queues we need to check the outbound queue parameter, but looks like the code was checking the "inbound queue parameter" and some customers who didn't have any data in outbound queues in the SAP system were seeing the below error in the workbook:
 
![image](https://github.com/microsoft/Application-Insights-Workbooks/assets/74435183/065242d2-be01-46a3-8c9b-2a8e10283312)

As a part of the fix, we updated the correct parameter to hide/show the tiles and also included proper step names for certain tiles to follow the appropriate nomenclature in the workbook.

IcM - https://portal.microsofticm.com/imp/v3/incidents/details/393660828/home

![image](https://github.com/microsoft/Application-Insights-Workbooks/assets/74435183/86576d22-f4ed-482f-8875-f1e87035f639)

2. Sub menu for the Queue Statistics tab is currently not displayed today when a customer creates SOAP-only providers and does not have any RFC providers. This PR includes a fix to remove that check and show all three sub-menu items
![image](https://github.com/microsoft/Application-Insights-Workbooks/assets/74435183/507eb5cc-a36d-4650-993a-c8ac536d4184)

Test case : https://microsoft-my.sharepoint.com/:x:/p/hsridharan/ESj-RgSbeghNqKAlLzGTM2MB4xpnUARWYyuOiPWlepM33A?e=lt4isX
