### PR TITLE
Updating alert rule details blade name

### DIFF
--- a/Workbooks/SapMonitor2.0/Alerts/Alerts/Alerts.workbook
+++ b/Workbooks/SapMonitor2.0/Alerts/Alerts/Alerts.workbook
@@ -484,9 +484,15 @@
                     "formatOptions": {
                       "linkTarget": "OpenBlade",
                       "bladeOpenContext": {
-                        "bladeName": "UpdateVNextAlertRuleBlade",
-                        "extensionName": "Microsoft_Azure_Monitoring",
-                        "bladeJsonParameters": "{\r\n\t\"ruleInputs\": {\r\n\t\t\"alertId\": \"{id_column}\"\r\n\t}\r\n}"
+                        "bladeName": "ViewAlertRuleDetails.ReactView",
+                        "extensionName": "Microsoft_Azure_Monitoring_Alerts",
+                        "bladeParameters": [
+                          {
+                            "name": "resourceId",
+                            "source": "column",
+                            "value": "id"
+                          }
+                        ]
                       },
                       "customColumnWidthSetting": "20%"
                     }


### PR DESCRIPTION
Updating the Alert Rule Details Blade.

After clicking on one of the alert rule -
<img width="809" alt="image" src="https://github.com/microsoft/Application-Insights-Workbooks/assets/74706195/e3bf1624-0223-4ab7-9e99-6311ca8fcf12">

* [X] Explain your changes, so people looking at the PR know *what* and *why*, the code changes are the *how*.
* [ ] Validate your changes using one or more of the [testing](../Documentation/Testing.md) methods.

### If adding or updating templates:
* [ ] post a screenshot of templates and/or gallery changes
* [ ] ensure your template has a corresponding gallery entry in the gallery folder
* [ ] If you are adding a new template, add your team and template/gallery file(s) to the CODEOWNERS file. CODEOWNERS entries should be teams, not individuals
* [ ] ensure all steps have meaningful names
* [ ] ensure all parameters and grid columns have display names set so they can be localized
* [ ] ensure that parameters id values are unique __or they will fail PR validation__ (parameter ids are used for localization)
* [ ] ensure that steps names are unique __or they will fail PR validation__ (step names are used for localization)
* [ ] grep `/subscription/` and ensure that your parameters don't have any hardcoded resourceIds __or they will fail PR validation__
* [ ] remove `fallbackResourceIds` and `fromTemplateId` fields from your template workbook __or they will fail PR validation__