### PR TITLE
Multi-VM Flyout and JIT Onboarding

### DIFF
--- a/Workbooks/SapMonitor2.0/AIOpsInsights/Availability Insights/Auto RCA.workbook
+++ b/Workbooks/SapMonitor2.0/AIOpsInsights/Availability Insights/Auto RCA.workbook
@@ -1938,7 +1938,7 @@
                 {
                   "type": 1,
                   "content": {
-                    "json": "<h1 style=\"text-align:center;\">Configure insights for your AMS instance: {AMSResource:name}</h1>\r\n<p style=\"text-align:center;\">To view VM Insights, please configure.</p>"
+                    "json": "<h1 style=\"text-align:center;\">Configure access to infrastructure to view further Insights</h1>"
                   },
                   "name": "text - 0"
                 },
@@ -1947,7 +1947,7 @@
                   "content": {
                     "json": ""
                   },
-                  "customWidth": "35",
+                  "customWidth": "42",
                   "name": "text - 1"
                 },
                 {
@@ -1976,7 +1976,7 @@
                       }
                     ]
                   },
-                  "customWidth": "30",
+                  "customWidth": "20",
                   "name": "links - 3"
                 },
                 {
@@ -1984,7 +1984,7 @@
                   "content": {
                     "json": ""
                   },
-                  "customWidth": "35",
+                  "customWidth": "38",
                   "name": "text - 2"
                 }
               ]
@@ -2358,5 +2358,5 @@
       "name": "vmInsights"
     }
   ],
-    "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
+  "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
 }

--- a/Workbooks/SapMonitor2.0/AIOpsInsights/Availability Insights/Auto RCA.workbook
+++ b/Workbooks/SapMonitor2.0/AIOpsInsights/Availability Insights/Auto RCA.workbook
@@ -353,7 +353,8 @@
               "{Workspace}"
             ],
             "queryType": 0,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "resourceType": "microsoft.operationalinsights/workspaces",
+            "label": "Provider"
           },
           {
             "id": "38856def-f524-46ed-a612-217dabaccaa1",
@@ -373,7 +374,8 @@
             },
             "defaultValue": "value::1",
             "queryType": 0,
-            "resourceType": "microsoft.operationalinsights/workspaces"
+            "resourceType": "microsoft.operationalinsights/workspaces",
+            "label": "VM"
           },
           {
             "id": "84afcc6c-4c47-4422-9bb1-99a94d242561",
@@ -1892,6 +1894,124 @@
               ],
               "parameters": [
                 {
+                  "id": "3ed864b2-36a1-4e81-94f5-8c486a4eb4ac",
+                  "version": "KqlParameterItem/1.0",
+                  "name": "tableExists",
+                  "type": 1,
+                  "query": "let checktable = (tb:string, columnName:string)\r\n{\r\n// 0 = no error\r\n// 1 = table does not exist (need to enable RFC)\r\n// 2 = table exists, but column v1 does not (or) column v1 exists but no data in the table (need to wait)\r\nlet dummy = \"unmÃ¶glicher-wert!\";\r\nlet MissingTable = view () { print miss = 1, columnV1 = dummy, records = -1 };\r\nlet checkRecords =\r\n  union\r\n    isfuzzy=true MissingTable,\r\n    (table(tb)\r\n      | summarize records = count()\r\n    )\r\n  | project records\r\n  | top 1 by records desc\r\n;\r\nlet checkTableExists =\r\n  union\r\n    isfuzzy=true MissingTable,\r\n    (table(tb)\r\n      | count\r\n      | extend miss = 0\r\n    )\r\n  | project miss\r\n  | limit 2\r\n  | top 1 by miss asc\r\n;\r\nlet checkColumnExists =\r\n  union\r\n    isfuzzy=true MissingTable,\r\n    (table(tb)\r\n      | extend miss = 0\r\n      | extend columnV1 = column_ifexists(columnName, dummy)\r\n    )\r\n  | project miss, columnV1\r\n  | limit 2\r\n  | top 1 by miss asc\r\n ;\r\nlet tableExists = toscalar(checkTableExists | summarize max(miss) != 1);\r\nlet columnV1Exists = toscalar(checkColumnExists | summarize max(columnV1) != dummy);\r\nlet tableRecords = toscalar(checkRecords | summarize max(records));\r\nlet x = iif(tableExists, iif(columnV1Exists, iif(tableRecords > 0, \"0\", \"2\"), \"2\"), \"1\");\r\ntoscalar(x)\r\n};\r\nlet system = checktable('SapNetweaver_GetSystemInstanceList_CL', 'SID_s');\r\nlet process = checktable('SapNetweaver_GetProcessList_CL', 'SID_s');\r\nlet vms = checktable('COMMON_VM_ArmId_Mapping_CL', 'VM_ARM_ID_s');\r\nlet hana = checktable('SapHana_SystemAvailability_CL', 'PROVIDER_INSTANCE_s');\r\n\r\nprint strcat(\r\n'{\"SapNetweaver_GetSystemInstanceList_CL\":',system, ',',\r\n'\"SapNetweaver_GetProcessList_CL\":',process, ',',\r\n'\"SapHana_SystemAvailability_CL\":',hana, ',',\r\n'\"COMMON_VM_ArmId_Mapping_CL\":',vms, '}')",
+                  "crossComponentResources": [
+                    "{Workspace}"
+                  ],
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces"
+                },
+                {
+                  "id": "b3745d6c-85d2-48df-ac33-2dd2e8f0d8df",
+                  "version": "KqlParameterItem/1.0",
+                  "name": "vmIdsExist",
+                  "type": 1,
+                  "query": "print input = parse_json('{tableExists}')\r\n| mv-apply input to typeof(dynamic) on (\r\n    project error=tostring(input[\"COMMON_VM_ArmId_Mapping_CL\"])\r\n    | where isnotempty(error)\r\n    | project error = tolong(error)\r\n)\r\n| project value=iff(error==0, true, false)",
+                  "crossComponentResources": [
+                    "{Workspace}"
+                  ],
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces"
+                }
+              ],
+              "style": "pills",
+              "queryType": 0,
+              "resourceType": "microsoft.operationalinsights/workspaces"
+            },
+            "conditionalVisibility": {
+              "parameterName": "hidden",
+              "comparison": "isEqualTo",
+              "value": "true"
+            },
+            "name": "vmInsightsCheckParams"
+          },
+          {
+            "type": 12,
+            "content": {
+              "version": "NotebookGroup/1.0",
+              "groupType": "editable",
+              "items": [
+                {
+                  "type": 1,
+                  "content": {
+                    "json": "<h1 style=\"text-align:center;\">Configure insights for your AMS instance: {AMSResource:name}</h1>\r\n<p style=\"text-align:center;\">To view VM Insights, please configure.</p>"
+                  },
+                  "name": "text - 0"
+                },
+                {
+                  "type": 1,
+                  "content": {
+                    "json": ""
+                  },
+                  "customWidth": "35",
+                  "name": "text - 1"
+                },
+                {
+                  "type": 11,
+                  "content": {
+                    "version": "LinkItem/1.0",
+                    "style": "list",
+                    "links": [
+                      {
+                        "id": "0fd2adda-e7b2-4af8-bec2-1418f7cbb4b0",
+                        "linkTarget": "OpenBlade",
+                        "linkLabel": "Configure Insights",
+                        "style": "primary",
+                        "linkIsContextBlade": true,
+                        "bladeOpenContext": {
+                          "bladeName": "ManageInsights.ReactView",
+                          "extensionName": "Microsoft_Azure_WorkloadMonitor",
+                          "bladeParameters": [
+                            {
+                              "name": "resourceId",
+                              "source": "parameter",
+                              "value": "AMSResource"
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  },
+                  "customWidth": "30",
+                  "name": "links - 3"
+                },
+                {
+                  "type": 1,
+                  "content": {
+                    "json": ""
+                  },
+                  "customWidth": "35",
+                  "name": "text - 2"
+                }
+              ]
+            },
+            "conditionalVisibilities": [
+              {
+                "parameterName": "Tab",
+                "comparison": "isEqualTo",
+                "value": "VM"
+              },
+              {
+                "parameterName": "vmIdsExist",
+                "comparison": "isNotEqualTo",
+                "value": "true"
+              }
+            ],
+            "name": "vmInsightsConfigure"
+          },
+          {
+            "type": 9,
+            "content": {
+              "version": "KqlParameterItem/1.0",
+              "crossComponentResources": [
+                "{Workspace}"
+              ],
+              "parameters": [
+                {
                   "id": "031b807f-c5d3-472a-814e-4aa30e2968ab",
                   "version": "KqlParameterItem/1.0",
                   "name": "VM2",
@@ -1924,6 +2044,11 @@
               "style": "pills",
               "queryType": 0,
               "resourceType": "microsoft.operationalinsights/workspaces"
+            },
+            "conditionalVisibility": {
+              "parameterName": "hidden",
+              "comparison": "isEqualTo",
+              "value": "true"
             },
             "name": "vmInsightParams"
           },
@@ -1959,11 +2084,18 @@
                 "rowLimit": 10000
               }
             },
-            "conditionalVisibility": {
-              "parameterName": "IsFixedGranularity",
-              "comparison": "isEqualTo",
-              "value": "true"
-            },
+            "conditionalVisibilities": [
+              {
+                "parameterName": "IsFixedGranularity",
+                "comparison": "isEqualTo",
+                "value": "true"
+              },
+              {
+                "parameterName": "vmIdsExist",
+                "comparison": "isEqualTo",
+                "value": "true"
+              }
+            ],
             "name": "vmAvailabilityMetric"
           },
           {
@@ -1981,7 +2113,7 @@
               ],
               "timeContextFromParameter": "TimeRange",
               "timeContext": {
-                "durationMs": 2592000000
+                "durationMs": 3600000
               },
               "metrics": [
                 {
@@ -1997,11 +2129,18 @@
                 "rowLimit": 10000
               }
             },
-            "conditionalVisibility": {
-              "parameterName": "IsFixedGranularity",
-              "comparison": "isEqualTo",
-              "value": "false"
-            },
+            "conditionalVisibilities": [
+              {
+                "parameterName": "IsFixedGranularity",
+                "comparison": "isEqualTo",
+                "value": "false"
+              },
+              {
+                "parameterName": "vmIdsExist",
+                "comparison": "isEqualTo",
+                "value": "true"
+              }
+            ],
             "name": "vmAvailabilityMetric - Auto Granularity"
           },
           {
@@ -2196,10 +2335,17 @@
                 }
               ]
             },
-            "conditionalVisibility": {
-              "parameterName": "healthData",
-              "comparison": "isNotEqualTo"
-            },
+            "conditionalVisibilities": [
+              {
+                "parameterName": "healthData",
+                "comparison": "isNotEqualTo"
+              },
+              {
+                "parameterName": "vmIdsExist",
+                "comparison": "isEqualTo",
+                "value": "true"
+              }
+            ],
             "name": "healthEventGroup"
           }
         ]
@@ -2212,5 +2358,5 @@
       "name": "vmInsights"
     }
   ],
-  "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
+    "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
 }

--- a/Workbooks/SapMonitor2.0/AIOpsInsights/Availability Insights/Auto RCA.workbook
+++ b/Workbooks/SapMonitor2.0/AIOpsInsights/Availability Insights/Auto RCA.workbook
@@ -197,7 +197,7 @@
                 }
               ],
               "allowCustom": true
-                        }
+            }
           },
           {
             "id": "74f08427-265d-4db2-a6d9-82318f892762",
@@ -291,8 +291,7 @@
             "id": "8562276b-bf96-4693-b913-3327220339cf",
             "version": "KqlParameterItem/1.0",
             "name": "NwVmList",
-            "type": 1,
-            "value": "[l15appvm1, l15appvm0, l15ers01cl2, l15scs00cl1]"
+            "type": 1
           },
           {
             "id": "a56b9464-e4f7-4360-b12d-f3abb55cf8b6",
@@ -345,10 +344,16 @@
         ],
         "parameters": [
           {
-            "id": "02d4877e-6d51-43b3-be31-fbacbdb20b60",
+            "id": "2d8db5ac-db37-4777-87c5-1aef698362e2",
             "version": "KqlParameterItem/1.0",
             "name": "selProvider",
-            "type": 1
+            "type": 1,
+            "query": "print \"{Provider}\"",
+            "crossComponentResources": [
+              "{Workspace}"
+            ],
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces"
           },
           {
             "id": "38856def-f524-46ed-a612-217dabaccaa1",
@@ -356,7 +361,7 @@
             "name": "selVmName",
             "type": 2,
             "isRequired": true,
-            "query": "union isfuzzy = true(\r\nSapNetweaver_GetSystemInstanceList_CL\r\n| where PROVIDER_INSTANCE_s == \"{selProvider}\"\r\n| distinct hostname_s\r\n| project HOST_s = hostname_s\r\n),\r\n(\r\nSapHana_SystemAvailability_CL\r\n| where PROVIDER_INSTANCE_s == \"{selProvider}\"\r\n| distinct HOST_s\r\n)",
+            "query": "union isfuzzy = true(\r\n    SapNetweaver_GetSystemInstanceList_CL\r\n    | where \"{selProvider}\" contains PROVIDER_INSTANCE_s\r\n    | distinct hostname_s\r\n    | project HOST_s = hostname_s\r\n),\r\n(\r\n    SapHana_SystemAvailability_CL\r\n    | where \"{selProvider}\" contains PROVIDER_INSTANCE_s\r\n    | distinct HOST_s\r\n)",
             "crossComponentResources": [
               "{Workspace}"
             ],
@@ -366,10 +371,6 @@
               ],
               "showDefault": false
             },
-            "timeContext": {
-              "durationMs": 0
-            },
-            "timeContextFromParameter": "TimeRange",
             "defaultValue": "value::1",
             "queryType": 0,
             "resourceType": "microsoft.operationalinsights/workspaces"
@@ -379,7 +380,7 @@
             "version": "KqlParameterItem/1.0",
             "name": "SAPComponent",
             "type": 1,
-            "query": "SapHana_SystemOverview_CL\r\n| summarize Count = countif(PROVIDER_INSTANCE_s == \"{selProvider}\")\r\n| project Result = iif(Count>0,\"SAP Hana\", \"SAP NetWeaver\")",
+            "query": "SapHana_SystemAvailability_CL\r\n| summarize Count = countif(HOST_s == \"{selVmName}\")\r\n| project Result = iif(Count>0,\"SAP Hana\", \"SAP NetWeaver\")",
             "crossComponentResources": [
               "{Workspace}"
             ],
@@ -392,6 +393,7 @@
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces"
       },
+      "customWidth": "0",
       "name": "parameters - 12"
     },
     {
@@ -519,8 +521,7 @@
             "jsonData": "[\r\n    {\"value\":\"Summary\",\r\n    \"label\":\"Process availability\"},\r\n    {\"value\":\"Process\",\r\n    \"label\":\"SAP platform\"},\r\n    {\"value\":\"VM\", \r\n    \"label\": \"Azure platform\"}\r\n]",
             "timeContext": {
               "durationMs": 86400000
-            },
-            "value": "Summary"
+            }
           }
         ],
         "style": "pills",
@@ -702,6 +703,11 @@
                       "name": "selVmName",
                       "source": "static",
                       "value": "{selVmName}"
+                    },
+                    {
+                      "name": "selProvider",
+                      "source": "parameter",
+                      "value": "selProvider"
                     }
                   ],
                   "viewerMode": false
@@ -734,11 +740,6 @@
                       "name": "TimePeriod",
                       "source": "parameter",
                       "value": "TimePeriod"
-                    },
-                    {
-                      "name": "VMID",
-                      "source": "parameter",
-                      "value": "VMID"
                     },
                     {
                       "name": "Provider",
@@ -774,8 +775,19 @@
                       "name": "Process",
                       "source": "column",
                       "value": "description_s"
+                    },
+                    {
+                      "name": "selVmName",
+                      "source": "static",
+                      "value": "{selVmName}"
+                    },
+                    {
+                      "name": "selProvider",
+                      "source": "parameter",
+                      "value": "selProvider"
                     }
-                  ]
+                  ],
+                  "viewerMode": false
                 }
               }
             },
@@ -836,10 +848,42 @@
       "name": "netweaverAvailability"
     },
     {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "crossComponentResources": [
+          "{Workspace}"
+        ],
+        "parameters": [
+          {
+            "id": "e050e49f-0732-4d78-9716-807f15a8a820",
+            "version": "KqlParameterItem/1.0",
+            "name": "param_database",
+            "type": 1,
+            "query": "SapHana_size01_CL\r\n| where TimeGenerated > ago(1d)\r\n| where PROVIDER_INSTANCE_s =~ \"{selProvider}\"\r\n| order by Time_Generated_t desc\r\n| take 1\r\n| project DATABASE_NAME_s",
+            "crossComponentResources": [
+              "{Workspace}"
+            ],
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          }
+        ],
+        "style": "pills",
+        "queryType": 0,
+        "resourceType": "microsoft.operationalinsights/workspaces"
+      },
+      "conditionalVisibility": {
+        "parameterName": "hidden",
+        "comparison": "isEqualTo",
+        "value": "true"
+      },
+      "name": "parameters - 14"
+    },
+    {
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let startTime = todatetime(\"{StartTime}\");\r\nlet endTime = todatetime(\"{EndTime}\");\r\n\r\nlet bin = tolong(\"{MinutesBin}\");\r\nlet binSize=iff(bin < 60, 60m, bin*1m);\r\nlet hundredBin=datetime_diff(\"hour\", endTime, startTime);\r\n\r\nlet ParentAvailTable=SapHana_SystemOverview_CL \r\n| extend sid = tostring(VALUE_s)\r\n| extend provider = tostring(PROVIDER_INSTANCE_s)\r\n| where provider == \"{selProvider}\"\r\n| where NAME_s == \"Instance ID\" and sid == \"{SID}\"\r\n| distinct SID_s = sid, PROVIDER_INSTANCE_s=provider\r\n| join kind=inner (SapHana_SystemAvailability_CL\r\n    | where Time_Generated_t between (startTime .. endTime)\r\n    ) on PROVIDER_INSTANCE_s\r\n| project-away DATABASE_NAME_s\r\n| join kind=inner (SapHana_size01_CL \r\n    | where SYSTEM_ID_s == \"{SID}\"\r\n    | distinct PROVIDER_INSTANCE_s, DATABASE_NAME_s\r\n    ) on PROVIDER_INSTANCE_s\r\n| project DATABASE_NAME_s, PORT_d, SERVICE_NAME_s, SERVICE_ACTIVE_s, HOST_s, HOST_ACTIVE_s, Time_Generated_t, SID_s\r\n| where HOST_s==\"{VM:name}\";\r\n\r\nunion(ParentAvailTable\r\n| make-series AvailabilityTrend=iff(count() > 0, round(toreal(countif(HOST_ACTIVE_s == 'YES')) / toreal(count()) * 100, 1), real(null)) default=real(null) on Time_Generated_t step binSize  by HOST_s, DATABASE_NAME_s\r\n| project Availability=round(toreal(series_stats_dynamic(series_fill_const(AvailabilityTrend, 0.0)).avg), 1), HOST_s, DATABASE_NAME_s \r\n| join kind=inner (\r\n    ParentAvailTable\r\n        | make-series AvailabilityTrend=iff(count() > 0, round(toreal(countif(HOST_ACTIVE_s == 'YES')) / toreal(count()) * 100, 1), real(null)) default=real(null) on Time_Generated_t step iff(hundredBin<100, 1h, hundredBin/100*1h) by HOST_s, DATABASE_NAME_s\r\n        | project AvailabilityTrend=series_fill_const(AvailabilityTrend, 0.0), HOST_s, DATABASE_NAME_s\r\n) on HOST_s, DATABASE_NAME_s\r\n| join kind=inner (\r\n    COMMON_VM_ArmId_Mapping_CL\r\n    | where (isempty(sid_s) or sid_s==\"{SID}\") and \"{Provider}\" contains PROVIDER_INSTANCE_s\r\n    | distinct VM_ARM_ID_s=tolower(VM_ARM_ID_s), vm_name_s) on $left.HOST_s==$right.vm_name_s\r\n| project description_s=DATABASE_NAME_s, VM_ARM_ID_s, Availability, AvailabilityTrend\r\n| where VM_ARM_ID_s=~\"{VM}\"\r\n| extend SID_s = \"{SID}\"\r\n| extend display_s=description_s, parentid=\"\", id=description_s, Service=\"\"),\r\n(ParentAvailTable\r\n| where isnotempty(SERVICE_NAME_s)\r\n| extend Service=strcat(SERVICE_NAME_s, \" (:\", toint(PORT_d), \")\")\r\n| make-series AvailabilityTrend=iff(count() > 0, round(toreal(countif(SERVICE_ACTIVE_s == 'YES')) / toreal(count()) * 100, 1), real(null)) default=real(null) on Time_Generated_t step binSize  by HOST_s, DATABASE_NAME_s, Service\r\n| project Availability=round(toreal(series_stats_dynamic(series_fill_const(AvailabilityTrend, 0.0)).avg), 1), HOST_s, DATABASE_NAME_s, Service \r\n| join kind=inner (\r\n    ParentAvailTable\r\n        | where isnotempty(SERVICE_NAME_s)\r\n        | extend Service=strcat(SERVICE_NAME_s, \" (:\", toint(PORT_d), \")\")\r\n        | make-series AvailabilityTrend=iff(count() > 0, round(toreal(countif(SERVICE_ACTIVE_s == 'YES')) / toreal(count()) * 100, 1), real(null)) default=real(null) on Time_Generated_t step iff(hundredBin<100, 1h, hundredBin/100*1h) by HOST_s, DATABASE_NAME_s, Service\r\n        | project AvailabilityTrend=series_fill_const(AvailabilityTrend, 0.0), HOST_s, DATABASE_NAME_s, Service\r\n) on HOST_s, DATABASE_NAME_s, Service\r\n| join kind=inner (\r\n    COMMON_VM_ArmId_Mapping_CL\r\n    | where (isempty(sid_s) or sid_s==\"{SID}\") and \"{Provider}\" contains PROVIDER_INSTANCE_s\r\n    | distinct VM_ARM_ID_s=tolower(VM_ARM_ID_s), vm_name_s) on $left.HOST_s==$right.vm_name_s\r\n| project description_s=DATABASE_NAME_s, Service, VM_ARM_ID_s, Availability, AvailabilityTrend\r\n| where VM_ARM_ID_s=~\"{VM}\"\r\n| extend SID_s = \"{SID}\"\r\n| extend display_s=Service\r\n| extend parentid=description_s\r\n| extend id=strcat(parentid,\"_\",Service))\r\n| project id, parentid, description_s, Service, VM_ARM_ID_s, SID_s, Availability, AvailabilityTrend, display_s, Action=\"SAP metric\", Action2=\"VM metric\"",
+        "query": "let startTime = todatetime(\"{StartTime}\");\r\nlet endTime = todatetime(\"{EndTime}\");\r\n\r\nlet bin = tolong(\"{MinutesBin}\");\r\nlet binSize=iff(bin < 60, 60m, bin*1m);\r\nlet hundredBin=datetime_diff(\"hour\", endTime, startTime);\r\n\r\nlet availability_table = SapHana_SystemAvailability_CL\r\n| where Time_Generated_t between (startTime .. endTime)\r\n| where PROVIDER_INSTANCE_s =~ \"{selProvider}\"\r\n| where HOST_s =~ \"{selVmName}\"\r\n| where SERVICE_NAME_s != \"\"\r\n| where DATABASE_NAME_s == \"{param_database}\"\r\n| extend service_event = iff(SERVICE_NAME_s == '', EVENT_NAME_s, SERVICE_NAME_s)\r\n| extend Status = case(SERVICE_ACTIVE_s == 'YES', 0,\r\n                       SERVICE_ACTIVE_s == 'STARTING', 1,\r\n                       SERVICE_ACTIVE_s == 'STOPPING', 2,                        \r\n                       SERVICE_ACTIVE_s == 'UNKNOWN', 3,\r\n                       4) //NO\r\n| project service_event, SERVICE_NAME_s, SERVICE_ACTIVE_s, Status, HOST_s, HOST_STATUS_s, HOST_ACTIVE_s, PORT_d, TimeGenerated, PROVIDER_INSTANCE_s, DATABASE_NAME_s\r\n;\r\nlet services_table = SapHana_Services_CL\r\n| where TimeGenerated > ago(24h)\r\n| where PROVIDER_INSTANCE_s =~ \"{selProvider}\"\r\n| where HOST_s =~ \"{selVmName}\"\r\n| extend Status = case(ACTIVE_STATUS_s == 'YES', 0,\r\n                       ACTIVE_STATUS_s == 'STARTING', 1,\r\n                       ACTIVE_STATUS_s == 'STOPPING', 2,                        \r\n                       ACTIVE_STATUS_s == 'UNKNOWN', 3,\r\n                       4) //NO\r\n| project SERVICE_NAME_s, HOST_s, PORT_d, Status, ACTIVE_STATUS_s, TimeGenerated, PROVIDER_INSTANCE_s\r\n;\r\nlet finalTable = availability_table\r\n| union services_table\r\n| summarize total=count(), failureCount=countif(Status != 0) by service_event, SERVICE_NAME_s, HOST_s, PORT_d, SERVICE_ACTIVE_s, PROVIDER_INSTANCE_s\r\n| extend Availability = round(((toreal(total) - toreal(failureCount)) / toreal(total)) * 100, 2)\r\n| summarize Availability = round(avg(Availability), 2), AvailabilityTrend = make_list(Availability) by PORT_d, SERVICE_NAME_s, HOST_s, PROVIDER_INSTANCE_s\r\n| extend Database = \"{param_database}\", id=strcat(HOST_s, \"_\", SERVICE_NAME_s), Action = \"\", Action2 = \"\", parentid=HOST_s\r\n;\r\nunion(finalTable),\r\n(finalTable\r\n| distinct HOST_s\r\n| extend id=HOST_s, Action = \"View\", Action2 = \"View\", Display=HOST_s)",
         "size": 3,
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
@@ -849,31 +893,7 @@
         "gridSettings": {
           "formatters": [
             {
-              "columnMatch": "id",
-              "formatter": 5
-            },
-            {
-              "columnMatch": "parentid",
-              "formatter": 5
-            },
-            {
-              "columnMatch": "description_s",
-              "formatter": 5
-            },
-            {
-              "columnMatch": "Service",
-              "formatter": 5
-            },
-            {
-              "columnMatch": "VM_ARM_ID_s",
-              "formatter": 13,
-              "formatOptions": {
-                "linkTarget": "Resource",
-                "showIcon": true
-              }
-            },
-            {
-              "columnMatch": "SID_s",
+              "columnMatch": "HOST_s",
               "formatter": 5
             },
             {
@@ -882,6 +902,11 @@
               "formatOptions": {
                 "thresholdsOptions": "icons",
                 "thresholdsGrid": [
+                  {
+                    "operator": "is Empty",
+                    "representation": "Blank",
+                    "text": "{0}{1}"
+                  },
                   {
                     "operator": "<",
                     "thresholdValue": "50",
@@ -918,8 +943,12 @@
               }
             },
             {
-              "columnMatch": "display_s",
-              "formatter": 1
+              "columnMatch": "Database",
+              "formatter": 5
+            },
+            {
+              "columnMatch": "id",
+              "formatter": 5
             },
             {
               "columnMatch": "Action",
@@ -949,14 +978,9 @@
                       "value": "TimePeriod"
                     },
                     {
-                      "name": "VMID",
+                      "name": "selProvider",
                       "source": "parameter",
-                      "value": "VMID"
-                    },
-                    {
-                      "name": "Provider",
-                      "source": "parameter",
-                      "value": "Provider"
+                      "value": "selProvider"
                     },
                     {
                       "name": "SAPComponent",
@@ -976,7 +1000,7 @@
                     {
                       "name": "Database",
                       "source": "column",
-                      "value": "description_s"
+                      "value": "Database"
                     },
                     {
                       "name": "TimeRange",
@@ -991,9 +1015,15 @@
                     {
                       "name": "Service",
                       "source": "column",
-                      "value": "Service"
+                      "value": "SERVICE_NAME_s"
+                    },
+                    {
+                      "name": "selVmName",
+                      "source": "parameter",
+                      "value": "selVmName"
                     }
-                  ]
+                  ],
+                  "viewerMode": false
                 }
               }
             },
@@ -1025,14 +1055,9 @@
                       "value": "TimePeriod"
                     },
                     {
-                      "name": "VMID",
+                      "name": "selProvider",
                       "source": "parameter",
-                      "value": "VMID"
-                    },
-                    {
-                      "name": "Provider",
-                      "source": "parameter",
-                      "value": "Provider"
+                      "value": "selProvider"
                     },
                     {
                       "name": "SAPComponent",
@@ -1052,7 +1077,7 @@
                     {
                       "name": "Database",
                       "source": "column",
-                      "value": "description_s"
+                      "value": "Database"
                     },
                     {
                       "name": "TimeRange",
@@ -1069,9 +1094,38 @@
                       "source": "column",
                       "value": "Service"
                     }
-                  ]
+                  ],
+                  "viewerMode": false
                 }
               }
