### PR TITLE
Change API to 2023-09-01-preview

### DIFF
--- a/Workbooks/Database watcher/Azure SQL Database/database/database.workbook
+++ b/Workbooks/Database watcher/Azure SQL Database/database/database.workbook
@@ -61,7 +61,7 @@
                   "version": "KqlParameterItem/1.0",
                   "name": "watcherResource",
                   "type": 1,
-                  "query": "{\"version\":\"ARMEndpoint/1.0\",\"data\":null,\"headers\":[],\"method\":\"GET\",\"path\":\"{watcherResourceId}?api-version=2023-03-01-preview\",\"urlParams\":[],\"batchDisabled\":false,\"transformers\":null}",
+                  "query": "{\"version\":\"ARMEndpoint/1.0\",\"data\":null,\"headers\":[],\"method\":\"GET\",\"path\":\"{watcherResourceId}\",\"urlParams\":[{\"key\":\"api-version\",\"value\":\"2023-09-01-preview\"}],\"batchDisabled\":false,\"transformers\":null}",
                   "isHiddenWhenLocked": true,
                   "queryType": 12
                 },
@@ -78,7 +78,7 @@
                   "version": "KqlParameterItem/1.0",
                   "name": "watcherAdxClusterUri",
                   "type": 1,
-                  "query": "{\"version\":\"1.0.0\",\"content\":\"{watcherResource}\",\"transformers\":[{\"type\":\"jsonpath\",\"settings\":{\"tablePath\":\"$.properties.datastore.adxClusterUri\",\"columns\":[]}}]}",
+                  "query": "{\"version\":\"1.0.0\",\"content\":\"{watcherResource}\",\"transformers\":[{\"type\":\"jsonpath\",\"settings\":{\"tablePath\":\"$.properties.datastore.kustoClusterUri\",\"columns\":[]}}]}",
                   "isHiddenWhenLocked": true,
                   "queryType": 8,
                   "id": "f0889b5f-3fa4-40a0-838d-443b4c0472b6"
@@ -88,7 +88,7 @@
                   "version": "KqlParameterItem/1.0",
                   "name": "watcherAdxDatabase",
                   "type": 1,
-                  "query": "{\"version\":\"1.0.0\",\"content\":\"{watcherResource}\",\"transformers\":[{\"type\":\"jsonpath\",\"settings\":{\"tablePath\":\"\",\"columns\":[{\"path\":\"$.properties.datastore.adxDatabaseResourceId\",\"columnid\":\"value\",\"columnType\":\"string\",\"substringRegexMatch\":\".*/(.*)\",\"substringReplace\":\"$1\"}]}}]}",
+                  "query": "{\"version\":\"1.0.0\",\"content\":\"{watcherResource}\",\"transformers\":[{\"type\":\"jsonpath\",\"settings\":{\"tablePath\":\"$.properties.datastore.kustoDatabaseName\",\"columns\":[]}}]}",
                   "isHiddenWhenLocked": true,
                   "queryType": 8
                 },
@@ -98,7 +98,7 @@
                   "name": "dataStore",
                   "label": "Choose a data store",
                   "type": 10,
