### PR TITLE
Added VM metrics, VM health, and VM Health Changes tiles to ACSS_Aggregated and SAP_Inventory_Checks workbooks.

### DIFF
--- a/Workbooks/Azure Center for SAP solutions/ACSS Aggregated/ACSS Aggregated.workbook
+++ b/Workbooks/Azure Center for SAP solutions/ACSS Aggregated/ACSS Aggregated.workbook
@@ -1429,7 +1429,7 @@
                       "{vmIds}"
                     ],
                     "timeContext": {
-                      "durationMs": 43200000
+                      "durationMs": 86400000
                     },
                     "metrics": [
                       {
@@ -1787,7 +1787,7 @@
                     "version": "KqlItem/1.0",
                     "query": "{\"version\":\"Merge/1.0\",\"merges\":[{\"id\":\"5e753f6d-18cd-4295-84c0-fc475611c0ac\",\"mergeType\":\"innerunique\",\"leftTable\":\"metric - Monitroing Key Metrics (Used for merge)\",\"rightTable\":\"query - VIS VM match (Used for merge)\",\"leftColumn\":\"Name\",\"rightColumn\":\"vmId\"}],\"projectRename\":[{\"originalName\":\"[metric - Monitroing Key Metrics (Used for merge)].Subscription\",\"mergedName\":\"Subscription\",\"fromId\":\"5e753f6d-18cd-4295-84c0-fc475611c0ac\"},{\"originalName\":\"[metric - Monitroing Key Metrics (Used for merge)].Name\",\"mergedName\":\"Storage Name\",\"fromId\":\"5e753f6d-18cd-4295-84c0-fc475611c0ac\"},{\"originalName\":\"[query - VIS VM match (Used for merge)].visId\",\"mergedName\":\"visId\",\"fromId\":\"5e753f6d-18cd-4295-84c0-fc475611c0ac\"},{\"originalName\":\"[metric - Monitroing Key Metrics (Used for merge)].microsoft.compute/virtualmachines--VmAvailabilityMetric\",\"mergedName\":\"VM Availability Metric (Preview) (Sum)\",\"fromId\":\"5e753f6d-18cd-4295-84c0-fc475611c0ac\"},{\"originalName\":\"[metric - Monitroing Key Metrics (Used for merge)].microsoft.compute/virtualmachines--VmAvailabilityMetric Timeline\",\"mergedName\":\"VM Availability Metric (Preview) Timeline\",\"fromId\":\"5e753f6d-18cd-4295-84c0-fc475611c0ac\"},{\"originalName\":\"[metric - Monitroing Key Metrics (Used for merge)].microsoft.compute/virtualmachines--Percentage CPU\",\"mergedName\":\"Percentage CPU (Average)\",\"fromId\":\"5e753f6d-18cd-4295-84c0-fc475611c0ac\"},{\"originalName\":\"[metric - Monitroing Key Metrics (Used for merge)].microsoft.compute/virtualmachines--Percentage CPU Timeline\",\"mergedName\":\"Percentage CPU Timeline\",\"fromId\":\"5e753f6d-18cd-4295-84c0-fc475611c0ac\"},{\"originalName\":\"[metric - Monitroing Key Metrics (Used for merge)].microsoft.compute/virtualmachines--Disk Read Bytes\",\"mergedName\":\"Disk Read Bytes (Sum)\",\"fromId\":\"5e753f6d-18cd-4295-84c0-fc475611c0ac\"},{\"originalName\":\"[metric - Monitroing Key Metrics (Used for merge)].microsoft.compute/virtualmachines--Disk Read Bytes Timeline\",\"mergedName\":\"Disk Read Bytes Timeline\",\"fromId\":\"5e753f6d-18cd-4295-84c0-fc475611c0ac\"},{\"originalName\":\"[metric - Monitroing Key Metrics (Used for merge)].microsoft.compute/virtualmachines--Disk Write Bytes\",\"mergedName\":\"Disk Write Bytes (Sum)\",\"fromId\":\"5e753f6d-18cd-4295-84c0-fc475611c0ac\"},{\"originalName\":\"[metric - Monitroing Key Metrics (Used for merge)].microsoft.compute/virtualmachines--Disk Write Bytes Timeline\",\"mergedName\":\"Disk Write Bytes Timeline\",\"fromId\":\"5e753f6d-18cd-4295-84c0-fc475611c0ac\"},{\"originalName\":\"[metric - Monitroing Key Metrics (Used for merge)].microsoft.compute/virtualmachines--Network In Total\",\"mergedName\":\"Network In Total (Sum)\",\"fromId\":\"5e753f6d-18cd-4295-84c0-fc475611c0ac\"},{\"originalName\":\"[metric - Monitroing Key Metrics (Used for merge)].microsoft.compute/virtualmachines--Network In Total Timeline\",\"mergedName\":\"Network In Total Timeline\",\"fromId\":\"5e753f6d-18cd-4295-84c0-fc475611c0ac\"},{\"originalName\":\"[metric - Monitroing Key Metrics (Used for merge)].microsoft.compute/virtualmachines--Network Out Total\",\"mergedName\":\"Network Out Total (Sum)\",\"fromId\":\"5e753f6d-18cd-4295-84c0-fc475611c0ac\"},{\"originalName\":\"[metric - Monitroing Key Metrics (Used for merge)].microsoft.compute/virtualmachines--Network Out Total Timeline\",\"mergedName\":\"Network Out Total Timeline\",\"fromId\":\"5e753f6d-18cd-4295-84c0-fc475611c0ac\"},{\"originalName\":\"[query - VIS VM match (Used for merge)].vmId\",\"mergedName\":\"vmId\",\"fromId\":\"5e753f6d-18cd-4295-84c0-fc475611c0ac\"},{\"originalName\":\"[query - VIS VM match].vmId\"}]}",
                     "size": 0,
-                    "title": "VM  Monitoring Key Metrics",
+                    "title": "VM  Monitoring Key Metrics (Last 24 hours)",
                     "queryType": 7,
                     "visualization": "table",
                     "gridSettings": {
@@ -1989,7 +1989,7 @@
                       "value": "No"
                     }
                   ],
-                  "name": "Virtual Machine Monitoring Metrics",
+                  "name": "Virtual Machine Monitoring Metrics (Last 24 hours)",
                   "styleSettings": {
                     "padding": "5px"
                   }

--- a/Workbooks/Azure Center for SAP solutions/ACSS Aggregated/ACSS Aggregated.workbook
+++ b/Workbooks/Azure Center for SAP solutions/ACSS Aggregated/ACSS Aggregated.workbook
@@ -1928,6 +1928,54 @@
                         {
                           "columnId": "visId",
                           "label": "SID"
+                        },
+                        {
+                          "columnId": "VM Availability Metric (Preview) (Sum)",
+                          "label": "VM Availability Metric (Preview) (Sum)"
+                        },
+                        {
+                          "columnId": "VM Availability Metric (Preview) Timeline",
+                          "label": "VM Availability Metric (Preview) Timeline"
+                        },
+                        {
+                          "columnId": "Percentage CPU (Average)",
+                          "label": "Percentage CPU (Average)"
+                        },
+                        {
+                          "columnId": "Percentage CPU Timeline",
+                          "label": "Percentage CPU Timeline"
+                        },
+                        {
+                          "columnId": "Disk Read Bytes (Sum)",
+                          "label": "Disk Read Bytes (Sum)"
+                        },
+                        {
+                          "columnId": "Disk Read Bytes Timeline",
+                          "label": "Disk Read Bytes Timeline"
+                        },
+                        {
+                          "columnId": "Disk Write Bytes (Sum)",
+                          "label": "Disk Write Bytes (Sum)"
+                        },
+                        {
+                          "columnId": "Disk Write Bytes Timeline",
+                          "label": "Disk Write Bytes Timeline"
+                        },
+                        {
+                          "columnId": "Network In Total (Sum)",
+                          "label": "Network In Total (Sum)"
+                        },
+                        {
+                          "columnId": "Network In Total Timeline",
+                          "label": "Network In Total Timeline"
+                        },
+                        {
+                          "columnId": "Network Out Total (Sum)",
+                          "label": "Network Out Total (Sum)"
+                        },
+                        {
+                          "columnId": "Network Out Total Timeline",
+                          "label": "Network Out Total Timeline"
                         }
                       ]
                     },
@@ -2078,6 +2126,18 @@
                         {
                           "columnId": "AvailabilityState",
                           "label": "Availability state"
+                        },
+                        {
+                          "columnId": "Reason",
+                          "label": "Reason"
+                        },
+                        {
+                          "columnId": "Context",
+                          "label": "Context"
+                        },
+                        {
+                          "columnId": "Category",
+                          "label": "Category"
                         }
                       ]
                     }

--- a/Workbooks/Azure Center for SAP solutions/ACSS Aggregated/ACSS Aggregated.workbook
+++ b/Workbooks/Azure Center for SAP solutions/ACSS Aggregated/ACSS Aggregated.workbook
@@ -141,6 +141,33 @@
             "defaultValue": "value::all",
             "queryType": 1,
             "resourceType": "microsoft.resourcegraph/resources"
+          },
+          {
+            "id": "1984c556-9b6e-4daf-ab13-b3082b7a99c2",
+            "version": "KqlParameterItem/1.0",
+            "name": "vmIds",
+            "type": 5,
+            "isRequired": true,
+            "multiSelect": true,
+            "quote": "'",
+            "delimiter": ",",
+            "query": "resources\r\n| where type =~ 'Microsoft.Workloads/sapVirtualInstances/centralInstances' or type =~ 'Microsoft.Workloads/sapVirtualInstances/databaseInstances'\r\n| extend visId = split(split(id, '/centralInstances')[0], '/databaseInstances')[0] // getting the VIS id out of child resource\r\n| extend visList = split('{current_vis:id}', ', ') // split the selected vis list in array to search\r\n| where set_has_element(visList, tostring(visId)) == 1 //check if the running vis exists in selected vis id.\r\n| mv-expand properties.vmDetails\r\n| extend vmId = tostring(properties_vmDetails.virtualMachineId)\r\n| where strlen(vmId) > 0\r\n| extend vmRole = split(type, \"/\")[2]\r\n| project vmId\r\n| union(\r\n    resources\r\n    | where type =~ 'Microsoft.Workloads/sapVirtualInstances/applicationInstances'\r\n    | extend visId = split(id, '/applicationInstances')[0]\r\n    | extend visList = split('{current_vis:id}', ', ') // split the selected vis list in array to search\r\n    | where set_has_element(visList, tostring(visId)) == 1\r\n    | mv-expand properties.vmDetails\r\n    | extend vmId = iff(apiVersion in (\"2021-12-01-preview\", \"2022-10-15-preview\"), tolower(properties.virtualMachineId), tolower(properties_vmDetails.virtualMachineId))\r\n    | where strlen(vmId) > 0\r\n    | extend vmRole = split(type, \"/\")[2]\r\n    | project vmId\r\n)\r\n| distinct vmId",
+            "crossComponentResources": [
+              "{Subscriptions}"
+            ],
+            "isHiddenWhenLocked": true,
+            "typeSettings": {
+              "resourceTypeFilter": {
+                "microsoft.compute/virtualmachines": true
+              },
+              "additionalResourceOptions": [
+                "value::all"
+              ],
+              "showDefault": false
+            },
+            "defaultValue": "value::all",
+            "queryType": 1,
+            "resourceType": "microsoft.resourcegraph/resources"
           }
         ],
         "style": "pills",
