### PR TITLE
MSSQL - Added hidden flag for AO failover parameter

### DIFF
--- a/Workbooks/SapMonitor2.0/MsSqlServer/MsSqlServer.workbook
+++ b/Workbooks/SapMonitor2.0/MsSqlServer/MsSqlServer.workbook
@@ -392,6 +392,7 @@
                         "name": "param_ao_failover_table_exists",
                         "type": 1,
                         "query": "let tableList = '{param_check_tables}';\r\nlet tableListValue = case(((tableList) contains 'MSSQL_AOFailovers_CL:0'), \"0\",\r\n                            ((tableList) contains 'MSSQL_AOFailovers_CL:1'),\"1\",\r\n                             ((tableList) contains 'MSSQL_AOFailovers_CL:2'),\"2\",\"2\");\r\nprint toscalar(tableListValue);",
+                        "isHiddenWhenLocked": true,
                         "queryType": 0,
                         "resourceType": "microsoft.operationalinsights/workspaces"
                       }


### PR DESCRIPTION
Added missing check for AO failover parameter which is used for checking existence for AO Failover table in LAWS.

<img width="212" alt="MicrosoftTeams-image (6)" src="https://github.com/microsoft/Application-Insights-Workbooks/assets/115653217/19499514-be0d-428c-93c2-3a082804d21d">

## PR Checklist

* [X] Explain your changes, so people looking at the PR know *what* and *why*, the code changes are the *how*.
* [X] Validate your changes using one or more of the [testing](../Documentation/Testing.md) methods.

### If adding or updating templates:
* [X] post a screenshot of templates and/or gallery changes
* [ ] ensure your template has a corresponding gallery entry in the gallery folder
* [ ] If you are adding a new template, add your team and template/gallery file(s) to the CODEOWNERS file. CODEOWNERS entries should be teams, not individuals
* [ ] ensure all steps have meaningful names
* [ ] ensure all parameters and grid columns have display names set so they can be localized
* [ ] ensure that parameters id values are unique __or they will fail PR validation__ (parameter ids are used for localization)
* [ ] ensure that steps names are unique __or they will fail PR validation__ (step names are used for localization)
* [ ] grep `/subscription/` and ensure that your parameters don't have any hardcoded resourceIds __or they will fail PR validation__
* [ ] remove `fallbackResourceIds` and `fromTemplateId` fields from your template workbook __or they will fail PR validation__