-                  "description": "By default, the workbook loads data from the data store for the current database watcher. You may use an alternate data store by entering its Kusto query URI and database name.",
+                  "description": "By default, the workbook loads data from the data store of the current database watcher. You may use an alternate data store by entering its Kusto query URI and database name.",
                   "isRequired": true,
                   "query": "{\"version\":\"1.0.0\",\"content\":\"[{\\\"value\\\":\\\"watcher\\\",\\\"label\\\":\\\"{watcherName}\\\"},{\\\"value\\\":\\\"alternate\\\",\\\"label\\\":\\\"Alternate\\\"}]\",\"transformers\":null}",
                   "typeSettings": {

--- a/Workbooks/Database watcher/Azure SQL Database/elastic pool/elastic pool.workbook
+++ b/Workbooks/Database watcher/Azure SQL Database/elastic pool/elastic pool.workbook
@@ -61,7 +61,7 @@
                   "version": "KqlParameterItem/1.0",
                   "name": "watcherResource",
                   "type": 1,
-                  "query": "{\"version\":\"ARMEndpoint/1.0\",\"data\":null,\"headers\":[],\"method\":\"GET\",\"path\":\"{watcherResourceId}?api-version=2023-03-01-preview\",\"urlParams\":[],\"batchDisabled\":false,\"transformers\":null}",
+                  "query": "{\"version\":\"ARMEndpoint/1.0\",\"data\":null,\"headers\":[],\"method\":\"GET\",\"path\":\"{watcherResourceId}\",\"urlParams\":[{\"key\":\"api-version\",\"value\":\"2023-09-01-preview\"}],\"batchDisabled\":false,\"transformers\":null}",
                   "isHiddenWhenLocked": true,
                   "queryType": 12
                 },
@@ -78,7 +78,7 @@
                   "version": "KqlParameterItem/1.0",
                   "name": "watcherAdxClusterUri",
                   "type": 1,
-                  "query": "{\"version\":\"1.0.0\",\"content\":\"{watcherResource}\",\"transformers\":[{\"type\":\"jsonpath\",\"settings\":{\"tablePath\":\"$.properties.datastore.adxClusterUri\",\"columns\":[]}}]}",
+                  "query": "{\"version\":\"1.0.0\",\"content\":\"{watcherResource}\",\"transformers\":[{\"type\":\"jsonpath\",\"settings\":{\"tablePath\":\"$.properties.datastore.kustoClusterUri\",\"columns\":[]}}]}",
                   "isHiddenWhenLocked": true,
                   "queryType": 8,
                   "id": "f0889b5f-3fa4-40a0-838d-443b4c0472b6"
@@ -88,7 +88,7 @@
                   "version": "KqlParameterItem/1.0",
                   "name": "watcherAdxDatabase",
                   "type": 1,
-                  "query": "{\"version\":\"1.0.0\",\"content\":\"{watcherResource}\",\"transformers\":[{\"type\":\"jsonpath\",\"settings\":{\"tablePath\":\"\",\"columns\":[{\"path\":\"$.properties.datastore.adxDatabaseResourceId\",\"columnid\":\"value\",\"columnType\":\"string\",\"substringRegexMatch\":\".*/(.*)\",\"substringReplace\":\"$1\"}]}}]}",
+                  "query": "{\"version\":\"1.0.0\",\"content\":\"{watcherResource}\",\"transformers\":[{\"type\":\"jsonpath\",\"settings\":{\"tablePath\":\"$.properties.datastore.kustoDatabaseName\",\"columns\":[]}}]}",
                   "isHiddenWhenLocked": true,
                   "queryType": 8
                 },
@@ -98,7 +98,7 @@
                   "name": "dataStore",
                   "label": "Choose a data store",
                   "type": 10,
-                  "description": "By default, the workbook loads data from the data store for the current database watcher. You may use an alternate data store by entering its Kusto query URI and database name.",
+                  "description": "By default, the workbook loads data from the data store of the current database watcher. You may use an alternate data store by entering its Kusto query URI and database name.",
                   "isRequired": true,
                   "query": "{\"version\":\"1.0.0\",\"content\":\"[{\\\"value\\\":\\\"watcher\\\",\\\"label\\\":\\\"{watcherName}\\\"},{\\\"value\\\":\\\"alternate\\\",\\\"label\\\":\\\"Alternate\\\"}]\",\"transformers\":null}",
                   "typeSettings": {

--- a/Workbooks/Database watcher/Azure SQL Database/estate/estate.workbook
+++ b/Workbooks/Database watcher/Azure SQL Database/estate/estate.workbook
@@ -61,7 +61,7 @@
                   "version": "KqlParameterItem/1.0",
                   "name": "watcherResource",
                   "type": 1,
-                  "query": "{\"version\":\"ARMEndpoint/1.0\",\"data\":null,\"headers\":[],\"method\":\"GET\",\"path\":\"{watcherResourceId}?api-version=2023-03-01-preview\",\"urlParams\":[],\"batchDisabled\":false,\"transformers\":null}",
+                  "query": "{\"version\":\"ARMEndpoint/1.0\",\"data\":null,\"headers\":[],\"method\":\"GET\",\"path\":\"{watcherResourceId}\",\"urlParams\":[{\"key\":\"api-version\",\"value\":\"2023-09-01-preview\"}],\"batchDisabled\":false,\"transformers\":null}",
                   "isHiddenWhenLocked": true,
                   "queryType": 12
                 },
