### PR TITLE
SPOG - Removed alerts limit and added external alerts filter

### DIFF
--- a/Workbooks/SapMonitor2.0/SapLandscapeMonitor/SapLandscapeMonitor.workbook
+++ b/Workbooks/SapMonitor2.0/SapLandscapeMonitor/SapLandscapeMonitor.workbook
@@ -13,7 +13,10 @@
             "id": "937d9357-dd2c-4dfa-b9d3-9fc72e2bb8dd",
             "version": "KqlParameterItem/1.0",
             "name": "TimeRange",
+            "label": "Time range",
             "type": 4,
+            "isRequired": true,
+            "isGlobal": true,
             "typeSettings": {
               "selectableValues": [
                 {
@@ -52,9 +55,8 @@
               ]
             },
             "value": {
-              "durationMs": 604800000
-            },
-            "label": "Time range"
+              "durationMs": 172800000
+            }
           },
           {
             "id": "dacc479e-f79c-4fba-91e0-3ec2d1da7023",
@@ -129,7 +131,7 @@
             "version": "KqlParameterItem/1.0",
             "name": "Alerts",
             "type": 1,
-            "query": "AlertsManagementResources\r\n| where type =~ 'microsoft.alertsmanagement/alerts'\r\n| extend StartTime = todatetime(properties.essentials.startDateTime)\r\n| where StartTime {TimeRange}\r\n| extend AlertCondition=tostring(properties.essentials.monitorCondition)\r\n| extend AlertRule=tolower(tostring(properties.essentials.alertRule))\r\n| extend Severity=tostring(properties.essentials.severity)\r\n| join kind=inner (Resources \r\n    | where type =~ 'microsoft.insights/scheduledQueryRules'\r\n    | extend workspace = tostring(properties.scopes[0])\r\n    | extend ProviderName=parse_json(tags)[\"profile-id\"]\r\n    | where workspace =~ '{Workspace}'\r\n    | project AlertRule=tolower(id), ProviderName) on AlertRule\r\n| where not(isnull(ProviderName))\r\n| where AlertCondition == \"Fired\"\r\n| order by Severity asc, StartTime\r\n| project Output = strcat(ProviderName, \"@\", Severity)\r\n| limit 250",
+            "query": "AlertsManagementResources\r\n| where type =~ 'microsoft.alertsmanagement/alerts'\r\n| extend StartTime = todatetime(properties.essentials.startDateTime)\r\n| where StartTime {TimeRange}\r\n| extend AlertCondition=tostring(properties.essentials.monitorCondition)\r\n| extend AlertRule=tolower(tostring(properties.essentials.alertRule))\r\n| extend Severity=tostring(properties.essentials.severity)\r\n| join kind=inner (Resources \r\n    | where type =~ 'microsoft.insights/scheduledQueryRules'\r\n    | extend workspace = tostring(properties.scopes[0])\r\n    | extend ProviderName=parse_json(tags)[\"profile-id\"]\r\n    | where isempty(tags.['alert-template-id']) == false\r\n    | where workspace =~ '{Workspace}'\r\n    | project AlertRule=tolower(id), ProviderName) on AlertRule\r\n| where not(isnull(ProviderName))\r\n| where AlertCondition == \"Fired\"\r\n| project Output = strcat(ProviderName, \"@\", Severity)",
             "crossComponentResources": [
               "{Subscription}"
             ],
@@ -769,7 +771,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "AlertsManagementResources\r\n| where type =~ 'microsoft.alertsmanagement/alerts'\r\n| extend StartTime = todatetime(properties.essentials.startDateTime)\r\n| where StartTime {TimeRange}\r\n| extend AlertCondition=tostring(properties.essentials.monitorCondition)\r\n| extend UserResponse=tostring(properties.essentials.alertState)\r\n| extend AlertRule=tolower(tostring(properties.essentials.alertRule))\r\n| extend Severity=tostring(properties.essentials.severity)\r\n| extend Description=tostring(properties.essentials.description)\r\n| join kind=inner (Resources \r\n    | where type =~ 'microsoft.insights/scheduledQueryRules'\r\n    | extend workspace = tostring(properties.scopes[0])\r\n    | extend ProviderName=parse_json(tags)[\"profile-id\"]\r\n    | where workspace =~ '{Workspace}'\r\n    | project AlertRule=tolower(id), ProviderName) on AlertRule\r\n| extend FiredTime=format_datetime(StartTime, 'MM/dd/yy, hh:mm tt')\r\n| where not(isnull(ProviderName))\r\n| where AlertCondition == \"Fired\"\r\n| where '*' in ({SeverityFilter}) or Severity in ({SeverityFilter})\r\n| order by Severity asc, StartTime\r\n| project Name=name, Severity, AlertCondition, UserResponse, Description, FiredTime, id, ProviderName\r\n| limit 250",
+              "query": "AlertsManagementResources\r\n| where type =~ 'microsoft.alertsmanagement/alerts'\r\n| extend StartTime = todatetime(properties.essentials.startDateTime)\r\n| where StartTime {TimeRange}\r\n| extend AlertCondition=tostring(properties.essentials.monitorCondition)\r\n| extend UserResponse=tostring(properties.essentials.alertState)\r\n| extend AlertRule=tolower(tostring(properties.essentials.alertRule))\r\n| extend Severity=tostring(properties.essentials.severity)\r\n| extend Description=tostring(properties.essentials.description)\r\n| join kind=inner (Resources \r\n    | where type =~ 'microsoft.insights/scheduledQueryRules'\r\n    | extend workspace = tostring(properties.scopes[0])\r\n    | extend ProviderName=parse_json(tags)[\"profile-id\"]\r\n    | where isempty(tags.['alert-template-id']) == false\r\n    | where workspace =~ '{Workspace}'\r\n    | project AlertRule=tolower(id), ProviderName) on AlertRule\r\n| extend FiredTime=format_datetime(StartTime, 'MM/dd/yy, hh:mm tt')\r\n| where not(isnull(ProviderName))\r\n| where AlertCondition == \"Fired\"\r\n| where '*' in ({SeverityFilter}) or Severity in ({SeverityFilter})\r\n| order by StartTime\r\n| project Name=name, Severity, AlertCondition, UserResponse, Description, FiredTime, id, ProviderName",
               "size": 0,
               "queryType": 1,
               "resourceType": "microsoft.resourcegraph/resources",
@@ -944,6 +946,7 @@
                     "formatter": 5
                   }
                 ],
