### PR TITLE
Fix display of tiles when value exceeds 1000

### DIFF
--- a/Workbooks/Azure Private MEC/PMEC Site Overview/PMEC Site Overview.workbook
+++ b/Workbooks/Azure Private MEC/PMEC Site Overview/PMEC Site Overview.workbook
@@ -702,14 +702,10 @@
                           ]
                         },
                         "numberFormat": {
-                          "unit": 17,
+                          "unit": 0,
                           "options": {
-                            "style": "decimal",
-                            "useGrouping": false,
-                            "maximumFractionDigits": 0,
-                            "maximumSignificantDigits": 3
-                          },
-                          "emptyValCustomText": "Error: metric not found"
+                            "style": "decimal"
+                          }
                         },
                         "tooltipFormat": {
                           "tooltip": "Number of provisioned subscribers out of subscriber limit"
@@ -829,9 +825,7 @@
                           "unit": 17,
                           "options": {
                             "style": "decimal",
-                            "useGrouping": false,
-                            "maximumFractionDigits": 0,
-                            "maximumSignificantDigits": 3
+                            "useGrouping": false
                           },
                           "emptyValCustomText": "Error: metric not found"
                         },
@@ -946,9 +940,7 @@
                           "unit": 17,
                           "options": {
                             "style": "decimal",
-                            "useGrouping": false,
-                            "maximumFractionDigits": 0,
-                            "maximumSignificantDigits": 3
+                            "useGrouping": false
                           },
                           "emptyValCustomText": "Error: metric not found"
                         },


### PR DESCRIPTION
Fix bug where when 1000 SIMs are provisioned it shows up as 1 in the workbook due to the conditional formatting we had set on the tiles.

Before:
![image](https://github.com/microsoft/Application-Insights-Workbooks/assets/3382572/f0001283-9897-4cc1-807f-2a5422a6fe90)

After:
![image](https://github.com/microsoft/Application-Insights-Workbooks/assets/3382572/77547b61-2ebc-4867-909a-46576a5f343c)

## PR Checklist

* [x] Explain your changes, so people looking at the PR know *what* and *why*, the code changes are the *how*.
* [x] Validate your changes using one or more of the [testing](../Documentation/Testing.md) methods.

### If adding or updating templates:
* [x] post a screenshot of templates and/or gallery changes
* [ ] ensure your template has a corresponding gallery entry in the gallery folder
* [ ] If you are adding a new template, add your team and template/gallery file(s) to the CODEOWNERS file. CODEOWNERS entries should be teams, not individuals
* [ ] ensure all steps have meaningful names
* [ ] ensure all parameters and grid columns have display names set so they can be localized
* [ ] ensure that parameters id values are unique __or they will fail PR validation__ (parameter ids are used for localization)
* [ ] ensure that steps names are unique __or they will fail PR validation__ (step names are used for localization)
* [ ] grep `/subscription/` and ensure that your parameters don't have any hardcoded resourceIds __or they will fail PR validation__
* [ ] remove `fallbackResourceIds` and `fromTemplateId` fields from your template workbook __or they will fail PR validation__