### PR TITLE
Improve UX of SIM Policies panel

### DIFF
--- a/Workbooks/Azure Private MEC/PMEC Site Overview/PMEC Site Overview.workbook
+++ b/Workbooks/Azure Private MEC/PMEC Site Overview/PMEC Site Overview.workbook
@@ -3467,7 +3467,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "resources\r\n| where type =~ \"microsoft.mobilenetwork/mobilenetworks/simpolicies\"\r\n| where id startswith \"{mobilenetwork}/simPolicies/\"\r\n| extend currentSiteProvisioningState = tostring(properties.siteProvisioningState[\"{siteLowerCase}\"])\r\n| where currentSiteProvisioningState != \"\"\r\n| where currentSiteProvisioningState != \"NotApplicable\"\r\n| extend sliceConfigurations = todynamic(properties.sliceConfigurations)\r\n| mv-expand sliceConfigurations\r\n| extend slice=sliceConfigurations.slice.id\r\n| extend dataNetworkConfigurations = todynamic(sliceConfigurations.dataNetworkConfigurations)\r\n| mv-expand dataNetworkConfigurations\r\n| extend dataNetwork = dataNetworkConfigurations.dataNetwork.id\r\n| project [\"SIM Policy\"]=id, [\"Provisioning State\"]=currentSiteProvisioningState, [\"Slice\"]=slice, [\"Default Data Network\"]=sliceConfigurations.defaultDataNetwork.id, [\"Data Network\"]=dataNetwork, [\"UE Downlink AMBR\"]=properties.ueAmbr.downlink, [\"UE Uplink AMBR\"]=properties.ueAmbr.uplink, [\"Session Downlink AMBR\"]=dataNetworkConfigurations.sessionAmbr.downlink, [\"Session Uplink AMBR\"]=dataNetworkConfigurations.sessionAmbr.uplink",
+              "query": "resources\r\n| where type =~ \"microsoft.mobilenetwork/mobilenetworks/simpolicies\"\r\n| where id startswith \"{mobilenetwork}/simPolicies/\"\r\n| extend currentSiteProvisioningState = tostring(properties.siteProvisioningState[\"{siteLowerCase}\"])\r\n| where currentSiteProvisioningState != \"\"\r\n| where currentSiteProvisioningState != \"NotApplicable\"\r\n| extend sliceConfigurations = todynamic(properties.sliceConfigurations)\r\n| mv-expand sliceConfigurations\r\n| extend slice=sliceConfigurations.slice.id\r\n| extend dataNetworkConfigurations = todynamic(sliceConfigurations.dataNetworkConfigurations)\r\n| mv-expand dataNetworkConfigurations\r\n| extend dataNetwork = dataNetworkConfigurations.dataNetwork.id\r\n| project id_=strcat(id, dataNetwork), parent_id_=id, [\"SIM Policy\"]=\"\", [\"Provisioning State\"]=\"\", [\"UE Downlink AMBR\"]=\"\", [\"UE Uplink AMBR\"]=\"\", [\"Slice\"]=slice, [\"Default Data Network\"]=sliceConfigurations.defaultDataNetwork.id, [\"Data Network\"]=dataNetwork, [\"Session Downlink AMBR\"]=dataNetworkConfigurations.sessionAmbr.downlink, [\"Session Uplink AMBR\"]=dataNetworkConfigurations.sessionAmbr.uplink\r\n| union (\r\n    resources\r\n    | where type =~ \"microsoft.mobilenetwork/mobilenetworks/simpolicies\"\r\n    | where id startswith \"{mobilenetwork}/simPolicies/\"\r\n    | extend currentSiteProvisioningState = tostring(properties.siteProvisioningState[\"{siteLowerCase}\"])\r\n    | where currentSiteProvisioningState != \"\"\r\n    | where currentSiteProvisioningState != \"NotApplicable\"\r\n    | project id_=id, parent_id_=\"\", [\"SIM Policy\"]=id, [\"Provisioning State\"]=currentSiteProvisioningState, [\"UE Downlink AMBR\"]=tostring(properties.ueAmbr.downlink), [\"UE Uplink AMBR\"]=tostring(properties.ueAmbr.uplink)\r\n)",
               "size": 1,
               "noDataMessage": " ",
               "queryType": 1,