@@ -1368,6 +1395,317 @@
                   "type": 3,
                   "content": {
                     "version": "KqlItem/1.0",
+                    "query": "resources\r\n| where type startswith 'Microsoft.Workloads/sapVirtualInstances/'\r\n| extend visId = split(split(split(id, '/centralInstances')[0], '/databaseInstances')[0], '/applicationInstances')[0] // getting the VIS id out of child resource\r\n| extend visList = split('{current_vis:id}', ', ') // split the selected vis list in array to search\r\n| where set_has_element(visList, tostring(visId)) == 1 //check if the running vis exists in selected vis id.\r\n| mv-expand properties.vmDetails\r\n| extend vmId = tostring(properties_vmDetails.virtualMachineId)\r\n| where strlen(vmId) > 0\r\n| extend vmRole = split(type, \"/\")[2]\r\n| distinct tostring(visId), vmId",
+                    "size": 0,
+                    "title": "VIS VM Mapping (Used for merge)",
+                    "queryType": 1,
+                    "resourceType": "microsoft.resourcegraph/resources",
+                    "crossComponentResources": [
+                      "value::all"
+                    ]
+                  },
+                  "customWidth": "50",
+                  "conditionalVisibility": {
+                    "parameterName": "SelectedTab",
+                    "comparison": "isEqualTo",
+                    "value": "-"
+                  },
+                  "name": "query - VIS VM match (Used for merge)",
+                  "styleSettings": {
+                    "padding": "5px"
+                  }
+                },
+                {
+                  "type": 10,
+                  "content": {
+                    "chartId": "workbook47fdc9d0-25c3-46cb-921a-b370fc0e5828",
+                    "version": "MetricsItem/2.0",
+                    "size": 0,
+                    "chartType": 0,
+                    "resourceType": "microsoft.compute/virtualmachines",
+                    "metricScope": 0,
+                    "resourceParameter": "vmIds",
+                    "resourceIds": [
+                      "{vmIds}"
+                    ],
+                    "timeContext": {
+                      "durationMs": 43200000
+                    },
+                    "metrics": [
+                      {
+                        "namespace": "microsoft.compute/virtualmachines",
+                        "metric": "microsoft.compute/virtualmachines--VmAvailabilityMetric",
+                        "aggregation": 4
+                      },
+                      {
+                        "namespace": "microsoft.compute/virtualmachines",
+                        "metric": "microsoft.compute/virtualmachines--Percentage CPU",
+                        "aggregation": 4
+                      },
+                      {
+                        "namespace": "microsoft.compute/virtualmachines",
+                        "metric": "microsoft.compute/virtualmachines--Disk Read Bytes",
+                        "aggregation": 1
+                      },
+                      {
+                        "namespace": "microsoft.compute/virtualmachines",
+                        "metric": "microsoft.compute/virtualmachines--Disk Write Bytes",
+                        "aggregation": 1
+                      },
+                      {
+                        "namespace": "microsoft.compute/virtualmachines",
+                        "metric": "microsoft.compute/virtualmachines--Network In Total",
+                        "aggregation": 1
+                      },
+                      {
+                        "namespace": "microsoft.compute/virtualmachines",
+                        "metric": "microsoft.compute/virtualmachines--Network Out Total",
+                        "aggregation": 1
+                      }
+                    ],
+                    "title": "VM  Monitoring Key Metrics (Used for merge)",
+                    "resourceLimit": 10000,
+                    "gridSettings": {
+                      "formatters": [
+                        {
+                          "columnMatch": "$gen_group",
+                          "formatter": 13,
+                          "formatOptions": {
+                            "linkTarget": "Resource",
+                            "showIcon": true
+                          }
+                        },
+                        {
+                          "columnMatch": "Subscription",
+                          "formatter": 5
+                        },
+                        {
+                          "columnMatch": "Name",
+                          "formatter": 5
+                        },
+                        {
+                          "columnMatch": "microsoft.compute/virtualmachines--VmAvailabilityMetric",
+                          "formatter": 5,
+                          "numberFormat": {
+                            "unit": 0,
+                            "options": {
+                              "style": "decimal"
+                            }
+                          }
+                        },
+                        {
+                          "columnMatch": "microsoft.compute/virtualmachines--VmAvailabilityMetric Timeline",
+                          "formatter": 21,
+                          "formatOptions": {
+                            "palette": "green",
+                            "linkTarget": "AvailabilityDetails",
+                            "linkIsContextBlade": true
+                          }
+                        },
+                        {
+                          "columnMatch": "microsoft.compute/virtualmachines--Percentage CPU",
+                          "formatter": 8,
+                          "formatOptions": {
+                            "palette": "blue"
+                          },
+                          "numberFormat": {
+                            "unit": 1,
+                            "options": {
+                              "style": "decimal"
+                            }
+                          }
+                        },
+                        {
+                          "columnMatch": "microsoft.compute/virtualmachines--Percentage CPU Timeline",
+                          "formatter": 21,
+                          "formatOptions": {
+                            "min": 0,
+                            "palette": "blue"
+                          }
+                        },
+                        {
+                          "columnMatch": "microsoft.compute/virtualmachines--Disk Read Bytes",
+                          "formatter": 8,
+                          "formatOptions": {
+                            "min": 0,
+                            "palette": "orange",
+                            "workbookContext": {
+                              "componentIdSource": "column",
+                              "componentId": "Name",
+                              "resourceIdsSource": "column",
+                              "resourceIds": "Name",
+                              "templateIdSource": "static",
+                              "templateId": "Community-Workbooks/Virtual Machines/Virtual machine details",
+                              "typeSource": "static",
+                              "type": "workbook",
+                              "gallerySource": "static",
+                              "gallery": "microsoft.compute/virtualmachines",
+                              "locationSource": "default"
+                            }
+                          },
+                          "numberFormat": {
+                            "unit": 2,
+                            "options": {
+                              "style": "decimal"
+                            }
+                          }
+                        },
+                        {
+                          "columnMatch": "microsoft.compute/virtualmachines--Disk Read Bytes Timeline",
+                          "formatter": 5
+                        },
+                        {
+                          "columnMatch": "microsoft.compute/virtualmachines--Disk Write Bytes",
+                          "formatter": 8,
+                          "formatOptions": {
+                            "palette": "orange"
+                          },
+                          "numberFormat": {
+                            "unit": 2,
+                            "options": {
+                              "style": "decimal"
+                            }
+                          }
+                        },
+                        {
+                          "columnMatch": "microsoft.compute/virtualmachines--Disk Write Bytes Timeline",
+                          "formatter": 5
+                        },
+                        {
+                          "columnMatch": "microsoft.compute/virtualmachines--Network In Total",
+                          "formatter": 8,
+                          "formatOptions": {
+                            "palette": "yellow"
+                          },
+                          "numberFormat": {
+                            "unit": 2,
+                            "options": {
+                              "style": "decimal"
+                            }
+                          }
+                        },
+                        {
+                          "columnMatch": "microsoft.compute/virtualmachines--Network In Total Timeline",
+                          "formatter": 5
+                        },
+                        {
+                          "columnMatch": "microsoft.compute/virtualmachines--Network Out Total",
+                          "formatter": 8,
+                          "formatOptions": {
+                            "palette": "yellow"
+                          },
+                          "numberFormat": {
+                            "unit": 2,
+                            "options": {
+                              "style": "decimal"
+                            }
+                          }
+                        },
+                        {
+                          "columnMatch": "microsoft.compute/virtualmachines--Network Out Total Timeline",
+                          "formatter": 5
+                        },
+                        {
+                          "columnMatch": "microsoft.compute/virtualmachines--Availability Timeline",
+                          "formatter": 5
+                        },
+                        {
+                          "columnMatch": "microsoft.compute/virtualmachines--Availability",
+                          "formatter": 5,
+                          "formatOptions": {
+                            "linkTarget": "GenericDetails",
+                            "linkIsContextBlade": true
+                          },
+                          "numberFormat": {
+                            "unit": 0,
+                            "options": {
+                              "style": "decimal"
+                            }
+                          }
+                        }
+                      ],
+                      "rowLimit": 10000,
+                      "filter": true,
+                      "hierarchySettings": {
+                        "treeType": 1,
+                        "groupBy": [
+                          "Subscription"
+                        ],
+                        "expandTopLevel": true,
+                        "finalBy": "Name"
+                      },
+                      "labelSettings": [
+                        {
+                          "columnId": "Name",
+                          "label": "Storage Name"
+                        },
+                        {
+                          "columnId": "microsoft.compute/virtualmachines--VmAvailabilityMetric",
+                          "label": "VM Availability Metric (Preview) (Sum)"
+                        },
+                        {
+                          "columnId": "microsoft.compute/virtualmachines--VmAvailabilityMetric Timeline",
+                          "label": "VM Availability Metric (Preview) Timeline"
+                        },
+                        {
+                          "columnId": "microsoft.compute/virtualmachines--Percentage CPU",
+                          "label": "Percentage CPU (Average)"
+                        },
+                        {
+                          "columnId": "microsoft.compute/virtualmachines--Percentage CPU Timeline",
+                          "label": "Percentage CPU Timeline"
+                        },
+                        {
+                          "columnId": "microsoft.compute/virtualmachines--Disk Read Bytes",
+                          "label": "Disk Read Bytes (Sum)"
+                        },
+                        {
+                          "columnId": "microsoft.compute/virtualmachines--Disk Read Bytes Timeline",
+                          "label": "Disk Read Bytes Timeline"
+                        },
+                        {
+                          "columnId": "microsoft.compute/virtualmachines--Disk Write Bytes",
+                          "label": "Disk Write Bytes (Sum)"
+                        },
+                        {
+                          "columnId": "microsoft.compute/virtualmachines--Disk Write Bytes Timeline",
+                          "label": "Disk Write Bytes Timeline"
+                        },
+                        {
+                          "columnId": "microsoft.compute/virtualmachines--Network In Total",
+                          "label": "Network In Total (Sum)"
+                        },
+                        {
+                          "columnId": "microsoft.compute/virtualmachines--Network In Total Timeline",
+                          "label": "Network In Total Timeline"
+                        },
+                        {
+                          "columnId": "microsoft.compute/virtualmachines--Network Out Total",
+                          "label": "Network Out Total (Sum)"
+                        },
+                        {
+                          "columnId": "microsoft.compute/virtualmachines--Network Out Total Timeline",
+                          "label": "Network Out Total Timeline"
+                        }
+                      ]
+                    },
+                    "showExportToExcel": true
+                  },
+                  "customWidth": "50",
+                  "conditionalVisibility": {
+                    "parameterName": "SelectedTab",
+                    "comparison": "isEqualTo",
+                    "value": "-"
+                  },
+                  "name": "metric - Monitroing Key Metrics (Used for merge)",
+                  "styleSettings": {
+                    "padding": "5px"
+                  }
+                },
+                {
+                  "type": 3,
+                  "content": {
+                    "version": "KqlItem/1.0",
                     "query": "resources\r\n| where type =~ \"microsoft.compute/virtualMachines\"\r\n| where ('{vmList}') has id\r\n| extend vmState = tostring(properties.extended.instanceView.powerState.displayStatus)\r\n| extend vmState = iif(isempty(vmState), \"VM State Unknown\", (vmState))\r\n| summarize count() by vmState",
                     "size": 3,
                     "title": "Azure Compute Summary ",
@@ -1419,7 +1757,7 @@
                       ]
                     }
                   },
-                  "customWidth": "65",
+                  "customWidth": "50",
                   "conditionalVisibilities": [
                     {
                       "parameterName": "SelectedTab",
@@ -1438,7 +1776,478 @@
                     }
                   ],
                   "showPin": true,