+            },
+            {
+              "columnMatch": "parentid",
+              "formatter": 5
+            },
+            {
+              "columnMatch": "description_s",
+              "formatter": 5
+            },
+            {
+              "columnMatch": "Service",
+              "formatter": 5
+            },
+            {
+              "columnMatch": "VM_ARM_ID_s",
+              "formatter": 13,
+              "formatOptions": {
+                "linkTarget": "Resource",
+                "showIcon": true
+              }
+            },
+            {
+              "columnMatch": "SID_s",
+              "formatter": 5
+            },
+            {
+              "columnMatch": "display_s",
+              "formatter": 1
             },
             {
               "columnMatch": "hostname_s",
@@ -1128,21 +1182,10 @@
             "idColumn": "id",
             "parentColumn": "parentid",
             "treeType": 0,
-            "expanderColumn": "display_s"
+            "expanderColumn": "Display",
+            "expandTopLevel": true
           },
           "labelSettings": [
-            {
-              "columnId": "description_s",
-              "label": "Process"
-            },
-            {
-              "columnId": "VM_ARM_ID_s",
-              "label": "VM Name"
-            },
-            {
-              "columnId": "SID_s",
-              "label": "SID"
-            },
             {
               "columnId": "Availability",
               "label": "Process Availability"
@@ -1152,12 +1195,12 @@
               "label": "Availability Trend"
             },
             {
-              "columnId": "display_s",
-              "label": "Database / Service"
+              "columnId": "Action",
+              "label": "SAP Metric"
             },
             {
               "columnId": "Action2",
-              "label": " "
+              "label": " VM Metric"
             }
           ]
         }
@@ -1238,7 +1281,7 @@
             "name": "Database",
             "type": 2,
             "isRequired": true,
-            "query": "SapHana_size01_CL \r\n| where SYSTEM_ID_s == \"{SID}\"\r\n| where \"{Provider}\" contains PROVIDER_INSTANCE_s\r\n| distinct DATABASE_NAME_s",
+            "query": "SapHana_size01_CL \r\n| where SYSTEM_ID_s == \"{SID}\"\r\n| where PROVIDER_INSTANCE_s =~ \"{selProvider}\"\r\n| distinct DATABASE_NAME_s",
             "crossComponentResources": [
               "{Workspace}"
             ],
@@ -1261,7 +1304,7 @@
             "multiSelect": true,
             "quote": "",
             "delimiter": ",",
-            "query": "let startTime = todatetime(\"{StartTime}\");\r\nlet endTime = todatetime(\"{EndTime}\");\r\n\r\nSapHana_SystemOverview_CL \r\n| extend sid = tostring(VALUE_s)\r\n| extend provider = tostring(PROVIDER_INSTANCE_s)\r\n| where \"{Provider}\" contains provider\r\n| where NAME_s == \"Instance ID\" and sid == \"{SID}\"\r\n| distinct SID_s = sid, PROVIDER_INSTANCE_s=provider\r\n| join kind=inner (SapHana_SystemAvailability_CL\r\n    | where Time_Generated_t between (startTime .. endTime)\r\n    | where \"{Provider}\" contains PROVIDER_INSTANCE_s and HOST_s==\"{VM:name}\"\r\n) on PROVIDER_INSTANCE_s\r\n| where DATABASE_NAME_s==\"{Database}\"\r\n| extend Service=strcat(SERVICE_NAME_s, \" (:\", toint(PORT_d), \")\")\r\n| distinct Service",
+            "query": "let startTime = todatetime(\"{StartTime}\");\r\nlet endTime = todatetime(\"{EndTime}\");\r\n\r\nSapHana_SystemOverview_CL \r\n| extend sid = tostring(VALUE_s)\r\n| extend provider = tostring(PROVIDER_INSTANCE_s)\r\n| where provider =~ \"{selProvider}\"\r\n| where NAME_s == \"Instance ID\" and sid == \"{SID}\"\r\n| distinct SID_s = sid, PROVIDER_INSTANCE_s=provider\r\n| join kind=inner (SapHana_SystemAvailability_CL\r\n    | where Time_Generated_t between (startTime .. endTime)\r\n    | where PROVIDER_INSTANCE_s =~ \"{selProvider}\"\r\n) on PROVIDER_INSTANCE_s\r\n| where DATABASE_NAME_s=~\"{Database}\"\r\n| extend Service=strcat(SERVICE_NAME_s, \" (:\", toint(PORT_d), \")\")\r\n| distinct Service",
             "crossComponentResources": [
               "{Workspace}"
             ],
@@ -1370,7 +1413,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "let startTime = todatetime(\"{StartTime}\");\r\nlet endTime = todatetime(\"{EndTime}\");\r\n\r\nlet bin = tolong(\"{MinutesBin}\");\r\nlet binSize=iff(bin < 60, 60, bin*1);\r\n\r\nlet insightsTable=SapHana_SystemOverview_CL \r\n| extend sid = tostring(VALUE_s)\r\n| extend provider = tostring(PROVIDER_INSTANCE_s)\r\n| where \"{Provider}\" contains provider\r\n| where NAME_s == \"Instance ID\" and sid == \"{SID}\"\r\n| distinct SID_s = sid, PROVIDER_INSTANCE_s=provider\r\n| join kind=inner (SapHana_LoadHistory_CL\r\n    | where Time_Generated_t between (startTime .. endTime) and \"{Provider}\" contains PROVIDER_INSTANCE_s and HOST_s==\"{VM:name}\"\r\n) on PROVIDER_INSTANCE_s\r\n| join kind=inner (SapHana_size01_CL \r\n    | where SYSTEM_ID_s == \"{SID}\"\r\n    | distinct PROVIDER_INSTANCE_s, DATABASE_NAME_s\r\n    ) on PROVIDER_INSTANCE_s\r\n| where DATABASE_NAME_s==\"{Database}\";\r\n\r\nunion \r\n(insightsTable\r\n| make-series Trend=round(max(MEMORY_USED_d / MEMORY_SIZE_d * 100), 1) default=real(null) on Time_Generated_t step binSize*1m\r\n| project Value=todouble(series_stats_dynamic(Trend)['max']), Trend, Type=\"Highest Memory Usage\", Order = 1),\r\n(insightsTable\r\n| make-series Trend=round(max(CPU_d), 1) default=real(null) on Time_Generated_t step binSize*1m\r\n| project Value=todouble(series_stats_dynamic(Trend)['max']), Trend, Type=\"Highest CPU Usage\", Order = 2),\r\n(insightsTable\r\n| make-series Trend=round(avg(MEMORY_USED_d / MEMORY_SIZE_d * 100), 1) default=real(null) on Time_Generated_t step binSize*1m\r\n| project Value=todouble(series_stats_dynamic(Trend)['avg']), Trend, Type=\"Average Memory Usage\", Order = 3),\r\n(insightsTable\r\n| make-series Trend=round(avg(CPU_d), 1) default=real(null) on Time_Generated_t step binSize*1m\r\n| project Value=todouble(series_stats_dynamic(Trend)['avg']), Trend, Type=\"Average CPU Usage\", Order = 4)\r\n\r\n",
+              "query": "let startTime = todatetime(\"{StartTime}\");\r\nlet endTime = todatetime(\"{EndTime}\");\r\n\r\nlet bin = tolong(\"{MinutesBin}\");\r\nlet binSize=iff(bin < 60, 60, bin*1);\r\n\r\nlet insightsTable=SapHana_SystemOverview_CL \r\n| extend sid = tostring(VALUE_s)\r\n| extend provider = tostring(PROVIDER_INSTANCE_s)\r\n| where provider =~ \"{selProvider}\"\r\n| where NAME_s == \"Instance ID\" and sid == \"{SID}\"\r\n| distinct SID_s = sid, PROVIDER_INSTANCE_s=provider\r\n| join kind=inner (SapHana_LoadHistory_CL\r\n    | where Time_Generated_t between (startTime .. endTime) and PROVIDER_INSTANCE_s =~ \"{selProvider}\"\r\n) on PROVIDER_INSTANCE_s\r\n| join kind=inner (SapHana_size01_CL \r\n    | where SYSTEM_ID_s == \"{SID}\"\r\n    | distinct PROVIDER_INSTANCE_s, DATABASE_NAME_s\r\n    ) on PROVIDER_INSTANCE_s\r\n| where DATABASE_NAME_s==\"{Database}\";\r\n\r\nunion \r\n(insightsTable\r\n| make-series Trend=round(max(MEMORY_USED_d / MEMORY_SIZE_d * 100), 1) default=real(null) on Time_Generated_t step binSize*1m\r\n| project Value=todouble(series_stats_dynamic(Trend)['max']), Trend, Type=\"Highest Memory Usage\", Order = 1),\r\n(insightsTable\r\n| make-series Trend=round(max(CPU_d), 1) default=real(null) on Time_Generated_t step binSize*1m\r\n| project Value=todouble(series_stats_dynamic(Trend)['max']), Trend, Type=\"Highest CPU Usage\", Order = 2),\r\n(insightsTable\r\n| make-series Trend=round(avg(MEMORY_USED_d / MEMORY_SIZE_d * 100), 1) default=real(null) on Time_Generated_t step binSize*1m\r\n| project Value=todouble(series_stats_dynamic(Trend)['avg']), Trend, Type=\"Average Memory Usage\", Order = 3),\r\n(insightsTable\r\n| make-series Trend=round(avg(CPU_d), 1) default=real(null) on Time_Generated_t step binSize*1m\r\n| project Value=todouble(series_stats_dynamic(Trend)['avg']), Trend, Type=\"Average CPU Usage\", Order = 4)\r\n\r\n",
               "size": 3,
               "title": "{Database} Server Load",
               "queryType": 0,
@@ -1451,7 +1494,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "let startTime = todatetime(\"{StartTime}\");\r\nlet endTime = todatetime(\"{EndTime}\");\r\n\r\nlet bin = tolong(\"{MinutesBin}\");\r\nlet binSize=iff(bin < 60, 60, bin*1);\r\n\r\nlet disksData = SapHana_SystemOverview_CL \r\n| extend sid = tostring(VALUE_s)\r\n| extend provider = tostring(PROVIDER_INSTANCE_s)\r\n| where \"{Provider}\" contains provider\r\n| where NAME_s == \"Instance ID\" and sid == \"{SID}\"\r\n| distinct SID_s = sid, PROVIDER_INSTANCE_s=provider\r\n| join kind=inner (SapHana_Disks_CL\r\n    | where Time_Generated_t between (startTime .. endTime) and \"{Provider}\" contains PROVIDER_INSTANCE_s and HOST_s==\"{VM:name}\"\r\n) on PROVIDER_INSTANCE_s\r\n| join kind=inner (SapHana_size01_CL \r\n    | where SYSTEM_ID_s == \"{SID}\"\r\n    | distinct PROVIDER_INSTANCE_s, DATABASE_NAME_s\r\n    ) on PROVIDER_INSTANCE_s\r\n| where DATABASE_NAME_s==\"{Database}\" and USAGE_TYPE_s !has \"LOG\";\r\n\r\nunion\r\n(disksData\r\n| summarize Value=round(max(toreal(USED_SIZE_d)/toreal(TOTAL_SIZE_d)*100), 1)\r\n| extend Type=\"Used\"),\r\n(disksData\r\n| summarize Value=round(100 - max(toreal(USED_SIZE_d)/toreal(TOTAL_SIZE_d)*100), 1)\r\n| extend Type=\"Free\")\r\n\r\n",
+              "query": "let startTime = todatetime(\"{StartTime}\");\r\nlet endTime = todatetime(\"{EndTime}\");\r\n\r\nlet bin = tolong(\"{MinutesBin}\");\r\nlet binSize=iff(bin < 60, 60, bin*1);\r\n\r\nlet disksData = SapHana_SystemOverview_CL \r\n| extend sid = tostring(VALUE_s)\r\n| extend provider = tostring(PROVIDER_INSTANCE_s)\r\n| where provider == \"{selProvider}\"\r\n| where NAME_s == \"Instance ID\" and sid == \"{SID}\"\r\n| distinct SID_s = sid, PROVIDER_INSTANCE_s=provider\r\n| join kind=inner (SapHana_Disks_CL\r\n    | where Time_Generated_t between (startTime .. endTime) and PROVIDER_INSTANCE_s == \"{selProvider}\"\r\n) on PROVIDER_INSTANCE_s\r\n| join kind=inner (SapHana_size01_CL \r\n    | where SYSTEM_ID_s == \"{SID}\"\r\n    | distinct PROVIDER_INSTANCE_s, DATABASE_NAME_s\r\n    ) on PROVIDER_INSTANCE_s\r\n| where DATABASE_NAME_s==\"{Database}\" and USAGE_TYPE_s !has \"LOG\";\r\n\r\nunion\r\n(disksData\r\n| summarize Value=round(max(toreal(USED_SIZE_d)/toreal(TOTAL_SIZE_d)*100), 1)\r\n| extend Type=\"Used\"),\r\n(disksData\r\n| summarize Value=round(100 - max(toreal(USED_SIZE_d)/toreal(TOTAL_SIZE_d)*100), 1)\r\n| extend Type=\"Free\")\r\n\r\n",
               "size": 1,
               "title": "Disk Usage",
               "queryType": 0,