@@ -78,7 +78,7 @@
                   "version": "KqlParameterItem/1.0",
                   "name": "watcherAdxClusterUri",
                   "type": 1,
-                  "query": "{\"version\":\"1.0.0\",\"content\":\"{watcherResource}\",\"transformers\":[{\"type\":\"jsonpath\",\"settings\":{\"tablePath\":\"$.properties.datastore.adxClusterUri\",\"columns\":[]}}]}",
+                  "query": "{\"version\":\"1.0.0\",\"content\":\"{watcherResource}\",\"transformers\":[{\"type\":\"jsonpath\",\"settings\":{\"tablePath\":\"$.properties.datastore.kustoClusterUri\",\"columns\":[]}}]}",
                   "isHiddenWhenLocked": true,
                   "queryType": 8,
                   "id": "f0889b5f-3fa4-40a0-838d-443b4c0472b6"
@@ -88,7 +88,7 @@
                   "version": "KqlParameterItem/1.0",
                   "name": "watcherAdxDatabase",
                   "type": 1,
-                  "query": "{\"version\":\"1.0.0\",\"content\":\"{watcherResource}\",\"transformers\":[{\"type\":\"jsonpath\",\"settings\":{\"tablePath\":\"\",\"columns\":[{\"path\":\"$.properties.datastore.adxDatabaseResourceId\",\"columnid\":\"value\",\"columnType\":\"string\",\"substringRegexMatch\":\".*/(.*)\",\"substringReplace\":\"$1\"}]}}]}",
+                  "query": "{\"version\":\"1.0.0\",\"content\":\"{watcherResource}\",\"transformers\":[{\"type\":\"jsonpath\",\"settings\":{\"tablePath\":\"$.properties.datastore.kustoDatabaseName\",\"columns\":[]}}]}",
                   "isHiddenWhenLocked": true,
                   "queryType": 8
                 },
@@ -98,7 +98,7 @@
                   "name": "dataStore",
                   "label": "Choose a data store",
                   "type": 10,
-                  "description": "By default, the workbook loads data from the data store for the current database watcher. You may use an alternate data store by entering its Kusto query URI and database name.",
+                  "description": "By default, the workbook loads data from the data store of the current database watcher. You may use an alternate data store by entering its Kusto query URI and database name.",
                   "isRequired": true,
                   "query": "{\"version\":\"1.0.0\",\"content\":\"[{\\\"value\\\":\\\"watcher\\\",\\\"label\\\":\\\"{watcherName}\\\"},{\\\"value\\\":\\\"alternate\\\",\\\"label\\\":\\\"Alternate\\\"}]\",\"transformers\":null}",
                   "typeSettings": {

--- a/Workbooks/Database watcher/Azure SQL Managed Instance/estate/estate.workbook
+++ b/Workbooks/Database watcher/Azure SQL Managed Instance/estate/estate.workbook
@@ -61,7 +61,7 @@
                   "version": "KqlParameterItem/1.0",
                   "name": "watcherResource",
                   "type": 1,
-                  "query": "{\"version\":\"ARMEndpoint/1.0\",\"data\":null,\"headers\":[],\"method\":\"GET\",\"path\":\"{watcherResourceId}?api-version=2023-03-01-preview\",\"urlParams\":[],\"batchDisabled\":false,\"transformers\":null}",
+                  "query": "{\"version\":\"ARMEndpoint/1.0\",\"data\":null,\"headers\":[],\"method\":\"GET\",\"path\":\"{watcherResourceId}\",\"urlParams\":[{\"key\":\"api-version\",\"value\":\"2023-09-01-preview\"}],\"batchDisabled\":false,\"transformers\":null}",
                   "isHiddenWhenLocked": true,
                   "queryType": 12
                 },