-                  "name": "query - Azure Compute Summary "
+                  "name": "query - Azure Compute Summary ",
+                  "styleSettings": {
+                    "padding": "5px"
+                  }
+                },
+                {
+                  "type": 3,
+                  "content": {
+                    "version": "KqlItem/1.0",
+                    "query": "{\"version\":\"Merge/1.0\",\"merges\":[{\"id\":\"5e753f6d-18cd-4295-84c0-fc475611c0ac\",\"mergeType\":\"innerunique\",\"leftTable\":\"metric - Monitroing Key Metrics (Used for merge)\",\"rightTable\":\"query - VIS VM match (Used for merge)\",\"leftColumn\":\"Name\",\"rightColumn\":\"vmId\"}],\"projectRename\":[{\"originalName\":\"[metric - Monitroing Key Metrics (Used for merge)].Subscription\",\"mergedName\":\"Subscription\",\"fromId\":\"5e753f6d-18cd-4295-84c0-fc475611c0ac\"},{\"originalName\":\"[metric - Monitroing Key Metrics (Used for merge)].Name\",\"mergedName\":\"Storage Name\",\"fromId\":\"5e753f6d-18cd-4295-84c0-fc475611c0ac\"},{\"originalName\":\"[query - VIS VM match (Used for merge)].visId\",\"mergedName\":\"visId\",\"fromId\":\"5e753f6d-18cd-4295-84c0-fc475611c0ac\"},{\"originalName\":\"[metric - Monitroing Key Metrics (Used for merge)].microsoft.compute/virtualmachines--VmAvailabilityMetric\",\"mergedName\":\"VM Availability Metric (Preview) (Sum)\",\"fromId\":\"5e753f6d-18cd-4295-84c0-fc475611c0ac\"},{\"originalName\":\"[metric - Monitroing Key Metrics (Used for merge)].microsoft.compute/virtualmachines--VmAvailabilityMetric Timeline\",\"mergedName\":\"VM Availability Metric (Preview) Timeline\",\"fromId\":\"5e753f6d-18cd-4295-84c0-fc475611c0ac\"},{\"originalName\":\"[metric - Monitroing Key Metrics (Used for merge)].microsoft.compute/virtualmachines--Percentage CPU\",\"mergedName\":\"Percentage CPU (Average)\",\"fromId\":\"5e753f6d-18cd-4295-84c0-fc475611c0ac\"},{\"originalName\":\"[metric - Monitroing Key Metrics (Used for merge)].microsoft.compute/virtualmachines--Percentage CPU Timeline\",\"mergedName\":\"Percentage CPU Timeline\",\"fromId\":\"5e753f6d-18cd-4295-84c0-fc475611c0ac\"},{\"originalName\":\"[metric - Monitroing Key Metrics (Used for merge)].microsoft.compute/virtualmachines--Disk Read Bytes\",\"mergedName\":\"Disk Read Bytes (Sum)\",\"fromId\":\"5e753f6d-18cd-4295-84c0-fc475611c0ac\"},{\"originalName\":\"[metric - Monitroing Key Metrics (Used for merge)].microsoft.compute/virtualmachines--Disk Read Bytes Timeline\",\"mergedName\":\"Disk Read Bytes Timeline\",\"fromId\":\"5e753f6d-18cd-4295-84c0-fc475611c0ac\"},{\"originalName\":\"[metric - Monitroing Key Metrics (Used for merge)].microsoft.compute/virtualmachines--Disk Write Bytes\",\"mergedName\":\"Disk Write Bytes (Sum)\",\"fromId\":\"5e753f6d-18cd-4295-84c0-fc475611c0ac\"},{\"originalName\":\"[metric - Monitroing Key Metrics (Used for merge)].microsoft.compute/virtualmachines--Disk Write Bytes Timeline\",\"mergedName\":\"Disk Write Bytes Timeline\",\"fromId\":\"5e753f6d-18cd-4295-84c0-fc475611c0ac\"},{\"originalName\":\"[metric - Monitroing Key Metrics (Used for merge)].microsoft.compute/virtualmachines--Network In Total\",\"mergedName\":\"Network In Total (Sum)\",\"fromId\":\"5e753f6d-18cd-4295-84c0-fc475611c0ac\"},{\"originalName\":\"[metric - Monitroing Key Metrics (Used for merge)].microsoft.compute/virtualmachines--Network In Total Timeline\",\"mergedName\":\"Network In Total Timeline\",\"fromId\":\"5e753f6d-18cd-4295-84c0-fc475611c0ac\"},{\"originalName\":\"[metric - Monitroing Key Metrics (Used for merge)].microsoft.compute/virtualmachines--Network Out Total\",\"mergedName\":\"Network Out Total (Sum)\",\"fromId\":\"5e753f6d-18cd-4295-84c0-fc475611c0ac\"},{\"originalName\":\"[metric - Monitroing Key Metrics (Used for merge)].microsoft.compute/virtualmachines--Network Out Total Timeline\",\"mergedName\":\"Network Out Total Timeline\",\"fromId\":\"5e753f6d-18cd-4295-84c0-fc475611c0ac\"},{\"originalName\":\"[query - VIS VM match (Used for merge)].vmId\",\"mergedName\":\"vmId\",\"fromId\":\"5e753f6d-18cd-4295-84c0-fc475611c0ac\"},{\"originalName\":\"[query - VIS VM match].vmId\"}]}",
+                    "size": 0,
+                    "title": "VM  Monitoring Key Metrics",
+                    "queryType": 7,
+                    "visualization": "table",
+                    "gridSettings": {
+                      "formatters": [
+                        {
+                          "columnMatch": "Subscription",
+                          "formatter": 5
+                        },
+                        {
+                          "columnMatch": "visId",
+                          "formatter": 0,
+                          "formatOptions": {
+                            "customColumnWidthSetting": "15ch"
+                          }
+                        },
+                        {
+                          "columnMatch": "VM Availability Metric (Preview) (Sum)",
+                          "formatter": 5
+                        },
+                        {
+                          "columnMatch": "VM Availability Metric (Preview) Timeline",
+                          "formatter": 21,
+                          "formatOptions": {
+                            "palette": "green",
+                            "linkTarget": "AvailabilityDetails",
+                            "linkIsContextBlade": true
+                          }
+                        },
+                        {
+                          "columnMatch": "Percentage CPU (Average)",
+                          "formatter": 8,
+                          "formatOptions": {
+                            "palette": "blue"
+                          },
+                          "numberFormat": {
+                            "unit": 1,
+                            "options": {
+                              "style": "decimal"
+                            }
+                          }
+                        },
+                        {
+                          "columnMatch": "Percentage CPU Timeline",
+                          "formatter": 21,
+                          "formatOptions": {
+                            "min": 0,
+                            "palette": "blue"
+                          }
+                        },
+                        {
+                          "columnMatch": "Disk Read Bytes (Sum)",
+                          "formatter": 8,
+                          "formatOptions": {
+                            "min": 0,
+                            "palette": "orange"
+                          },
+                          "numberFormat": {
+                            "unit": 2,
+                            "options": {
+                              "style": "decimal"
+                            }
+                          }
+                        },
+                        {
+                          "columnMatch": "Disk Read Bytes Timeline",
+                          "formatter": 5
+                        },
+                        {
+                          "columnMatch": "Disk Write Bytes (Sum)",
+                          "formatter": 8,
+                          "formatOptions": {
+                            "palette": "orange"
+                          },
+                          "numberFormat": {
+                            "unit": 2,
+                            "options": {
+                              "style": "decimal"
+                            }
+                          }
+                        },
+                        {
+                          "columnMatch": "Disk Write Bytes Timeline",
+                          "formatter": 5
+                        },
+                        {
+                          "columnMatch": "Network In Total (Sum)",
+                          "formatter": 8,
+                          "formatOptions": {
+                            "palette": "yellow"
+                          },
+                          "numberFormat": {
+                            "unit": 2,
+                            "options": {
+                              "style": "decimal"
+                            }
+                          }
+                        },
+                        {
+                          "columnMatch": "Network In Total Timeline",
+                          "formatter": 5
+                        },
+                        {
+                          "columnMatch": "Network Out Total (Sum)",
+                          "formatter": 8,
+                          "formatOptions": {
+                            "palette": "yellow"
+                          },
+                          "numberFormat": {
+                            "unit": 2,
+                            "options": {
+                              "style": "decimal"
+                            }
+                          }
+                        },
+                        {
+                          "columnMatch": "Network Out Total Timeline",
+                          "formatter": 5
+                        },
+                        {
+                          "columnMatch": "vmId",
+                          "formatter": 5
+                        },
+                        {
+                          "columnMatch": "Virtual Machine",
+                          "formatter": 5
+                        }
+                      ],
+                      "filter": true,
+                      "labelSettings": [
+                        {
+                          "columnId": "Subscription",
+                          "label": "-"
+                        },
+                        {
+                          "columnId": "Storage Name",
+                          "label": "Virtual machine"
+                        },
+                        {
+                          "columnId": "visId",
+                          "label": "SID"
+                        }
+                      ]
+                    },
+                    "tileSettings": {
+                      "showBorder": false,
+                      "titleContent": {
+                        "columnMatch": "Subscription",
+                        "formatter": 1
+                      },
+                      "leftContent": {
+                        "columnMatch": "VM Availability Metric (Preview) (Sum)",
+                        "formatter": 12,
+                        "formatOptions": {
+                          "palette": "auto"
+                        },
+                        "numberFormat": {
+                          "unit": 17,
+                          "options": {
+                            "maximumSignificantDigits": 3,
+                            "maximumFractionDigits": 2
+                          }
+                        }
+                      }
+                    },
+                    "graphSettings": {
+                      "type": 0,
+                      "topContent": {
+                        "columnMatch": "Subscription",
+                        "formatter": 1
+                      },
+                      "centerContent": {
+                        "columnMatch": "VM Availability Metric (Preview) (Sum)",
+                        "formatter": 1,
+                        "numberFormat": {
+                          "unit": 17,
+                          "options": {
+                            "maximumSignificantDigits": 3,
+                            "maximumFractionDigits": 2
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "customWidth": "50",
+                  "conditionalVisibilities": [
+                    {
+                      "parameterName": "SelectedTab",
+                      "comparison": "isEqualTo",
+                      "value": "compute"
+                    },
+                    {
+                      "parameterName": "compute",
+                      "comparison": "isEqualTo",
+                      "value": "azure"
+                    },
+                    {
+                      "parameterName": "Report_check",
+                      "comparison": "isEqualTo",
+                      "value": "No"
+                    }
+                  ],
+                  "name": "Virtual Machine Monitoring Metrics",
+                  "styleSettings": {
+                    "padding": "5px"
+                  }
+                },
+                {
+                  "type": 3,
+                  "content": {
+                    "version": "KqlItem/1.0",
+                    "query": "resources\r\n| where type startswith 'microsoft.workloads/sapvirtualinstances/'\r\n| extend visId = tostring(split(split(split(id, '/centralInstances')[0], '/databaseInstances')[0], '/applicationInstances')[0])\r\n| extend visList = split('{current_vis:id}', ', ')\r\n| where set_has_element(visList, visId) == 1\r\n| mv-expand vm = properties.vmDetails\r\n| extend vmId = tolower(vm.virtualMachineId)\r\n| where strlen(vmId) > 0\r\n| distinct vmId, visId, subscriptionId\r\n| join kind = leftouter (\r\n    HealthResources \r\n    | where type =~ 'microsoft.resourcehealth/availabilitystatuses' or type =~ 'microsoft.resourcehealth/resourceannotations'\r\n    | extend vmId = tolower(properties.targetResourceId)\r\n    | project vmId, AvailabilityState = tostring(properties.availabilityState), Reason = tostring(properties.reason), Context = tostring(properties.context), Category = tostring(properties.category)\r\n) on vmId\r\n| summarize make_set_if(AvailabilityState, isnotempty(AvailabilityState)), make_set_if(Reason, isnotempty(Reason)), make_set_if(Context, isnotempty(Context)), make_set_if(Category, isnotempty(Category)) by vmId, visId, subscriptionId\r\n| project subscriptionId, vmId, visId,\r\n    AvailabilityState = iff(isnull(set_AvailabilityState[0]), \"Unknown\", set_AvailabilityState[0]),\r\n    Reason = iff(isnull(set_Reason[0]), \"-\", set_Reason[0]),\r\n    Context = iff(isnull(set_Context[0]), \"-\", set_Context[0]),\r\n    Category = iff(isnull(set_Category[0]), \"-\", set_Category[0])",
+                    "size": 0,
+                    "title": "Current VM Health & Annotations",
+                    "exportToExcelOptions": "all",
+                    "queryType": 1,
+                    "resourceType": "microsoft.resourcegraph/resources",
+                    "crossComponentResources": [
+                      "value::all"
+                    ],
+                    "gridSettings": {
+                      "formatters": [
+                        {
+                          "columnMatch": "subscriptionId",
+                          "formatter": 5,
+                          "formatOptions": {
+                            "linkTarget": "Resource",
+                            "linkIsContextBlade": false
+                          }
+                        },
+                        {
+                          "columnMatch": "vmId",
+                          "formatter": 13,
+                          "formatOptions": {
+                            "linkTarget": "Resource",
+                            "subTarget": "resourcehealth",
+                            "showIcon": true,
+                            "bladeOpenContext": {
+                              "bladeName": "ResourceMenuBlade",
+                              "extensionName": "HubsExtension",
+                              "bladeParameters": [
+                                {
+                                  "name": "id",
+                                  "source": "cell",
+                                  "value": ""
+                                },
+                                {
+                                  "name": "menuid",
+                                  "source": "static",
+                                  "value": "resourcehealth"
+                                }
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "columnMatch": "visId",
+                          "formatter": 13,
+                          "formatOptions": {
+                            "linkTarget": "Resource",
+                            "showIcon": true,
+                            "customColumnWidthSetting": "15ch"
+                          }
+                        },
+                        {
+                          "columnMatch": "AvailabilityState",
+                          "formatter": 11,
+                          "formatOptions": {
+                            "linkTarget": "Resource",
+                            "subTarget": "resourceHealth",
+                            "linkIsContextBlade": true
+                          }
+                        }
+                      ],
+                      "filter": true,
+                      "labelSettings": [
+                        {
+                          "columnId": "subscriptionId",
+                          "label": "Subscription / Virtual machine"
+                        },
+                        {
+                          "columnId": "vmId",
+                          "label": "Virtual machine"
+                        },
+                        {
+                          "columnId": "visId",
+                          "label": "SID"
+                        },
+                        {
+                          "columnId": "AvailabilityState",
+                          "label": "Availability state"
+                        }
+                      ]
+                    }
+                  },
+                  "customWidth": "50",
+                  "conditionalVisibilities": [
+                    {
+                      "parameterName": "SelectedTab",
+                      "comparison": "isEqualTo",
+                      "value": "compute"
+                    },
+                    {
+                      "parameterName": "compute",
+                      "comparison": "isEqualTo",
+                      "value": "azure"
+                    },
+                    {
+                      "parameterName": "Report_check",
+                      "comparison": "isEqualTo",
+                      "value": "No"
+                    }
+                  ],
+                  "showPin": true,
+                  "name": "query - Current VM Health & Annotations",
+                  "styleSettings": {
+                    "padding": "5px"
+                  }
+                },
+                {
+                  "type": 3,
+                  "content": {
+                    "version": "KqlItem/1.0",
+                    "query": "resources\r\n| where type startswith 'microsoft.workloads/sapvirtualinstances/'\r\n| extend visId = tostring(split(split(split(id, '/centralInstances')[0], '/databaseInstances')[0], '/applicationInstances')[0])\r\n| extend visList = split('{current_vis:id}', ', ')\r\n| where set_has_element(visList, tostring(visId)) == 1\r\n| mv-expand vm = properties.vmDetails\r\n| extend vmId = tolower(vm.virtualMachineId)\r\n| where strlen(vmId) > 0\r\n| distinct vmId, visId, subscriptionId\r\n| join kind = inner (\r\n    healthresourcechanges\r\n    | where type == \"microsoft.resources/changes\"\r\n    | where properties.targetResourceType =~ \"microsoft.resourcehealth/resourceannotations\"\r\n    | extend Id = tolower(split(properties.targetResourceId, '/providers/Microsoft.ResourceHealth/resourceAnnotations/current')[0]),\r\n    Timestamp = todatetime(properties.changeAttributes.timestamp), AnnotationName = properties['changes']['properties.annotationName']['newValue'], Reason = properties['changes']['properties.reason']['newValue'], \r\n    Context = iff(isempty(properties['changes']['properties.context']['newValue']), \"-\", properties['changes']['properties.context']['newValue']),\r\n    Category = iff(isempty(properties['changes']['properties.category']['newValue']), \"-\", properties['changes']['properties.category']['newValue'])\r\n    | where isnotempty(AnnotationName)\r\n    | where Timestamp > ago(14d)) on $left.vmId == $right.Id\r\n| project subscriptionId, vmId, visId, Timestamp, Reason, AnnotationName, PreviousAnnotation = properties['changes']['properties.annotationName']['previousValue'], Context, Category \r\n| order by Timestamp desc\r\n| extend Timestamp = format_datetime(Timestamp, 'dd/MM/yyyy, hh:mm:ss tt')",
+                    "size": 0,
+                    "title": "VM Health Changes (Last 14 days)",
+                    "noDataMessage": "No health changes found in the last 14 days",
+                    "queryType": 1,
+                    "resourceType": "microsoft.resourcegraph/resources",
+                    "crossComponentResources": [
+                      "value::all"
+                    ],
+                    "gridSettings": {
+                      "formatters": [
+                        {
+                          "columnMatch": "$gen_group",
+                          "formatter": 13,
+                          "formatOptions": {
+                            "linkTarget": "Resource",
+                            "subTarget": "resourcehealth",
+                            "showIcon": true
+                          }
+                        },
+                        {
+                          "columnMatch": "subscriptionId",
+                          "formatter": 5
+                        },
+                        {
+                          "columnMatch": "vmId",
+                          "formatter": 5,
+                          "formatOptions": {
+                            "linkTarget": "Resource",
+                            "subTarget": "resourcehealth"
+                          }
+                        },
+                        {
+                          "columnMatch": "visId",
+                          "formatter": 13,
+                          "formatOptions": {
+                            "linkTarget": "Resource",
+                            "showIcon": true,
+                            "customColumnWidthSetting": "15ch"
+                          }
+                        },
+                        {
+                          "columnMatch": "Timestamp",
+                          "formatter": 5
+                        },
+                        {
+                          "columnMatch": "Reason",
+                          "formatter": 1
+                        },
+                        {
+                          "columnMatch": "AnnotationName",
+                          "formatter": 1
+                        },
+                        {
+                          "columnMatch": "PreviousAnnotation",
+                          "formatter": 1
+                        },
+                        {
+                          "columnMatch": "Context",
+                          "formatter": 1
+                        },
+                        {
+                          "columnMatch": "Category",
+                          "formatter": 1
+                        }
+                      ],
+                      "filter": true,
+                      "hierarchySettings": {
+                        "treeType": 1,
+                        "groupBy": [
+                          "vmId"
+                        ],
+                        "expandTopLevel": true,
+                        "finalBy": "Timestamp"
+                      },
+                      "labelSettings": [
+                        {
+                          "columnId": "subscriptionId",
+                          "label": "Subscription"
+                        },
+                        {
+                          "columnId": "vmId",
+                          "label": "Virtual machine"
+                        },
+                        {
+                          "columnId": "visId",
+                          "label": "SID"
+                        },
+                        {
+                          "columnId": "Timestamp",
+                          "label": "Timestamp"
+                        },
+                        {
+                          "columnId": "Reason",
+                          "label": "Reason"
+                        },
+                        {
+                          "columnId": "AnnotationName",
+                          "label": "Annotation"
+                        },
+                        {
+                          "columnId": "PreviousAnnotation",
+                          "label": "Previous annotation"
+                        },
+                        {
+                          "columnId": "Context",
+                          "label": "Context"
+                        },
+                        {
+                          "columnId": "Category",
+                          "label": "Category"
+                        }
+                      ]
+                    }
+                  },
+                  "customWidth": "50",
+                  "conditionalVisibilities": [
+                    {
+                      "parameterName": "SelectedTab",
+                      "comparison": "isEqualTo",
+                      "value": "compute"
+                    },
+                    {
+                      "parameterName": "compute",
+                      "comparison": "isEqualTo",
+                      "value": "azure"
+                    },
+                    {
+                      "parameterName": "Report_check",
+                      "comparison": "isEqualTo",
+                      "value": "No"
+                    }
+                  ],
+                  "showPin": true,
+                  "name": "query - VM Health Changes (Last 14 days)",
+                  "styleSettings": {
+                    "padding": "5px"
+                  }
                 },
                 {
                   "type": 1,
@@ -4521,8 +5330,7 @@
                       {
                         "namespace": "microsoft.network/loadbalancers",
                         "metric": "microsoft.network/loadbalancers--DipAvailability",
-                        "aggregation": 3,
-                        "splitBy": null
+                        "aggregation": 3
                       }
                     ],
                     "title": "Backend health probe by Backend IP",
@@ -5014,8 +5822,7 @@
                       {
                         "namespace": "microsoft.network/applicationgateways",
                         "metric": "microsoft.network/applicationgateways--CurrentConnections",
-                        "aggregation": 1,
-                        "splitBy": null
+                        "aggregation": 1
                       }
                     ],
                     "title": " Current Connections",
@@ -5065,8 +5872,7 @@
                       {
                         "namespace": "microsoft.network/applicationgateways",
                         "metric": "microsoft.network/applicationgateways--NewConnectionsPerSecond",
-                        "aggregation": 4,
-                        "splitBy": null
+                        "aggregation": 4
                       }
                     ],
                     "title": "Avg. New  Connections per second",
@@ -5115,8 +5921,7 @@
                       {
                         "namespace": "microsoft.network/applicationgateways",
                         "metric": "microsoft.network/applicationgateways--TotalRequests",
-                        "aggregation": 1,
-                        "splitBy": null
+                        "aggregation": 1
                       }
                     ],
                     "title": "Total Requests",
@@ -5166,8 +5971,7 @@
                       {
                         "namespace": "microsoft.network/applicationgateways",
                         "metric": "microsoft.network/applicationgateways--Throughput",
-                        "aggregation": 4,
-                        "splitBy": null
+                        "aggregation": 4
                       }
                     ],
                     "title": "Throughput",
@@ -5216,8 +6020,7 @@
                       {
                         "namespace": "microsoft.network/applicationgateways",
                         "metric": "microsoft.network/applicationgateways--ComputeUnits",
-                        "aggregation": 4,
-                        "splitBy": null
+                        "aggregation": 4
                       }
                     ],
                     "title": "Avg Current Compute Units",
@@ -5271,8 +6074,7 @@
                       {
                         "namespace": "microsoft.network/applicationgateways",
                         "metric": "microsoft.network/applicationgateways--HealthyHostCount",
-                        "aggregation": 4,
-                        "splitBy": null
+                        "aggregation": 4
                       }
                     ],
                     "title": "Avg Health Host count",

--- a/Workbooks/Azure Center for SAP solutions/ACSS Aggregated/ACSS Aggregated.workbook
+++ b/Workbooks/Azure Center for SAP solutions/ACSS Aggregated/ACSS Aggregated.workbook
@@ -1355,7 +1355,7 @@
                       }
                     ]
                   },