@@ -1548,7 +1591,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "let startTime = todatetime(\"{StartTime}\");\r\nlet endTime = todatetime(\"{EndTime}\");\r\n\r\nlet bin = tolong(\"{MinutesBin}\");\r\nlet binSize=iff(bin < 60, 60, bin*1);\r\n\r\nlet services=split(\"{Service}\", \",\");\r\n\r\nlet service_name=iff(isnotempty(\"{Service}\"), tostring(split(\"{Service}\", \" (:\")[0]), \"\");\r\nlet service_port=iff(isnotempty(\"{Service}\"), replace_string(tostring(split(\"{Service}\", \" (:\")[1]), \")\", \"\"), \"\");\r\n\r\nlet insightsTable=SapHana_SystemOverview_CL \r\n| extend sid = tostring(VALUE_s)\r\n| extend provider = tostring(PROVIDER_INSTANCE_s)\r\n| where \"{Provider}\" contains provider\r\n| where NAME_s == \"Instance ID\" and sid == \"{SID}\"\r\n| distinct SID_s = sid, PROVIDER_INSTANCE_s=provider\r\n| join kind=inner (SapHana_LoadHistory_CL\r\n    | where Time_Generated_t between (startTime .. endTime) and \"{Provider}\" contains PROVIDER_INSTANCE_s and HOST_s==\"{VM:name}\"\r\n) on PROVIDER_INSTANCE_s\r\n| join kind=inner (SapHana_size01_CL \r\n    | where SYSTEM_ID_s == \"{SID}\"\r\n    | distinct PROVIDER_INSTANCE_s, DATABASE_NAME_s\r\n    ) on PROVIDER_INSTANCE_s\r\n| where DATABASE_NAME_s==\"{Database}\";\r\n\r\nunion \r\n(SapHana_SystemOverview_CL \r\n| extend sid = tostring(VALUE_s)\r\n| extend provider = tostring(PROVIDER_INSTANCE_s)\r\n| where \"{Provider}\" contains provider\r\n| where NAME_s == \"Instance ID\" and sid == \"{SID}\"\r\n| distinct SID_s = sid, PROVIDER_INSTANCE_s=provider\r\n| join kind=inner (SapHana_SystemAvailability_CL\r\n    | where Time_Generated_t between (startTime .. endTime) and \"{Provider}\" contains PROVIDER_INSTANCE_s and HOST_s==\"{VM:name}\"\r\n) on PROVIDER_INSTANCE_s\r\n| project-away DATABASE_NAME_s\r\n| join kind=inner (SapHana_size01_CL \r\n    | where SYSTEM_ID_s == \"{SID}\"\r\n    | distinct PROVIDER_INSTANCE_s, DATABASE_NAME_s\r\n    ) on PROVIDER_INSTANCE_s\r\n| where DATABASE_NAME_s==\"{Database}\"\r\n| project DATABASE_NAME_s, SID_s=\"{SID}\", HOST_s, HOST_ACTIVE_s, TimeGenerated=Time_Generated_t\r\n| make-series AvailabilityTrend=round(iff(count() > 0, toreal(countif(HOST_ACTIVE_s == 'YES')) / toreal(count()) * 100, real(null)), 1) default=real(null) on TimeGenerated step binSize*1m\r\n| project Value=strcat(round(toreal(series_stats_dynamic(series_fill_const(AvailabilityTrend, 0.0)).avg), 1), \"%\"), Type=\"{Database} Availability\", Order = 1),\r\n(SapHana_SystemOverview_CL \r\n| extend sid = tostring(VALUE_s)\r\n| extend provider = tostring(PROVIDER_INSTANCE_s)\r\n| where \"{Provider}\" contains provider\r\n| where NAME_s == \"Instance ID\" and sid == \"{SID}\"\r\n| distinct SID_s = sid, PROVIDER_INSTANCE_s=provider\r\n| mv-expand bagexpansion=array Service=services to typeof(string)\r\n| extend service_name=iff(isnotempty(Service), tostring(split(Service, \" (:\")[0]), \"\"), service_port=toreal(iff(isnotempty(Service), replace_string(tostring(split(Service, \" (:\")[1]), \")\", \"\"), \"\"))\r\n| join kind=inner (SapHana_SystemAvailability_CL\r\n    | where Time_Generated_t between (startTime .. endTime) and \"{Provider}\" contains PROVIDER_INSTANCE_s and HOST_s==\"{VM:name}\"\r\n) on PROVIDER_INSTANCE_s, $right.SERVICE_NAME_s==$left.service_name and $right.PORT_d==$left.service_port\r\n| project-away DATABASE_NAME_s\r\n| join kind=inner (SapHana_size01_CL \r\n    | where SYSTEM_ID_s == \"{SID}\"\r\n    | distinct PROVIDER_INSTANCE_s, DATABASE_NAME_s\r\n    ) on PROVIDER_INSTANCE_s\r\n| where DATABASE_NAME_s==\"{Database}\"\r\n| project DATABASE_NAME_s, SID_s=\"{SID}\", HOST_s, SERVICE_ACTIVE_s, TimeGenerated=Time_Generated_t, Service\r\n| make-series AvailabilityTrend=round(iff(count() > 0, toreal(countif(SERVICE_ACTIVE_s == 'YES')) / toreal(count()) * 100, real(null)), 1) default=real(null) on TimeGenerated step binSize*1m by Service\r\n| project Value=strcat(round(toreal(series_stats_dynamic(series_fill_const(AvailabilityTrend, 0.0)).avg), 1), \"%\"), Type=strcat(Service, \" Availability\"), Order = 2),\r\n(SapHana_License_Status_CL\r\n| where Time_Generated_t between (startTime .. endTime) and SID_s==\"{SID}\" and \"{Provider}\" contains PROVIDER_INSTANCE_s and HOSTNAME_s==\"{VM:name}\"\r\n| top 1 by Time_Generated_t desc\r\n| project VALID_s\r\n| extend Value=iff(VALID_s=~\"True\", \"VALID\", \"INVALID\"), Type=\"License Status\", Order = 3\r\n| project-away VALID_s)\r\n\r\n",
+              "query": "let startTime = todatetime(\"{StartTime}\");\r\nlet endTime = todatetime(\"{EndTime}\");\r\n\r\nlet bin = tolong(\"{MinutesBin}\");\r\nlet binSize=iff(bin < 60, 60, bin*1);\r\n\r\nlet services=split(\"{Service}\", \",\");\r\n\r\nlet service_name=iff(isnotempty(\"{Service}\"), tostring(split(\"{Service}\", \" (:\")[0]), \"\");\r\nlet service_port=iff(isnotempty(\"{Service}\"), replace_string(tostring(split(\"{Service}\", \" (:\")[1]), \")\", \"\"), \"\");\r\n\r\nlet insightsTable=SapHana_SystemOverview_CL \r\n| extend sid = tostring(VALUE_s)\r\n| extend provider = tostring(PROVIDER_INSTANCE_s)\r\n| where provider == \"{selProvider}\"\r\n| where NAME_s == \"Instance ID\" and sid == \"{SID}\"\r\n| distinct SID_s = sid, PROVIDER_INSTANCE_s=provider\r\n| join kind=inner (SapHana_LoadHistory_CL\r\n    | where Time_Generated_t between (startTime .. endTime) and PROVIDER_INSTANCE_s == \"{selProvider}\"\r\n) on PROVIDER_INSTANCE_s\r\n| join kind=inner (SapHana_size01_CL \r\n    | where SYSTEM_ID_s == \"{SID}\"\r\n    | distinct PROVIDER_INSTANCE_s, DATABASE_NAME_s\r\n    ) on PROVIDER_INSTANCE_s\r\n| where DATABASE_NAME_s==\"{Database}\";\r\n\r\nunion \r\n(SapHana_SystemOverview_CL \r\n| extend sid = tostring(VALUE_s)\r\n| extend provider = tostring(PROVIDER_INSTANCE_s)\r\n| where provider =~ \"{selProvider}\"\r\n| where NAME_s == \"Instance ID\" and sid == \"{SID}\"\r\n| distinct SID_s = sid, PROVIDER_INSTANCE_s=provider\r\n| join kind=inner (SapHana_SystemAvailability_CL\r\n    | where Time_Generated_t between (startTime .. endTime) and PROVIDER_INSTANCE_s =~ \"{selProvider}\"\r\n) on PROVIDER_INSTANCE_s\r\n| project-away DATABASE_NAME_s\r\n| join kind=inner (SapHana_size01_CL \r\n    | where SYSTEM_ID_s == \"{SID}\"\r\n    | distinct PROVIDER_INSTANCE_s, DATABASE_NAME_s\r\n    ) on PROVIDER_INSTANCE_s\r\n| where DATABASE_NAME_s==\"{Database}\"\r\n| project DATABASE_NAME_s, SID_s=\"{SID}\", HOST_s, HOST_ACTIVE_s, TimeGenerated=Time_Generated_t\r\n| make-series AvailabilityTrend=round(iff(count() > 0, toreal(countif(HOST_ACTIVE_s == 'YES')) / toreal(count()) * 100, real(null)), 1) default=real(null) on TimeGenerated step binSize*1m\r\n| project Value=strcat(round(toreal(series_stats_dynamic(series_fill_const(AvailabilityTrend, 0.0)).avg), 1), \"%\"), Type=\"{Database} Availability\", Order = 1),\r\n(SapHana_SystemOverview_CL \r\n| extend sid = tostring(VALUE_s)\r\n| extend provider = tostring(PROVIDER_INSTANCE_s)\r\n| where provider =~ \"{selProvider}\"\r\n| where NAME_s == \"Instance ID\" and sid == \"{SID}\"\r\n| distinct SID_s = sid, PROVIDER_INSTANCE_s=provider\r\n| mv-expand bagexpansion=array Service=services to typeof(string)\r\n| extend service_name=iff(isnotempty(Service), tostring(split(Service, \" (:\")[0]), \"\"), service_port=toreal(iff(isnotempty(Service), replace_string(tostring(split(Service, \" (:\")[1]), \")\", \"\"), \"\"))\r\n| join kind=inner (SapHana_SystemAvailability_CL\r\n    | where Time_Generated_t between (startTime .. endTime) and PROVIDER_INSTANCE_s =~ \"{selProvider}\"\r\n) on PROVIDER_INSTANCE_s, $right.SERVICE_NAME_s==$left.service_name and $right.PORT_d==$left.service_port\r\n| project-away DATABASE_NAME_s\r\n| join kind=inner (SapHana_size01_CL \r\n    | where SYSTEM_ID_s == \"{SID}\"\r\n    | distinct PROVIDER_INSTANCE_s, DATABASE_NAME_s\r\n    ) on PROVIDER_INSTANCE_s\r\n| where DATABASE_NAME_s==\"{Database}\"\r\n| project DATABASE_NAME_s, SID_s=\"{SID}\", HOST_s, SERVICE_ACTIVE_s, TimeGenerated=Time_Generated_t, Service\r\n| make-series AvailabilityTrend=round(iff(count() > 0, toreal(countif(SERVICE_ACTIVE_s == 'YES')) / toreal(count()) * 100, real(null)), 1) default=real(null) on TimeGenerated step binSize*1m by Service\r\n| project Value=strcat(round(toreal(series_stats_dynamic(series_fill_const(AvailabilityTrend, 0.0)).avg), 1), \"%\"), Type=strcat(Service, \" Availability\"), Order = 2),\r\n(SapHana_License_Status_CL\r\n| where Time_Generated_t between (startTime .. endTime) and SID_s==\"{SID}\" and PROVIDER_INSTANCE_s =~ \"{selProvider}\"\r\n| top 1 by Time_Generated_t desc\r\n| project VALID_s\r\n| extend Value=iff(VALID_s=~\"True\", \"VALID\", \"INVALID\"), Type=\"License Status\", Order = 3\r\n| project-away VALID_s)\r\n\r\n",
               "size": 3,
               "title": "{Database} Server Details",
               "queryType": 0,
@@ -1625,7 +1668,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "let startTime = todatetime(\"{StartTime}\");\r\nlet endTime = todatetime(\"{EndTime}\");\r\n\r\nlet bin = tolong(\"{MinutesBin}\");\r\nlet binSize=iff(bin < 60, 60, bin*1);\r\n\r\nlet insightsTable=SapHana_SystemOverview_CL \r\n| extend sid = tostring(VALUE_s)\r\n| extend provider = tostring(PROVIDER_INSTANCE_s)\r\n| where \"{Provider}\" contains provider\r\n| where NAME_s == \"Instance ID\" and sid == \"{SID}\"\r\n| distinct SID_s = sid, PROVIDER_INSTANCE_s=provider\r\n| join kind=inner (SapHana_LoadHistory_CL\r\n    | where Time_Generated_t between (startTime .. endTime) and \"{Provider}\" contains PROVIDER_INSTANCE_s and HOST_s==\"{VM:name}\"\r\n) on PROVIDER_INSTANCE_s\r\n| join kind=inner (SapHana_size01_CL \r\n    | where SYSTEM_ID_s == \"{SID}\"\r\n    | distinct PROVIDER_INSTANCE_s, DATABASE_NAME_s\r\n    ) on PROVIDER_INSTANCE_s\r\n| where DATABASE_NAME_s==\"{Database}\";\r\n\r\nunion \r\n(SapHana_SystemOverview_CL \r\n| extend sid = tostring(VALUE_s)\r\n| extend provider = tostring(PROVIDER_INSTANCE_s)\r\n| where \"{Provider}\" contains provider\r\n| where NAME_s == \"Instance ID\" and sid == \"{SID}\"\r\n| distinct SID_s = sid, PROVIDER_INSTANCE_s=provider\r\n| join kind=inner (SapHana_SystemAvailability_CL\r\n    | where Time_Generated_t between (startTime .. endTime) and \"{Provider}\" contains PROVIDER_INSTANCE_s and HOST_s==\"{VM:name}\"\r\n) on PROVIDER_INSTANCE_s\r\n| project-away DATABASE_NAME_s\r\n| join kind=inner (SapHana_size01_CL \r\n    | where SYSTEM_ID_s == \"{SID}\"\r\n    | distinct PROVIDER_INSTANCE_s, DATABASE_NAME_s\r\n    ) on PROVIDER_INSTANCE_s\r\n| where DATABASE_NAME_s==\"{Database}\"\r\n| project DATABASE_NAME_s, SID_s=\"{SID}\", HOST_s, HOST_ACTIVE_s, TimeGenerated=Time_Generated_t\r\n| make-series AvailabilityTrend=round(iff(count() > 0, toreal(countif(HOST_ACTIVE_s == 'YES')) / toreal(count()) * 100, real(null)), 1) default=real(null) on TimeGenerated step binSize*1m\r\n| project Value=strcat(round(toreal(series_stats_dynamic(series_fill_const(AvailabilityTrend, 0.0)).avg), 1), \"%\"), Type=\"{Database} Availability\", Order = 2),\r\n(SapHana_License_Status_CL\r\n| where Time_Generated_t between (startTime .. endTime) and SID_s==\"{SID}\" and \"{Provider}\" contains PROVIDER_INSTANCE_s and HOSTNAME_s==\"{VM:name}\"\r\n| top 1 by Time_Generated_t desc\r\n| project VALID_s\r\n| extend Value=iff(VALID_s=~\"True\", \"VALID\", \"INVALID\"), Type=\"License Status\", Order = 3\r\n| project-away VALID_s)\r\n\r\n",
+              "query": "let startTime = todatetime(\"{StartTime}\");\r\nlet endTime = todatetime(\"{EndTime}\");\r\n\r\nlet bin = tolong(\"{MinutesBin}\");\r\nlet binSize=iff(bin < 60, 60, bin*1);\r\n\r\nlet insightsTable=SapHana_SystemOverview_CL \r\n| extend sid = tostring(VALUE_s)\r\n| extend provider = tostring(PROVIDER_INSTANCE_s)\r\n| where \"{Provider}\" contains provider\r\n| where NAME_s == \"Instance ID\" and sid == \"{SID}\"\r\n| distinct SID_s = sid, PROVIDER_INSTANCE_s=provider\r\n| join kind=inner (SapHana_LoadHistory_CL\r\n    | where Time_Generated_t between (startTime .. endTime) and \"{Provider}\" contains PROVIDER_INSTANCE_s\r\n) on PROVIDER_INSTANCE_s\r\n| join kind=inner (SapHana_size01_CL \r\n    | where SYSTEM_ID_s == \"{SID}\"\r\n    | distinct PROVIDER_INSTANCE_s, DATABASE_NAME_s\r\n    ) on PROVIDER_INSTANCE_s\r\n| where DATABASE_NAME_s==\"{Database}\";\r\n\r\nunion \r\n(SapHana_SystemOverview_CL \r\n| extend sid = tostring(VALUE_s)\r\n| extend provider = tostring(PROVIDER_INSTANCE_s)\r\n| where provider =~ \"{selProvider}\"\r\n| where NAME_s == \"Instance ID\" and sid == \"{SID}\"\r\n| distinct SID_s = sid, PROVIDER_INSTANCE_s=provider\r\n| join kind=inner (SapHana_SystemAvailability_CL\r\n    | where Time_Generated_t between (startTime .. endTime) and PROVIDER_INSTANCE_s =~ \"{selProvider}\"\r\n) on PROVIDER_INSTANCE_s\r\n| project-away DATABASE_NAME_s\r\n| join kind=inner (SapHana_size01_CL \r\n    | where SYSTEM_ID_s == \"{SID}\"\r\n    | distinct PROVIDER_INSTANCE_s, DATABASE_NAME_s\r\n    ) on PROVIDER_INSTANCE_s\r\n| where DATABASE_NAME_s==\"{Database}\"\r\n| project DATABASE_NAME_s, SID_s=\"{SID}\", HOST_s, HOST_ACTIVE_s, TimeGenerated=Time_Generated_t\r\n| make-series AvailabilityTrend=round(iff(count() > 0, toreal(countif(HOST_ACTIVE_s == 'YES')) / toreal(count()) * 100, real(null)), 1) default=real(null) on TimeGenerated step binSize*1m\r\n| project Value=strcat(round(toreal(series_stats_dynamic(series_fill_const(AvailabilityTrend, 0.0)).avg), 1), \"%\"), Type=\"{Database} Availability\", Order = 2),\r\n(SapHana_License_Status_CL\r\n| where Time_Generated_t between (startTime .. endTime) and SID_s==\"{SID}\" and PROVIDER_INSTANCE_s =~ \"{selProvider}\"\r\n| top 1 by Time_Generated_t desc\r\n| project VALID_s\r\n| extend Value=iff(VALID_s=~\"True\", \"VALID\", \"INVALID\"), Type=\"License Status\", Order = 3\r\n| project-away VALID_s)\r\n\r\n",
               "size": 3,
               "title": "{Database} Server Details",
               "queryType": 0,
@@ -1742,7 +1785,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "let startTime = todatetime(\"{StartTime}\");\r\nlet endTime = todatetime(\"{EndTime}\");\r\n\r\nlet bin = tolong(\"{MinutesBin}\");\r\nlet hundredBin=datetime_diff(\"hour\", endTime, startTime);\r\n\r\nSapHana_SystemOverview_CL \r\n| extend sid = tostring(VALUE_s)\r\n| extend provider = tostring(PROVIDER_INSTANCE_s)\r\n| where \"{Provider}\" contains provider\r\n| where NAME_s == \"Instance ID\" and sid == \"{SID}\"\r\n| distinct SID_s = sid, PROVIDER_INSTANCE_s=provider\r\n| join kind=inner (SapHana_SystemAvailability_CL\r\n    | where Time_Generated_t between (startTime .. endTime)\r\n    | where \"{Provider}\" contains PROVIDER_INSTANCE_s and HOST_s==\"{VM:name}\"\r\n) on PROVIDER_INSTANCE_s\r\n| project-away DATABASE_NAME_s\r\n| join kind=inner (SapHana_size01_CL \r\n    | where SYSTEM_ID_s == \"{SID}\"\r\n    | distinct PROVIDER_INSTANCE_s, DATABASE_NAME_s\r\n    ) on PROVIDER_INSTANCE_s\r\n| where DATABASE_NAME_s == \"{Database}\"\r\n| project HOST_ACTIVE_s, TimeGenerated=Time_Generated_t\r\n| summarize Availability=round(iff(count() > 0, toreal(countif(HOST_ACTIVE_s == 'YES')) / toreal(count()) * 100, real(null)), 1) by bin(TimeGenerated, iff(hundredBin<100, 1h, hundredBin/100*1h))",
+              "query": "let startTime = todatetime(\"{StartTime}\");\r\nlet endTime = todatetime(\"{EndTime}\");\r\n\r\nlet bin = tolong(\"{MinutesBin}\");\r\nlet hundredBin=datetime_diff(\"hour\", endTime, startTime);\r\n\r\nSapHana_SystemOverview_CL \r\n| extend sid = tostring(VALUE_s)\r\n| extend provider = tostring(PROVIDER_INSTANCE_s)\r\n| where provider =~ \"{selProvider}\"\r\n| where NAME_s == \"Instance ID\" and sid == \"{SID}\"\r\n| distinct SID_s = sid, PROVIDER_INSTANCE_s=provider\r\n| join kind=inner (SapHana_SystemAvailability_CL\r\n    | where Time_Generated_t between (startTime .. endTime)\r\n    | where PROVIDER_INSTANCE_s =~ \"{selProvider}\"\r\n) on PROVIDER_INSTANCE_s\r\n| project-away DATABASE_NAME_s\r\n| join kind=inner (SapHana_size01_CL \r\n    | where SYSTEM_ID_s == \"{SID}\"\r\n    | distinct PROVIDER_INSTANCE_s, DATABASE_NAME_s\r\n    ) on PROVIDER_INSTANCE_s\r\n| where DATABASE_NAME_s == \"{Database}\"\r\n| project HOST_ACTIVE_s, TimeGenerated=Time_Generated_t\r\n| summarize Availability=round(iff(count() > 0, toreal(countif(HOST_ACTIVE_s == 'YES')) / toreal(count()) * 100, real(null)), 1) by bin(TimeGenerated, iff(hundredBin<100, 1h, hundredBin/100*1h))",
               "size": 1,
               "aggregation": 3,
               "title": "{Database} Availability Status Trend",
@@ -1782,7 +1825,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "let startTime = todatetime(\"{StartTime}\");\r\nlet endTime = todatetime(\"{EndTime}\");\r\n\r\nlet bin = tolong(\"{MinutesBin}\");\r\nlet hundredBin=datetime_diff(\"hour\", endTime, startTime);\r\n\r\nlet services=split(\"{Service}\", \",\");\r\n\r\nSapHana_SystemOverview_CL \r\n| extend sid = tostring(VALUE_s)\r\n| extend provider = tostring(PROVIDER_INSTANCE_s)\r\n| where \"{Provider}\" contains provider\r\n| where NAME_s == \"Instance ID\" and sid == \"{SID}\"\r\n| distinct SID_s = sid, PROVIDER_INSTANCE_s=provider\r\n| mv-expand bagexpansion=array Service=services to typeof(string)\r\n| extend service_name=iff(isnotempty(Service), tostring(split(Service, \" (:\")[0]), \"\"), service_port=toreal(iff(isnotempty(Service), replace_string(tostring(split(Service, \" (:\")[1]), \")\", \"\"), \"\"))\r\n| join kind=inner (SapHana_SystemAvailability_CL\r\n    | where Time_Generated_t between (startTime .. endTime)\r\n    | where \"{Provider}\" contains PROVIDER_INSTANCE_s and HOST_s==\"{VM:name}\"\r\n) on PROVIDER_INSTANCE_s, $right.SERVICE_NAME_s==$left.service_name and $right.PORT_d==$left.service_port\r\n| project-away DATABASE_NAME_s\r\n| join kind=inner (SapHana_size01_CL \r\n    | where SYSTEM_ID_s == \"{SID}\"\r\n    | distinct PROVIDER_INSTANCE_s, DATABASE_NAME_s\r\n    ) on PROVIDER_INSTANCE_s\r\n| where DATABASE_NAME_s == \"{Database}\"\r\n| project SERVICE_ACTIVE_s, TimeGenerated=Time_Generated_t, Service\r\n| summarize Availability=round(iff(count() > 0, toreal(countif(SERVICE_ACTIVE_s == 'YES')) / toreal(count()) * 100, real(null)), 1) by bin(TimeGenerated, iff(hundredBin<100, 1h, hundredBin/100*1h)), Service",
+              "query": "let startTime = todatetime(\"{StartTime}\");\r\nlet endTime = todatetime(\"{EndTime}\");\r\n\r\nlet bin = tolong(\"{MinutesBin}\");\r\nlet hundredBin=datetime_diff(\"hour\", endTime, startTime);\r\n\r\nlet services=split(\"{Service}\", \",\");\r\n\r\nSapHana_SystemOverview_CL \r\n| extend sid = tostring(VALUE_s)\r\n| extend provider = tostring(PROVIDER_INSTANCE_s)\r\n| where provider =~ \"{selProvider}\"\r\n| where NAME_s == \"Instance ID\" and sid == \"{SID}\"\r\n| distinct SID_s = sid, PROVIDER_INSTANCE_s=provider\r\n| mv-expand bagexpansion=array Service=services to typeof(string)\r\n| extend service_name=iff(isnotempty(Service), tostring(split(Service, \" (:\")[0]), \"\"), service_port=toreal(iff(isnotempty(Service), replace_string(tostring(split(Service, \" (:\")[1]), \")\", \"\"), \"\"))\r\n| join kind=inner (SapHana_SystemAvailability_CL\r\n    | where Time_Generated_t between (startTime .. endTime)\r\n    | where PROVIDER_INSTANCE_s =~ \"{selProvider}\" and HOST_s==\"{selVmName}\"\r\n) on PROVIDER_INSTANCE_s, $right.SERVICE_NAME_s==$left.service_name and $right.PORT_d==$left.service_port\r\n| project-away DATABASE_NAME_s\r\n| join kind=inner (SapHana_size01_CL \r\n    | where SYSTEM_ID_s == \"{SID}\"\r\n    | distinct PROVIDER_INSTANCE_s, DATABASE_NAME_s\r\n    ) on PROVIDER_INSTANCE_s\r\n| where DATABASE_NAME_s == \"{Database}\"\r\n| project SERVICE_ACTIVE_s, TimeGenerated=Time_Generated_t, Service\r\n| summarize Availability=round(iff(count() > 0, toreal(countif(SERVICE_ACTIVE_s == 'YES')) / toreal(count()) * 100, real(null)), 1) by bin(TimeGenerated, iff(hundredBin<100, 1h, hundredBin/100*1h)), Service",
               "size": 1,
               "aggregation": 3,
               "title": "Service Availability Status Trend for {Database}",
