### PR TITLE
Minor tweaks to alert and ASE IP config views

### DIFF
--- a/Workbooks/Azure Private MEC/PMEC Site Overview/PMEC Site Overview.workbook
+++ b/Workbooks/Azure Private MEC/PMEC Site Overview/PMEC Site Overview.workbook
@@ -1943,7 +1943,7 @@
             "content": {
               "version": "KqlItem/1.0",
               "query": "{\"version\":\"ARMEndpoint/1.0\",\"data\":null,\"headers\":[],\"method\":\"GET\",\"path\":\"{ase}/networkSettings/default?api-version=2021-02-01\",\"urlParams\":[{\"key\":\"\",\"value\":\"\"},{\"key\":\"\",\"value\":\"\"}],\"batchDisabled\":false,\"transformers\":[{\"type\":\"jsonpath\",\"settings\":{\"tablePath\":\"properties.networkAdapters\",\"columns\":[{\"path\":\"index\",\"columnid\":\"Port\",\"columnType\":\"string\"},{\"path\":\"ipv4Configuration.ipAddress\",\"columnid\":\"IP\",\"columnType\":\"string\"},{\"path\":\"ipv4Configuration.gateway\",\"columnid\":\"Gateway\",\"columnType\":\"string\"},{\"path\":\"ipv4Configuration.subnet\",\"columnid\":\"Subnet Mask\",\"columnType\":\"string\"},{\"path\":\"dhcpStatus\",\"columnid\":\"DHCP\",\"columnType\":\"string\"}]}}]}",
-              "size": 0,
+              "size": 3,
               "title": "IP Config",
               "queryType": 12,
               "gridSettings": {
@@ -2018,7 +2018,7 @@
                 }
               ]
             },
-            "customWidth": "50",
+            "customWidth": "55",
             "name": "IP Config"
           },
           {

--- a/Workbooks/Azure Private MEC/PMEC Site Overview/PMEC Site Overview.workbook
+++ b/Workbooks/Azure Private MEC/PMEC Site Overview/PMEC Site Overview.workbook
@@ -946,7 +946,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "alertsmanagementresources\r\n| where type == 'microsoft.alertsmanagement/alerts'\r\n| extend severity = tostring(properties[\"essentials\"][\"severity\"])\r\n| extend startTime = properties[\"essentials\"][\"startDateTime\"]\r\n| extend description = properties[\"essentials\"][\"description\"]\r\n| extend condition = properties[\"essentials\"][\"monitorCondition\"]\r\n| where properties[\"essentials\"][\"targetResource\"] in~ (\"{ase}\", \"{pccp}\", \"{kubernetesCluster}\")\r\n| project [\"Alert Time\"]=todatetime(startTime),[\"Severity\"]=severity,[\"Alert\"]=name,[\"Description\"]=description, [\"Alert Condition\"]=condition\r\n| order by [\"Alert Time\"] desc",
+              "query": "alertsmanagementresources\r\n| where type == 'microsoft.alertsmanagement/alerts'\r\n| extend severity = tostring(properties[\"essentials\"][\"severity\"])\r\n| extend startTime = properties[\"essentials\"][\"startDateTime\"]\r\n| extend description = properties[\"essentials\"][\"description\"]\r\n| extend condition = properties[\"essentials\"][\"monitorCondition\"]\r\n| where properties[\"essentials\"][\"targetResource\"] in~ (\"{ase}\", \"{pccp}\", \"{kubernetesCluster}\")\r\n| where condition == \"Fired\" or startTime {timespan:query}\r\n| project [\"Alert Time\"]=todatetime(startTime),[\"Severity\"]=severity,[\"Alert\"]=name,[\"Description\"]=description, [\"Alert Condition\"]=condition, [\"Resource\"]=tostring(properties[\"essentials\"][\"targetResource\"])\r\n| order by [\"Alert Time\"] desc",
               "size": 4,
               "title": "All Alerts",
               "noDataMessage": "No active alerts",
@@ -1825,7 +1825,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "alertsmanagementresources\r\n| where type == 'microsoft.alertsmanagement/alerts'\r\n| extend severity = tostring(properties[\"essentials\"][\"severity\"])\r\n| extend startTime = properties[\"essentials\"][\"startDateTime\"]\r\n| extend description = properties[\"essentials\"][\"description\"]\r\n| extend condition = properties[\"essentials\"][\"monitorCondition\"]\r\n| where properties[\"essentials\"][\"targetResource\"] =~ '{ase}'\r\n| project [\"Alert Time\"]=todatetime(startTime),[\"Severity\"]=severity,[\"Alert\"]=name,[\"Description\"]=description,[\"Alert Condition\"]=condition\r\n| order by [\"Alert Time\"] desc",
+              "query": "alertsmanagementresources\r\n| where type == 'microsoft.alertsmanagement/alerts'\r\n| extend severity = tostring(properties[\"essentials\"][\"severity\"])\r\n| extend startTime = properties[\"essentials\"][\"startDateTime\"]\r\n| extend description = properties[\"essentials\"][\"description\"]\r\n| extend condition = properties[\"essentials\"][\"monitorCondition\"]\r\n| where properties[\"essentials\"][\"targetResource\"] =~ '{ase}'\r\n| where condition == \"Fired\" or startTime {timespan:query}\r\n| project [\"Alert Time\"]=todatetime(startTime),[\"Severity\"]=severity,[\"Alert\"]=name,[\"Description\"]=description,[\"Alert Condition\"]=condition\r\n| order by [\"Alert Time\"] desc",
               "size": 1,
               "showAnalytics": true,
               "title": "ASE Alerts",


### PR DESCRIPTION
A couple of small tweaks to the PMEC Site Overview:
* Only show resolved alerts within the timespan, and show which resource the alert was triggered on. Update the filtering to show either alerts that are firing or ones that resolved within the configured timespan. On the all alerts view, show the resource that the alert is firing on. 
![image](https://github.com/microsoft/Application-Insights-Workbooks/assets/3382572/237eea86-40ad-4824-aa1b-38f0458b3044)

* Fix the size of the ASE IP config panel to properly fit the content. 
![image](https://github.com/microsoft/Application-Insights-Workbooks/assets/3382572/f4269116-61d1-48ed-9854-28fb8ed53060)

## PR Checklist

* [x] Explain your changes, so people looking at the PR know *what* and *why*, the code changes are the *how*.
* [x] Validate your changes using one or more of the [testing](../Documentation/Testing.md) methods.

### If adding or updating templates:
* [x] post a screenshot of templates and/or gallery changes
* [x] ensure your template has a corresponding gallery entry in the gallery folder
* [x] If you are adding a new template, add your team and template/gallery file(s) to the CODEOWNERS file. CODEOWNERS entries should be teams, not individuals
* [x] ensure all steps have meaningful names
* [x] ensure all parameters and grid columns have display names set so they can be localized
* [x] ensure that parameters id values are unique __or they will fail PR validation__ (parameter ids are used for localization)
* [x] ensure that steps names are unique __or they will fail PR validation__ (step names are used for localization)
* [x] grep `/subscription/` and ensure that your parameters don't have any hardcoded resourceIds __or they will fail PR validation__
* [x] remove `fallbackResourceIds` and `fromTemplateId` fields from your template workbook __or they will fail PR validation__