### PR TITLE
Fix incorrect PLMN ID display

### DIFF
--- a/Workbooks/Azure Private MEC/PMEC Site Overview/PMEC Site Overview.workbook
+++ b/Workbooks/Azure Private MEC/PMEC Site Overview/PMEC Site Overview.workbook
@@ -362,7 +362,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "resources\r\n| where id == \"{mobilenetwork}\"\r\n| extend plmnid = todynamic(properties.publicLandMobileNetworkIdentifier)\r\n| extend MCC = toint(plmnid.mcc)\r\n| extend MNC = toint(plmnid.mnc)\r\n| project id, plmnid=\"PLMN ID\", MCC, MNC",
+              "query": "resources\r\n| where id == \"{mobilenetwork}\"\r\n| extend plmnid = todynamic(properties.publicLandMobileNetworkIdentifier)\r\n| extend MCC = tostring(plmnid.mcc)\r\n| extend MNC = tostring(plmnid.mnc)\r\n| extend plmnid_str = strcat(MCC, \" \", MNC)\r\n| project id, plmnid=\"PLMN ID\", plmnid_str",
               "size": 4,
               "queryType": 1,
               "resourceType": "microsoft.resourcegraph/resources",
@@ -386,31 +386,13 @@
                   }
                 },
                 "leftContent": {
-                  "columnMatch": "MCC",
+                  "columnMatch": "plmnid_str",
                   "formatter": 1,
                   "numberFormat": {
                     "unit": 0,
                     "options": {
-                      "style": "decimal",
-                      "minimumIntegerDigits": 3
+                      "style": "decimal"
                     }
-                  },
-                  "tooltipFormat": {
-                    "tooltip": "MCC"
-                  }
-                },
-                "rightContent": {
-                  "columnMatch": "MNC",
-                  "formatter": 1,
-                  "numberFormat": {
-                    "unit": 0,
-                    "options": {
-                      "style": "decimal",
-                      "minimumIntegerDigits": 2
-                    }
-                  },
-                  "tooltipFormat": {
-                    "tooltip": "MCC"
                   }
                 },
                 "showBorder": false,


### PR DESCRIPTION
Ensure that when the MNC has a leading zero it is displayed in full. Fix a bug where the leading zero was omitted.

With PLMN ID 315 010, old behaviour:
![image](https://github.com/microsoft/Application-Insights-Workbooks/assets/3382572/3e7c1e92-4f57-4740-baf9-5af1e90c1954)

New behaviour:
![image](https://github.com/microsoft/Application-Insights-Workbooks/assets/3382572/856939b5-209d-4a2d-a7f1-a22a28356109)

## PR Checklist

* [x] Explain your changes, so people looking at the PR know *what* and *why*, the code changes are the *how*.
* [x] Validate your changes using one or more of the [testing](../Documentation/Testing.md) methods.

### If adding or updating templates:
* [x] post a screenshot of templates and/or gallery changes
* [ ] ensure your template has a corresponding gallery entry in the gallery folder
* [ ] If you are adding a new template, add your team and template/gallery file(s) to the CODEOWNERS file. CODEOWNERS entries should be teams, not individuals
* [ ] ensure all steps have meaningful names
* [ ] ensure all parameters and grid columns have display names set so they can be localized
* [ ] ensure that parameters id values are unique __or they will fail PR validation__ (parameter ids are used for localization)
* [ ] ensure that steps names are unique __or they will fail PR validation__ (step names are used for localization)
* [ ] grep `/subscription/` and ensure that your parameters don't have any hardcoded resourceIds __or they will fail PR validation__
* [ ] remove `fallbackResourceIds` and `fromTemplateId` fields from your template workbook __or they will fail PR validation__