-                  "customWidth": "50",
+                  "customWidth": "51",
                   "conditionalVisibilities": [
                     {
                       "parameterName": "SelectedTab",
@@ -1376,7 +1376,7 @@
                     "json": "Microsoft is constantly updating its platform and submitting new certification details to SAP in order to ensure Microsoft Azure is the best platform on which to run your SAP workloads.\r\n\r\n💡 Learn more about [SAP certifications and configurations running on Microsoft Azure](https://docs.microsoft.com/en-us/azure/virtual-machines/workloads/sap/sap-certifications)",
                     "style": "info"
                   },
-                  "customWidth": "50",
+                  "customWidth": "49",
                   "conditionalVisibilities": [
                     {
                       "parameterName": "SelectedTab",
@@ -1387,9 +1387,39 @@
                       "parameterName": "Report_check",
                       "comparison": "isEqualTo",
                       "value": "No"
+                    },
+                    {
+                      "parameterName": "Help",
+                      "comparison": "isEqualTo",
+                      "value": "Yes"
                     }
                   ],
                   "name": "text - Compute Info"
+                },
+                {
+                  "type": 1,
+                  "content": {
+                    "json": "This query could not run because some parameters are not set.\r\nPlease set: VIS",
+                    "style": "info"
+                  },
+                  "conditionalVisibilities": [
+                    {
+                      "parameterName": "SelectedTab",
+                      "comparison": "isEqualTo",
+                      "value": "compute"
+                    },
+                    {
+                      "parameterName": "Report_check",
+                      "comparison": "isEqualTo",
+                      "value": "No"
+                    },
+                    {
+                      "parameterName": "current_vis",
+                      "comparison": "isEqualTo",
+                      "value": ""
+                    }
+                  ],
+                  "name": "text - VIS not selected"
                 },
                 {
                   "type": 3,
@@ -1773,6 +1803,11 @@
                       "parameterName": "Report_check",
                       "comparison": "isEqualTo",
                       "value": "No"
+                    },
+                    {
+                      "parameterName": "current_vis",
+                      "comparison": "isNotEqualTo",
+                      "value": ""
                     }
                   ],
                   "showPin": true,
@@ -2035,6 +2070,11 @@
                       "parameterName": "Report_check",
                       "comparison": "isEqualTo",
                       "value": "No"
+                    },
+                    {
+                      "parameterName": "current_vis",
+                      "comparison": "isNotEqualTo",
+                      "value": ""
                     }
                   ],
                   "name": "Virtual Machine Monitoring Metrics (Last 24 hours)",
@@ -2158,6 +2198,11 @@
                       "parameterName": "Report_check",
                       "comparison": "isEqualTo",
                       "value": "No"