@@ -1893,9 +1936,9 @@
               "chartType": 2,
               "resourceType": "microsoft.compute/virtualmachines",
               "metricScope": 0,
-              "resourceParameter": "VM",
+              "resourceParameter": "VM2",
               "resourceIds": [
-                "{VM}"
+                "{VM2}"
               ],
               "timeContextFromParameter": "TimeRange",
               "timeContext": {
@@ -1938,7 +1981,7 @@
               ],
               "timeContextFromParameter": "TimeRange",
               "timeContext": {
-                "durationMs": 0
+                "durationMs": 2592000000
               },
               "metrics": [
                 {
@@ -1985,7 +2028,7 @@
                   "type": 3,
                   "content": {
                     "version": "KqlItem/1.0",
-                    "query": "print input = parse_json(\"{healthData:escapejson}\").value\r\n| mv-apply input to typeof(dynamic) on (\r\n    project properties=input.properties\r\n)\r\n| extend VM=\"{VM}\"\r\n| evaluate bag_unpack(properties) : (VM: string, occuredTime: datetime, title: string, reasonType: string, summary: string, availabilityState: string, healthEventType: string, resolutionETA: datetime)\r\n| where occuredTime {TimeRange}\r\n| order by occuredTime desc",
+                    "query": "print input = parse_json(\"{healthData:escapejson}\").value\r\n| mv-apply input to typeof(dynamic) on (\r\n    project properties=input.properties\r\n)\r\n| extend VM=\"{VM2}\"\r\n| evaluate bag_unpack(properties) : (VM: string, occuredTime: datetime, title: string, reasonType: string, summary: string, availabilityState: string, healthEventType: string, resolutionETA: datetime)\r\n| where occuredTime {TimeRange}\r\n| order by occuredTime desc",
                     "size": 3,
                     "noDataMessage": "No health events have been logged in this time period.",
                     "exportedParameters": [
@@ -2143,7 +2186,7 @@
                 {
                   "type": 1,
                   "content": {
-                    "json": "<span style=\"font-size:0.8rem;\">Root Cause Analysis (RCA) - {rcaTitle}</span>\r\n\r\n<span style=\"font-size:0.8rem;\">**Availability State:** {rcaAvailabilityState}</span><br/>\r\n<span style=\"font-size:0.8rem;\">**Event Type:** {rcaEventType}</span><br/>\r\n<span style=\"font-size:0.8rem;\">**Root Cause**</span><br/>\r\n<span style=\"font-size:0.8rem;\">{rcaDescription}</span><br><br/>\r\n<span style=\"font-size:0.8rem;\">**Occured Time (UTC):** {rcaDateTime}</span><br/>\r\n<span style=\"font-size:0.8rem;\">**Resolution ETA (UTC):** {rcaResolution}</span><br/>\r\n<span style=\"font-size:0.8rem;\">**Instance Name:** {VM:name}</span><br/>\r\n<span style=\"font-size:0.8rem;\">**Azure Resource Id:** {VM:id}</span><br/>"
+                    "json": "<span style=\"font-size:0.8rem;\">Root Cause Analysis (RCA) - {rcaTitle}</span>\r\n\r\n<span style=\"font-size:0.8rem;\">**Availability State:** {rcaAvailabilityState}</span><br/>\r\n<span style=\"font-size:0.8rem;\">**Event Type:** {rcaEventType}</span><br/>\r\n<span style=\"font-size:0.8rem;\">**Root Cause**</span><br/>\r\n<span style=\"font-size:0.8rem;\">{rcaDescription}</span><br><br/>\r\n<span style=\"font-size:0.8rem;\">**Occured Time (UTC):** {rcaDateTime}</span><br/>\r\n<span style=\"font-size:0.8rem;\">**Resolution ETA (UTC):** {rcaResolution}</span><br/>\r\n<span style=\"font-size:0.8rem;\">**Instance Name:** {VM2:name}</span><br/>\r\n<span style=\"font-size:0.8rem;\">**Azure Resource Id:** {VM2:id}</span><br/>"
                   },
                   "conditionalVisibility": {
                     "parameterName": "rcaDateTime",
@@ -2169,5 +2212,5 @@
       "name": "vmInsights"
     }
   ],
-    "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
+  "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
 }

--- a/Workbooks/SapMonitor2.0/AIOpsInsights/Availability Insights/Auto RCA.workbook
+++ b/Workbooks/SapMonitor2.0/AIOpsInsights/Availability Insights/Auto RCA.workbook
@@ -143,13 +143,6 @@
             "defaultValue": "value::all"
           },
           {
-            "id": "5f818549-c01f-4a9c-b804-d7cd18e67d60",
-            "version": "KqlParameterItem/1.0",
-            "name": "SAPComponent",
-            "type": 1,
-            "isHiddenWhenLocked": true
-          },
-          {
             "id": "3c1299c9-2fdb-4d25-98ff-f7c84381057f",
             "version": "KqlParameterItem/1.0",
             "name": "TimeRange",
@@ -204,7 +197,7 @@
                 }
               ],
               "allowCustom": true
-            }
+                        }
           },
           {
             "id": "74f08427-265d-4db2-a6d9-82318f892762",
@@ -293,6 +286,36 @@
             "defaultValue": "value::1",
             "queryType": 0,
             "resourceType": "microsoft.operationalinsights/workspaces"
+          },
+          {
+            "id": "8562276b-bf96-4693-b913-3327220339cf",
+            "version": "KqlParameterItem/1.0",
+            "name": "NwVmList",
+            "type": 1,
+            "value": "[l15appvm1, l15appvm0, l15ers01cl2, l15scs00cl1]"
+          },
+          {
+            "id": "a56b9464-e4f7-4360-b12d-f3abb55cf8b6",
+            "version": "KqlParameterItem/1.0",
+            "name": "HanaVmList",
+            "type": 1
+          },
+          {
+            "id": "48f6b2b8-bd12-48d1-96a5-99d641e6e71a",
+            "version": "KqlParameterItem/1.0",
+            "name": "VMID2",
+            "type": 2,
+            "query": "union isfuzzy = true(\r\nSapNetweaver_GetSystemInstanceList_CL\r\n| distinct hostname_s\r\n| where \"{NwVmList}\" contains hostname_s\r\n| project HOST_s = hostname_s\r\n),\r\n(\r\nSapHana_SystemAvailability_CL\r\n| distinct HOST_s\r\n| where \"{HanaVmList}\" contains HOST_s\r\n)",
+            "crossComponentResources": [
+              "{Workspace}"
+            ],
+            "typeSettings": {
+              "additionalResourceOptions": [],
+              "showDefault": false
+            },
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces",
+            "value": null
           }
         ],
         "style": "pills",
@@ -312,6 +335,64 @@
         "json": "Availability insights for the selected alert. View the insights to investigate the root cause."
       },
       "name": "introText"
+    },
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "crossComponentResources": [
+          "{Workspace}"
+        ],
+        "parameters": [
+          {
+            "id": "02d4877e-6d51-43b3-be31-fbacbdb20b60",
+            "version": "KqlParameterItem/1.0",
+            "name": "selProvider",
+            "type": 1
+          },
+          {
+            "id": "38856def-f524-46ed-a612-217dabaccaa1",
+            "version": "KqlParameterItem/1.0",
+            "name": "selVmName",
+            "type": 2,
+            "isRequired": true,
+            "query": "union isfuzzy = true(\r\nSapNetweaver_GetSystemInstanceList_CL\r\n| where PROVIDER_INSTANCE_s == \"{selProvider}\"\r\n| distinct hostname_s\r\n| project HOST_s = hostname_s\r\n),\r\n(\r\nSapHana_SystemAvailability_CL\r\n| where PROVIDER_INSTANCE_s == \"{selProvider}\"\r\n| distinct HOST_s\r\n)",
+            "crossComponentResources": [
+              "{Workspace}"
+            ],
+            "typeSettings": {
+              "additionalResourceOptions": [
+                "value::1"
+              ],
+              "showDefault": false
+            },
+            "timeContext": {
+              "durationMs": 0
+            },
+            "timeContextFromParameter": "TimeRange",
+            "defaultValue": "value::1",
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          },
+          {
+            "id": "84afcc6c-4c47-4422-9bb1-99a94d242561",
+            "version": "KqlParameterItem/1.0",
+            "name": "SAPComponent",
+            "type": 1,
+            "query": "SapHana_SystemOverview_CL\r\n| summarize Count = countif(PROVIDER_INSTANCE_s == \"{selProvider}\")\r\n| project Result = iif(Count>0,\"SAP Hana\", \"SAP NetWeaver\")",
+            "crossComponentResources": [
+              "{Workspace}"
+            ],
+            "isHiddenWhenLocked": true,
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          }
+        ],
+        "style": "pills",
+        "queryType": 0,
+        "resourceType": "microsoft.operationalinsights/workspaces"
+      },
+      "name": "parameters - 12"
     },
     {
       "type": 12,
@@ -409,23 +490,12 @@
             "name": "vmLabel"
           },
           {
-            "type": 11,
+            "type": 1,
             "content": {
-              "version": "LinkItem/1.0",
-              "style": "paragraph",
-              "links": [
-                {
-                  "id": "3a9ffd56-f0d6-4220-9195-be36e8317be4",
-                  "cellValue": "{VM:id}",
-                  "linkTarget": "Resource",
-                  "linkLabel": "{VM:name}",
-                  "preText": ": ",
-                  "style": "link"
-                }
-              ]
+              "json": ": {selVmName}"
             },
             "customWidth": "80",
-            "name": "vmValue"
+            "name": "text - 4"
           }
         ]
       },
@@ -463,7 +533,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let startTime = todatetime(\"{StartTime}\");\r\nlet endTime = todatetime(\"{EndTime}\");\r\n\r\nlet binSize=tolong(\"{MinutesBin}\")*1m;\r\nlet hundredBin=datetime_diff(\"minute\", endTime, startTime);\r\n\r\nlet ParentAvailTable=SapNetweaver_GetProcessList_CL\r\n| where serverTimestamp_t between (startTime .. endTime) and SID_s==\"{SID}\" and \"{Provider}\" contains PROVIDER_INSTANCE_s\r\n| project description_s, SID_s, hostname_s, dispstatus_s, serverTimestamp_t, ApplicationServer=strcat(hostname_s, \"_\", iff(toint(instanceNr_d)<10, strcat(\"0\", toint(instanceNr_d)), tostring(toint(instanceNr_d))));\r\n\r\nParentAvailTable\r\n| make-series AvailabilityTrend=iff(count() > 0, round(toreal(countif(dispstatus_s == 'SAPControl-GREEN')) / toreal(count()) * 100, 1), real(null)) default=real(null) on serverTimestamp_t step binSize  by SID_s, hostname_s, description_s, ApplicationServer\r\n| project Availability=toreal(series_stats_dynamic(series_fill_const(AvailabilityTrend, 0.0)).avg), SID_s, hostname_s, description_s, ApplicationServer \r\n| join kind=inner (\r\n    ParentAvailTable\r\n        | make-series AvailabilityTrend=iff(count() > 0, round(toreal(countif(dispstatus_s == 'SAPControl-GREEN')) / toreal(count()) * 100, 1), real(null)) default=real(null) on serverTimestamp_t step iff(hundredBin<100, 1m, hundredBin/100*1m) by SID_s, hostname_s, description_s\r\n        | project AvailabilityTrend=series_fill_const(AvailabilityTrend, 0.0), SID_s, hostname_s, description_s\r\n) on hostname_s, description_s, SID_s\r\n| join kind=inner (\r\n    COMMON_VM_ArmId_Mapping_CL\r\n    | where (isempty(sid_s) or sid_s==\"{SID}\") and \"{Provider}\" contains PROVIDER_INSTANCE_s\r\n    | distinct VM_ARM_ID_s=tolower(VM_ARM_ID_s), vm_name_s) on $left.hostname_s==$right.vm_name_s\r\n| where VM_ARM_ID_s=~\"{VM}\"\r\n| project description_s, SID_s, ApplicationServer, VM_ARM_ID_s, hostname_s, Availability, AvailabilityTrend\r\n| extend Action=\"View\", Action2=\"View\", SAPComponent='SAP NetWeaver'",
+        "query": "let startTime = todatetime(\"{StartTime}\");\r\nlet endTime = todatetime(\"{EndTime}\");\r\n\r\nlet binSize=tolong(\"{MinutesBin}\")*1m;\r\nlet hundredBin=datetime_diff(\"minute\", endTime, startTime);\r\n\r\nlet ParentAvailTable=SapNetweaver_GetProcessList_CL\r\n| where serverTimestamp_t between (startTime .. endTime) and SID_s =~ \"{SID}\" and hostname_s =~ \"{selVmName}\"\r\n| project description_s, SID_s, hostname_s, dispstatus_s, serverTimestamp_t, ApplicationServer=strcat(hostname_s, \"_\", iff(toint(instanceNr_d)<10, strcat(\"0\", toint(instanceNr_d)), tostring(toint(instanceNr_d))));\r\n\r\nParentAvailTable\r\n| make-series AvailabilityTrend=iff(count() > 0, round(toreal(countif(dispstatus_s == 'SAPControl-GREEN')) / toreal(count()) * 100, 1), real(null)) default=real(null) on serverTimestamp_t step binSize  by SID_s, hostname_s, description_s, ApplicationServer\r\n| project Availability=toreal(series_stats_dynamic(series_fill_const(AvailabilityTrend, 0.0)).avg), SID_s, hostname_s, description_s, ApplicationServer \r\n| join kind=inner (\r\n    ParentAvailTable\r\n        | make-series AvailabilityTrend=iff(count() > 0, round(toreal(countif(dispstatus_s == 'SAPControl-GREEN')) / toreal(count()) * 100, 1), real(null)) default=real(null) on serverTimestamp_t step iff(hundredBin<100, 1m, hundredBin/100*1m) by SID_s, hostname_s, description_s\r\n        | project AvailabilityTrend=series_fill_const(AvailabilityTrend, 0.0), SID_s, hostname_s, description_s\r\n) on hostname_s, description_s, SID_s\r\n| where hostname_s=~\"{selVmName}\"\r\n| project description_s, SID_s, ApplicationServer, hostname_s, Availability, AvailabilityTrend\r\n| extend Action=\"View\", Action2=\"View\", SAPComponent='SAP NetWeaver'",
         "size": 3,
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
@@ -515,10 +585,6 @@
                   ]
                 }
               }
-            },
-            {
-              "columnMatch": "VM_ARM_ID_s",
-              "formatter": 5
             },
             {
               "columnMatch": "hostname_s",
@@ -593,11 +659,6 @@
                       "value": "TimePeriod"
                     },
                     {
-                      "name": "VMID",
-                      "source": "parameter",
-                      "value": "VMID"
-                    },
-                    {
                       "name": "Provider",
                       "source": "parameter",
                       "value": "Provider"
@@ -631,8 +692,19 @@
                       "name": "Process",
                       "source": "column",
                       "value": "description_s"
+                    },
+                    {
+                      "name": "NwVmList",
+                      "source": "static",
+                      "value": "{NwVmList}"
+                    },
+                    {
+                      "name": "selVmName",
+                      "source": "static",
+                      "value": "{selVmName}"
                     }
-                  ]
+                  ],
+                  "viewerMode": false
                 }
               }
             },