@@ -78,7 +78,7 @@
                   "version": "KqlParameterItem/1.0",
                   "name": "watcherAdxClusterUri",
                   "type": 1,
-                  "query": "{\"version\":\"1.0.0\",\"content\":\"{watcherResource}\",\"transformers\":[{\"type\":\"jsonpath\",\"settings\":{\"tablePath\":\"$.properties.datastore.adxClusterUri\",\"columns\":[]}}]}",
+                  "query": "{\"version\":\"1.0.0\",\"content\":\"{watcherResource}\",\"transformers\":[{\"type\":\"jsonpath\",\"settings\":{\"tablePath\":\"$.properties.datastore.kustoClusterUri\",\"columns\":[]}}]}",
                   "isHiddenWhenLocked": true,
                   "queryType": 8,
                   "id": "f0889b5f-3fa4-40a0-838d-443b4c0472b6"
@@ -88,7 +88,7 @@
                   "version": "KqlParameterItem/1.0",
                   "name": "watcherAdxDatabase",
                   "type": 1,
-                  "query": "{\"version\":\"1.0.0\",\"content\":\"{watcherResource}\",\"transformers\":[{\"type\":\"jsonpath\",\"settings\":{\"tablePath\":\"\",\"columns\":[{\"path\":\"$.properties.datastore.adxDatabaseResourceId\",\"columnid\":\"value\",\"columnType\":\"string\",\"substringRegexMatch\":\".*/(.*)\",\"substringReplace\":\"$1\"}]}}]}",
+                  "query": "{\"version\":\"1.0.0\",\"content\":\"{watcherResource}\",\"transformers\":[{\"type\":\"jsonpath\",\"settings\":{\"tablePath\":\"$.properties.datastore.kustoDatabaseName\",\"columns\":[]}}]}",
                   "isHiddenWhenLocked": true,
                   "queryType": 8
                 },
@@ -98,7 +98,7 @@
                   "name": "dataStore",
                   "label": "Choose a data store",
                   "type": 10,
-                  "description": "By default, the workbook loads data from the data store for the current database watcher. You may use an alternate data store by entering its Kusto query URI and database name.",
+                  "description": "By default, the workbook loads data from the data store of the current database watcher. You may use an alternate data store by entering its Kusto query URI and database name.",
                   "isRequired": true,
                   "query": "{\"version\":\"1.0.0\",\"content\":\"[{\\\"value\\\":\\\"watcher\\\",\\\"label\\\":\\\"{watcherName}\\\"},{\\\"value\\\":\\\"alternate\\\",\\\"label\\\":\\\"Alternate\\\"}]\",\"transformers\":null}",
                   "typeSettings": {

--- a/Workbooks/Database watcher/Azure SQL Managed Instance/instance/instance.workbook
+++ b/Workbooks/Database watcher/Azure SQL Managed Instance/instance/instance.workbook
@@ -61,7 +61,7 @@
                   "version": "KqlParameterItem/1.0",
                   "name": "watcherResource",
                   "type": 1,
-                  "query": "{\"version\":\"ARMEndpoint/1.0\",\"data\":null,\"headers\":[],\"method\":\"GET\",\"path\":\"{watcherResourceId}?api-version=2023-03-01-preview\",\"urlParams\":[],\"batchDisabled\":false,\"transformers\":null}",
+                  "query": "{\"version\":\"ARMEndpoint/1.0\",\"data\":null,\"headers\":[],\"method\":\"GET\",\"path\":\"{watcherResourceId}\",\"urlParams\":[{\"key\":\"api-version\",\"value\":\"2023-09-01-preview\"}],\"batchDisabled\":false,\"transformers\":null}",
                   "isHiddenWhenLocked": true,
                   "queryType": 12
                 },