+                    },
+                    {
+                      "parameterName": "current_vis",
+                      "comparison": "isNotEqualTo",
+                      "value": ""
                     }
                   ],
                   "showPin": true,
@@ -2301,6 +2346,11 @@
                       "parameterName": "Report_check",
                       "comparison": "isEqualTo",
                       "value": "No"
+                    },
+                    {
+                      "parameterName": "current_vis",
+                      "comparison": "isNotEqualTo",
+                      "value": ""
                     }
                   ],
                   "showPin": true,

--- a/Workbooks/Azure Center for SAP solutions/SAP Inventory Checks/SAP Inventory Checks.workbook
+++ b/Workbooks/Azure Center for SAP solutions/SAP Inventory Checks/SAP Inventory Checks.workbook
@@ -1705,7 +1705,7 @@
                       }
                     ]
                   },
-                  "customWidth": "50",
+                  "customWidth": "51",
                   "conditionalVisibilities": [
                     {
                       "parameterName": "SelectedTab",
@@ -1726,7 +1726,7 @@
                     "json": "Microsoft is constantly updating its platform and submitting new certification details to SAP in order to ensure Microsoft Azure is the best platform on which to run your SAP workloads.\r\n\r\n💡 Learn more about [SAP certifications and configurations running on Microsoft Azure](https://docs.microsoft.com/en-us/azure/virtual-machines/workloads/sap/sap-certifications)",
                     "style": "info"
                   },
-                  "customWidth": "50",
+                  "customWidth": "49",
                   "conditionalVisibilities": [
                     {
                       "parameterName": "SelectedTab",
@@ -1737,6 +1737,11 @@
                       "parameterName": "Report_check",
                       "comparison": "isEqualTo",
                       "value": "No"
+                    },
+                    {
+                      "parameterName": "Help",
+                      "comparison": "isEqualTo",
+                      "value": "Yes"
                     }
                   ],
                   "name": "text - Compute Info"

--- a/Workbooks/Azure Center for SAP solutions/SAP Inventory Checks/SAP Inventory Checks.workbook
+++ b/Workbooks/Azure Center for SAP solutions/SAP Inventory Checks/SAP Inventory Checks.workbook
@@ -1345,6 +1345,318 @@
               "groupType": "editable",
               "items": [
                 {
+                  "type": 3,
+                  "content": {
+                    "version": "KqlItem/1.0",
+                    "query": "resources\r\n| where type startswith 'microsoft.workloads/sapvirtualinstances/'\r\n| where id startswith '{current_vis}'\r\n| extend visId = tostring(split(split(split(id, '/centralInstances')[0], '/databaseInstances')[0], '/applicationInstances')[0])\r\n| mv-expand vm = properties.vmDetails\r\n| extend vmId = tostring(vm.virtualMachineId)\r\n| distinct visId, vmId",
+                    "size": 0,
+                    "title": "VIS VM Mapping (Used for merge)",
+                    "queryType": 1,
+                    "resourceType": "microsoft.resourcegraph/resources"
+                  },
+                  "customWidth": "50",
+                  "conditionalVisibility": {
+                    "parameterName": "SelectedTab",
+                    "comparison": "isEqualTo",
+                    "value": "-"
+                  },
+                  "name": "query - VIS VM match (Used for merge)",
+                  "styleSettings": {
+                    "padding": "5px"
+                  }
+                },
+                {
+                  "type": 10,
+                  "content": {
+                    "chartId": "workbookecda832e-ec26-4656-a8f4-6edc293590cc",
+                    "version": "MetricsItem/2.0",
+                    "size": 0,
+                    "chartType": 0,
+                    "resourceType": "microsoft.compute/virtualmachines",
+                    "metricScope": 0,
+                    "resourceParameter": "vmList",
+                    "resourceIds": [
+                      "{vmList}"
+                    ],
+                    "timeContext": {
+                      "durationMs": 43200000
+                    },
+                    "metrics": [
+                      {
+                        "namespace": "microsoft.compute/virtualmachines",
+                        "metric": "microsoft.compute/virtualmachines--VmAvailabilityMetric",
+                        "aggregation": 4
+                      },
+                      {
+                        "namespace": "microsoft.compute/virtualmachines",
+                        "metric": "microsoft.compute/virtualmachines--Percentage CPU",
+                        "aggregation": 4
+                      },
+                      {
+                        "namespace": "microsoft.compute/virtualmachines",
+                        "metric": "microsoft.compute/virtualmachines--Disk Read Bytes",
+                        "aggregation": 1
+                      },
+                      {
+                        "namespace": "microsoft.compute/virtualmachines",
+                        "metric": "microsoft.compute/virtualmachines--Disk Write Bytes",
+                        "aggregation": 1
+                      },
+                      {
+                        "namespace": "microsoft.compute/virtualmachines",
+                        "metric": "microsoft.compute/virtualmachines--Network In Total",
+                        "aggregation": 1
+                      },
+                      {
+                        "namespace": "microsoft.compute/virtualmachines",
+                        "metric": "microsoft.compute/virtualmachines--Network Out Total",
+                        "aggregation": 1
+                      }
+                    ],
+                    "title": "VM  Monitoring Key Metrics (Used for merge)",
+                    "resourceLimit": 10000,
+                    "gridSettings": {
+                      "formatters": [
+                        {
+                          "columnMatch": "Subscription",
+                          "formatter": 5
+                        },
+                        {
+                          "columnMatch": "microsoft.compute/virtualmachines--VmAvailabilityMetric",
+                          "formatter": 5,
+                          "numberFormat": {
+                            "unit": 0,
+                            "options": {
+                              "style": "decimal"
+                            }
+                          }
+                        },
+                        {
+                          "columnMatch": "microsoft.compute/virtualmachines--VmAvailabilityMetric Timeline",
+                          "formatter": 21,
+                          "formatOptions": {
+                            "palette": "green",
+                            "linkTarget": "AvailabilityDetails",
+                            "linkIsContextBlade": true
+                          }
+                        },
+                        {
+                          "columnMatch": "microsoft.compute/virtualmachines--Percentage CPU",
+                          "formatter": 8,
+                          "formatOptions": {
+                            "palette": "blue"
+                          },
+                          "numberFormat": {
+                            "unit": 1,
+                            "options": {
+                              "style": "decimal"
+                            }
+                          }
+                        },
+                        {
+                          "columnMatch": "microsoft.compute/virtualmachines--Percentage CPU Timeline",
+                          "formatter": 21,
+                          "formatOptions": {
+                            "min": 0,
+                            "palette": "blue"
+                          }
+                        },
+                        {
+                          "columnMatch": "microsoft.compute/virtualmachines--Disk Read Bytes",
+                          "formatter": 8,
+                          "formatOptions": {
+                            "min": 0,
+                            "palette": "orange",
+                            "workbookContext": {
+                              "componentIdSource": "column",
+                              "componentId": "Name",
+                              "resourceIdsSource": "column",
+                              "resourceIds": "Name",
+                              "templateIdSource": "static",
+                              "templateId": "Community-Workbooks/Virtual Machines/Virtual machine details",
+                              "typeSource": "static",
+                              "type": "workbook",
+                              "gallerySource": "static",
+                              "gallery": "microsoft.compute/virtualmachines",
+                              "locationSource": "default"
+                            }
+                          },
+                          "numberFormat": {
+                            "unit": 2,
+                            "options": {
+                              "style": "decimal"
+                            }
+                          }
+                        },
+                        {
+                          "columnMatch": "microsoft.compute/virtualmachines--Disk Read Bytes Timeline",
+                          "formatter": 5
+                        },
+                        {
+                          "columnMatch": "microsoft.compute/virtualmachines--Disk Write Bytes",
+                          "formatter": 8,
+                          "formatOptions": {
+                            "palette": "orange"
+                          },
+                          "numberFormat": {
+                            "unit": 2,
+                            "options": {
+                              "style": "decimal"
+                            }
+                          }
+                        },
+                        {
+                          "columnMatch": "microsoft.compute/virtualmachines--Disk Write Bytes Timeline",
+                          "formatter": 5
+                        },
+                        {
+                          "columnMatch": "microsoft.compute/virtualmachines--Network In Total",
+                          "formatter": 8,
+                          "formatOptions": {
+                            "palette": "yellow"
+                          },
+                          "numberFormat": {
+                            "unit": 2,
+                            "options": {
+                              "style": "decimal"
+                            }
+                          }
+                        },
+                        {
+                          "columnMatch": "microsoft.compute/virtualmachines--Network In Total Timeline",
+                          "formatter": 5
+                        },
+                        {
+                          "columnMatch": "microsoft.compute/virtualmachines--Network Out Total",
+                          "formatter": 8,
+                          "formatOptions": {
+                            "palette": "yellow"
+                          },
+                          "numberFormat": {
+                            "unit": 2,
+                            "options": {
+                              "style": "decimal"
+                            }
+                          }
+                        },
+                        {
+                          "columnMatch": "microsoft.compute/virtualmachines--Network Out Total Timeline",
+                          "formatter": 5
+                        },
+                        {
+                          "columnMatch": "microsoft.compute/virtualmachines--Availability Timeline",
+                          "formatter": 5
+                        },
+                        {
+                          "columnMatch": "microsoft.compute/virtualmachines--Availability",
+                          "formatter": 5,
+                          "formatOptions": {
+                            "linkTarget": "GenericDetails",
+                            "linkIsContextBlade": true
+                          },
+                          "numberFormat": {
+                            "unit": 0,
+                            "options": {
+                              "style": "decimal"
+                            }
+                          }
+                        },
+                        {
+                          "columnMatch": "Name",
+                          "formatter": 13,
+                          "formatOptions": {
+                            "linkTarget": "Resource"
+                          }
+                        }
+                      ],
+                      "rowLimit": 10000,
+                      "filter": true,
+                      "labelSettings": [
+                        {
+                          "columnId": "Subscription",
+                          "label": "-"
+                        },
+                        {
+                          "columnId": "Name",
+                          "label": "Virtual machine"
+                        },
+                        {
+                          "columnId": "microsoft.compute/virtualmachines--VmAvailabilityMetric",
+                          "label": "VM Availability Metric (Preview) (Sum)"
+                        },
+                        {
+                          "columnId": "microsoft.compute/virtualmachines--VmAvailabilityMetric Timeline",
+                          "label": "VM Availability Metric (Preview) Timeline"
+                        },
+                        {
+                          "columnId": "microsoft.compute/virtualmachines--Percentage CPU",
+                          "label": "Percentage CPU (Average)"
+                        },
+                        {
+                          "columnId": "microsoft.compute/virtualmachines--Percentage CPU Timeline",
+                          "label": "Percentage CPU Timeline"
+                        },
+                        {
+                          "columnId": "microsoft.compute/virtualmachines--Disk Read Bytes",
+                          "label": "Disk Read Bytes (Sum)"
+                        },
+                        {
+                          "columnId": "microsoft.compute/virtualmachines--Disk Read Bytes Timeline",
+                          "label": "Disk Read Bytes Timeline"
+                        },
+                        {
+                          "columnId": "microsoft.compute/virtualmachines--Disk Write Bytes",
+                          "label": "Disk Write Bytes (Sum)"
+                        },
+                        {
+                          "columnId": "microsoft.compute/virtualmachines--Disk Write Bytes Timeline",
+                          "label": "Disk Write Bytes Timeline"
+                        },
+                        {
+                          "columnId": "microsoft.compute/virtualmachines--Network In Total",
+                          "label": "Network In Total (Sum)"
+                        },
+                        {
+                          "columnId": "microsoft.compute/virtualmachines--Network In Total Timeline",
+                          "label": "Network In Total Timeline"
+                        },
+                        {
+                          "columnId": "microsoft.compute/virtualmachines--Network Out Total",
+                          "label": "Network Out Total (Sum)"
+                        },
+                        {
+                          "columnId": "microsoft.compute/virtualmachines--Network Out Total Timeline",
+                          "label": "Network Out Total Timeline"
+                        }
+                      ]
+                    },
+                    "showExportToExcel": true
+                  },
+                  "customWidth": "50",
+                  "conditionalVisibilities": [
+                    {
+                      "parameterName": "SelectedTab",
+                      "comparison": "isEqualTo",
+                      "value": "-"
+                    },
+                    {
+                      "parameterName": "compute",
+                      "comparison": "isEqualTo",
+                      "value": "azure"
+                    },
+                    {
+                      "parameterName": "Report_check",
+                      "comparison": "isEqualTo",
+                      "value": "No"
+                    }
+                  ],
+                  "showPin": true,
+                  "name": "metric - Monitroing Key Metrics (Used for merge)",
+                  "styleSettings": {
+                    "padding": "5px"
+                  }
+                },
+                {
                   "type": 11,
                   "content": {
                     "version": "LinkItem/1.0",
@@ -1484,7 +1796,7 @@
                       ]
                     }
                   },
-                  "customWidth": "65",
+                  "customWidth": "50",
                   "conditionalVisibilities": [
                     {
                       "parameterName": "SelectedTab",
@@ -1504,6 +1816,484 @@
                   ],
                   "showPin": true,
                   "name": "query - Azure Compute Summary "
+                },
+                {
+                  "type": 3,
+                  "content": {
+                    "version": "KqlItem/1.0",
+                    "query": "{\"version\":\"Merge/1.0\",\"merges\":[{\"id\":\"5e753f6d-18cd-4295-84c0-fc475611c0ac\",\"mergeType\":\"innerunique\",\"leftTable\":\"metric - Monitroing Key Metrics (Used for merge)\",\"rightTable\":\"query - VIS VM match (Used for merge)\",\"leftColumn\":\"Name\",\"rightColumn\":\"vmId\"}],\"projectRename\":[{\"originalName\":\"[metric - Monitroing Key Metrics (Used for merge)].Subscription\",\"mergedName\":\"Subscription\",\"fromId\":\"5e753f6d-18cd-4295-84c0-fc475611c0ac\"},{\"originalName\":\"[metric - Monitroing Key Metrics (Used for merge)].Name\",\"mergedName\":\"Storage Name\",\"fromId\":\"5e753f6d-18cd-4295-84c0-fc475611c0ac\"},{\"originalName\":\"[query - VIS VM match (Used for merge)].visId\",\"mergedName\":\"visId\",\"fromId\":\"5e753f6d-18cd-4295-84c0-fc475611c0ac\"},{\"originalName\":\"[metric - Monitroing Key Metrics (Used for merge)].microsoft.compute/virtualmachines--VmAvailabilityMetric\",\"mergedName\":\"VM Availability Metric (Preview) (Sum)\",\"fromId\":\"5e753f6d-18cd-4295-84c0-fc475611c0ac\"},{\"originalName\":\"[metric - Monitroing Key Metrics (Used for merge)].microsoft.compute/virtualmachines--VmAvailabilityMetric Timeline\",\"mergedName\":\"VM Availability Metric (Preview) Timeline\",\"fromId\":\"5e753f6d-18cd-4295-84c0-fc475611c0ac\"},{\"originalName\":\"[metric - Monitroing Key Metrics (Used for merge)].microsoft.compute/virtualmachines--Percentage CPU\",\"mergedName\":\"Percentage CPU (Average)\",\"fromId\":\"5e753f6d-18cd-4295-84c0-fc475611c0ac\"},{\"originalName\":\"[metric - Monitroing Key Metrics (Used for merge)].microsoft.compute/virtualmachines--Percentage CPU Timeline\",\"mergedName\":\"Percentage CPU Timeline\",\"fromId\":\"5e753f6d-18cd-4295-84c0-fc475611c0ac\"},{\"originalName\":\"[metric - Monitroing Key Metrics (Used for merge)].microsoft.compute/virtualmachines--Disk Read Bytes\",\"mergedName\":\"Disk Read Bytes (Sum)\",\"fromId\":\"5e753f6d-18cd-4295-84c0-fc475611c0ac\"},{\"originalName\":\"[metric - Monitroing Key Metrics (Used for merge)].microsoft.compute/virtualmachines--Disk Read Bytes Timeline\",\"mergedName\":\"Disk Read Bytes Timeline\",\"fromId\":\"5e753f6d-18cd-4295-84c0-fc475611c0ac\"},{\"originalName\":\"[metric - Monitroing Key Metrics (Used for merge)].microsoft.compute/virtualmachines--Disk Write Bytes\",\"mergedName\":\"Disk Write Bytes (Sum)\",\"fromId\":\"5e753f6d-18cd-4295-84c0-fc475611c0ac\"},{\"originalName\":\"[metric - Monitroing Key Metrics (Used for merge)].microsoft.compute/virtualmachines--Disk Write Bytes Timeline\",\"mergedName\":\"Disk Write Bytes Timeline\",\"fromId\":\"5e753f6d-18cd-4295-84c0-fc475611c0ac\"},{\"originalName\":\"[metric - Monitroing Key Metrics (Used for merge)].microsoft.compute/virtualmachines--Network In Total\",\"mergedName\":\"Network In Total (Sum)\",\"fromId\":\"5e753f6d-18cd-4295-84c0-fc475611c0ac\"},{\"originalName\":\"[metric - Monitroing Key Metrics (Used for merge)].microsoft.compute/virtualmachines--Network In Total Timeline\",\"mergedName\":\"Network In Total Timeline\",\"fromId\":\"5e753f6d-18cd-4295-84c0-fc475611c0ac\"},{\"originalName\":\"[metric - Monitroing Key Metrics (Used for merge)].microsoft.compute/virtualmachines--Network Out Total\",\"mergedName\":\"Network Out Total (Sum)\",\"fromId\":\"5e753f6d-18cd-4295-84c0-fc475611c0ac\"},{\"originalName\":\"[metric - Monitroing Key Metrics (Used for merge)].microsoft.compute/virtualmachines--Network Out Total Timeline\",\"mergedName\":\"Network Out Total Timeline\",\"fromId\":\"5e753f6d-18cd-4295-84c0-fc475611c0ac\"},{\"originalName\":\"[query - VIS VM match (Used for merge)].vmId\",\"mergedName\":\"vmId\",\"fromId\":\"5e753f6d-18cd-4295-84c0-fc475611c0ac\"},{\"originalName\":\"[query - VIS VM match].vmId\"},{\"originalName\":\"[metric - Monitroing Key Metrics].Subscription\"}]}",
+                    "size": 0,
+                    "title": "VM Monitoring Key Metrics",
+                    "exportToExcelOptions": "all",
+                    "queryType": 7,
+                    "visualization": "table",
+                    "gridSettings": {
+                      "formatters": [
+                        {
+                          "columnMatch": "Subscription",
+                          "formatter": 5
+                        },
+                        {
+                          "columnMatch": "visId",
+                          "formatter": 0,
+                          "formatOptions": {
+                            "customColumnWidthSetting": "15ch"
+                          }
+                        },
+                        {
+                          "columnMatch": "VM Availability Metric (Preview) (Sum)",
+                          "formatter": 5
+                        },
+                        {
+                          "columnMatch": "VM Availability Metric (Preview) Timeline",
+                          "formatter": 21,
+                          "formatOptions": {
+                            "palette": "green",
+                            "linkTarget": "AvailabilityDetails",
+                            "linkIsContextBlade": true
+                          }
+                        },
+                        {
+                          "columnMatch": "Percentage CPU (Average)",
+                          "formatter": 8,
+                          "formatOptions": {
+                            "palette": "blue"
+                          },
+                          "numberFormat": {
+                            "unit": 1,
+                            "options": {
+                              "style": "decimal"
+                            }
+                          }
+                        },
+                        {
+                          "columnMatch": "Percentage CPU Timeline",
+                          "formatter": 21,
+                          "formatOptions": {
+                            "min": 0,
+                            "palette": "blue"
+                          }
+                        },
+                        {
+                          "columnMatch": "Disk Read Bytes (Sum)",
+                          "formatter": 8,
+                          "formatOptions": {
+                            "min": 0,
+                            "palette": "orange"
+                          },
+                          "numberFormat": {
+                            "unit": 2,
+                            "options": {
+                              "style": "decimal"
+                            }
+                          }
+                        },
+                        {
+                          "columnMatch": "Disk Read Bytes Timeline",
+                          "formatter": 5
+                        },
+                        {
+                          "columnMatch": "Disk Write Bytes (Sum)",
+                          "formatter": 8,
+                          "formatOptions": {
+                            "palette": "orange"
+                          },
+                          "numberFormat": {
+                            "unit": 2,
+                            "options": {
+                              "style": "decimal"
+                            }
+                          }
+                        },
+                        {
+                          "columnMatch": "Disk Write Bytes Timeline",
+                          "formatter": 5
+                        },
+                        {
+                          "columnMatch": "Network In Total (Sum)",
+                          "formatter": 8,
+                          "formatOptions": {
+                            "palette": "yellow"
+                          },
+                          "numberFormat": {
+                            "unit": 2,
+                            "options": {
+                              "style": "decimal"
+                            }
+                          }
+                        },
+                        {
+                          "columnMatch": "Network In Total Timeline",
+                          "formatter": 5
+                        },
+                        {
+                          "columnMatch": "Network Out Total (Sum)",
+                          "formatter": 8,
+                          "formatOptions": {
+                            "palette": "yellow"
+                          },
+                          "numberFormat": {
+                            "unit": 2,
+                            "options": {
+                              "style": "decimal"
+                            }
+                          }
+                        },
+                        {
+                          "columnMatch": "Network Out Total Timeline",
+                          "formatter": 5
+                        },
+                        {
+                          "columnMatch": "vmId",
+                          "formatter": 5
+                        },
+                        {
+                          "columnMatch": "Virtual Machine",
+                          "formatter": 13,
+                          "formatOptions": {
+                            "linkTarget": "Resource",
+                            "showIcon": true
+                          }
+                        },
+                        {
+                          "columnMatch": "SID",
+                          "formatter": 0,
+                          "formatOptions": {
+                            "customColumnWidthSetting": "15ch"
+                          }
+                        }
+                      ],
+                      "filter": true,
+                      "labelSettings": [
+                        {
+                          "columnId": "Subscription",
+                          "label": "-"
+                        },
+                        {
+                          "columnId": "Storage Name",
+                          "label": "Virtual machine"
+                        },
+                        {
+                          "columnId": "visId",
+                          "label": "SID"
+                        }
+                      ]
+                    },
+                    "tileSettings": {
+                      "showBorder": false,
+                      "titleContent": {
+                        "columnMatch": "Subscription",
+                        "formatter": 1
+                      },
+                      "leftContent": {
+                        "columnMatch": "VM Availability Metric (Preview) (Sum)",
+                        "formatter": 12,
+                        "formatOptions": {
+                          "palette": "auto"
+                        },
+                        "numberFormat": {
+                          "unit": 17,
+                          "options": {
+                            "maximumSignificantDigits": 3,
+                            "maximumFractionDigits": 2
+                          }
+                        }
+                      }
+                    },
+                    "graphSettings": {
+                      "type": 0,
+                      "topContent": {
+                        "columnMatch": "Subscription",
+                        "formatter": 1
+                      },
+                      "centerContent": {
+                        "columnMatch": "VM Availability Metric (Preview) (Sum)",
+                        "formatter": 1,
+                        "numberFormat": {
+                          "unit": 17,
+                          "options": {
+                            "maximumSignificantDigits": 3,
+                            "maximumFractionDigits": 2
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "customWidth": "50",
+                  "conditionalVisibilities": [
+                    {
+                      "parameterName": "SelectedTab",
+                      "comparison": "isEqualTo",
+                      "value": "compute"
+                    },
+                    {
+                      "parameterName": "compute",
+                      "comparison": "isEqualTo",
+                      "value": "azure"
+                    },
+                    {
+                      "parameterName": "Report_check",
+                      "comparison": "isEqualTo",
+                      "value": "No"
+                    }
+                  ],
+                  "showPin": false,
+                  "name": "Virtual Machine Monitoring Metrics",
+                  "styleSettings": {
+                    "padding": "5px"
+                  }
+                },
+                {
+                  "type": 3,
+                  "content": {
+                    "version": "KqlItem/1.0",
+                    "query": "resources\r\n| where type startswith 'microsoft.workloads/sapvirtualinstances/'\r\n| where id startswith '{current_vis}'\r\n| extend visId = tostring(split(split(split(id, '/centralInstances')[0], '/databaseInstances')[0], '/applicationInstances')[0])\r\n| mv-expand vm = properties.vmDetails\r\n| extend vmId = tolower(vm.virtualMachineId)\r\n| distinct vmId, visId, subscriptionId\r\n| join kind = leftouter (\r\n    HealthResources \r\n    | where type =~ 'microsoft.resourcehealth/availabilitystatuses' or type =~ 'microsoft.resourcehealth/resourceannotations'\r\n    | extend vmId = tolower(properties.targetResourceId)\r\n    | project vmId, AvailabilityState = tostring(properties.availabilityState), Reason = tostring(properties.reason), Context = tostring(properties.context), Category = tostring(properties.category)\r\n) on vmId\r\n| summarize make_set_if(AvailabilityState, isnotempty(AvailabilityState)), make_set_if(Reason, isnotempty(Reason)), make_set_if(Context, isnotempty(Context)), make_set_if(Category, isnotempty(Category)) by vmId, visId, subscriptionId\r\n| project subscriptionId, vmId, visId,\r\n    AvailabilityState = iff(isnull(set_AvailabilityState[0]), \"Unknown\", set_AvailabilityState[0]),\r\n    Reason = iff(isnull(set_Reason[0]), \"-\", set_Reason[0]),\r\n    Context = iff(isnull(set_Context[0]), \"-\", set_Context[0]),\r\n    Category = iff(isnull(set_Category[0]), \"-\", set_Category[0])",
+                    "size": 0,
+                    "title": "Current VM Health & Annotations",
+                    "exportToExcelOptions": "all",
+                    "queryType": 1,
+                    "resourceType": "microsoft.resourcegraph/resources",
+                    "crossComponentResources": [
+                      "value::all"
+                    ],
+                    "gridSettings": {
+                      "formatters": [
+                        {
+                          "columnMatch": "subscriptionId",
+                          "formatter": 5,
+                          "formatOptions": {
+                            "linkTarget": "Resource",
+                            "linkIsContextBlade": false
+                          }
+                        },
+                        {
+                          "columnMatch": "vmId",
+                          "formatter": 13,
+                          "formatOptions": {
+                            "linkTarget": "Resource",
+                            "subTarget": "resourcehealth",
+                            "showIcon": true,
+                            "bladeOpenContext": {
+                              "bladeName": "ResourceMenuBlade",
+                              "extensionName": "HubsExtension",
+                              "bladeParameters": [
+                                {
+                                  "name": "id",
+                                  "source": "cell",
+                                  "value": ""
+                                },
+                                {
+                                  "name": "menuid",
+                                  "source": "static",
+                                  "value": "resourcehealth"
+                                }
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "columnMatch": "visId",
+                          "formatter": 13,
+                          "formatOptions": {
+                            "linkTarget": "Resource",
+                            "showIcon": true,
+                            "customColumnWidthSetting": "15ch"
+                          }
+                        },
+                        {
+                          "columnMatch": "AvailabilityState",
+                          "formatter": 11,
+                          "formatOptions": {
+                            "linkTarget": "Resource",
+                            "subTarget": "resourceHealth",
+                            "linkIsContextBlade": true
+                          }
+                        }
+                      ],
+                      "filter": true,
+                      "labelSettings": [
+                        {
+                          "columnId": "subscriptionId",
+                          "label": "Subscription"
+                        },
+                        {
+                          "columnId": "vmId",
+                          "label": "Virtual machine"
+                        },
+                        {
+                          "columnId": "visId",
+                          "label": "SID"
+                        },
+                        {
+                          "columnId": "AvailabilityState",
+                          "label": "Availability state"
+                        }
+                      ]
+                    }
+                  },
+                  "customWidth": "50",
+                  "conditionalVisibilities": [
+                    {
+                      "parameterName": "SelectedTab",
+                      "comparison": "isEqualTo",
+                      "value": "compute"
+                    },
+                    {
+                      "parameterName": "compute",
+                      "comparison": "isEqualTo",
+                      "value": "azure"
+                    },
+                    {
+                      "parameterName": "Report_check",
+                      "comparison": "isEqualTo",
+                      "value": "No"
+                    }
+                  ],
+                  "showPin": true,
+                  "name": "query - Current VM Health & Annotations"
+                },
+                {
+                  "type": 3,
+                  "content": {
+                    "version": "KqlItem/1.0",
+                    "query": "resources\r\n| where type startswith 'microsoft.workloads/sapvirtualinstances/'\r\n| where id startswith '{current_vis}'\r\n| extend visId = tostring(split(split(split(id, '/centralInstances')[0], '/databaseInstances')[0], '/applicationInstances')[0])\r\n| mv-expand vm = properties.vmDetails\r\n| extend vmId = tolower(vm.virtualMachineId)\r\n| distinct vmId, visId, subscriptionId\r\n| join kind = inner (\r\n    healthresourcechanges\r\n    | where type == \"microsoft.resources/changes\"\r\n    | where properties.targetResourceType =~ \"microsoft.resourcehealth/resourceannotations\"\r\n    | extend Id = tolower(split(properties.targetResourceId, '/providers/Microsoft.ResourceHealth/resourceAnnotations/current')[0]),\r\n    Timestamp = todatetime(properties.changeAttributes.timestamp), AnnotationName = properties['changes']['properties.annotationName']['newValue'], Reason = properties['changes']['properties.reason']['newValue'], \r\n    Context = iff(isempty(properties['changes']['properties.context']['newValue']), \"-\", properties['changes']['properties.context']['newValue']),\r\n    Category = iff(isempty(properties['changes']['properties.category']['newValue']), \"-\", properties['changes']['properties.category']['newValue'])\r\n    | where isnotempty(AnnotationName)\r\n    | where Timestamp > ago(14d)) on $left.vmId == $right.Id\r\n| project subscriptionId, vmId, visId, Timestamp, Reason, AnnotationName, PreviousAnnotation = properties['changes']['properties.annotationName']['previousValue'], Context, Category \r\n| order by Timestamp desc\r\n| extend Timestamp = format_datetime(Timestamp, 'dd/MM/yyyy, hh:mm:ss tt')",
+                    "size": 0,
+                    "title": "VM Health Changes (Last 14 days)",
+                    "noDataMessage": "No health changes found in the last 14 days",
+                    "queryType": 1,
+                    "resourceType": "microsoft.resourcegraph/resources",
+                    "crossComponentResources": [
+                      "value::all"
+                    ],
+                    "gridSettings": {
+                      "formatters": [
+                        {
+                          "columnMatch": "$gen_group",
+                          "formatter": 13,
+                          "formatOptions": {
+                            "linkTarget": "Resource",
+                            "subTarget": "resourcehealth",
+                            "showIcon": true
+                          }
+                        },
+                        {
+                          "columnMatch": "subscriptionId",
+                          "formatter": 5
+                        },
+                        {
+                          "columnMatch": "vmId",
+                          "formatter": 5,
+                          "formatOptions": {
+                            "linkTarget": "Resource",
+                            "subTarget": "resourcehealth"
+                          }
+                        },
+                        {
+                          "columnMatch": "visId",
+                          "formatter": 13,
+                          "formatOptions": {
+                            "linkTarget": "Resource",
+                            "showIcon": true,
+                            "customColumnWidthSetting": "15ch"
+                          }
+                        },
+                        {
+                          "columnMatch": "Timestamp",
+                          "formatter": 5
+                        },
+                        {
+                          "columnMatch": "Reason",
+                          "formatter": 1
+                        },
+                        {
+                          "columnMatch": "AnnotationName",
+                          "formatter": 1
+                        },
+                        {
+                          "columnMatch": "PreviousAnnotation",
+                          "formatter": 1
+                        },
+                        {
+                          "columnMatch": "Context",
+                          "formatter": 1
+                        },
+                        {
+                          "columnMatch": "Category",
+                          "formatter": 1
+                        }
+                      ],
+                      "filter": true,
+                      "hierarchySettings": {
+                        "treeType": 1,
+                        "groupBy": [
+                          "vmId"
+                        ],
+                        "expandTopLevel": true,
+                        "finalBy": "Timestamp"
+                      },
+                      "labelSettings": [
+                        {
+                          "columnId": "subscriptionId",
+                          "label": "Subscription"
+                        },
+                        {
+                          "columnId": "vmId",
+                          "label": "Virtual machine"
+                        },
+                        {
+                          "columnId": "visId",
+                          "label": "SID"
+                        },
+                        {
+                          "columnId": "Timestamp",
+                          "label": "Timestamp"
+                        },
+                        {
+                          "columnId": "Reason",
+                          "label": "Reason"
+                        },
+                        {
+                          "columnId": "AnnotationName",
+                          "label": "Annotation"
+                        },
+                        {
+                          "columnId": "PreviousAnnotation",
+                          "label": "Previous annotation"
+                        },
+                        {
+                          "columnId": "Context",
+                          "label": "Context"
+                        },
+                        {
+                          "columnId": "Category",
+                          "label": "Category"
+                        }
+                      ]
+                    }
+                  },
+                  "customWidth": "50",
+                  "conditionalVisibilities": [
+                    {
+                      "parameterName": "SelectedTab",
+                      "comparison": "isEqualTo",
+                      "value": "compute"
+                    },
+                    {
+                      "parameterName": "compute",
+                      "comparison": "isEqualTo",
+                      "value": "azure"
+                    },
+                    {
+                      "parameterName": "Report_check",
+                      "comparison": "isEqualTo",
+                      "value": "No"
+                    }
+                  ],
+                  "showPin": true,
+                  "name": "query - VM Health Changes (Last 14 days)",
+                  "styleSettings": {
+                    "padding": "10"
+                  }
                 },
                 {
                   "type": 1,
@@ -4439,8 +5229,7 @@
                       {
                         "namespace": "microsoft.network/loadbalancers",
                         "metric": "microsoft.network/loadbalancers--DipAvailability",
-                        "aggregation": 3,
-                        "splitBy": null
+                        "aggregation": 3
                       }
                     ],
                     "title": "Backend health probe by Backend IP",
@@ -4932,8 +5721,7 @@
                       {
                         "namespace": "microsoft.network/applicationgateways",
                         "metric": "microsoft.network/applicationgateways--CurrentConnections",
-                        "aggregation": 1,
-                        "splitBy": null
+                        "aggregation": 1
                       }
                     ],
                     "title": " Current Connections",
@@ -4983,8 +5771,7 @@
                       {
                         "namespace": "microsoft.network/applicationgateways",
                         "metric": "microsoft.network/applicationgateways--NewConnectionsPerSecond",
-                        "aggregation": 4,
-                        "splitBy": null
+                        "aggregation": 4
                       }
                     ],
                     "title": "Avg. New  Connections per second",
@@ -5033,8 +5820,7 @@
                       {
                         "namespace": "microsoft.network/applicationgateways",
                         "metric": "microsoft.network/applicationgateways--TotalRequests",
-                        "aggregation": 1,
-                        "splitBy": null
+                        "aggregation": 1
                       }
                     ],
                     "title": "Total Requests",
@@ -5084,8 +5870,7 @@
                       {
                         "namespace": "microsoft.network/applicationgateways",
                         "metric": "microsoft.network/applicationgateways--Throughput",
-                        "aggregation": 4,
-                        "splitBy": null
+                        "aggregation": 4
                       }
                     ],
                     "title": "Throughput",
@@ -5134,8 +5919,7 @@
                       {
                         "namespace": "microsoft.network/applicationgateways",
                         "metric": "microsoft.network/applicationgateways--ComputeUnits",
-                        "aggregation": 4,
-                        "splitBy": null
+                        "aggregation": 4
                       }
                     ],
                     "title": "Avg Current Compute Units",
@@ -5189,8 +5973,7 @@
                       {
                         "namespace": "microsoft.network/applicationgateways",
                         "metric": "microsoft.network/applicationgateways--HealthyHostCount",
-                        "aggregation": 4,
-                        "splitBy": null
+                        "aggregation": 4
                       }
                     ],
                     "title": "Avg Health Host count",

--- a/Workbooks/Azure Center for SAP solutions/SAP Inventory Checks/SAP Inventory Checks.workbook
+++ b/Workbooks/Azure Center for SAP solutions/SAP Inventory Checks/SAP Inventory Checks.workbook
@@ -1379,7 +1379,7 @@
                       "{vmList}"
                     ],
                     "timeContext": {
-                      "durationMs": 43200000
+                      "durationMs": 86400000
                     },
                     "metrics": [
                       {
@@ -1815,7 +1815,10 @@
                     }
                   ],
                   "showPin": true,
-                  "name": "query - Azure Compute Summary "
+                  "name": "query - Azure Compute Summary ",
+                  "styleSettings": {
+                    "padding": "5px"
+                  }
                 },
                 {
                   "type": 3,
@@ -1823,7 +1826,7 @@
                     "version": "KqlItem/1.0",
                     "query": "{\"version\":\"Merge/1.0\",\"merges\":[{\"id\":\"5e753f6d-18cd-4295-84c0-fc475611c0ac\",\"mergeType\":\"innerunique\",\"leftTable\":\"metric - Monitroing Key Metrics (Used for merge)\",\"rightTable\":\"query - VIS VM match (Used for merge)\",\"leftColumn\":\"Name\",\"rightColumn\":\"vmId\"}],\"projectRename\":[{\"originalName\":\"[metric - Monitroing Key Metrics (Used for merge)].Subscription\",\"mergedName\":\"Subscription\",\"fromId\":\"5e753f6d-18cd-4295-84c0-fc475611c0ac\"},{\"originalName\":\"[metric - Monitroing Key Metrics (Used for merge)].Name\",\"mergedName\":\"Storage Name\",\"fromId\":\"5e753f6d-18cd-4295-84c0-fc475611c0ac\"},{\"originalName\":\"[query - VIS VM match (Used for merge)].visId\",\"mergedName\":\"visId\",\"fromId\":\"5e753f6d-18cd-4295-84c0-fc475611c0ac\"},{\"originalName\":\"[metric - Monitroing Key Metrics (Used for merge)].microsoft.compute/virtualmachines--VmAvailabilityMetric\",\"mergedName\":\"VM Availability Metric (Preview) (Sum)\",\"fromId\":\"5e753f6d-18cd-4295-84c0-fc475611c0ac\"},{\"originalName\":\"[metric - Monitroing Key Metrics (Used for merge)].microsoft.compute/virtualmachines--VmAvailabilityMetric Timeline\",\"mergedName\":\"VM Availability Metric (Preview) Timeline\",\"fromId\":\"5e753f6d-18cd-4295-84c0-fc475611c0ac\"},{\"originalName\":\"[metric - Monitroing Key Metrics (Used for merge)].microsoft.compute/virtualmachines--Percentage CPU\",\"mergedName\":\"Percentage CPU (Average)\",\"fromId\":\"5e753f6d-18cd-4295-84c0-fc475611c0ac\"},{\"originalName\":\"[metric - Monitroing Key Metrics (Used for merge)].microsoft.compute/virtualmachines--Percentage CPU Timeline\",\"mergedName\":\"Percentage CPU Timeline\",\"fromId\":\"5e753f6d-18cd-4295-84c0-fc475611c0ac\"},{\"originalName\":\"[metric - Monitroing Key Metrics (Used for merge)].microsoft.compute/virtualmachines--Disk Read Bytes\",\"mergedName\":\"Disk Read Bytes (Sum)\",\"fromId\":\"5e753f6d-18cd-4295-84c0-fc475611c0ac\"},{\"originalName\":\"[metric - Monitroing Key Metrics (Used for merge)].microsoft.compute/virtualmachines--Disk Read Bytes Timeline\",\"mergedName\":\"Disk Read Bytes Timeline\",\"fromId\":\"5e753f6d-18cd-4295-84c0-fc475611c0ac\"},{\"originalName\":\"[metric - Monitroing Key Metrics (Used for merge)].microsoft.compute/virtualmachines--Disk Write Bytes\",\"mergedName\":\"Disk Write Bytes (Sum)\",\"fromId\":\"5e753f6d-18cd-4295-84c0-fc475611c0ac\"},{\"originalName\":\"[metric - Monitroing Key Metrics (Used for merge)].microsoft.compute/virtualmachines--Disk Write Bytes Timeline\",\"mergedName\":\"Disk Write Bytes Timeline\",\"fromId\":\"5e753f6d-18cd-4295-84c0-fc475611c0ac\"},{\"originalName\":\"[metric - Monitroing Key Metrics (Used for merge)].microsoft.compute/virtualmachines--Network In Total\",\"mergedName\":\"Network In Total (Sum)\",\"fromId\":\"5e753f6d-18cd-4295-84c0-fc475611c0ac\"},{\"originalName\":\"[metric - Monitroing Key Metrics (Used for merge)].microsoft.compute/virtualmachines--Network In Total Timeline\",\"mergedName\":\"Network In Total Timeline\",\"fromId\":\"5e753f6d-18cd-4295-84c0-fc475611c0ac\"},{\"originalName\":\"[metric - Monitroing Key Metrics (Used for merge)].microsoft.compute/virtualmachines--Network Out Total\",\"mergedName\":\"Network Out Total (Sum)\",\"fromId\":\"5e753f6d-18cd-4295-84c0-fc475611c0ac\"},{\"originalName\":\"[metric - Monitroing Key Metrics (Used for merge)].microsoft.compute/virtualmachines--Network Out Total Timeline\",\"mergedName\":\"Network Out Total Timeline\",\"fromId\":\"5e753f6d-18cd-4295-84c0-fc475611c0ac\"},{\"originalName\":\"[query - VIS VM match (Used for merge)].vmId\",\"mergedName\":\"vmId\",\"fromId\":\"5e753f6d-18cd-4295-84c0-fc475611c0ac\"},{\"originalName\":\"[query - VIS VM match].vmId\"},{\"originalName\":\"[metric - Monitroing Key Metrics].Subscription\"}]}",
                     "size": 0,
-                    "title": "VM Monitoring Key Metrics",
+                    "title": "VM Monitoring Key Metrics (Last 24 hours)",
                     "exportToExcelOptions": "all",
                     "queryType": 7,
                     "visualization": "table",
@@ -2038,7 +2041,7 @@
                     }
                   ],
                   "showPin": false,
