### PR TITLE
Some minor PMEC Site Overview improvements

### DIFF
--- a/Workbooks/Azure Private MEC/PMEC Site Overview/PMEC Site Overview.workbook
+++ b/Workbooks/Azure Private MEC/PMEC Site Overview/PMEC Site Overview.workbook
@@ -1142,7 +1142,7 @@
               "chartId": "workbookf8dd8de0-d1a7-46eb-a350-7ef588c92788",
               "version": "MetricsItem/2.0",
               "size": 0,
-              "chartType": 2,
+              "chartType": 1,
               "resourceType": "microsoft.kubernetes/connectedclusters/providers/extensions",
               "metricScope": 0,
               "resourceParameter": "pcmeExtensionId",

--- a/Workbooks/Azure Private MEC/PMEC Site Overview/PMEC Site Overview.workbook
+++ b/Workbooks/Azure Private MEC/PMEC Site Overview/PMEC Site Overview.workbook
@@ -2912,7 +2912,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "resources\r\n| where type =~ \"microsoft.mobilenetwork/mobilenetworks/simpolicies\"\r\n| where id startswith \"{mobilenetwork}/simPolicies/\"\r\n| extend currentSiteProvisioningState = tostring(properties.siteProvisioningState[\"{siteLowerCase}\"])\r\n| where currentSiteProvisioningState != \"\"\r\n| where currentSiteProvisioningState != \"NotApplicable\"\r\n| extend sliceConfigurations = todynamic(properties.sliceConfigurations)\r\n| mv-expand sliceConfigurations\r\n| extend slice=sliceConfigurations.slice.id\r\n| extend sliceName=split(slice,\"/\")[-1]\r\n| extend dataNetworkConfigurations = todynamic(sliceConfigurations.dataNetworkConfigurations)\r\n| mv-expand dataNetworkConfigurations\r\n| extend dataNetwork = dataNetworkConfigurations.dataNetwork.id\r\n| project [\"SIM Policy\"]=id, name, [\"Provisioning State\"]=currentSiteProvisioningState, [\"UE Downlink AMBR\"]=properties.ueAmbr.downlink, [\"UE Uplink AMBR\"]=properties.ueAmbr.uplink, [\"Slice\"]=slice, sliceName, [\"Default Data Network\"]=sliceConfigurations.defaultDataNetwork.id, [\"Data Network\"]=dataNetwork, [\"Session Downlink AMBR\"]=dataNetworkConfigurations.sessionAmbr.downlink, [\"Session Uplink AMBR\"]=dataNetworkConfigurations.sessionAmbr.uplink",
+              "query": "resources\r\n| where type =~ \"microsoft.mobilenetwork/mobilenetworks/simpolicies\"\r\n| where id startswith \"{mobilenetwork}/simPolicies/\"\r\n| extend currentSiteProvisioningState = tostring(properties.siteProvisioningState[\"{siteLowerCase}\"])\r\n| where currentSiteProvisioningState != \"\"\r\n| where currentSiteProvisioningState != \"NotApplicable\"\r\n| extend sliceConfigurations = todynamic(properties.sliceConfigurations)\r\n| mv-expand sliceConfigurations\r\n| extend slice=sliceConfigurations.slice.id\r\n| extend dataNetworkConfigurations = todynamic(sliceConfigurations.dataNetworkConfigurations)\r\n| mv-expand dataNetworkConfigurations\r\n| extend dataNetwork = dataNetworkConfigurations.dataNetwork.id\r\n| project [\"SIM Policy\"]=id, [\"Provisioning State\"]=currentSiteProvisioningState, [\"Slice\"]=slice, [\"Default Data Network\"]=sliceConfigurations.defaultDataNetwork.id, [\"Data Network\"]=dataNetwork, [\"UE Downlink AMBR\"]=properties.ueAmbr.downlink, [\"UE Uplink AMBR\"]=properties.ueAmbr.uplink, [\"Session Downlink AMBR\"]=dataNetworkConfigurations.sessionAmbr.downlink, [\"Session Uplink AMBR\"]=dataNetworkConfigurations.sessionAmbr.uplink",
               "size": 1,
               "noDataMessage": " ",
               "queryType": 1,