@@ -710,14 +782,6 @@
             {
               "columnMatch": "SAPComponent",
               "formatter": 5
-            },
-            {
-              "columnMatch": "Insights",
-              "formatter": 5
-            },
-            {
-              "columnMatch": "VM Name",
-              "formatter": 5
             }
           ],
           "labelSettings": [
@@ -775,7 +839,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let startTime = todatetime(\"{StartTime}\");\r\nlet endTime = todatetime(\"{EndTime}\");\r\n\r\nlet bin = tolong(\"{MinutesBin}\");\r\nlet binSize=iff(bin < 60, 60m, bin*1m);\r\nlet hundredBin=datetime_diff(\"hour\", endTime, startTime);\r\n\r\nlet ParentAvailTable=SapHana_SystemOverview_CL \r\n| extend sid = tostring(VALUE_s)\r\n| extend provider = tostring(PROVIDER_INSTANCE_s)\r\n| where \"{Provider}\" contains provider\r\n| where NAME_s == \"Instance ID\" and sid == \"{SID}\"\r\n| distinct SID_s = sid, PROVIDER_INSTANCE_s=provider\r\n| join kind=inner (SapHana_SystemAvailability_CL\r\n    | where Time_Generated_t between (startTime .. endTime)\r\n    ) on PROVIDER_INSTANCE_s\r\n| project-away DATABASE_NAME_s\r\n| join kind=inner (SapHana_size01_CL \r\n    | where SYSTEM_ID_s == \"{SID}\"\r\n    | distinct PROVIDER_INSTANCE_s, DATABASE_NAME_s\r\n    ) on PROVIDER_INSTANCE_s\r\n| project DATABASE_NAME_s, PORT_d, SERVICE_NAME_s, SERVICE_ACTIVE_s, HOST_s, HOST_ACTIVE_s, Time_Generated_t, SID_s\r\n| where HOST_s==\"{VM:name}\";\r\n\r\nunion(ParentAvailTable\r\n| make-series AvailabilityTrend=iff(count() > 0, round(toreal(countif(HOST_ACTIVE_s == 'YES')) / toreal(count()) * 100, 1), real(null)) default=real(null) on Time_Generated_t step binSize  by HOST_s, DATABASE_NAME_s\r\n| project Availability=round(toreal(series_stats_dynamic(series_fill_const(AvailabilityTrend, 0.0)).avg), 1), HOST_s, DATABASE_NAME_s \r\n| join kind=inner (\r\n    ParentAvailTable\r\n        | make-series AvailabilityTrend=iff(count() > 0, round(toreal(countif(HOST_ACTIVE_s == 'YES')) / toreal(count()) * 100, 1), real(null)) default=real(null) on Time_Generated_t step iff(hundredBin<100, 1h, hundredBin/100*1h) by HOST_s, DATABASE_NAME_s\r\n        | project AvailabilityTrend=series_fill_const(AvailabilityTrend, 0.0), HOST_s, DATABASE_NAME_s\r\n) on HOST_s, DATABASE_NAME_s\r\n| join kind=inner (\r\n    COMMON_VM_ArmId_Mapping_CL\r\n    | where (isempty(sid_s) or sid_s==\"{SID}\") and \"{Provider}\" contains PROVIDER_INSTANCE_s\r\n    | distinct VM_ARM_ID_s=tolower(VM_ARM_ID_s), vm_name_s) on $left.HOST_s==$right.vm_name_s\r\n| project description_s=DATABASE_NAME_s, VM_ARM_ID_s, Availability, AvailabilityTrend\r\n| where VM_ARM_ID_s=~\"{VM}\"\r\n| extend SID_s = \"{SID}\"\r\n| extend display_s=description_s, parentid=\"\", id=description_s, Service=\"\"),\r\n(ParentAvailTable\r\n| where isnotempty(SERVICE_NAME_s)\r\n| extend Service=strcat(SERVICE_NAME_s, \" (:\", toint(PORT_d), \")\")\r\n| make-series AvailabilityTrend=iff(count() > 0, round(toreal(countif(SERVICE_ACTIVE_s == 'YES')) / toreal(count()) * 100, 1), real(null)) default=real(null) on Time_Generated_t step binSize  by HOST_s, DATABASE_NAME_s, Service\r\n| project Availability=round(toreal(series_stats_dynamic(series_fill_const(AvailabilityTrend, 0.0)).avg), 1), HOST_s, DATABASE_NAME_s, Service \r\n| join kind=inner (\r\n    ParentAvailTable\r\n        | where isnotempty(SERVICE_NAME_s)\r\n        | extend Service=strcat(SERVICE_NAME_s, \" (:\", toint(PORT_d), \")\")\r\n        | make-series AvailabilityTrend=iff(count() > 0, round(toreal(countif(SERVICE_ACTIVE_s == 'YES')) / toreal(count()) * 100, 1), real(null)) default=real(null) on Time_Generated_t step iff(hundredBin<100, 1h, hundredBin/100*1h) by HOST_s, DATABASE_NAME_s, Service\r\n        | project AvailabilityTrend=series_fill_const(AvailabilityTrend, 0.0), HOST_s, DATABASE_NAME_s, Service\r\n) on HOST_s, DATABASE_NAME_s, Service\r\n| join kind=inner (\r\n    COMMON_VM_ArmId_Mapping_CL\r\n    | where (isempty(sid_s) or sid_s==\"{SID}\") and \"{Provider}\" contains PROVIDER_INSTANCE_s\r\n    | distinct VM_ARM_ID_s=tolower(VM_ARM_ID_s), vm_name_s) on $left.HOST_s==$right.vm_name_s\r\n| project description_s=DATABASE_NAME_s, Service, VM_ARM_ID_s, Availability, AvailabilityTrend\r\n| where VM_ARM_ID_s=~\"{VM}\"\r\n| extend SID_s = \"{SID}\"\r\n| extend display_s=Service\r\n| extend parentid=description_s\r\n| extend id=strcat(parentid,\"_\",Service))\r\n| project id, parentid, description_s, Service, VM_ARM_ID_s, SID_s, Availability, AvailabilityTrend, display_s, Action=\"SAP metric\", Action2=\"VM metric\"",
+        "query": "let startTime = todatetime(\"{StartTime}\");\r\nlet endTime = todatetime(\"{EndTime}\");\r\n\r\nlet bin = tolong(\"{MinutesBin}\");\r\nlet binSize=iff(bin < 60, 60m, bin*1m);\r\nlet hundredBin=datetime_diff(\"hour\", endTime, startTime);\r\n\r\nlet ParentAvailTable=SapHana_SystemOverview_CL \r\n| extend sid = tostring(VALUE_s)\r\n| extend provider = tostring(PROVIDER_INSTANCE_s)\r\n| where provider == \"{selProvider}\"\r\n| where NAME_s == \"Instance ID\" and sid == \"{SID}\"\r\n| distinct SID_s = sid, PROVIDER_INSTANCE_s=provider\r\n| join kind=inner (SapHana_SystemAvailability_CL\r\n    | where Time_Generated_t between (startTime .. endTime)\r\n    ) on PROVIDER_INSTANCE_s\r\n| project-away DATABASE_NAME_s\r\n| join kind=inner (SapHana_size01_CL \r\n    | where SYSTEM_ID_s == \"{SID}\"\r\n    | distinct PROVIDER_INSTANCE_s, DATABASE_NAME_s\r\n    ) on PROVIDER_INSTANCE_s\r\n| project DATABASE_NAME_s, PORT_d, SERVICE_NAME_s, SERVICE_ACTIVE_s, HOST_s, HOST_ACTIVE_s, Time_Generated_t, SID_s\r\n| where HOST_s==\"{VM:name}\";\r\n\r\nunion(ParentAvailTable\r\n| make-series AvailabilityTrend=iff(count() > 0, round(toreal(countif(HOST_ACTIVE_s == 'YES')) / toreal(count()) * 100, 1), real(null)) default=real(null) on Time_Generated_t step binSize  by HOST_s, DATABASE_NAME_s\r\n| project Availability=round(toreal(series_stats_dynamic(series_fill_const(AvailabilityTrend, 0.0)).avg), 1), HOST_s, DATABASE_NAME_s \r\n| join kind=inner (\r\n    ParentAvailTable\r\n        | make-series AvailabilityTrend=iff(count() > 0, round(toreal(countif(HOST_ACTIVE_s == 'YES')) / toreal(count()) * 100, 1), real(null)) default=real(null) on Time_Generated_t step iff(hundredBin<100, 1h, hundredBin/100*1h) by HOST_s, DATABASE_NAME_s\r\n        | project AvailabilityTrend=series_fill_const(AvailabilityTrend, 0.0), HOST_s, DATABASE_NAME_s\r\n) on HOST_s, DATABASE_NAME_s\r\n| join kind=inner (\r\n    COMMON_VM_ArmId_Mapping_CL\r\n    | where (isempty(sid_s) or sid_s==\"{SID}\") and \"{Provider}\" contains PROVIDER_INSTANCE_s\r\n    | distinct VM_ARM_ID_s=tolower(VM_ARM_ID_s), vm_name_s) on $left.HOST_s==$right.vm_name_s\r\n| project description_s=DATABASE_NAME_s, VM_ARM_ID_s, Availability, AvailabilityTrend\r\n| where VM_ARM_ID_s=~\"{VM}\"\r\n| extend SID_s = \"{SID}\"\r\n| extend display_s=description_s, parentid=\"\", id=description_s, Service=\"\"),\r\n(ParentAvailTable\r\n| where isnotempty(SERVICE_NAME_s)\r\n| extend Service=strcat(SERVICE_NAME_s, \" (:\", toint(PORT_d), \")\")\r\n| make-series AvailabilityTrend=iff(count() > 0, round(toreal(countif(SERVICE_ACTIVE_s == 'YES')) / toreal(count()) * 100, 1), real(null)) default=real(null) on Time_Generated_t step binSize  by HOST_s, DATABASE_NAME_s, Service\r\n| project Availability=round(toreal(series_stats_dynamic(series_fill_const(AvailabilityTrend, 0.0)).avg), 1), HOST_s, DATABASE_NAME_s, Service \r\n| join kind=inner (\r\n    ParentAvailTable\r\n        | where isnotempty(SERVICE_NAME_s)\r\n        | extend Service=strcat(SERVICE_NAME_s, \" (:\", toint(PORT_d), \")\")\r\n        | make-series AvailabilityTrend=iff(count() > 0, round(toreal(countif(SERVICE_ACTIVE_s == 'YES')) / toreal(count()) * 100, 1), real(null)) default=real(null) on Time_Generated_t step iff(hundredBin<100, 1h, hundredBin/100*1h) by HOST_s, DATABASE_NAME_s, Service\r\n        | project AvailabilityTrend=series_fill_const(AvailabilityTrend, 0.0), HOST_s, DATABASE_NAME_s, Service\r\n) on HOST_s, DATABASE_NAME_s, Service\r\n| join kind=inner (\r\n    COMMON_VM_ArmId_Mapping_CL\r\n    | where (isempty(sid_s) or sid_s==\"{SID}\") and \"{Provider}\" contains PROVIDER_INSTANCE_s\r\n    | distinct VM_ARM_ID_s=tolower(VM_ARM_ID_s), vm_name_s) on $left.HOST_s==$right.vm_name_s\r\n| project description_s=DATABASE_NAME_s, Service, VM_ARM_ID_s, Availability, AvailabilityTrend\r\n| where VM_ARM_ID_s=~\"{VM}\"\r\n| extend SID_s = \"{SID}\"\r\n| extend display_s=Service\r\n| extend parentid=description_s\r\n| extend id=strcat(parentid,\"_\",Service))\r\n| project id, parentid, description_s, Service, VM_ARM_ID_s, SID_s, Availability, AvailabilityTrend, display_s, Action=\"SAP metric\", Action2=\"VM metric\"",
         "size": 3,
         "queryType": 0,
         "resourceType": "microsoft.operationalinsights/workspaces",
@@ -1126,7 +1190,7 @@
             "name": "Process",
             "type": 2,
             "isRequired": true,
-            "query": "let startTime = todatetime(\"{StartTime}\");\r\nlet endTime = todatetime(\"{EndTime}\");\r\n\r\nSapNetweaver_GetProcessList_CL\r\n| where serverTimestamp_t between (startTime .. endTime) and SID_s==\"{SID}\" and \"{Provider}\" contains PROVIDER_INSTANCE_s\r\n| where hostname_s=~\"{VM:name}\"\r\n| distinct description_s",
+            "query": "let startTime = todatetime(\"{StartTime}\");\r\nlet endTime = todatetime(\"{EndTime}\");\r\n\r\nSapNetweaver_GetProcessList_CL\r\n| where serverTimestamp_t between (startTime .. endTime) and SID_s==\"{SID}\"\r\n| where hostname_s == \"{selVmName}\"\r\n| distinct description_s",
             "crossComponentResources": [
               "{Workspace}"
             ],
@@ -1240,7 +1304,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "let startTime = todatetime(\"{StartTime}\");\r\nlet endTime = todatetime(\"{EndTime}\");\r\n\r\nlet binSize = tolong(\"{MinutesBin}\");\r\n\r\nunion isfuzzy=true \r\n(SapNetweaver_GetProcessList_CL\r\n| where serverTimestamp_t between (startTime .. endTime) and SID_s==\"{SID}\" and \"{Provider}\" contains PROVIDER_INSTANCE_s and hostname_s==\"{VM:name}\" and description_s==\"{Process}\"\r\n| project description_s, SID_s, hostname_s, dispstatus_s, TimeGenerated=serverTimestamp_t\r\n| make-series AvailabilityTrend=round(iff(count() > 0, toreal(countif(dispstatus_s == 'SAPControl-GREEN')) / toreal(count()) * 100, real(null)), 1) default=real(null) on TimeGenerated step binSize*1m\r\n| project Value=strcat(round(toreal(series_stats_dynamic(series_fill_const(AvailabilityTrend, 0.0)).avg), 1), \"%\"), Type=\"Availability\", Selection=\"Availability\", Tab=\"\", Order = 1),\r\n(SapNetweaver_SysLogs_CL\r\n| where serverTimestamp_t between (startTime .. endTime) and SID_s==\"{SID}\" and \"{Provider}\" contains PROVIDER_INSTANCE_s and hostname_s==\"{VM:name}\" and E2E_SEVERITY_s==1\r\n| distinct E2E_SEVERITY_s, E2E_HOST_s, Problem_Class_s, Application_Comp_s, Program_s, Msg_area_Msd_Id_s, Description_s, timestamp_t, E2E_USER_s\r\n| summarize Value=tostring(count())\r\n| extend Type=\"Error Messages SM21\", Selection=\"Application\", Tab=\"SysLogs\", Order = 2),\r\n(SapNetweaver_EnqueueRead_CL\r\n| where serverTimestamp_t between (startTime .. endTime) and SID_s==\"{SID}\" and \"{Provider}\" contains PROVIDER_INSTANCE_s and hostname_s==\"{VM:name}\"\r\n| summarize GTNAME = dcount(GNAME_s) by GMODE_s, GOBJ_s, GUNAME_s, GTWP_s, hostname_s, serverTimestamp_t\r\n| summarize Value=tostring(count())\r\n| extend Type=\"Lock Entries SM12\", Selection=\"Application\", Tab=\"LockEntries\", Order = 3),\r\n(SapNetweaver_BatchJobs_CL\r\n| where serverTimestamp_t between (startTime .. endTime) and SID_s==\"{SID}\" and \"{Provider}\" contains PROVIDER_INSTANCE_s and hostname_s==\"{VM:name}\"\r\n| distinct STATUS_s, STRTDATE_s, STRTTIME_s, SDLSTRTDT_s, SDLSTRTTM_s, JOBNAME_s, ENDDATE_s, ENDTIME_s \r\n| summarize Value=tostring(countif(STATUS_s == 'A' or STATUS_s == 'X'))\r\n| extend Type=\"Cancelled Jobs SM37\", Selection=\"Application\", Tab=\"BatchJob\", Order = 4)\r\n\r\n",
+              "query": "let startTime = todatetime(\"{StartTime}\");\r\nlet endTime = todatetime(\"{EndTime}\");\r\n\r\nlet binSize = tolong(\"{MinutesBin}\");\r\n\r\nunion isfuzzy=true \r\n(SapNetweaver_GetProcessList_CL\r\n| where serverTimestamp_t between (startTime .. endTime) and SID_s==\"{SID}\" and hostname_s==\"{selVmName}\" and description_s==\"{Process}\"\r\n| project description_s, SID_s, hostname_s, dispstatus_s, TimeGenerated=serverTimestamp_t\r\n| make-series AvailabilityTrend=round(iff(count() > 0, toreal(countif(dispstatus_s == 'SAPControl-GREEN')) / toreal(count()) * 100, real(null)), 1) default=real(null) on TimeGenerated step binSize*1m\r\n| project Value=strcat(round(toreal(series_stats_dynamic(series_fill_const(AvailabilityTrend, 0.0)).avg), 1), \"%\"), Type=\"Availability\", Selection=\"Availability\", Tab=\"\", Order = 1),\r\n(SapNetweaver_SysLogs_CL\r\n| where serverTimestamp_t between (startTime .. endTime) and SID_s==\"{SID}\" and hostname_s==\"{selVmName}\" and E2E_SEVERITY_s==1\r\n| distinct E2E_SEVERITY_s, E2E_HOST_s, Problem_Class_s, Application_Comp_s, Program_s, Msg_area_Msd_Id_s, Description_s, timestamp_t, E2E_USER_s\r\n| summarize Value=tostring(count())\r\n| extend Type=\"Error Messages SM21\", Selection=\"Application\", Tab=\"SysLogs\", Order = 2),\r\n(SapNetweaver_EnqueueRead_CL\r\n| where serverTimestamp_t between (startTime .. endTime) and SID_s==\"{SID}\" and hostname_s==\"{selVmName}\"\r\n| summarize GTNAME = dcount(GNAME_s) by GMODE_s, GOBJ_s, GUNAME_s, GTWP_s, hostname_s, serverTimestamp_t\r\n| summarize Value=tostring(count())\r\n| extend Type=\"Lock Entries SM12\", Selection=\"Application\", Tab=\"LockEntries\", Order = 3),\r\n(SapNetweaver_BatchJobs_CL\r\n| where serverTimestamp_t between (startTime .. endTime) and SID_s==\"{SID}\" and hostname_s==\"{selVmName}\"\r\n| distinct STATUS_s, STRTDATE_s, STRTTIME_s, SDLSTRTDT_s, SDLSTRTTM_s, JOBNAME_s, ENDDATE_s, ENDTIME_s \r\n| summarize Value=tostring(countif(STATUS_s == 'A' or STATUS_s == 'X'))\r\n| extend Type=\"Cancelled Jobs SM37\", Selection=\"Application\", Tab=\"BatchJob\", Order = 4)\r\n\r\n",
               "size": 4,
               "title": "{Process} Availability Insights",
               "queryType": 0,
@@ -1638,7 +1702,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "let startTime = todatetime(\"{StartTime}\");\r\nlet endTime = todatetime(\"{EndTime}\");\r\n\r\nlet binSize = tolong(\"{MinutesBin}\");\r\n\r\nSapNetweaver_GetProcessList_CL\r\n| where serverTimestamp_t between (startTime .. endTime)\r\n| where SID_s==\"{SID}\" and \"{Provider}\" contains PROVIDER_INSTANCE_s and description_s==\"{Process}\" and hostname_s==\"{VM:name}\"\r\n| project description_s, SID_s, hostname_s, dispstatus_s, TimeGenerated=serverTimestamp_t\r\n| summarize Availability=round(iff(count() > 0, toreal(countif(dispstatus_s == 'SAPControl-GREEN')) / toreal(count()) * 100, toreal(0)), 1) by bin(TimeGenerated, binSize * 1m)",
+              "query": "let startTime = todatetime(\"{StartTime}\");\r\nlet endTime = todatetime(\"{EndTime}\");\r\n\r\nlet binSize = tolong(\"{MinutesBin}\");\r\n\r\nSapNetweaver_GetProcessList_CL\r\n| where serverTimestamp_t between (startTime .. endTime)\r\n| where SID_s==\"{SID}\" and description_s==\"{Process}\" and hostname_s==\"{selVmName}\"\r\n| project description_s, SID_s, hostname_s, dispstatus_s, TimeGenerated=serverTimestamp_t\r\n| summarize Availability=round(iff(count() > 0, toreal(countif(dispstatus_s == 'SAPControl-GREEN')) / toreal(count()) * 100, toreal(0)), 1) by bin(TimeGenerated, binSize * 1m)",
               "size": 1,
               "aggregation": 3,
               "title": "{Process} Availability Status Trend",
@@ -1780,19 +1844,43 @@
             "type": 9,
             "content": {
               "version": "KqlParameterItem/1.0",
+              "crossComponentResources": [
+                "{Workspace}"
+              ],
               "parameters": [
+                {
+                  "id": "031b807f-c5d3-472a-814e-4aa30e2968ab",
+                  "version": "KqlParameterItem/1.0",
+                  "name": "VM2",
+                  "type": 5,
+                  "query": "COMMON_VM_ArmId_Mapping_CL\r\n| where vm_name_s == \"{selVmName}\"\r\n| distinct VM_ARM_ID_s",
+                  "crossComponentResources": [
+                    "{Workspace}"
+                  ],
+                  "isHiddenWhenLocked": true,
+                  "typeSettings": {
+                    "additionalResourceOptions": [
+                      "value::1"
+                    ],
+                    "showDefault": false
+                  },
+                  "defaultValue": "value::1",
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces"
+                },
                 {
                   "id": "5322a519-9a45-4464-98b4-26d5bdfed4f2",
                   "version": "KqlParameterItem/1.0",
                   "name": "healthData",
                   "type": 1,
-                  "query": "{\"version\":\"ARMEndpoint/1.0\",\"data\":null,\"headers\":[],\"method\":\"GET\",\"path\":\"{VM:id}/providers/Microsoft.ResourceHealth/availabilityStatuses\",\"urlParams\":[{\"key\":\"api-version\",\"value\":\"2018-07-01\"},{\"key\":\"$filter\",\"value\":\"properties/availabilityState ne 'Available'\"}],\"batchDisabled\":true,\"transformers\":null}",
+                  "query": "{\"version\":\"ARMEndpoint/1.0\",\"data\":null,\"headers\":[],\"method\":\"GET\",\"path\":\"{VM2}/providers/Microsoft.ResourceHealth/availabilityStatuses\",\"urlParams\":[{\"key\":\"api-version\",\"value\":\"2018-07-01\"},{\"key\":\"$filter\",\"value\":\"properties/availabilityState ne 'Available'\"}],\"batchDisabled\":true,\"transformers\":null}",
                   "isHiddenWhenLocked": true,
                   "queryType": 12
                 }
               ],
               "style": "pills",
-              "queryType": 12
+              "queryType": 0,
+              "resourceType": "microsoft.operationalinsights/workspaces"
             },
             "name": "vmInsightParams"
           },
@@ -1844,9 +1932,9 @@
               "chartType": 2,
               "resourceType": "microsoft.compute/virtualmachines",
               "metricScope": 0,
-              "resourceParameter": "VM",
+              "resourceParameter": "VM2",
               "resourceIds": [
-                "{VM}"
+                "{VM2}"
               ],
               "timeContextFromParameter": "TimeRange",
               "timeContext": {

--- a/Workbooks/SapMonitor2.0/AIOpsInsights/Performance Insights/Auto Perf RCA.workbook
+++ b/Workbooks/SapMonitor2.0/AIOpsInsights/Performance Insights/Auto Perf RCA.workbook
@@ -2737,6 +2737,11 @@
                     "queryType": 0,
                     "resourceType": "microsoft.operationalinsights/workspaces"
                   },
+                  "conditionalVisibility": {
+                    "parameterName": "hidden",
+                    "comparison": "isEqualTo",
+                    "value": "true"
+                  },
                   "name": "vmDetails"
                 },
                 {
@@ -2758,11 +2763,18 @@
               ]
             },
             "customWidth": "42",
-            "conditionalVisibility": {
-              "parameterName": "Tab",
-              "comparison": "isEqualTo",
-              "value": "Config"
-            },
+            "conditionalVisibilities": [
+              {
+                "parameterName": "Tab",
+                "comparison": "isEqualTo",
+                "value": "Config"
+              },
+              {
+                "parameterName": "vmsExist",
+                "comparison": "isEqualTo",
+                "value": "true"
+              }
+            ],
             "name": "configDrifts"
           }
         ]
@@ -2775,5 +2787,5 @@
       "name": "visibilityCheck"
     }
   ],
-    "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
+  "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
 }

--- a/Workbooks/SapMonitor2.0/AIOpsInsights/Performance Insights/Auto Perf RCA.workbook
+++ b/Workbooks/SapMonitor2.0/AIOpsInsights/Performance Insights/Auto Perf RCA.workbook
@@ -135,7 +135,7 @@
                 }
               ],
               "allowCustom": true
-                        }
+            }
           },
           {
             "id": "cac1f668-ad31-4771-a21e-ae61d0ebd43f",
@@ -328,6 +328,50 @@
         }
       ],
       "name": "longBatchJobPlot"
