### PR TITLE
Fix the expedite KPI card denominator issue. 

### DIFF
--- a/Workbooks/UpdateCompliance/Quality updates/Quality Updates.workbook
+++ b/Workbooks/UpdateCompliance/Quality updates/Quality Updates.workbook
@@ -179,7 +179,7 @@
           {
             "id": "15f9ba5b-6c06-4d6b-8266-e57430a1ddd0",
             "version": "KqlParameterItem/1.0",
-            "name": "ExpediteDevicesDenominator",
+            "name": "_ExpediteDevicesDenominator",
             "type": 1,
             "query": "let _SnapshotTime = datetime({_SnapshotTime});\r\nUCClientUpdateStatus\r\n| where TimeGenerated == _SnapshotTime\r\n| where UpdateReleaseTime == \"{ExpediteLatestDeployment}\"\r\n| where UpdateCategory == \"WindowsQualityUpdate\"\r\n| where isnotempty(DeploymentId) and isnotempty(UpdateReleaseTime)\r\n| where DeploymentId == \"{ExpediteLatestDeploymentId}\"\r\n| summarize DeviceCount = count() by DeploymentId, UpdateReleaseTime\r\n| project DeviceCount",
             "crossComponentResources": [
@@ -195,6 +195,52 @@
         "resourceType": "microsoft.operationalinsights/workspaces"
       },
       "name": "parameters - 10"
+ },
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "parameters": [
+          {
+            "id": "59135f81-182f-4be3-9b5f-2083243d1601",
+            "version": "KqlParameterItem/1.0",
+            "name": "ExpediteDevicesDenominator",
+            "type": 1,
+            "isHiddenWhenLocked": true,
+            "criteriaData": [
+              {
+                "criteriaContext": {
+                  "leftOperand": "_ExpediteDevicesDenominator",
+                  "operator": "is Empty",
+                  "rightValType": "param",
+                  "resultValType": "static",
+                  "resultVal": "-1"
+                }
+              },
+              {
+                "criteriaContext": {
+                  "leftOperand": "_ExpediteDevicesDenominator",
+                  "operator": "isNotNull",
+                  "rightValType": "param",
+                  "resultValType": "param",
+                  "resultVal": "_ExpediteDevicesDenominator"
+                }
+              },
+              {
+                "criteriaContext": {
+                  "operator": "Default",
+                  "rightValType": "param",
+                  "resultValType": "param"
+                }
+              }
+            ]
+          }
+        ],
+        "style": "pills",
+        "queryType": 0,
+        "resourceType": "microsoft.operationalinsights/workspaces"
+      },
+      "name": "parameters - 10 - Copy"
     },
     {
       "type": 1,
@@ -659,7 +705,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "UCClientUpdateStatus\r\n| extend Title=\"Latest expedited update\", Subtitle = \"Install status\"\r\n| extend ViewDetails = \"View details\"\r\n| extend Percentage = min_of(1, todouble({ExpediteDevicesNumerator}) / todouble({ExpediteDevicesDenominator}))\r\n| take 1",
+        "query": "UCClientUpdateStatus\r\n| extend Title=\"Latest expedited update\", Subtitle = \"Install status\"\r\n| extend ViewDetails = \"View details\"\r\n| extend Percentage = iff({ExpediteDevicesDenominator}== -1,todouble(0), min_of(1, todouble({ExpediteDevicesNumerator}) / todouble({ExpediteDevicesDenominator})))\r\n| take 1",
         "size": 3,
         "title": "Expedite Performance",
         "noDataMessage": "No expedited updates",


### PR DESCRIPTION
fixing denominator missing issues

## PR Checklist

* [ ] When there are no expedite deployments, _ExpediteDevicesDenominator variable is not causing kusto query to fail. The exception is not meaningful for the user to understand. 
* [ ] Validate your changes using one or more of the [testing](../Documentation/Testing.md) methods.

### If adding or updating templates:
* [ ] post a screenshot of templates and/or gallery changes
* [ ] ensure your template has a corresponding gallery entry in the gallery folder
* [ ] If you are adding a new template, add your team and template/gallery file(s) to the CODEOWNERS file. CODEOWNERS entries should be teams, not individuals
* [ ] ensure all steps have meaningful names
* [ ] ensure all parameters and grid columns have display names set so they can be localized
* [ ] ensure that parameters id values are unique __or they will fail PR validation__ (parameter ids are used for localization)
* [ ] ensure that steps names are unique __or they will fail PR validation__ (step names are used for localization)
* [ ] grep `/subscription/` and ensure that your parameters don't have any hardcoded resourceIds __or they will fail PR validation__
* [ ] remove `fallbackResourceIds` and `fromTemplateId` fields from your template workbook __or they will fail PR validation__