@@ -3478,27 +3478,12 @@
               "gridSettings": {
                 "formatters": [
                   {
-                    "columnMatch": "$gen_group",
-                    "formatter": 13,
-                    "formatOptions": {
-                      "linkTarget": "Resource",
-                      "showIcon": true
-                    }
+                    "columnMatch": "id_",
+                    "formatter": 5
                   },
                   {
-                    "columnMatch": "Group",
-                    "formatter": 13,
-                    "formatOptions": {
-                      "linkTarget": "Resource",
-                      "showIcon": true
-                    }
-                  },
-                  {
-                    "columnMatch": "SIM Policy",
-                    "formatter": 5,
-                    "formatOptions": {
-                      "linkTarget": "Resource"
-                    }
+                    "columnMatch": "parent_id_",
+                    "formatter": 5
                   },
                   {
                     "columnMatch": "Provisioning State",
@@ -3543,6 +3528,10 @@
                           "text": "{0}{1}"
                         },
                         {
+                          "operator": "is Empty",
+                          "text": "{1}"
+                        },
+                        {
                           "operator": "Default",
                           "thresholdValue": null,
                           "representation": "more",
@@ -3550,6 +3539,14 @@
                         }
                       ]
                     }
+                  },
+                  {
+                    "columnMatch": "UE Downlink AMBR",
+                    "formatter": 1
+                  },
+                  {
+                    "columnMatch": "UE Uplink AMBR",
+                    "formatter": 1
                   },
                   {
                     "columnMatch": "Slice",
@@ -3568,20 +3565,20 @@
                     }
                   },
                   {
-                    "columnMatch": "UE Downlink AMBR",
-                    "formatter": 1
-                  },
-                  {
-                    "columnMatch": "UE Uplink AMBR",
-                    "formatter": 1
-                  },
-                  {
                     "columnMatch": "Session Downlink AMBR",
                     "formatter": 1
                   },
                   {
                     "columnMatch": "Session Uplink AMBR",
                     "formatter": 1
+                  },
+                  {
+                    "columnMatch": "Group",
+                    "formatter": 13,
+                    "formatOptions": {
+                      "linkTarget": "Resource",
+                      "showIcon": true
+                    }
                   },
                   {
                     "columnMatch": "name",
@@ -3597,25 +3594,14 @@
                   }
                 ],
                 "hierarchySettings": {
-                  "treeType": 1,
-                  "groupBy": [
-                    "SIM Policy"
-                  ],
+                  "idColumn": "id_",
+                  "parentColumn": "parent_id_",
+                  "treeType": 0,
+                  "expanderColumn": "SIM Policy",
                   "expandTopLevel": true
-                },
-                "sortBy": [
-                  {
-                    "itemKey": "$gen_link_SIM Policy_1",
-                    "sortOrder": 1
-                  }
-                ]
-              },
-              "sortBy": [
-                {
-                  "itemKey": "$gen_link_SIM Policy_1",
-                  "sortOrder": 1
                 }
-              ]
+              },
+              "sortBy": []
             },
             "name": "query - 2"
           },


### PR DESCRIPTION
Use a parent-child relationship in the grid to only show values that are at the SIM policy scope once per policy, rather than once per data network.

SIM policies are now displayed like this:
![image](https://github.com/microsoft/Application-Insights-Workbooks/assets/3382572/e00af1e7-462d-4b3d-96b4-e519a36aa4d5)
Previously this looked like this:
![image](https://github.com/microsoft/Application-Insights-Workbooks/assets/3382572/3555dd81-efdd-4400-bfda-76cb86e93490)
(note how the Provisioning State is shown three times for MultiDN-Policy, even though it only applies to the top-level SIM policy).

## PR Checklist

* [x] Explain your changes, so people looking at the PR know *what* and *why*, the code changes are the *how*.
* [x] Validate your changes using one or more of the [testing](../Documentation/Testing.md) methods.

### If adding or updating templates:
* [x] post a screenshot of templates and/or gallery changes
* [ ] ensure your template has a corresponding gallery entry in the gallery folder
* [ ] If you are adding a new template, add your team and template/gallery file(s) to the CODEOWNERS file. CODEOWNERS entries should be teams, not individuals
* [ ] ensure all steps have meaningful names
* [ ] ensure all parameters and grid columns have display names set so they can be localized
* [ ] ensure that parameters id values are unique __or they will fail PR validation__ (parameter ids are used for localization)
* [ ] ensure that steps names are unique __or they will fail PR validation__ (step names are used for localization)
* [ ] grep `/subscription/` and ensure that your parameters don't have any hardcoded resourceIds __or they will fail PR validation__
* [ ] remove `fallbackResourceIds` and `fromTemplateId` fields from your template workbook __or they will fail PR validation__