+    },
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "crossComponentResources": [
+          "{Workspace}"
+        ],
+        "parameters": [
+          {
+            "id": "09ad9401-7f67-4ab5-95cb-f38639bbf6ee",
+            "version": "KqlParameterItem/1.0",
+            "name": "tableExists",
+            "type": 1,
+            "query": "let checktable = (tb:string, columnName:string)\r\n{\r\n// 0 = no error\r\n// 1 = table does not exist (need to enable RFC)\r\n// 2 = table exists, but column v1 does not (or) column v1 exists but no data in the table (need to wait)\r\nlet dummy = \"unmÃ¶glicher-wert!\";\r\nlet MissingTable = view () { print miss = 1, columnV1 = dummy, records = -1 };\r\nlet checkRecords =\r\n  union\r\n    isfuzzy=true MissingTable,\r\n    (table(tb)\r\n      | summarize records = count()\r\n    )\r\n  | project records\r\n  | top 1 by records desc\r\n;\r\nlet checkTableExists =\r\n  union\r\n    isfuzzy=true MissingTable,\r\n    (table(tb)\r\n      | count\r\n      | extend miss = 0\r\n    )\r\n  | project miss\r\n  | limit 2\r\n  | top 1 by miss asc\r\n;\r\nlet checkColumnExists =\r\n  union\r\n    isfuzzy=true MissingTable,\r\n    (table(tb)\r\n      | extend miss = 0\r\n      | extend columnV1 = column_ifexists(columnName, dummy)\r\n    )\r\n  | project miss, columnV1\r\n  | limit 2\r\n  | top 1 by miss asc\r\n ;\r\nlet tableExists = toscalar(checkTableExists | summarize max(miss) != 1);\r\nlet columnV1Exists = toscalar(checkColumnExists | summarize max(columnV1) != dummy);\r\nlet tableRecords = toscalar(checkRecords | summarize max(records));\r\nlet x = iif(tableExists, iif(columnV1Exists, iif(tableRecords > 0, \"0\", \"2\"), \"2\"), \"1\");\r\ntoscalar(x)\r\n};\r\nlet system = checktable('SapNetweaver_GetSystemInstanceList_CL', 'SID_s');\r\nlet process = checktable('SapNetweaver_GetProcessList_CL', 'SID_s');\r\nlet vms = checktable('COMMON_VM_ArmId_Mapping_CL', 'VM_ARM_ID_s');\r\nlet hana = checktable('SapHana_SystemAvailability_CL', 'PROVIDER_INSTANCE_s');\r\n\r\nprint strcat(\r\n'{\"SapNetweaver_GetSystemInstanceList_CL\":',system, ',',\r\n'\"SapNetweaver_GetProcessList_CL\":',process, ',',\r\n'\"SapHana_SystemAvailability_CL\":',hana, ',',\r\n'\"COMMON_VM_ArmId_Mapping_CL\":',vms, '}')",
+            "crossComponentResources": [
+              "{Workspace}"
+            ],
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          },
+          {
+            "id": "e738e9dd-ad72-4199-bf7a-4407a583addf",
+            "version": "KqlParameterItem/1.0",
+            "name": "vmsExist",
+            "type": 1,
+            "query": "print input = parse_json('{tableExists}')\r\n| mv-apply input to typeof(dynamic) on (\r\n    project error=tostring(input[\"COMMON_VM_ArmId_Mapping_CL\"])\r\n    | where isnotempty(error)\r\n    | project error = tolong(error)\r\n)\r\n| project value=iff(error==0, true, false)",
+            "crossComponentResources": [
+              "{Workspace}"
+            ],
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          }
+        ],
+        "style": "pills",
+        "queryType": 0,
+        "resourceType": "microsoft.operationalinsights/workspaces"
+      },
+      "conditionalVisibility": {
+        "parameterName": "hidden",
+        "comparison": "isEqualTo",
+        "value": "true"
+      },
+      "name": "parameters - 7"
     },
     {
       "type": 9,
@@ -1273,7 +1317,7 @@
                         "type": 3,
                         "content": {
                           "version": "KqlItem/1.0",
-                          "query": "let startTime=todatetime(\"{StartTime}\");\r\nlet endTime=todatetime(\"{EndTime}\");\r\n\r\nSapNetweaver_EnqueueRead_CL\r\n| where serverTimestamp_t between (startTime .. endTime) and  SID_s == \"{SID}\" and \"{Provider}\" contains PROVIDER_INSTANCE_s\r\n| extend GTCODE = column_ifexists(\"GTCODE_s\", \"\")\r\n| extend GBCKTYPE = column_ifexists(\"GBCKTYPE_s\", \"\")\r\n| summarize GNAME = dcount(GNAME_s) by GNAME_s, GMODE_s, GOBJ_s, GUNAME_s, GTWP_s, hostname_s, serverTimestamp_t\r\n| summarize locks = count() by GOBJ_s, GNAME_s, GUNAME_s, hostname_s\r\n| join kind=inner (\r\n    COMMON_VM_ArmId_Mapping_CL\r\n    | where (isempty(sid_s) or sid_s==\"{SID}\") and \"{Provider}\" contains PROVIDER_INSTANCE_s\r\n    | distinct vmid_s=tolower(VM_ARM_ID_s), hostname_s=tolower(vm_name_s)\r\n) on hostname_s\r\n| project-away hostname_s1",
+                          "query": "let startTime=todatetime(\"{StartTime}\");\r\nlet endTime=todatetime(\"{EndTime}\");\r\n\r\nSapNetweaver_EnqueueRead_CL\r\n| where serverTimestamp_t between (startTime .. endTime) and  SID_s == \"{SID}\" and \"{Provider}\" contains PROVIDER_INSTANCE_s\r\n| extend GTCODE = column_ifexists(\"GTCODE_s\", \"\")\r\n| extend GBCKTYPE = column_ifexists(\"GBCKTYPE_s\", \"\")\r\n| summarize GNAME = dcount(GNAME_s) by GNAME_s, GMODE_s, GOBJ_s, GUNAME_s, GTWP_s, hostname_s, serverTimestamp_t\r\n| summarize locks = count() by GOBJ_s, GNAME_s, GUNAME_s, hostname_s",
                           "size": 3,
                           "title": "Lock entries",
                           "queryType": 0,
@@ -1341,7 +1385,7 @@
                               "type": 3,
                               "content": {
                                 "version": "KqlItem/1.0",
-                                "query": "let dummy = \"unmÃ¶glicher-wert!\";\r\nlet MissingTable = view () { print dummy_miss = 1, dummy_columnV1 = dummy, dummy_records = -1 };\r\n\r\nlet startTime=todatetime(\"{StartTime}\");\r\nlet endTime=todatetime(\"{EndTime}\");\r\n\r\nlet batches = \r\nunion isfuzzy=true \r\n(MissingTable\r\n| where false),\r\n(SapNetweaver_BatchJobs_CL\r\n| where serverTimestamp_t between (startTime .. endTime) and SID_s == \"{SID}\" and \"{Provider}\" contains PROVIDER_INSTANCE_s\r\n| extend planneddatetime =  todatetime(strcat(SDLSTRTDT_s, SDLSTRTTM_s))\r\n| extend startdatetime =  todatetime(strcat(STRTDATE_s, STRTTIME_s))\r\n| extend enddatetime =  todatetime(strcat(ENDDATE_s, ENDTIME_s))\r\n| extend Status = case( STATUS_s == 'F', 'Finished',\r\n                        STATUS_s == 'S', 'Released',\r\n                        STATUS_s == 'P', 'Scheduled',\r\n                        STATUS_s == 'A', 'Cancelled',\r\n                        STATUS_s == 'Z', 'Active',\r\n                        STATUS_s == 'Y', 'Ready', '')    \r\n| distinct Status, JOBNAME_s, JOBCLASS_s, PERIODIC_s, planneddatetime, startdatetime, enddatetime, hostname_s\r\n| join kind=inner (\r\n    COMMON_VM_ArmId_Mapping_CL\r\n    | where (isempty(sid_s) or sid_s==\"{SID}\") and \"{Provider}\" contains PROVIDER_INSTANCE_s\r\n    | distinct vmid_s=tolower(VM_ARM_ID_s), hostname_s=tolower(vm_name_s)\r\n) on hostname_s\r\n| project-away hostname_s1);\r\n\r\nunion isfuzzy=true \r\n(MissingTable\r\n| where false),\r\n(\r\nunion isfuzzy=true \r\n(\r\n    batches\r\n    | where Status==\"Active\"\r\n    | summarize Value=count() by hostname_s, vmid_s\r\n    | extend Category=\"Active Jobs\"\r\n), \r\n(\r\n    batches\r\n    | summarize Value=countif(datetime_diff(\"minute\", enddatetime, startdatetime) > 30) by hostname_s, vmid_s\r\n    | extend Category=\"Runtime > 30 Minutes\"\r\n), \r\n(\r\n    batches\r\n    | where Status != 'Scheduled' and Status != 'Released' and Status != 'Ready'\r\n    | summarize Value=countif(startdatetime > planneddatetime) by hostname_s, vmid_s\r\n    | extend Category=\"Jobs With Delayed Start\"\r\n)\r\n| order by Category, hostname_s)",
+                                "query": "let dummy = \"unmÃ¶glicher-wert!\";\r\nlet MissingTable = view () { print dummy_miss = 1, dummy_columnV1 = dummy, dummy_records = -1 };\r\n\r\nlet startTime=todatetime(\"{StartTime}\");\r\nlet endTime=todatetime(\"{EndTime}\");\r\n\r\nlet batches = \r\nunion isfuzzy=true \r\n(MissingTable\r\n| where false),\r\n(SapNetweaver_BatchJobs_CL\r\n| where serverTimestamp_t between (startTime .. endTime) and SID_s == \"{SID}\" and \"{Provider}\" contains PROVIDER_INSTANCE_s\r\n| extend planneddatetime =  todatetime(strcat(SDLSTRTDT_s, SDLSTRTTM_s))\r\n| extend startdatetime =  todatetime(strcat(STRTDATE_s, STRTTIME_s))\r\n| extend enddatetime =  todatetime(strcat(ENDDATE_s, ENDTIME_s))\r\n| extend Status = case( STATUS_s == 'F', 'Finished',\r\n                        STATUS_s == 'S', 'Released',\r\n                        STATUS_s == 'P', 'Scheduled',\r\n                        STATUS_s == 'A', 'Cancelled',\r\n                        STATUS_s == 'Z', 'Active',\r\n                        STATUS_s == 'Y', 'Ready', '')    \r\n| distinct Status, JOBNAME_s, JOBCLASS_s, PERIODIC_s, planneddatetime, startdatetime, enddatetime, hostname_s\r\n);\r\n\r\nunion isfuzzy=true \r\n(MissingTable\r\n| where false),\r\n(\r\nunion isfuzzy=true \r\n(\r\n    batches\r\n    | where Status==\"Active\"\r\n    | summarize Value=count() by hostname_s, vmid_s\r\n    | extend Category=\"Active Jobs\"\r\n), \r\n(\r\n    batches\r\n    | summarize Value=countif(datetime_diff(\"minute\", enddatetime, startdatetime) > 30) by hostname_s, vmid_s\r\n    | extend Category=\"Runtime > 30 Minutes\"\r\n), \r\n(\r\n    batches\r\n    | where Status != 'Scheduled' and Status != 'Released' and Status != 'Ready'\r\n    | summarize Value=countif(startdatetime > planneddatetime) by hostname_s, vmid_s\r\n    | extend Category=\"Jobs With Delayed Start\"\r\n)\r\n| order by Category, hostname_s)",
                                 "size": 3,
                                 "exportFieldName": "Category",
                                 "exportParameterName": "batchCategory",
@@ -1387,7 +1431,7 @@
                               "type": 3,
                               "content": {
                                 "version": "KqlItem/1.0",
-                                "query": "let startTime=todatetime(\"{StartTime}\");\r\nlet endTime=todatetime(\"{EndTime}\");\r\n\r\nSapNetweaver_BatchJobs_CL\r\n| where serverTimestamp_t between (startTime .. endTime) and SID_s == \"{SID}\" and \"{Provider}\" contains PROVIDER_INSTANCE_s\r\n| extend planneddatetime =  todatetime(strcat(SDLSTRTDT_s, SDLSTRTTM_s))\r\n| extend startdatetime =  todatetime(strcat(STRTDATE_s, STRTTIME_s))\r\n| extend enddatetime =  todatetime(strcat(ENDDATE_s, ENDTIME_s))\r\n| extend Status = case( STATUS_s == 'F', 'Finished',\r\n                        STATUS_s == 'S', 'Released',\r\n                        STATUS_s == 'P', 'Scheduled',\r\n                        STATUS_s == 'A', 'Cancelled',\r\n                        STATUS_s == 'Z', 'Active',\r\n                        STATUS_s == 'Y', 'Ready', '')    \r\n| where (\"{batchCategory}\" =~ \"Jobs with Delayed Start\" and Status != 'Scheduled' and Status != 'Released' and Status != 'Ready' and startdatetime > planneddatetime) or (\"{batchCategory}\" =~ \"Active Jobs\" and Status == \"Active\") or (\"{batchCategory}\" =~ \"Runtime > 30 minutes\" and datetime_diff(\"minute\", enddatetime, startdatetime) > 30)\r\n| distinct Status, JOBNAME_s, JOBCLASS_s, PERIODIC_s, planneddatetime, startdatetime, enddatetime, hostname_s, LASTCHNAME_s\r\n| join kind=inner (\r\n    COMMON_VM_ArmId_Mapping_CL\r\n    | where (isempty(sid_s) or sid_s==\"{SID}\") and \"{Provider}\" contains PROVIDER_INSTANCE_s\r\n    | distinct vmid_s=tolower(VM_ARM_ID_s), hostname_s=tolower(vm_name_s)\r\n) on hostname_s\r\n| project-away hostname_s1, hostname_s\r\n| order by planneddatetime desc",
+                                "query": "let startTime=todatetime(\"{StartTime}\");\r\nlet endTime=todatetime(\"{EndTime}\");\r\n\r\nSapNetweaver_BatchJobs_CL\r\n| where serverTimestamp_t between (startTime .. endTime) and SID_s == \"{SID}\" and \"{Provider}\" contains PROVIDER_INSTANCE_s\r\n| extend planneddatetime =  todatetime(strcat(SDLSTRTDT_s, SDLSTRTTM_s))\r\n| extend startdatetime =  todatetime(strcat(STRTDATE_s, STRTTIME_s))\r\n| extend enddatetime =  todatetime(strcat(ENDDATE_s, ENDTIME_s))\r\n| extend Status = case( STATUS_s == 'F', 'Finished',\r\n                        STATUS_s == 'S', 'Released',\r\n                        STATUS_s == 'P', 'Scheduled',\r\n                        STATUS_s == 'A', 'Cancelled',\r\n                        STATUS_s == 'Z', 'Active',\r\n                        STATUS_s == 'Y', 'Ready', '')    \r\n| where (\"{batchCategory}\" =~ \"Jobs with Delayed Start\" and Status != 'Scheduled' and Status != 'Released' and Status != 'Ready' and startdatetime > planneddatetime) or (\"{batchCategory}\" =~ \"Active Jobs\" and Status == \"Active\") or (\"{batchCategory}\" =~ \"Runtime > 30 minutes\" and datetime_diff(\"minute\", enddatetime, startdatetime) > 30)\r\n| distinct Status, JOBNAME_s, JOBCLASS_s, PERIODIC_s, planneddatetime, startdatetime, enddatetime, hostname_s, LASTCHNAME_s\r\n| order by planneddatetime desc",
                                 "size": 1,
                                 "queryType": 0,
                                 "resourceType": "microsoft.operationalinsights/workspaces",
@@ -2157,6 +2201,80 @@
               "groupType": "editable",
               "items": [
                 {
+                  "type": 1,
+                  "content": {
+                    "json": "<h1 style=\"text-align:center;\">Configure insights for your AMS instance: {AMSResource:name}</h1>\r\n<p style=\"text-align:center;\">To view VM metrics, please configure insights.</p>"
+                  },
+                  "name": "text - 0"
+                },
+                {
+                  "type": 1,
+                  "content": {
+                    "json": ""
+                  },
+                  "customWidth": "42",
+                  "name": "text - 2"
+                },
+                {
+                  "type": 11,
+                  "content": {
+                    "version": "LinkItem/1.0",
+                    "style": "list",
+                    "links": [
+                      {
+                        "id": "f7ead4d9-b990-4ade-a58d-74e8b6800936",
+                        "linkTarget": "OpenBlade",
+                        "linkLabel": "Configure Insights",
+                        "style": "primary",
+                        "linkIsContextBlade": true,
+                        "bladeOpenContext": {
+                          "bladeName": "ManageInsights.ReactView",
+                          "extensionName": "Microsoft_Azure_WorkloadMonitor",
+                          "bladeParameters": [
+                            {
+                              "name": "resourceId",
+                              "source": "parameter",
+                              "value": "AMSResource"
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  },
+                  "customWidth": "16",
+                  "name": "links - 1"
+                },
+                {
+                  "type": 1,
+                  "content": {
+                    "json": ""
+                  },
+                  "customWidth": "42",
+                  "name": "text - 3"
+                }
+              ]
+            },
+            "conditionalVisibilities": [
+              {
+                "parameterName": "Tab",
+                "comparison": "isEqualTo",
+                "value": "VM"
+              },
+              {
+                "parameterName": "vmsExist",
+                "comparison": "isNotEqualTo",
+                "value": "true"
+              }
+            ],
+            "name": "vmMetricsCheck"
+          },
+          {
+            "type": 12,
+            "content": {
+              "version": "NotebookGroup/1.0",
+              "groupType": "editable",
+              "items": [
+                {
                   "type": 12,
                   "content": {
                     "version": "NotebookGroup/1.0",
@@ -2466,12 +2584,93 @@
                 }
               ]
             },
-            "conditionalVisibility": {
-              "parameterName": "Tab",
-              "comparison": "isEqualTo",
-              "value": "VM"
-            },
+            "conditionalVisibilities": [
+              {
+                "parameterName": "Tab",
+                "comparison": "isEqualTo",
+                "value": "VM"
+              },
+              {
+                "parameterName": "vmsExist",
+                "comparison": "isEqualTo",
+                "value": "true"
+              }
+            ],
             "name": "vmMetrics"
+          },
+          {
+            "type": 12,
+            "content": {
+              "version": "NotebookGroup/1.0",
+              "groupType": "editable",
+              "items": [
+                {
+                  "type": 1,
+                  "content": {
+                    "json": "<h1 style=\"text-align:center;\">Configure insights for your AMS instance: {AMSResource:name}</h1>\r\n<p style=\"text-align:center;\">To view Config Drifts, please configure insights.</p>"
+                  },
+                  "name": "text - 0"
+                },
+                {
+                  "type": 1,
+                  "content": {
+                    "json": ""
+                  },
+                  "customWidth": "42",
+                  "name": "PreConfigureBuffer"
+                },
+                {
+                  "type": 11,
+                  "content": {
+                    "version": "LinkItem/1.0",
+                    "style": "list",
+                    "links": [
+                      {
+                        "id": "04f58472-2dda-4c18-89a8-ea336cc5f36c",
+                        "linkTarget": "OpenBlade",
+                        "linkLabel": "Configure Insights",
+                        "style": "primary",
+                        "linkIsContextBlade": true,
+                        "bladeOpenContext": {
+                          "bladeName": "ManageInsights.ReactView",
+                          "extensionName": "Microsoft_Azure_WorkloadMonitor",
+                          "bladeParameters": [
+                            {
+                              "name": "resourceId",
+                              "source": "parameter",
+                              "value": "AMSResource"
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  },
+                  "customWidth": "16",
+                  "name": "links - 2"
+                },
+                {
+                  "type": 1,
+                  "content": {
+                    "json": ""
+                  },
+                  "customWidth": "42",
+                  "name": "text - 3"
+                }
+              ]
+            },
+            "conditionalVisibilities": [
+              {
+                "parameterName": "Tab",
+                "comparison": "isEqualTo",
+                "value": "Config"
+              },
+              {
+                "parameterName": "vmsExist",
+                "comparison": "isNotEqualTo",
+                "value": "true"
+              }
+            ],
+            "name": "configDriftsCheck"
           },
           {
             "type": 12,
@@ -2558,6 +2757,7 @@
                 }
               ]
             },
+            "customWidth": "42",
             "conditionalVisibility": {
               "parameterName": "Tab",
               "comparison": "isEqualTo",

--- a/Workbooks/SapMonitor2.0/AIOpsInsights/Performance Insights/Auto Perf RCA.workbook
+++ b/Workbooks/SapMonitor2.0/AIOpsInsights/Performance Insights/Auto Perf RCA.workbook
@@ -2203,7 +2203,7 @@
                 {
                   "type": 1,
                   "content": {
-                    "json": "<h1 style=\"text-align:center;\">Configure insights for your AMS instance: {AMSResource:name}</h1>\r\n<p style=\"text-align:center;\">To view VM metrics, please configure insights.</p>"
+                    "json": "<h1 style=\"text-align:center;\">Configure access to infrastructure to view further Insights</h1>"
                   },
                   "name": "text - 0"
                 },
@@ -2241,7 +2241,7 @@
                       }
                     ]
                   },
-                  "customWidth": "16",
+                  "customWidth": "20",
                   "name": "links - 1"
                 },
                 {
@@ -2249,7 +2249,7 @@
                   "content": {
                     "json": ""
                   },
-                  "customWidth": "42",
+                  "customWidth": "38",
                   "name": "text - 3"
                 }
               ]
@@ -2607,7 +2607,7 @@
                 {
                   "type": 1,
                   "content": {
-                    "json": "<h1 style=\"text-align:center;\">Configure insights for your AMS instance: {AMSResource:name}</h1>\r\n<p style=\"text-align:center;\">To view Config Drifts, please configure insights.</p>"
+                    "json": "<h1 style=\"text-align:center;\">Configure access to infrastructure to view further Insights</h1>"
                   },
                   "name": "text - 0"
                 },
@@ -2645,7 +2645,7 @@
                       }
                     ]
                   },
-                  "customWidth": "16",
+                  "customWidth": "20",
                   "name": "links - 2"
                 },
                 {
@@ -2653,7 +2653,7 @@
                   "content": {
                     "json": ""
                   },
-                  "customWidth": "42",
+                  "customWidth": "38",
                   "name": "text - 3"
                 }
               ]

--- a/Workbooks/SapMonitor2.0/AIOpsInsights/SAP AMS.workbook
+++ b/Workbooks/SapMonitor2.0/AIOpsInsights/SAP AMS.workbook
@@ -1938,7 +1938,8 @@
                                 "showDefault": false
                               },
                               "queryType": 0,
-                              "resourceType": "microsoft.workloads/monitors"
+                              "resourceType": "microsoft.workloads/monitors",
+                              "value": "netweaver"
                             }
                           ],
                           "style": "pills",
@@ -2087,8 +2088,8 @@
                                       },
                                       {
                                         "name": "Provider",
-                                        "source": "parameter",
-                                        "value": "providerInstance"
+                                        "source": "static",
+                                        "value": "{providerInstance}"
                                       },
                                       {
                                         "name": "TimePeriod",
@@ -2557,15 +2558,16 @@
                                         },
                                         {
                                           "name": "Provider",
-                                          "source": "parameter",
-                                          "value": "providerInstance"
+                                          "source": "static",
+                                          "value": "{providerInstance}"
                                         },
                                         {
                                           "name": "AlertTemplate",
                                           "source": "static",
                                           "value": "sapnetweaver-response-time"
                                         }
-                                      ]
+                                      ],
+                                      "viewerMode": false
                                     }
                                   }
                                 ]
@@ -2647,15 +2649,16 @@
                                         },
                                         {
                                           "name": "Provider",
-                                          "source": "parameter",
-                                          "value": "providerInstance"
+                                          "source": "static",
+                                          "value": "{providerInstance}"
                                         },
                                         {
                                           "name": "AlertTemplate",
                                           "source": "static",
                                           "value": "sapnetweaver-batch-job-jobname"
                                         }
-                                      ]
+                                      ],
+                                      "viewerMode": false
                                     }
                                   }
                                 ]

--- a/Workbooks/SapMonitor2.0/AIOpsInsights/SAP AMS.workbook
+++ b/Workbooks/SapMonitor2.0/AIOpsInsights/SAP AMS.workbook
@@ -547,19 +547,6 @@
                   "type": 1,
                   "value": "yes",
                   "isHiddenWhenLocked": true
-                },
-                {
-                  "id": "3a7cab95-02f1-43db-ae7e-b303f0bf999b",
-                  "version": "KqlParameterItem/1.0",
-                  "name": "DefaultProcess2",
-                  "type": 1,
-                  "query": "SapNetweaver_GetProcessList_CL\r\n| where serverTimestamp_t between (todatetime(\"{timePeriod:startISO}\") .. todatetime(\"{timePeriod:endISO}\")) and SID_s==\"{selSID}\" and \"{providerInstance}\" contains PROVIDER_INSTANCE_s\r\n| limit 1\r\n| project description_s",
-                  "crossComponentResources": [
-                    "{workspace}"
-                  ],
-                  "isHiddenWhenLocked": true,
-                  "queryType": 0,
-                  "resourceType": "microsoft.operationalinsights/workspaces"
                 }
               ],
               "style": "pills",
@@ -621,6 +608,40 @@
               }
             ],
             "name": "ConfigureButton_Main"
+          },
+          {
+            "type": 9,
+            "content": {
+              "version": "KqlParameterItem/1.0",
+              "crossComponentResources": [
+                "{workspace}"
+              ],
+              "parameters": [
+                {
+                  "id": "0ee961d3-8d06-43fd-8bbe-7f1162dbcc62",
+                  "version": "KqlParameterItem/1.0",
+                  "name": "DefaultProcess2",
+                  "type": 1,
+                  "query": "SapNetweaver_GetProcessList_CL\r\n| where serverTimestamp_t between (todatetime(\"{timePeriod:startISO}\") .. todatetime(\"{timePeriod:endISO}\")) and SID_s==\"{selSID}\" and \"{providerInstance}\" contains PROVIDER_INSTANCE_s\r\n| limit 1\r\n| project description_s",
+                  "crossComponentResources": [
+                    "{workspace}"
+                  ],
+                  "isHiddenWhenLocked": true,
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces",
+                  "value": null
+                }
+              ],
+              "style": "pills",
+              "queryType": 0,
+              "resourceType": "microsoft.operationalinsights/workspaces"
+            },
+            "conditionalVisibility": {
+              "parameterName": "hidden",
+              "comparison": "isEqualTo",
+              "value": "true"
+            },
+            "name": "defaultProcessParam"
           },
           {
             "type": 1,
@@ -2469,5 +2490,5 @@
       "name": "parentGroup"
     }
   ],
-  "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
+    "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
 }

--- a/Workbooks/SapMonitor2.0/AIOpsInsights/SAP AMS.workbook
+++ b/Workbooks/SapMonitor2.0/AIOpsInsights/SAP AMS.workbook
@@ -148,7 +148,7 @@
                   "version": "KqlParameterItem/1.0",
                   "name": "showData",
                   "type": 2,
-                  "query": "print \"{vmIdsExist}\"==\"true\" and (\"{nwExists}\"==\"true\" or \"{hanaExists}\"==\"true\")",
+                  "query": "print (\"{nwExists}\"==\"true\" or \"{hanaExists}\"==\"true\")",
                   "crossComponentResources": [
                     "{workspace}"
                   ],
@@ -401,6 +401,11 @@
                 "parameterName": "vmIdsExist",
                 "comparison": "isEqualTo",
                 "value": "false"
+              },
+              {
+                "parameterName": "hidden",
+                "comparison": "isEqualTo",
+                "value": "true"
               }
             ],
             "name": "vmIdsMissing"
@@ -1144,6 +1149,11 @@
                                   "name": "TimePeriod",
                                   "source": "column",
                                   "value": "displayTime"
+                                },
+                                {
+                                  "name": "Provider",
+                                  "source": "static",
+                                  "value": "{providerInstance}"
                                 }
                               ],
                               "viewerMode": false
@@ -2459,5 +2469,5 @@
       "name": "parentGroup"
     }
   ],
-    "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
+  "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
 }