@@ -2923,15 +2923,26 @@
               "gridSettings": {
                 "formatters": [
                   {
-                    "columnMatch": "name",
-                    "formatter": 1
-                  },
-                  {
-                    "columnMatch": "SIM Policy",
+                    "columnMatch": "$gen_group",
                     "formatter": 13,
                     "formatOptions": {
                       "linkTarget": "Resource",
                       "showIcon": true
+                    }
+                  },
+                  {
+                    "columnMatch": "Group",
+                    "formatter": 13,
+                    "formatOptions": {
+                      "linkTarget": "Resource",
+                      "showIcon": true
+                    }
+                  },
+                  {
+                    "columnMatch": "SIM Policy",
+                    "formatter": 5,
+                    "formatOptions": {
+                      "linkTarget": "Resource"
                     }
                   },
                   {
@@ -2994,10 +3005,6 @@
                     }
                   },
                   {
-                    "columnMatch": "sliceName",
-                    "formatter": 5
-                  },
-                  {
                     "columnMatch": "Data Network",
                     "formatter": 13,
                     "formatOptions": {
@@ -3006,8 +3013,28 @@
                     }
                   },
                   {
-                    "columnMatch": "Group",
+                    "columnMatch": "UE Downlink AMBR",
                     "formatter": 1
+                  },
+                  {
+                    "columnMatch": "UE Uplink AMBR",
+                    "formatter": 1
+                  },
+                  {
+                    "columnMatch": "Session Downlink AMBR",
+                    "formatter": 1
+                  },
+                  {
+                    "columnMatch": "Session Uplink AMBR",
+                    "formatter": 1
+                  },
+                  {
+                    "columnMatch": "name",
+                    "formatter": 1
+                  },
+                  {
+                    "columnMatch": "sliceName",
+                    "formatter": 5
                   },
                   {
                     "columnMatch": "dataNetworkName",
@@ -3017,10 +3044,9 @@
                 "hierarchySettings": {
                   "treeType": 1,
                   "groupBy": [
-                    "name",
-                    "sliceName"
+                    "SIM Policy"
                   ],
-                  "expandTopLevel": false
+                  "expandTopLevel": true
                 },
                 "sortBy": [
                   {

--- a/Workbooks/Azure Private MEC/PMEC Site Overview/PMEC Site Overview.workbook
+++ b/Workbooks/Azure Private MEC/PMEC Site Overview/PMEC Site Overview.workbook
@@ -6,7 +6,7 @@
       "content": {
         "version": "KqlParameterItem/1.0",
         "crossComponentResources": [
-          "{site}"
+          "{pccp}"
         ],
         "parameters": [
           {
@@ -155,7 +155,7 @@
             "type": 5,
             "query": "resources\r\n| where id =~ \"{pccp:id}\"\r\n| extend customLocationId = tostring(properties.platform.customLocation.id)\r\n| join (\r\n    resources\r\n    | where type =~ \"Microsoft.ExtendedLocation/customLocations\"\r\n    | extend clusterId = tostring(properties.hostResourceId)\r\n    | extend customLocationId = id\r\n) on customLocationId\r\n| project id=clusterId, selected=\"true\"",
             "crossComponentResources": [
-              "{ase}"
+              "{pccp}"
             ],
             "isHiddenWhenLocked": true,
             "typeSettings": {


### PR DESCRIPTION
1. cd1ec6c8511bd3f561740ba92f92e5dbb88d5a29 Fix Subscription scope for Kubernetes cluster parameter. This fixes the metrics not working if the Packet Core Control Plane does not have an ASE resource.
2. 905bd86e4d9b3dd1f38a3873097f5a6a15a71c42 Make the packet core control plane errors a bar chart instead of a line chart to make it easier to see cumulative errors.
![image](https://github.com/microsoft/Application-Insights-Workbooks/assets/3382572/30a90803-7012-4b83-864b-3e78bba391f2)

3. 28f57ec49002a2cef4d215c8d4dee1503e2d3d34 Expand SIM policies by default. Modify the SIM policy view so that they are visible without needing to expand. ![image](https://github.com/microsoft/Application-Insights-Workbooks/assets/3382572/ed3498ed-8433-42a3-8f1e-e4278021c7b4)

## PR Checklist

* [x] Explain your changes, so people looking at the PR know *what* and *why*, the code changes are the *how*.
* [x] Validate your changes using one or more of the [testing](../Documentation/Testing.md) methods.

### If adding or updating templates:
* [x] post a screenshot of templates and/or gallery changes
* [x] ensure your template has a corresponding gallery entry in the gallery folder
* [x] If you are adding a new template, add your team and template/gallery file(s) to the CODEOWNERS file. CODEOWNERS entries should be teams, not individuals
* [x] ensure all steps have meaningful names
* [x] ensure all parameters and grid columns have display names set so they can be localized
* [x] ensure that parameters id values are unique __or they will fail PR validation__ (parameter ids are used for localization)
* [x] ensure that steps names are unique __or they will fail PR validation__ (step names are used for localization)
* [x] grep `/subscription/` and ensure that your parameters don't have any hardcoded resourceIds __or they will fail PR validation__
* [x] remove `fallbackResourceIds` and `fromTemplateId` fields from your template workbook __or they will fail PR validation__