-                  "name": "Virtual Machine Monitoring Metrics",
+                  "name": "Virtual Machine Monitoring Metrics (Last 24 hours)",
                   "styleSettings": {
                     "padding": "5px"
                   }
@@ -2150,7 +2153,10 @@
                     }
                   ],
                   "showPin": true,
-                  "name": "query - Current VM Health & Annotations"
+                  "name": "query - Current VM Health & Annotations",
+                  "styleSettings": {
+                    "padding": "5px"
+                  }
                 },
                 {
                   "type": 3,
@@ -2292,7 +2298,7 @@
                   "showPin": true,
                   "name": "query - VM Health Changes (Last 14 days)",
                   "styleSettings": {
-                    "padding": "10"
+                    "padding": "5px"
                   }
                 },
                 {

--- a/Workbooks/Azure Center for SAP solutions/SAP Inventory Checks/SAP Inventory Checks.workbook
+++ b/Workbooks/Azure Center for SAP solutions/SAP Inventory Checks/SAP Inventory Checks.workbook
@@ -1979,6 +1979,54 @@
                         {
                           "columnId": "visId",
                           "label": "SID"
+                        },
+                        {
+                          "columnId": "VM Availability Metric (Preview) (Sum)",
+                          "label": "VM Availability Metric (Preview) (Sum)"
+                        },
+                        {
+                          "columnId": "VM Availability Metric (Preview) Timeline",
+                          "label": "VM Availability Metric (Preview) Timeline"
+                        },
+                        {
+                          "columnId": "Percentage CPU (Average)",
+                          "label": "Percentage CPU (Average)"
+                        },
+                        {
+                          "columnId": "Percentage CPU Timeline",
+                          "label": "Percentage CPU Timeline"
+                        },
+                        {
+                          "columnId": "Disk Read Bytes (Sum)",
+                          "label": "Disk Read Bytes (Sum)"
+                        },
+                        {
+                          "columnId": "Disk Read Bytes Timeline",
+                          "label": "Disk Read Bytes Timeline"
+                        },
+                        {
+                          "columnId": "Disk Write Bytes (Sum)",
+                          "label": "Disk Write Bytes (Sum)"
+                        },
+                        {
+                          "columnId": "Disk Write Bytes Timeline",
+                          "label": "Disk Write Bytes Timeline"
+                        },
+                        {
+                          "columnId": "Network In Total (Sum)",
+                          "label": "Network In Total (Sum)"
+                        },
+                        {
+                          "columnId": "Network In Total Timeline",
+                          "label": "Network In Total Timeline"
+                        },
+                        {
+                          "columnId": "Network Out Total (Sum)",
+                          "label": "Network Out Total (Sum)"
+                        },
+                        {
+                          "columnId": "Network Out Total Timeline",
+                          "label": "Network Out Total Timeline"
                         }
                       ]
                     },
