### PR TITLE
Accessibility fix for "Bug 2710510: [Programmatic access – SQL IaaS –…

### DIFF
--- a/Workbooks/Azure SQL VM/SQL Assessment/SQL Assessment.workbook
+++ b/Workbooks/Azure SQL VM/SQL Assessment/SQL Assessment.workbook
@@ -117,7 +117,7 @@
                 {
                   "type": 1,
                   "content": {
-                    "json": "**<span style=\"font-size: 2em\">SQL best practices assessment results</span>**"
+                    "json": "<h3 style=\"font-size: 2em\">SQL best practices assessment results</h3>"
                   },
                   "customWidth": "0",
                   "name": "title",


### PR DESCRIPTION
… Result]: 'SQL best practices assessment results' text visually appears as heading but not defined programmatically."

https://msdata.visualstudio.com/Database%20Systems/_workitems/edit/2710510

What: 'SQL best practices assessment results' text visually appears as heading but not defined programmatically. The fix is to use heading tag \<h3\> to replace \<span\> tag. Also removed "**" as they mess up the vertical layout when we use heading tag

Why: fix for accessibility requirement

Screenshot:
![image](https://github.com/microsoft/Application-Insights-Workbooks/assets/53497183/172baf58-fefa-445a-bda0-a658b93d0bc2)

![image](https://github.com/microsoft/Application-Insights-Workbooks/assets/53497183/08b51927-6370-4a12-bb6d-8130a0b735a9)