--- a/Workbooks/SapMonitor2.0/AIOpsInsights/SAP AMS.workbook
+++ b/Workbooks/SapMonitor2.0/AIOpsInsights/SAP AMS.workbook
@@ -974,25 +974,6 @@
                   "type": 3,
                   "content": {
                     "version": "KqlItem/1.0",
-                    "query": "let allVMs=COMMON_VM_ArmId_Mapping_CL \r\n| distinct PROVIDER_INSTANCE_s, Provider_Type_s, VM_ARM_ID_s=tolower(VM_ARM_ID_s), vm_name_s=tolower(vm_name_s)\r\n| where isnotempty(VM_ARM_ID_s)\r\n| extend SAPComponent=iff(Provider_Type_s=~\"SapHana\", \"SAP Hana\", iff(Provider_Type_s=~\"SapNetWeaver\", \"SAP NetWeaver\", \"\"));\r\nunion isfuzzy=true (\r\n    allVMs\r\n    | where Provider_Type_s =~ \"SapNetWeaver\"\r\n    | join kind=inner (\r\n        SapNetweaver_GetProcessList_CL\r\n        | where SID_s == \"{selSID}\"\r\n        | distinct hostname_s=tolower(hostname_s), PROVIDER_INSTANCE_s\r\n    ) on $left.vm_name_s==$right.hostname_s, PROVIDER_INSTANCE_s\r\n    | project Provider_Type_s, SAPComponent, PROVIDER_INSTANCE_s, VM_ARM_ID_s\r\n),\r\n(\r\n    allVMs\r\n    | where Provider_Type_s =~ \"SapHana\"\r\n    | join kind=inner (\r\n        SapHana_SystemAvailability_CL\r\n        | distinct hostname_s=tolower(HOST_s), PROVIDER_INSTANCE_s\r\n    ) on $left.vm_name_s==$right.hostname_s, PROVIDER_INSTANCE_s\r\n    | project Provider_Type_s, SAPComponent, PROVIDER_INSTANCE_s, VM_ARM_ID_s\r\n)",
-                    "size": 3,
-                    "queryType": 0,
-                    "resourceType": "microsoft.operationalinsights/workspaces",
-                    "crossComponentResources": [
-                      "{workspace}"
-                    ]
-                  },
-                  "conditionalVisibility": {
-                    "parameterName": "hidden",
-                    "comparison": "isEqualTo",
-                    "value": "no"
-                  },
-                  "name": "providerTypeMapping"
-                },
-                {
-                  "type": 3,
-                  "content": {
-                    "version": "KqlItem/1.0",
                     "query": "AlertsManagementResources\r\n| where type =~ 'microsoft.alertsmanagement/alerts'\r\n| extend StartTime = todatetime(properties.essentials.startDateTime)\r\n| where StartTime between (todatetime(\"{timePeriod:startISO}\") .. todatetime(\"{timePeriod:endISO}\"))\r\n| extend State=tostring(properties.essentials.alertState)\r\n| extend AlertRule=tolower(tostring(properties.essentials.alertRule))\r\n| extend Severity=tostring(properties.essentials.severity)\r\n| extend MonitorCondition=tostring(properties.essentials.monitorCondition)\r\n| where isempty(\"{alertSeverity}\") or \"{alertSeverity}\" contains Severity\r\n| join kind=inner (Resources \r\n    | where type =~ 'microsoft.insights/scheduledQueryRules'\r\n    | extend workspace = tostring(properties.scopes[0])\r\n    | extend thresholdTag = strcat(properties.criteria.allOf[0].operator, \" \", properties.criteria.allOf[0].threshold)\r\n\t| extend pInstance=tags.['profile-id'], templateId=tags.['alert-template-id']\r\n    | where workspace =~ '{workspace}' and ((\"{selTab}\"==\"Availability\" and \"{availabilityAlertTemplates}\" contains templateId) or (\"{selTab}\"!=\"Availability\" and \"{performanceAlertTemplates}\" contains templateId)) and (\"{providerInstance}\") contains pInstance\r\n    | project AlertRule=tolower(id), Description=properties.description, pInstance, templateId, thresholdTag) on AlertRule\r\n| order by Severity asc, State, StartTime\r\n| project Name=strcat(name, \" (\", thresholdTag, \")\"), pInstance, Severity, State, StartTime, id, templateId, Insights=\"Investigate\", displayTime=strcat(datetime_add(\"minute\", -30, StartTime), \" - \", datetime_add(\"minute\", 30, StartTime))",
                     "size": 1,
                     "noDataMessage": "No alerts found in this time range or no alert rules have been configured for this monitoring profile.",
@@ -1108,6 +1089,72 @@
                           "formatter": 5
                         },
                         {
+                          "columnMatch": "Insights",
+                          "formatter": 1,
+                          "formatOptions": {
+                            "linkTarget": "WorkbookTemplate",
+                            "linkIsContextBlade": true,
+                            "workbookContext": {
+                              "componentIdSource": "workbook",
+                              "resourceIdsSource": "workbook",
+                              "templateIdSource": "static",
+                              "templateId": "Community-Workbooks/SapMonitor2.0/AIOpsInsights/Availability Insights",
+                              "typeSource": "workbook",
+                              "gallerySource": "workbook",
+                              "locationSource": "workbook",
+                              "workbookName": "Availability alert investigation for {selSID}",
+                              "passSpecificParams": true,
+                              "templateParameters": [
+                                {
+                                  "name": "SID",
+                                  "source": "parameter",
+                                  "value": "selSID"
+                                },
+                                {
+                                  "name": "selProvider",
+                                  "source": "column",
+                                  "value": "pInstance"
+                                },
+                                {
+                                  "name": "TimeRange",
+                                  "source": "parameter",
+                                  "value": "timePeriod"
+                                },
+                                {
+                                  "name": "AlertName",
+                                  "source": "column",
+                                  "value": "Name"
+                                },
+                                {
+                                  "name": "AlertFired",
+                                  "source": "column",
+                                  "value": "StartTime"
+                                },
+                                {
+                                  "name": "Process",
+                                  "source": "parameter",
+                                  "value": "DefaultProcess2"
+                                },
+                                {
+                                  "name": "Tab",
+                                  "source": "static",
+                                  "value": "Summary"
+                                },
+                                {
+                                  "name": "TimePeriod",
+                                  "source": "column",
+                                  "value": "displayTime"
+                                }
+                              ],
+                              "viewerMode": false
+                            }
+                          }
+                        },
+                        {
+                          "columnMatch": "displayTime",
+                          "formatter": 5
+                        },
+                        {
                           "columnMatch": "AlertInfo",
                           "formatter": 5,
                           "formatOptions": {
@@ -1171,7 +1218,6 @@
                     },
                     "sortBy": []
                   },
-                  "customWidth": "0",
                   "conditionalVisibilities": [
                     {
                       "parameterName": "selTab",
@@ -1186,341 +1232,10 @@
                       "parameterName": "alertsOptsData",
                       "comparison": "isNotEqualTo",
                       "value": "[]"
-                    },
-                    {
-                      "parameterName": "hidden",
-                      "comparison": "isEqualTo",
-                      "value": "no"
                     }
                   ],
                   "showPin": false,
                   "name": "firedAlertsAvail"
-                },
-                {
-                  "type": 3,
-                  "content": {
-                    "version": "KqlItem/1.0",
-                    "query": "{\"version\":\"Merge/1.0\",\"merges\":[{\"id\":\"31e8cdd4-6e9b-496a-b63a-e47b40872160\",\"mergeType\":\"inner\",\"leftTable\":\"firedAlertsAvail\",\"rightTable\":\"providerTypeMapping\",\"leftColumn\":\"pInstance\",\"rightColumn\":\"PROVIDER_INSTANCE_s\"}],\"projectRename\":[{\"originalName\":\"[firedAlertsAvail].Name\",\"mergedName\":\"Name\",\"fromId\":\"31e8cdd4-6e9b-496a-b63a-e47b40872160\"},{\"originalName\":\"[firedAlertsAvail].pInstance\",\"mergedName\":\"pInstance\",\"fromId\":\"31e8cdd4-6e9b-496a-b63a-e47b40872160\"},{\"originalName\":\"[providerTypeMapping].VM_ARM_ID_s\",\"mergedName\":\"VM_ARM_ID_s\",\"fromId\":\"unknown\"},{\"originalName\":\"[firedAlertsAvail].id\",\"mergedName\":\"id\",\"fromId\":\"31e8cdd4-6e9b-496a-b63a-e47b40872160\"},{\"originalName\":\"[firedAlertsAvail].Severity\",\"mergedName\":\"Severity\",\"fromId\":\"31e8cdd4-6e9b-496a-b63a-e47b40872160\"},{\"originalName\":\"[firedAlertsAvail].State\",\"mergedName\":\"State\",\"fromId\":\"31e8cdd4-6e9b-496a-b63a-e47b40872160\"},{\"originalName\":\"[firedAlertsAvail].StartTime\",\"mergedName\":\"Fired Time\",\"fromId\":\"31e8cdd4-6e9b-496a-b63a-e47b40872160\"},{\"originalName\":\"[firedAlertsAvail].templateId\",\"mergedName\":\"templateId\",\"fromId\":\"31e8cdd4-6e9b-496a-b63a-e47b40872160\"},{\"originalName\":\"[providerTypeMapping].PROVIDER_INSTANCE_s\",\"mergedName\":\"PROVIDER_INSTANCE_s\",\"fromId\":\"31e8cdd4-6e9b-496a-b63a-e47b40872160\"},{\"originalName\":\"[providerTypeMapping].Provider_Type_s\",\"mergedName\":\"Provider_Type_s\",\"fromId\":\"31e8cdd4-6e9b-496a-b63a-e47b40872160\"},{\"originalName\":\"[providerTypeMapping].SAPComponent\",\"mergedName\":\"SAPComponent\",\"fromId\":\"31e8cdd4-6e9b-496a-b63a-e47b40872160\"},{\"originalName\":\"[firedAlertsAvail].Insights\",\"mergedName\":\"Insights\",\"fromId\":\"unknown\"},{\"originalName\":\"[firedAlertsAvail].displayTime\",\"mergedName\":\"displayTime\",\"fromId\":\"unknown\"}]}",
-                    "size": 1,
-                    "noDataMessage": "No alerts found in this time range or no alert rules have been configured for this monitoring profile.",
-                    "exportedParameters": [
-                      {
-                        "fieldName": "Fired Time",
-                        "parameterName": "param_firedTime",
-                        "parameterType": 1
-                      },
-                      {
-                        "fieldName": "templateId",
-                        "parameterName": "param_templateId",
-                        "parameterType": 1
-                      },
-                      {
-                        "fieldName": "Name",
-                        "parameterName": "param_AlertName",
-                        "parameterType": 1
-                      }
-                    ],
-                    "queryType": 7,
-                    "gridSettings": {
-                      "formatters": [
-                        {
-                          "columnMatch": "Name",
-                          "formatter": 1,
-                          "formatOptions": {
-                            "linkTarget": "OpenBlade",
-                            "linkIsContextBlade": true,
-                            "workbookContext": {
-                              "componentIdSource": "workbook",
-                              "resourceIdsSource": "workbook",
-                              "templateIdSource": "parameter",
-                              "templateId": "sapInsightsWB",
-                              "typeSource": "workbook",
-                              "gallerySource": "workbook",
-                              "locationSource": "workbook",
-                              "passSpecificParams": true,
-                              "templateParameters": [
-                                {
-                                  "name": "timePeriod",
-                                  "source": "column",
-                                  "value": "StartTime"
-                                }
-                              ]
-                            },
-                            "bladeOpenContext": {
-                              "bladeName": "AlertDetailsTemplateBlade",
-                              "extensionName": "Microsoft_Azure_Monitoring",
-                              "bladeParameters": [
-                                {
-                                  "name": "alertId",
-                                  "source": "column",
-                                  "value": "id"
-                                }
-                              ]
-                            },
-                            "customColumnWidthSetting": "34%"
-                          },
-                          "tooltipFormat": {
-                            "tooltip": "Click on this to filter insights specific to this alert."
-                          }
-                        },
-                        {
-                          "columnMatch": "pInstance",
-                          "formatter": 1,
-                          "formatOptions": {
-                            "customColumnWidthSetting": "15%"
-                          }
-                        },
-                        {
-                          "columnMatch": "id",
-                          "formatter": 5
-                        },
-                        {
-                          "columnMatch": "Severity",
-                          "formatter": 18,
-                          "formatOptions": {
-                            "thresholdsOptions": "icons",
-                            "thresholdsGrid": [
-                              {
-                                "operator": "==",
-                                "thresholdValue": "Sev0",
-                                "representation": "Sev0",
-                                "text": "0: Critical"
-                              },
-                              {
-                                "operator": "==",
-                                "thresholdValue": "Sev1",
-                                "representation": "Sev1",
-                                "text": "1: Error"
-                              },
-                              {
-                                "operator": "==",
-                                "thresholdValue": "Sev2",
-                                "representation": "Sev2",
-                                "text": "2: Warning"
-                              },
-                              {
-                                "operator": "==",
-                                "thresholdValue": "Sev3",
-                                "representation": "Sev3",
-                                "text": "3: Information"
-                              },
-                              {
-                                "operator": "==",
-                                "thresholdValue": "Sev4",
-                                "representation": "Sev4",
-                                "text": "4: Verbose"
-                              },
-                              {
-                                "operator": "Default",
-                                "thresholdValue": null,
-                                "representation": "success",
-                                "text": "{0}{1}"
-                              }
-                            ],
-                            "customColumnWidthSetting": "15%"
-                          }
-                        },
-                        {
-                          "columnMatch": "State",
-                          "formatter": 0,
-                          "formatOptions": {
-                            "customColumnWidthSetting": "10%"
-                          }
-                        },
-                        {
-                          "columnMatch": "Fired Time",
-                          "formatter": 6,
-                          "formatOptions": {
-                            "customColumnWidthSetting": "16%"
-                          },
-                          "dateFormat": {
-                            "showUtcTime": null,
-                            "formatName": "shortDateTimePattern"
-                          }
-                        },
-                        {
-                          "columnMatch": "templateId",
-                          "formatter": 5
-                        },
-                        {
-                          "columnMatch": "PROVIDER_INSTANCE_s",
-                          "formatter": 5
-                        },
-                        {
-                          "columnMatch": "SAPComponent",
-                          "formatter": 5
-                        },
-                        {
-                          "columnMatch": "Insights",
-                          "formatter": 1,
-                          "formatOptions": {
-                            "linkTarget": "WorkbookTemplate",
-                            "linkIsContextBlade": true,
-                            "workbookContext": {
-                              "componentIdSource": "workbook",
-                              "resourceIdsSource": "workbook",
-                              "templateIdSource": "static",
-                              "templateId": "Community-Workbooks/SapMonitor2.0/AIOpsInsights/Availability Insights",
-                              "typeSource": "workbook",
-                              "gallerySource": "workbook",
-                              "locationSource": "workbook",
-                              "workbookName": "Availability alert investigation for {selSID}",
-                              "passSpecificParams": true,
-                              "templateParameters": [
-                                {
-                                  "name": "SID",
-                                  "source": "parameter",
-                                  "value": "selSID"
-                                },
-                                {
-                                  "name": "Provider",
-                                  "source": "static",
-                                  "value": "{providerInstance}"
-                                },
-                                {
-                                  "name": "TimeRange",
-                                  "source": "parameter",
-                                  "value": "timePeriod"
-                                },
-                                {
-                                  "name": "TimePeriod",
-                                  "source": "column",
-                                  "value": "displayTime"
-                                },
-                                {
-                                  "name": "SAPComponent",
-                                  "source": "column",
-                                  "value": "SAPComponent"
-                                },
-                                {
-                                  "name": "AlertName",
-                                  "source": "column",
-                                  "value": "Name"
-                                },
-                                {
-                                  "name": "AlertFired",
-                                  "source": "column",
-                                  "value": "Fired Time"
-                                },
-                                {
-                                  "name": "VMID",
-                                  "source": "column",
-                                  "value": "VM_ARM_ID_s"
-                                },
-                                {
-                                  "name": "Process",
-                                  "source": "parameter",
-                                  "value": "DefaultProcess2"
-                                },
-                                {
-                                  "name": "Tab",
-                                  "source": "static",
-                                  "value": "Summary"
-                                }
-                              ]
-                            },
-                            "customColumnWidthSetting": "10%"
-                          }
-                        },
-                        {
-                          "columnMatch": "displayTime",
-                          "formatter": 5
-                        },
-                        {
-                          "columnMatch": "StartTime",
-                          "formatter": 6,
-                          "dateFormat": {
-                            "showUtcTime": null,
-                            "formatName": "shortDateTimePattern"
-                          }
-                        },
-                        {
-                          "columnMatch": "AlertInfo",
-                          "formatter": 5,
-                          "formatOptions": {
-                            "linkTarget": "OpenBlade",
-                            "linkIsContextBlade": false,
-                            "bladeOpenContext": {
-                              "bladeName": "AlertDetailsTemplateBlade",
-                              "extensionName": "Microsoft_Azure_Monitoring",
-                              "bladeParameters": [
-                                {
-                                  "name": "alertId",
-                                  "source": "column",
-                                  "value": "id"
-                                }
-                              ]
-                            }
-                          }
-                        },
-                        {
-                          "columnMatch": "MonitorCondition",
-                          "formatter": 18,
-                          "formatOptions": {
-                            "thresholdsOptions": "icons",
-                            "thresholdsGrid": [
-                              {
-                                "operator": "==",
-                                "thresholdValue": "Resolved",
-                                "representation": "Resolved",
-                                "text": "{0}{1}"
-                              },
-                              {
-                                "operator": "==",
-                                "thresholdValue": "Fired",
-                                "representation": "Fired",
-                                "text": "{0}{1}"
-                              },
-                              {
-                                "operator": "Default",
-                                "thresholdValue": null,
-                                "representation": "success",
-                                "text": "{0}{1}"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "columnMatch": "Description",
-                          "formatter": 1
-                        }
-                      ],
-                      "labelSettings": [
-                        {
-                          "columnId": "pInstance",
-                          "label": "Provider"
-                        },
-                        {
-                          "columnId": "VM_ARM_ID_s",
-                          "label": "VM Name"
-                        },
-                        {
-                          "columnId": "Insights",
-                          "label": "Action"
-                        }
-                      ]
-                    },
-                    "sortBy": []
-                  },
-                  "customWidth": "100",
-                  "conditionalVisibilities": [
-                    {
-                      "parameterName": "selTab",
-                      "comparison": "isEqualTo",
-                      "value": "Availability"
-                    },
-                    {
-                      "parameterName": "alertsOptsData",
-                      "comparison": "isNotEqualTo"
-                    },
-                    {
-                      "parameterName": "alertsOptsData",
-                      "comparison": "isNotEqualTo",
-                      "value": "[]"
-                    }
-                  ],
-                  "showPin": false,
-                  "name": "firedAlertsAvailMerged"
                 },
                 {
                   "type": 3,
@@ -1884,6 +1599,40 @@
                   "isHiddenWhenLocked": true,
                   "queryType": 0,
                   "resourceType": "microsoft.operationalinsights/workspaces"
+                },
+                {
+                  "id": "92892857-d475-4ecb-948a-49ac54b9c66a",
+                  "version": "KqlParameterItem/1.0",
+                  "name": "NWVMList",
+                  "type": 1,
+                  "query": "let startTime = todatetime(\"{startTime}\");\r\nlet endTime = todatetime(\"{endTime}\");\r\n\r\nSapNetweaver_GetSystemInstanceList_CL\r\n| where serverTimestamp_t between (startTime .. endTime)\r\n| where SID_s == \"{selSID}\" and \"{providerInstance}\" contains PROVIDER_INSTANCE_s\r\n| distinct hostname_s",
+                  "crossComponentResources": [
+                    "{workspace}"
+                  ],
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces"
+                },
+                {
+                  "id": "d185c54f-1d11-4bab-a80d-03847f22453f",
+                  "version": "KqlParameterItem/1.0",
+                  "name": "HanaVmList",
+                  "type": 2,
+                  "multiSelect": true,
+                  "quote": "'",
+                  "delimiter": ",",
+                  "query": "let startTime = todatetime(\"{startTime}\");\r\nlet endTime = todatetime(\"{endTime}\");\r\n\r\nSapHana_SystemAvailability_CL\r\n| where Time_Generated_t between (startTime .. endTime)\r\n| where \"{providerInstance}\" contains PROVIDER_INSTANCE_s\r\n| distinct HOST_s",
+                  "crossComponentResources": [
+                    "{workspace}"
+                  ],
+                  "typeSettings": {
+                    "additionalResourceOptions": [
+                      "value::all"
+                    ],
+                    "showDefault": false
+                  },
+                  "defaultValue": "value::all",
+                  "queryType": 0,
+                  "resourceType": "microsoft.operationalinsights/workspaces"
                 }
               ],
               "style": "pills",
@@ -1952,7 +1701,7 @@
                         "type": 3,
                         "content": {
                           "version": "KqlItem/1.0",
-                          "query": "let startTime = todatetime(\"{startTime}\");\r\nlet endTime = todatetime(\"{endTime}\");\r\n\r\nlet binSize=tolong(\"{minutesBin}\")*1m;\r\nlet hundredBin=datetime_diff(\"minute\", endTime, startTime);\r\n\r\nlet ParentAvailTable=SapNetweaver_GetProcessList_CL\r\n| where serverTimestamp_t between (startTime .. endTime) and SID_s==\"{selSID}\" and \"{providerInstance}\" contains PROVIDER_INSTANCE_s\r\n| project description_s, SID_s, hostname_s, dispstatus_s, serverTimestamp_t, ApplicationServer=strcat(hostname_s, \"_\", iff(toint(instanceNr_d)<10, strcat(\"0\", toint(instanceNr_d)), tostring(toint(instanceNr_d))));\r\n\r\nunion(ParentAvailTable\r\n| make-series AvailabilityTrend=iff(count() > 0, round(toreal(countif(dispstatus_s == 'SAPControl-GREEN')) / toreal(count()) * 100, 1), real(null)) default=real(null) on serverTimestamp_t step binSize  by SID_s, hostname_s, description_s, ApplicationServer\r\n| project Availability=toreal(series_stats_dynamic(series_fill_const(AvailabilityTrend, 0.0)).avg), SID_s, hostname_s, description_s, ApplicationServer \r\n| join kind=inner (\r\n    ParentAvailTable\r\n        | make-series AvailabilityTrend=iff(count() > 0, round(toreal(countif(dispstatus_s == 'SAPControl-GREEN')) / toreal(count()) * 100, 1), real(null)) default=real(null) on serverTimestamp_t step iff(hundredBin<100, 1m, hundredBin/100*1m) by SID_s, hostname_s, description_s\r\n        | project AvailabilityTrend=series_fill_const(AvailabilityTrend, 0.0), SID_s, hostname_s, description_s\r\n) on hostname_s, description_s, SID_s\r\n| join kind=inner (\r\n    COMMON_VM_ArmId_Mapping_CL\r\n    | where (isempty(sid_s) or sid_s==\"{selSID}\") and \"{providerInstance}\" contains PROVIDER_INSTANCE_s\r\n    | distinct VM_ARM_ID_s=tolower(VM_ARM_ID_s), vm_name_s) on $left.hostname_s==$right.vm_name_s\r\n| project description_s, SID_s, ApplicationServer, VM_ARM_ID_s, hostname_s, Availability, AvailabilityTrend\r\n| extend Insights=\"\", Display=\"\", SAPComponent='SAP NetWeaver', id=strcat(hostname_s,\"_\",description_s),parentid=hostname_s),\r\n(ParentAvailTable\r\n| distinct hostname_s\r\n| join kind=inner (\r\n    COMMON_VM_ArmId_Mapping_CL\r\n    | where (isempty(sid_s) or sid_s==\"{selSID}\") and \"{providerInstance}\" contains PROVIDER_INSTANCE_s\r\n    | distinct VM_ARM_ID_s=tolower(VM_ARM_ID_s), vm_name_s) on $left.hostname_s==$right.vm_name_s\r\n| project-away vm_name_s\r\n| extend id=hostname_s, parentid=\"\", SAPComponent='SAP NetWeaver', Insights=\"Investigate\", Display=hostname_s)",
+                          "query": "let startTime = todatetime(\"{startTime}\");\r\nlet endTime = todatetime(\"{endTime}\");\r\n\r\nlet binSize=tolong(\"{minutesBin}\")*1m;\r\nlet hundredBin=datetime_diff(\"minute\", endTime, startTime);\r\n\r\nlet ParentAvailTable=SapNetweaver_GetProcessList_CL\r\n| where serverTimestamp_t between (startTime .. endTime) and SID_s==\"{selSID}\" and \"{providerInstance}\" contains PROVIDER_INSTANCE_s\r\n| project description_s, SID_s, hostname_s, dispstatus_s, serverTimestamp_t, ApplicationServer=strcat(hostname_s, \"_\", iff(toint(instanceNr_d)<10, strcat(\"0\", toint(instanceNr_d)), tostring(toint(instanceNr_d))));\r\n\r\nunion(ParentAvailTable\r\n| make-series AvailabilityTrend=iff(count() > 0, round(toreal(countif(dispstatus_s == 'SAPControl-GREEN')) / toreal(count()) * 100, 1), real(null)) default=real(null) on serverTimestamp_t step binSize  by SID_s, hostname_s, description_s, ApplicationServer\r\n| project Availability=toreal(series_stats_dynamic(series_fill_const(AvailabilityTrend, 0.0)).avg), SID_s, hostname_s, description_s, ApplicationServer \r\n| join kind=inner (\r\n    ParentAvailTable\r\n        | make-series AvailabilityTrend=iff(count() > 0, round(toreal(countif(dispstatus_s == 'SAPControl-GREEN')) / toreal(count()) * 100, 1), real(null)) default=real(null) on serverTimestamp_t step iff(hundredBin<100, 1m, hundredBin/100*1m) by SID_s, hostname_s, description_s\r\n        | project AvailabilityTrend=series_fill_const(AvailabilityTrend, 0.0), SID_s, hostname_s, description_s\r\n) on hostname_s, description_s, SID_s\r\n| project description_s, SID_s, ApplicationServer, hostname_s, Availability, AvailabilityTrend\r\n| extend Insights=\"\", Display=\"\", SAPComponent='SAP NetWeaver', id=strcat(hostname_s,\"_\",description_s),parentid=hostname_s),\r\n(ParentAvailTable\r\n| distinct hostname_s\r\n| extend id=hostname_s, parentid=\"\", SAPComponent='SAP NetWeaver', Insights=\"Investigate\", Display=hostname_s)",
                           "size": 3,
                           "queryType": 0,
                           "resourceType": "microsoft.operationalinsights/workspaces",
@@ -1995,15 +1744,6 @@
                                       }
                                     ]
                                   }