@@ -2130,6 +2178,18 @@
                         {
                           "columnId": "AvailabilityState",
                           "label": "Availability state"
+                        },
+                        {
+                          "columnId": "Reason",
+                          "label": "Reason"
+                        },
+                        {
+                          "columnId": "Context",
+                          "label": "Context"
+                        },
+                        {
+                          "columnId": "Category",
+                          "label": "Category"
                         }
                       ]
                     }


### PR DESCRIPTION
### Added the following tiles to the ACSS_Aggregated workbook:
- **VM Monitoring Metrics (Last 24 hours):**

Shows the list of VMs for the selected VIS(es), and their health metrics in the past 24 hours.

![image](https://github.com/microsoft/Application-Insights-Workbooks/assets/91113392/713c3e96-f1ff-41f7-aca3-0cee164d816b)

![image](https://github.com/microsoft/Application-Insights-Workbooks/assets/91113392/70c1b941-f460-43ee-93da-ad2ad93b9864)

Since this is a metrics tile which gets the metrics for VMs, I had to find a workaround to add a column for the SID of the VMs. To do that I had to create 2 hidden steps, and then create a 3rd query step in which I'm getting the data by merging the results of the previous 2 steps.

![8](https://github.com/microsoft/Application-Insights-Workbooks/assets/91113392/f99c7a77-26f8-42a9-8a4f-76b1cf8e6571)

- **Current VM Health & Annotations:**

Shows the list of VMs for the selected VIS(es), and their current health and annotations.

![image](https://github.com/microsoft/Application-Insights-Workbooks/assets/91113392/d5fe320d-4027-424e-91fc-27bbca170608)

![4](https://github.com/microsoft/Application-Insights-Workbooks/assets/91113392/d6352350-65f3-4a4b-b254-f485cca54b4b)

- **VM Health Changes (Last 14 days):**

Shows the list of VMs for the selected VIS(es), and their corresponding health changes in the past 14 days.

![5](https://github.com/microsoft/Application-Insights-Workbooks/assets/91113392/e07081de-65ba-4dc3-8503-52097e28a188)

![6](https://github.com/microsoft/Application-Insights-Workbooks/assets/91113392/14197c29-96d3-45cf-a7fe-80efcbfe7f9a)

I also had to add a parameter **vmIds** to the ACSS_Aggregated workbook, as I had to supply that column to get the metrics for the VMs. The existing vmList parameter is a list of comma separated visIds and vmIds.

![9](https://github.com/microsoft/Application-Insights-Workbooks/assets/91113392/deed674a-e384-40fe-a6a5-a0e79800e8b9)

### Added the same tiles to the SAP_Inventory_Checks workbook:

![7](https://github.com/microsoft/Application-Insights-Workbooks/assets/91113392/0056323a-50e7-4e00-942d-d4d454bf90ac)

**Link to try out changes:** https://ms.portal.azure.com/?feature.workbookGalleryRedirect=https%3A%2F%2Fworkbookpoctemplates.blob.core.windows.net%2Facss-workbook-templates%2Fpackage#home


## PR Checklist

* [x] Explain your changes, so people looking at the PR know *what* and *why*, the code changes are the *how*.
* [x] Validate your changes using one or more of the [testing](../Documentation/Testing.md) methods.

### If adding or updating templates:
* [x] post a screenshot of templates and/or gallery changes
* [x] ensure your template has a corresponding gallery entry in the gallery folder
* [ ] If you are adding a new template, add your team and template/gallery file(s) to the CODEOWNERS file. CODEOWNERS entries should be teams, not individuals
* [x] ensure all steps have meaningful names
* [x] ensure all parameters and grid columns have display names set so they can be localized
* [x] ensure that parameters id values are unique __or they will fail PR validation__ (parameter ids are used for localization)
* [x] ensure that steps names are unique __or they will fail PR validation__ (step names are used for localization)
* [x] grep `/subscription/` and ensure that your parameters don't have any hardcoded resourceIds __or they will fail PR validation__
* [x] remove `fallbackResourceIds` and `fromTemplateId` fields from your template workbook __or they will fail PR validation__