### PR TITLE
Fix aggregation for provisioned subscribers

### DIFF
--- a/Workbooks/Azure Private MEC/PMEC Site Overview/PMEC Site Overview.workbook
+++ b/Workbooks/Azure Private MEC/PMEC Site Overview/PMEC Site Overview.workbook
@@ -618,7 +618,7 @@
                       {
                         "namespace": "microsoft.kubernetesconfiguration/extensions",
                         "metric": "microsoft.kubernetesconfiguration/extensions-Traffic-ProvisionedSubscribers",
-                        "aggregation": 4,
+                        "aggregation": 3,
                         "columnName": "Provisioned Subscribers"
                       }
                     ],


### PR DESCRIPTION
Use maximum rather than average as the aggregation for provisioned subscribers - bringing in line with the other metrics (connected nodeBs, registered/connected subscribers). This wasn't possible previously due to a metrics bug, but this is now fixed. This avoids an issue where provisioned subscribers can show as a decimal value if there are multiple values being aggregated over.

## PR Checklist

* [x] Explain your changes, so people looking at the PR know *what* and *why*, the code changes are the *how*.
* [x] Validate your changes using one or more of the [testing](../Documentation/Testing.md) methods.

### If adding or updating templates:
* [ ] post a screenshot of templates and/or gallery changes
* [ ] ensure your template has a corresponding gallery entry in the gallery folder
* [ ] If you are adding a new template, add your team and template/gallery file(s) to the CODEOWNERS file. CODEOWNERS entries should be teams, not individuals
* [ ] ensure all steps have meaningful names
* [ ] ensure all parameters and grid columns have display names set so they can be localized
* [ ] ensure that parameters id values are unique __or they will fail PR validation__ (parameter ids are used for localization)
* [ ] ensure that steps names are unique __or they will fail PR validation__ (step names are used for localization)
* [ ] grep `/subscription/` and ensure that your parameters don't have any hardcoded resourceIds __or they will fail PR validation__
* [ ] remove `fallbackResourceIds` and `fromTemplateId` fields from your template workbook __or they will fail PR validation__