@@ -78,7 +78,7 @@
                   "version": "KqlParameterItem/1.0",
                   "name": "watcherAdxClusterUri",
                   "type": 1,
-                  "query": "{\"version\":\"1.0.0\",\"content\":\"{watcherResource}\",\"transformers\":[{\"type\":\"jsonpath\",\"settings\":{\"tablePath\":\"$.properties.datastore.adxClusterUri\",\"columns\":[]}}]}",
+                  "query": "{\"version\":\"1.0.0\",\"content\":\"{watcherResource}\",\"transformers\":[{\"type\":\"jsonpath\",\"settings\":{\"tablePath\":\"$.properties.datastore.kustoClusterUri\",\"columns\":[]}}]}",
                   "isHiddenWhenLocked": true,
                   "queryType": 8,
                   "id": "f0889b5f-3fa4-40a0-838d-443b4c0472b6"
@@ -88,7 +88,7 @@
                   "version": "KqlParameterItem/1.0",
                   "name": "watcherAdxDatabase",
                   "type": 1,
-                  "query": "{\"version\":\"1.0.0\",\"content\":\"{watcherResource}\",\"transformers\":[{\"type\":\"jsonpath\",\"settings\":{\"tablePath\":\"\",\"columns\":[{\"path\":\"$.properties.datastore.adxDatabaseResourceId\",\"columnid\":\"value\",\"columnType\":\"string\",\"substringRegexMatch\":\".*/(.*)\",\"substringReplace\":\"$1\"}]}}]}",
+                  "query": "{\"version\":\"1.0.0\",\"content\":\"{watcherResource}\",\"transformers\":[{\"type\":\"jsonpath\",\"settings\":{\"tablePath\":\"$.properties.datastore.kustoDatabaseName\",\"columns\":[]}}]}",
                   "isHiddenWhenLocked": true,
                   "queryType": 8
                 },
@@ -98,7 +98,7 @@
                   "name": "dataStore",
                   "label": "Choose a data store",
                   "type": 10,
-                  "description": "By default, the workbook loads data from the data store for the current database watcher. You may use an alternate data store by entering its Kusto query URI and database name.",
+                  "description": "By default, the workbook loads data from the data store of the current database watcher. You may use an alternate data store by entering its Kusto query URI and database name.",
                   "isRequired": true,
                   "query": "{\"version\":\"1.0.0\",\"content\":\"[{\\\"value\\\":\\\"watcher\\\",\\\"label\\\":\\\"{watcherName}\\\"},{\\\"value\\\":\\\"alternate\\\",\\\"label\\\":\\\"Alternate\\\"}]\",\"transformers\":null}",
                   "typeSettings": {

--- a/Workbooks/Database watcher/SQL Server/estate/estate.workbook
+++ b/Workbooks/Database watcher/SQL Server/estate/estate.workbook
@@ -61,7 +61,7 @@
                   "version": "KqlParameterItem/1.0",
                   "name": "watcherResource",
                   "type": 1,
-                  "query": "{\"version\":\"ARMEndpoint/1.0\",\"data\":null,\"headers\":[],\"method\":\"GET\",\"path\":\"{watcherResourceId}?api-version=2023-03-01-preview\",\"urlParams\":[],\"batchDisabled\":false,\"transformers\":null}",
+                  "query": "{\"version\":\"ARMEndpoint/1.0\",\"data\":null,\"headers\":[],\"method\":\"GET\",\"path\":\"{watcherResourceId}\",\"urlParams\":[{\"key\":\"api-version\",\"value\":\"2023-09-01-preview\"}],\"batchDisabled\":false,\"transformers\":null}",
                   "isHiddenWhenLocked": true,
                   "queryType": 12
                 },