+                "rowLimit": 500,
                 "filter": true,
                 "labelSettings": [
                   {


### PR DESCRIPTION
- Removed 250 alerts count limit and set limit of 500 for displaying alert details in tabular view
- Added check for 'alert-template-id' tag in alert rule to filter out external alerts created on the same LA workspace
- Set 48 hours as default selection for time range

![image](https://github.com/microsoft/Application-Insights-Workbooks/assets/115653217/f1855982-2296-4d29-99b1-bdbec2209f18)

## PR Checklist

* [X] Explain your changes, so people looking at the PR know *what* and *why*, the code changes are the *how*.
* [X] Validate your changes using one or more of the [testing](../Documentation/Testing.md) methods.

### If adding or updating templates:
* [ ] post a screenshot of templates and/or gallery changes
* [ ] ensure your template has a corresponding gallery entry in the gallery folder
* [ ] If you are adding a new template, add your team and template/gallery file(s) to the CODEOWNERS file. CODEOWNERS entries should be teams, not individuals
* [ ] ensure all steps have meaningful names
* [ ] ensure all parameters and grid columns have display names set so they can be localized
* [ ] ensure that parameters id values are unique __or they will fail PR validation__ (parameter ids are used for localization)
* [ ] ensure that steps names are unique __or they will fail PR validation__ (step names are used for localization)
* [ ] grep `/subscription/` and ensure that your parameters don't have any hardcoded resourceIds __or they will fail PR validation__
* [ ] remove `fallbackResourceIds` and `fromTemplateId` fields from your template workbook __or they will fail PR validation__