### PR TITLE
remove the hidden resource group param from keyvault insights

### DIFF
--- a/Workbooks/KeyVault/AzureMonitor/AzureMonitor.workbook
+++ b/Workbooks/KeyVault/AzureMonitor/AzureMonitor.workbook
@@ -32,34 +32,6 @@
             "resourceType": "microsoft.resourcegraph/resources"
           },
           {
-            "id": "3be310b0-14a6-416f-ae3c-0a98fda5c729",
-            "version": "KqlParameterItem/1.0",
-            "name": "ResourceGroups",
-            "label": "Resource groups",
-            "type": 2,
-            "isRequired": true,
-            "multiSelect": true,
-            "quote": "'",
-            "delimiter": ",",
-            "query": "where type in~('microsoft.keyvault/vaults')\r\n| summarize Count = count() by resourceGroup\r\n| order by Count desc\r\n| extend Rank = row_number()\r\n| project value = resourceGroup, label = resourceGroup, selected = Rank == 1",
-            "crossComponentResources": [
-              "{Subscriptions}"
-            ],
-            "value": [
-              "value::all"
-            ],
-            "isHiddenWhenLocked": true,
-            "typeSettings": {
-              "additionalResourceOptions": [
-                "value::all"
-              ],
-              "selectAllValue": "",
-              "showDefault": false
-            },
-            "queryType": 1,
-            "resourceType": "microsoft.resourcegraph/resources"
-          },
-          {
             "id": "827a53dc-62fe-49ee-88a6-f9f751ed5ab3",
             "version": "KqlParameterItem/1.0",
             "name": "Resources",
@@ -69,7 +41,7 @@
             "multiSelect": true,
             "quote": "\"",
             "delimiter": ",",
-            "query": "Resources\r\n| where type =~ 'microsoft.keyvault/vaults' and resourceGroup in~({ResourceGroups}) \r\n| project name, id\r\n| union (Resources\r\n| where type =~ 'microsoft.keyvault/vaults' and resourceGroup in~({ResourceGroups}) \r\n| order by name asc\r\n| take 5\r\n| project id, name)\r\n| summarize Count = count() by id, name\r\n| order by name asc\r\n| project value = id, label = id, selected = Count > 1",
+            "query": "Resources\r\n| where type =~ 'microsoft.keyvault/vaults'\r\n| order by name asc\r\n| extend Rank = row_number()\r\n| project value = id, label = id, selected = Rank <= 5\r\n",
             "crossComponentResources": [
               "{Subscriptions}"
             ],
@@ -131,7 +103,7 @@
             "version": "KqlParameterItem/1.0",
             "name": "Message",
             "type": 1,
-            "query": "where type =~ 'microsoft.keyvault/vaults' and resourceGroup in~({ResourceGroups}) \r\n| summarize Selected = countif(id in ({Resources:value})), Total = count()\r\n| extend Selected = iff(Selected > 200, 200, Selected)\r\n| project Message = strcat('# ', Selected, ' / ', Total)",
+            "query": "where type =~ 'microsoft.keyvault/vaults' \r\n| summarize Selected = countif(id in ({Resources:value})), Total = count()\r\n| project Message = strcat('# ', Selected, ' / ', Total)",
             "crossComponentResources": [
               "{Subscriptions}"
             ],
@@ -149,7 +121,6 @@
             "name": "ResourceName",
             "type": 1,
             "description": "Used in 'No Subscription' workbook template",
-            "value": "Key vault",
             "isHiddenWhenLocked": true,
             "criteriaData": [
               {
@@ -219,6 +190,7 @@
               "style": "tabs",
               "links": [
                 {
+                  "id": "644ede5e-3f0e-4e1f-9222-2d4eb12028b7",
                   "cellValue": "selectedTab",
                   "linkTarget": "parameter",
                   "linkLabel": "Overview",
@@ -226,6 +198,7 @@
                   "style": "link"
                 },
                 {
+                  "id": "4e563f1b-be89-42b1-8565-905612222b23",
                   "cellValue": "selectedTab",
                   "linkTarget": "parameter",
                   "linkLabel": "Failures",
@@ -946,9 +919,6 @@
       },
       "name": "Key Vault Resources"
     }
-  ],
-  "fallbackResourceIds": [
-    "Azure Monitor"
   ],
   "workbookPin": "Key vault overview metrics",
   "styleSettings": {


### PR DESCRIPTION
its hidden, always set to all
but it makes an extra unnecessary query to arg to get the RG's for all the subs and makes the queries more complicated

There's no *visible* or functional changes in insights, only when editing:

### before
![image](https://github.com/microsoft/Application-Insights-Workbooks/assets/10158007/063886eb-d044-48d9-afce-c930f3c39315)

you can see the "resource groups" all

### after
![image](https://github.com/microsoft/Application-Insights-Workbooks/assets/10158007/16c2574f-9fe9-4015-b9eb-88ce3c113ae9)

after, doesn't.