@@ -78,7 +78,7 @@
                   "version": "KqlParameterItem/1.0",
                   "name": "watcherAdxClusterUri",
                   "type": 1,
-                  "query": "{\"version\":\"1.0.0\",\"content\":\"{watcherResource}\",\"transformers\":[{\"type\":\"jsonpath\",\"settings\":{\"tablePath\":\"$.properties.datastore.adxClusterUri\",\"columns\":[]}}]}",
+                  "query": "{\"version\":\"1.0.0\",\"content\":\"{watcherResource}\",\"transformers\":[{\"type\":\"jsonpath\",\"settings\":{\"tablePath\":\"$.properties.datastore.kustoClusterUri\",\"columns\":[]}}]}",
                   "isHiddenWhenLocked": true,
                   "queryType": 8,
                   "id": "f0889b5f-3fa4-40a0-838d-443b4c0472b6"
@@ -88,7 +88,7 @@
                   "version": "KqlParameterItem/1.0",
                   "name": "watcherAdxDatabase",
                   "type": 1,
-                  "query": "{\"version\":\"1.0.0\",\"content\":\"{watcherResource}\",\"transformers\":[{\"type\":\"jsonpath\",\"settings\":{\"tablePath\":\"\",\"columns\":[{\"path\":\"$.properties.datastore.adxDatabaseResourceId\",\"columnid\":\"value\",\"columnType\":\"string\",\"substringRegexMatch\":\".*/(.*)\",\"substringReplace\":\"$1\"}]}}]}",
+                  "query": "{\"version\":\"1.0.0\",\"content\":\"{watcherResource}\",\"transformers\":[{\"type\":\"jsonpath\",\"settings\":{\"tablePath\":\"$.properties.datastore.kustoDatabaseName\",\"columns\":[]}}]}",
                   "isHiddenWhenLocked": true,
                   "queryType": 8
                 },
@@ -98,7 +98,7 @@
                   "name": "dataStore",
                   "label": "Choose a data store",
                   "type": 10,
-                  "description": "By default, the workbook loads data from the data store for the current database watcher. You may use an alternate data store by entering its Kusto query URI and database name.",
+                  "description": "By default, the workbook loads data from the data store of the current database watcher. You may use an alternate data store by entering its Kusto query URI and database name.",
                   "isRequired": true,
                   "query": "{\"version\":\"1.0.0\",\"content\":\"[{\\\"value\\\":\\\"watcher\\\",\\\"label\\\":\\\"{watcherName}\\\"},{\\\"value\\\":\\\"alternate\\\",\\\"label\\\":\\\"Alternate\\\"}]\",\"transformers\":null}",
                   "typeSettings": {

--- a/Workbooks/Database watcher/SQL Server/instance/instance.workbook
+++ b/Workbooks/Database watcher/SQL Server/instance/instance.workbook
@@ -61,7 +61,7 @@
                   "version": "KqlParameterItem/1.0",
                   "name": "watcherResource",
                   "type": 1,
-                  "query": "{\"version\":\"ARMEndpoint/1.0\",\"data\":null,\"headers\":[],\"method\":\"GET\",\"path\":\"{watcherResourceId}?api-version=2023-03-01-preview\",\"urlParams\":[],\"batchDisabled\":false,\"transformers\":null}",
+                  "query": "{\"version\":\"ARMEndpoint/1.0\",\"data\":null,\"headers\":[],\"method\":\"GET\",\"path\":\"{watcherResourceId}\",\"urlParams\":[{\"key\":\"api-version\",\"value\":\"2023-09-01-preview\"}],\"batchDisabled\":false,\"transformers\":null}",
                   "isHiddenWhenLocked": true,
                   "queryType": 12
                 },