-                                }
-                              },
-                              {
-                                "columnMatch": "VM_ARM_ID_s",
-                                "formatter": 5,
-                                "formatOptions": {
-                                  "linkTarget": "Resource",
-                                  "linkIsContextBlade": false,
-                                  "customColumnWidthSetting": "5%"
                                 }
                               },
                               {
@@ -2077,9 +1817,9 @@
                                     "passSpecificParams": true,
                                     "templateParameters": [
                                       {
-                                        "name": "VMID",
+                                        "name": "selVmName",
                                         "source": "column",
-                                        "value": "VM_ARM_ID_s"
+                                        "value": "hostname_s"
                                       },
                                       {
                                         "name": "SID",
@@ -2125,8 +1865,14 @@
                                         "name": "Tab",
                                         "source": "static",
                                         "value": "Summary"
+                                      },
+                                      {
+                                        "name": "NwVmList",
+                                        "source": "parameter",
+                                        "value": "NWVMList"
                                       }
-                                    ]
+                                    ],
+                                    "viewerMode": false
                                   }
                                 }
                               },
@@ -2141,10 +1887,6 @@
                               {
                                 "columnMatch": "parentid",
                                 "formatter": 5
-                              },
-                              {
-                                "columnMatch": "VM Name",
-                                "formatter": 1
                               },
                               {
                                 "columnMatch": "display_s",
@@ -2178,10 +1920,6 @@
                               {
                                 "columnId": "ApplicationServer",
                                 "label": "Application Server"
-                              },
-                              {
-                                "columnId": "VM_ARM_ID_s",
-                                "label": "VM Name"
                               },
                               {
                                 "columnId": "hostname_s",
@@ -2226,11 +1964,46 @@
                         "name": "netweaverAvailability"
                       },
                       {
+                        "type": 9,
+                        "content": {
+                          "version": "KqlParameterItem/1.0",
+                          "crossComponentResources": [
+                            "{workspace}"
+                          ],
+                          "parameters": [
+                            {
+                              "id": "afbe4846-ea41-4452-9d6f-4f0d11ed4f15",
+                              "version": "KqlParameterItem/1.0",
+                              "name": "param_database",
+                              "type": 1,
+                              "query": "SapHana_size01_CL\r\n| where TimeGenerated > ago(1d)\r\n| where \"{providerInstance}\" contains PROVIDER_INSTANCE_s \r\n| order by Time_Generated_t desc\r\n| take 1\r\n| project DATABASE_NAME_s",
+                              "crossComponentResources": [
+                                "{workspace}"
+                              ],
+                              "timeContext": {
+                                "durationMs": 86400000
+                              },
+                              "queryType": 0,
+                              "resourceType": "microsoft.operationalinsights/workspaces"
+                            }
+                          ],
+                          "style": "pills",
+                          "queryType": 0,
+                          "resourceType": "microsoft.operationalinsights/workspaces"
+                        },
+                        "conditionalVisibility": {
+                          "parameterName": "hidden",
+                          "comparison": "isEqualTo",
+                          "value": "true"
+                        },
+                        "name": "parameters - 2"
+                      },
+                      {
                         "type": 3,
                         "content": {
                           "version": "KqlItem/1.0",
-                          "query": "let startTime = todatetime(\"{startTime}\");\r\nlet endTime = todatetime(\"{endTime}\");\r\n\r\nlet bin = tolong(\"{minutesBin}\");\r\nlet binSize=iff(bin < 60, 60m, bin*1m);\r\nlet hundredBin=datetime_diff(\"hour\", endTime, startTime);\r\n\r\nlet ParentAvailTable=SapHana_SystemOverview_CL \r\n| extend sid = tostring(VALUE_s)\r\n| extend provider = tostring(PROVIDER_INSTANCE_s)\r\n| where \"{providerInstance}\" contains provider\r\n| where NAME_s == \"Instance ID\" and sid == \"{selSID}\"\r\n| distinct SID_s = sid, PROVIDER_INSTANCE_s=provider\r\n| join kind=inner (SapHana_SystemAvailability_CL\r\n    | where Time_Generated_t between (startTime .. endTime)\r\n    ) on PROVIDER_INSTANCE_s\r\n| project-away DATABASE_NAME_s\r\n| join kind=inner (SapHana_size01_CL \r\n    | where SYSTEM_ID_s == \"{selSID}\"\r\n    | distinct PROVIDER_INSTANCE_s, DATABASE_NAME_s\r\n    ) on PROVIDER_INSTANCE_s\r\n| project DATABASE_NAME_s, PORT_d, SERVICE_NAME_s, SERVICE_ACTIVE_s, HOST_s, HOST_ACTIVE_s, Time_Generated_t, SID_s;\r\n\r\nunion(ParentAvailTable\r\n| make-series AvailabilityTrend=iff(count() > 0, round(toreal(countif(HOST_ACTIVE_s == 'YES')) / toreal(count()) * 100, 1), real(null)) default=real(null) on Time_Generated_t step binSize  by HOST_s, DATABASE_NAME_s\r\n| project Availability=round(toreal(series_stats_dynamic(series_fill_const(AvailabilityTrend, 0.0)).avg), 1), HOST_s, DATABASE_NAME_s \r\n| join kind=inner (\r\n    ParentAvailTable\r\n        | make-series AvailabilityTrend=iff(count() > 0, round(toreal(countif(HOST_ACTIVE_s == 'YES')) / toreal(count()) * 100, 1), real(null)) default=real(null) on Time_Generated_t step iff(hundredBin<100, 1h, hundredBin/100*1h) by HOST_s, DATABASE_NAME_s\r\n        | project AvailabilityTrend=series_fill_const(AvailabilityTrend, 0.0), HOST_s, DATABASE_NAME_s\r\n) on HOST_s, DATABASE_NAME_s\r\n| join kind=inner (\r\n    COMMON_VM_ArmId_Mapping_CL\r\n    | where (isempty(sid_s) or sid_s==\"{selSID}\") and \"{providerInstance}\" contains PROVIDER_INSTANCE_s\r\n    | distinct VM_ARM_ID_s=tolower(VM_ARM_ID_s), vm_name_s) on $left.HOST_s==$right.vm_name_s\r\n| project description_s=DATABASE_NAME_s, VM_ARM_ID_s, Availability, AvailabilityTrend\r\n| extend Insights=\"Investigate\", SAPComponent='SAP Hana', SID_s = \"{selSID}\"\r\n| extend display_s=description_s, parentid=\"\", id=description_s, Service=\"\"),\r\n(ParentAvailTable\r\n| where isnotempty(SERVICE_NAME_s)\r\n| extend Service=strcat(SERVICE_NAME_s, \" (:\", toint(PORT_d), \")\")\r\n| make-series AvailabilityTrend=iff(count() > 0, round(toreal(countif(SERVICE_ACTIVE_s == 'YES')) / toreal(count()) * 100, 1), real(null)) default=real(null) on Time_Generated_t step binSize  by HOST_s, DATABASE_NAME_s, Service\r\n| project Availability=round(toreal(series_stats_dynamic(series_fill_const(AvailabilityTrend, 0.0)).avg), 1), HOST_s, DATABASE_NAME_s, Service \r\n| join kind=inner (\r\n    ParentAvailTable\r\n        | where isnotempty(SERVICE_NAME_s)\r\n        | extend Service=strcat(SERVICE_NAME_s, \" (:\", toint(PORT_d), \")\")\r\n        | make-series AvailabilityTrend=iff(count() > 0, round(toreal(countif(SERVICE_ACTIVE_s == 'YES')) / toreal(count()) * 100, 1), real(null)) default=real(null) on Time_Generated_t step iff(hundredBin<100, 1h, hundredBin/100*1h) by HOST_s, DATABASE_NAME_s, Service\r\n        | project AvailabilityTrend=series_fill_const(AvailabilityTrend, 0.0), HOST_s, DATABASE_NAME_s, Service\r\n) on HOST_s, DATABASE_NAME_s, Service\r\n| join kind=inner (\r\n    COMMON_VM_ArmId_Mapping_CL\r\n    | where (isempty(sid_s) or sid_s==\"{selSID}\") and \"{providerInstance}\" contains PROVIDER_INSTANCE_s\r\n    | distinct VM_ARM_ID_s=tolower(VM_ARM_ID_s), vm_name_s) on $left.HOST_s==$right.vm_name_s\r\n| project description_s=DATABASE_NAME_s, Service, VM_ARM_ID_s, Availability, AvailabilityTrend\r\n| extend Insights=\"\", SAPComponent='SAP Hana', SID_s = \"{selSID}\"\r\n| extend display_s=Service\r\n| extend parentid=description_s\r\n| extend id=strcat(parentid,\"_\",Service))\r\n| project id, parentid, description_s, Service, VM_ARM_ID_s, SID_s, Availability, AvailabilityTrend, Insights, SAPComponent, display_s",
-                          "size": 3,
+                          "query": "let startTime = todatetime(\"{startTime}\");\r\nlet endTime = todatetime(\"{endTime}\");\r\n\r\nlet availability_table = SapHana_SystemAvailability_CL\r\n| where Time_Generated_t between (startTime ..endTime)\r\n| where \"{providerInstance}\" contains PROVIDER_INSTANCE_s\r\n| where SERVICE_NAME_s != \"\"\r\n| where DATABASE_NAME_s == \"{param_database}\"\r\n| extend service_event = iff(SERVICE_NAME_s == '', EVENT_NAME_s, SERVICE_NAME_s)\r\n| extend Status = case(SERVICE_ACTIVE_s == 'YES', 0,\r\n                       SERVICE_ACTIVE_s == 'STARTING', 1,\r\n                       SERVICE_ACTIVE_s == 'STOPPING', 2,                        \r\n                       SERVICE_ACTIVE_s == 'UNKNOWN', 3,\r\n                       4) //NO\r\n| project service_event, SERVICE_NAME_s, SERVICE_ACTIVE_s, Status, HOST_s, HOST_STATUS_s, HOST_ACTIVE_s, PORT_d, TimeGenerated, PROVIDER_INSTANCE_s\r\n;\r\nlet services_table = SapHana_Services_CL\r\n| where TimeGenerated > ago(24h)\r\n| where \"{providerInstance}\" contains PROVIDER_INSTANCE_s\r\n| extend Status = case(ACTIVE_STATUS_s == 'YES', 0,\r\n                       ACTIVE_STATUS_s == 'STARTING', 1,\r\n                       ACTIVE_STATUS_s == 'STOPPING', 2,                        \r\n                       ACTIVE_STATUS_s == 'UNKNOWN', 3,\r\n                       4) //NO\r\n| project SERVICE_NAME_s, HOST_s, PORT_d, Status, ACTIVE_STATUS_s, TimeGenerated, PROVIDER_INSTANCE_s\r\n;\r\navailability_table\r\n| union services_table\r\n| summarize total=count(), failureCount=countif(Status != 0) by service_event, SERVICE_NAME_s, HOST_s, PORT_d, SERVICE_ACTIVE_s, PROVIDER_INSTANCE_s\r\n| extend Availability = round(((toreal(total) - toreal(failureCount)) / toreal(total)) * 100, 2)\r\n| summarize Availability = round(avg(Availability), 2), AvailabilityTrend = make_list(Availability) by PORT_d, SERVICE_NAME_s, HOST_s, PROVIDER_INSTANCE_s\r\n| extend id=strcat(HOST_s,\"_\",SERVICE_NAME_s), Insights = \"Investigate\", parentid=PROVIDER_INSTANCE_s",
+                          "size": 0,
                           "queryType": 0,
                           "resourceType": "microsoft.operationalinsights/workspaces",
                           "crossComponentResources": [
@@ -2239,33 +2012,16 @@
                           "gridSettings": {
                             "formatters": [
                               {
-                                "columnMatch": "id",
+                                "columnMatch": "$gen_group",
+                                "formatter": 1
+                              },
+                              {
+                                "columnMatch": "HOST_s",
                                 "formatter": 5
                               },
                               {
-                                "columnMatch": "parentid",
+                                "columnMatch": "PROVIDER_INSTANCE_s",
                                 "formatter": 5
-                              },
-                              {
-                                "columnMatch": "description_s",
-                                "formatter": 5
-                              },
-                              {
-                                "columnMatch": "Service",
-                                "formatter": 5,
-                                "formatOptions": {
-                                  "customColumnWidthSetting": "10%"
-                                }
-                              },
-                              {
-                                "columnMatch": "VM_ARM_ID_s",
-                                "formatter": 13,
-                                "formatOptions": {
-                                  "linkTarget": "Resource",
-                                  "linkIsContextBlade": false,
-                                  "showIcon": true,
-                                  "customColumnWidthSetting": "3%"
-                                }
                               },
                               {
                                 "columnMatch": "Availability",
@@ -2274,16 +2030,19 @@
                                   "thresholdsOptions": "icons",
                                   "thresholdsGrid": [
                                     {
-                                      "operator": "<",
-                                      "thresholdValue": "50",
-                                      "representation": "4",
+                                      "operator": "is Empty",
+                                      "representation": "Blank",
                                       "text": "{0}{1}"
                                     },
                                     {
                                       "operator": "<",
+                                      "thresholdValue": "50",
+                                      "representation": "4"
+                                    },
+                                    {
+                                      "operator": "<",
                                       "thresholdValue": "100",
-                                      "representation": "2",
-                                      "text": "{0}{1}"
+                                      "representation": "2"
                                     },
                                     {
                                       "operator": "Default",
@@ -2298,11 +2057,8 @@
                                   "options": {
                                     "style": "decimal",
                                     "useGrouping": true,
-                                    "maximumFractionDigits": 2
+                                    "minimumSignificantDigits": 2
                                   }
-                                },
-                                "tooltipFormat": {
-                                  "tooltip": "Click on this to expand availability trend and RCA."
                                 }
                               },
                               {
@@ -2313,6 +2069,10 @@
                                   "max": 100,
                                   "palette": "green"
                                 }
+                              },
+                              {
+                                "columnMatch": "id",
+                                "formatter": 5
                               },
                               {
                                 "columnMatch": "Insights",
@@ -2332,14 +2092,9 @@
                                     "passSpecificParams": true,
                                     "templateParameters": [
                                       {
-                                        "name": "Database",
+                                        "name": "selVmName",
                                         "source": "column",
-                                        "value": "description_s"
-                                      },
-                                      {
-                                        "name": "VMID",
-                                        "source": "column",
-                                        "value": "VM_ARM_ID_s"
+                                        "value": "HOST_s"
                                       },
                                       {
                                         "name": "SID",
@@ -2347,19 +2102,9 @@
                                         "value": "selSID"
                                       },
                                       {
-                                        "name": "Provider",
-                                        "source": "parameter",
-                                        "value": "providerInstance"
-                                      },
-                                      {
                                         "name": "TimePeriod",
                                         "source": "parameter",
                                         "value": "displayRange"
-                                      },
-                                      {
-                                        "name": "SAPComponent",
-                                        "source": "column",
-                                        "value": "SAPComponent"
                                       },
                                       {
                                         "name": "TimeRange",
@@ -2375,39 +2120,69 @@
                                         "name": "AlertFired",
                                         "source": "parameter",
                                         "value": "param_firedTime"
+                                      },
+                                      {
+                                        "name": "Process",
+                                        "source": "parameter",
+                                        "value": "DefaultProcess"
+                                      },
+                                      {
+                                        "name": "Tab",
+                                        "source": "static",
+                                        "value": "Summary"
+                                      },
+                                      {
+                                        "name": "selProvider",
+                                        "source": "column",
+                                        "value": "PROVIDER_INSTANCE_s"
+                                      },
+                                      {
+                                        "name": "SAP Component",
+                                        "source": "static",
+                                        "value": "SAP Hana"
                                       }
-                                    ]
+                                    ],
+                                    "viewerMode": false
                                   }
                                 }
                               },
                               {
-                                "columnMatch": "SAPComponent",
+                                "columnMatch": "parentid",
                                 "formatter": 5
                               },
                               {
-                                "columnMatch": "display_s",
-                                "formatter": 1
-                              },
-                              {
-                                "columnMatch": "hostname_s",
-                                "formatter": 5
+                                "columnMatch": "Action",
+                                "formatter": 5,
+                                "formatOptions": {
+                                  "aggregation": "Average"
+                                }
                               }
                             ],
                             "hierarchySettings": {
-                              "idColumn": "id",
-                              "parentColumn": "parentid",
-                              "treeType": 0,
-                              "expanderColumn": "display_s",
-                              "expandTopLevel": false
+                              "treeType": 1,
+                              "groupBy": [
+                                "PROVIDER_INSTANCE_s",
+                                "HOST_s"
+                              ],
+                              "expandTopLevel": true,
+                              "finalBy": "HOST_s"
                             },
                             "labelSettings": [
                               {
-                                "columnId": "VM_ARM_ID_s",
-                                "label": "VM Name"
+                                "columnId": "PORT_d",
+                                "label": " Port"
                               },
                               {
-                                "columnId": "SID_s",
-                                "label": "SID"
+                                "columnId": "SERVICE_NAME_s",
+                                "label": "Service Name"
+                              },
+                              {
+                                "columnId": "HOST_s",
+                                "label": "Host"
+                              },
+                              {
+                                "columnId": "PROVIDER_INSTANCE_s",
+                                "label": "Provider/Host"
                               },
                               {
                                 "columnId": "Availability",
@@ -2420,19 +2195,10 @@
                               {
                                 "columnId": "Insights",
                                 "label": "Action"
-                              },
-                              {
-                                "columnId": "SAPComponent",
-                                "label": "Component"
-                              },
-                              {
-                                "columnId": "display_s",
-                                "label": "Database / Service"
                               }
                             ]
                           }
                         },
-                        "customWidth": "0",
                         "conditionalVisibilities": [
                           {
                             "parameterName": "hanaExists",
@@ -2693,5 +2459,5 @@
       "name": "parentGroup"
     }
   ],
-  "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
+    "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
 }

--- a/Workbooks/SapMonitor2.0/AIOpsInsights/SAP AMS.workbook
+++ b/Workbooks/SapMonitor2.0/AIOpsInsights/SAP AMS.workbook
@@ -1718,8 +1718,7 @@
                                 "showDefault": false
                               },
                               "queryType": 0,
-                              "resourceType": "microsoft.workloads/monitors",
-                              "value": "netweaver"
+                              "resourceType": "microsoft.workloads/monitors"
                             }
                           ],
                           "style": "pills",


### PR DESCRIPTION
Changes:
- Multi-VM Flyout: To remove the issue of duplicate alerts, the alerts have been grouped by Providers. The flyout that opens up has multi-vm flyout, where customer can even select the VM to see insights.
- JIT Onboarding: The configuration of infra access is no longer a prerequisite for viewing insights. Only specific areas of the workbook now request configuring.
- Minor bug fixes
 
## PR Checklist

* [x] Explain your changes, so people looking at the PR know *what* and *why*, the code changes are the *how*.
* [x] Validate your changes using one or more of the [testing](../Documentation/Testing.md) methods.

### If adding or updating templates:
* [ ] post a screenshot of templates and/or gallery changes
* [ ] ensure your template has a corresponding gallery entry in the gallery folder
* [ ] If you are adding a new template, add your team and template/gallery file(s) to the CODEOWNERS file. CODEOWNERS entries should be teams, not individuals
* [ ] ensure all steps have meaningful names
* [ ] ensure all parameters and grid columns have display names set so they can be localized
* [ ] ensure that parameters id values are unique __or they will fail PR validation__ (parameter ids are used for localization)
* [ ] ensure that steps names are unique __or they will fail PR validation__ (step names are used for localization)
* [ ] grep `/subscription/` and ensure that your parameters don't have any hardcoded resourceIds __or they will fail PR validation__
* [ ] remove `fallbackResourceIds` and `fromTemplateId` fields from your template workbook __or they will fail PR validation__