@@ -78,7 +78,7 @@
                   "version": "KqlParameterItem/1.0",
                   "name": "watcherAdxClusterUri",
                   "type": 1,
-                  "query": "{\"version\":\"1.0.0\",\"content\":\"{watcherResource}\",\"transformers\":[{\"type\":\"jsonpath\",\"settings\":{\"tablePath\":\"$.properties.datastore.adxClusterUri\",\"columns\":[]}}]}",
+                  "query": "{\"version\":\"1.0.0\",\"content\":\"{watcherResource}\",\"transformers\":[{\"type\":\"jsonpath\",\"settings\":{\"tablePath\":\"$.properties.datastore.kustoClusterUri\",\"columns\":[]}}]}",
                   "isHiddenWhenLocked": true,
                   "queryType": 8,
                   "id": "f0889b5f-3fa4-40a0-838d-443b4c0472b6"
@@ -88,7 +88,7 @@
                   "version": "KqlParameterItem/1.0",
                   "name": "watcherAdxDatabase",
                   "type": 1,
-                  "query": "{\"version\":\"1.0.0\",\"content\":\"{watcherResource}\",\"transformers\":[{\"type\":\"jsonpath\",\"settings\":{\"tablePath\":\"\",\"columns\":[{\"path\":\"$.properties.datastore.adxDatabaseResourceId\",\"columnid\":\"value\",\"columnType\":\"string\",\"substringRegexMatch\":\".*/(.*)\",\"substringReplace\":\"$1\"}]}}]}",
+                  "query": "{\"version\":\"1.0.0\",\"content\":\"{watcherResource}\",\"transformers\":[{\"type\":\"jsonpath\",\"settings\":{\"tablePath\":\"$.properties.datastore.kustoDatabaseName\",\"columns\":[]}}]}",
                   "isHiddenWhenLocked": true,
                   "queryType": 8
                 },
@@ -98,7 +98,7 @@
                   "name": "dataStore",
                   "label": "Choose a data store",
                   "type": 10,
-                  "description": "By default, the workbook loads data from the data store for the current database watcher. You may use an alternate data store by entering its Kusto query URI and database name.",
+                  "description": "By default, the workbook loads data from the data store of the current database watcher. You may use an alternate data store by entering its Kusto query URI and database name.",
                   "isRequired": true,
                   "query": "{\"version\":\"1.0.0\",\"content\":\"[{\\\"value\\\":\\\"watcher\\\",\\\"label\\\":\\\"{watcherName}\\\"},{\\\"value\\\":\\\"alternate\\\",\\\"label\\\":\\\"Alternate\\\"}]\",\"transformers\":null}",
                   "typeSettings": {

--- a/Workbooks/Database watcher/watcher.workbook
+++ b/Workbooks/Database watcher/watcher.workbook
@@ -19,7 +19,7 @@
             "version": "KqlParameterItem/1.0",
             "name": "watcherResource",
             "type": 1,
-            "query": "{\"version\":\"ARMEndpoint/1.0\",\"data\":null,\"headers\":[],\"method\":\"GET\",\"path\":\"{watcherResourceId}?api-version=2023-03-01-preview\",\"urlParams\":[],\"batchDisabled\":false,\"transformers\":null}",
+            "query": "{\"version\":\"ARMEndpoint/1.0\",\"data\":null,\"headers\":[],\"method\":\"GET\",\"path\":\"{watcherResourceId}\",\"urlParams\":[{\"key\":\"api-version\",\"value\":\"2023-09-01-preview\"}],\"batchDisabled\":false,\"transformers\":null}",
             "isHiddenWhenLocked": true,
             "queryType": 12
           },
@@ -36,7 +36,7 @@
             "version": "KqlParameterItem/1.0",
             "name": "watcherAdxClusterUri",
             "type": 1,
-            "query": "{\"version\":\"1.0.0\",\"content\":\"{watcherResource}\",\"transformers\":[{\"type\":\"jsonpath\",\"settings\":{\"tablePath\":\"$.properties.datastore.adxClusterUri\",\"columns\":[]}}]}",
+            "query": "{\"version\":\"1.0.0\",\"content\":\"{watcherResource}\",\"transformers\":[{\"type\":\"jsonpath\",\"settings\":{\"tablePath\":\"$.properties.datastore.kustoClusterUri\",\"columns\":[]}}]}",
             "isHiddenWhenLocked": true,
             "queryType": 8,
             "id": "f0889b5f-3fa4-40a0-838d-443b4c0472b6"
@@ -46,7 +46,7 @@
             "version": "KqlParameterItem/1.0",
             "name": "watcherAdxDatabase",
             "type": 1,
-            "query": "{\"version\":\"1.0.0\",\"content\":\"{watcherResource}\",\"transformers\":[{\"type\":\"jsonpath\",\"settings\":{\"tablePath\":\"\",\"columns\":[{\"path\":\"$.properties.datastore.adxDatabaseResourceId\",\"columnid\":\"value\",\"columnType\":\"string\",\"substringRegexMatch\":\".*/(.*)\",\"substringReplace\":\"$1\"}]}}]}",
+            "query": "{\"version\":\"1.0.0\",\"content\":\"{watcherResource}\",\"transformers\":[{\"type\":\"jsonpath\",\"settings\":{\"tablePath\":\"$.properties.datastore.kustoDatabaseName\",\"columns\":[]}}]}",
             "isHiddenWhenLocked": true,
             "queryType": 8
           }
@@ -79,7 +79,7 @@
                   "name": "dataStore",
                   "label": "Choose a data store",
                   "type": 10,
-                  "description": "By default, the workbook loads data from the data store for the current database watcher. You may use an alternate data store by entering its Kusto query URI and database name.",
+                  "description": "By default, the workbook loads data from the data store of the current database watcher. You may use an alternate data store by entering its Kusto query URI and database name.",
                   "isRequired": true,
                   "query": "{\"version\":\"1.0.0\",\"content\":\"[{\\\"value\\\":\\\"watcher\\\",\\\"label\\\":\\\"{watcherName}\\\"},{\\\"value\\\":\\\"alternate\\\",\\\"label\\\":\\\"Alternate\\\"}]\",\"transformers\":null}",
                   "typeSettings": {


### PR DESCRIPTION
## PR Checklist

This PR changes the API version used to get the properties of the specified watcher resource, from 2023-03-01-preview to 2023-09-01-preview. Reflecting API changes, it also changes how the Kusto cluster URI and database name are derived from the watcher resource properties.

* [x] Explain your changes, so people looking at the PR know *what* and *why*, the code changes are the *how*.
* [x] Validate your changes using one or more of the [testing](../Documentation/Testing.md) methods.

### If adding or updating templates:
* [n/a] post a screenshot of templates and/or gallery changes
* [x] ensure your template has a corresponding gallery entry in the gallery folder
* [x] If you are adding a new template, add your team and template/gallery file(s) to the CODEOWNERS file. CODEOWNERS entries should be teams, not individuals
* [x] ensure all steps have meaningful names
* [x] ensure all parameters and grid columns have display names set so they can be localized
* [x] ensure that parameters id values are unique __or they will fail PR validation__ (parameter ids are used for localization)
* [x] ensure that steps names are unique __or they will fail PR validation__ (step names are used for localization)
* [x] grep `/subscription/` and ensure that your parameters don't have any hardcoded resourceIds __or they will fail PR validation__
* [x] remove `fallbackResourceIds` and `fromTemplateId` fields from your template workbook __or they will fail PR validation__