### PR TITLE
Removed unnecessary link from VM Availability Metric timeline.

### DIFF
--- a/Workbooks/Azure Center for SAP solutions/ACSS Aggregated/ACSS Aggregated.workbook
+++ b/Workbooks/Azure Center for SAP solutions/ACSS Aggregated/ACSS Aggregated.workbook
@@ -1527,9 +1527,7 @@
                           "columnMatch": "microsoft.compute/virtualmachines--VmAvailabilityMetric Timeline",
                           "formatter": 21,
                           "formatOptions": {
-                            "palette": "green",
-                            "linkTarget": "AvailabilityDetails",
-                            "linkIsContextBlade": true
+                            "palette": "green"
                           }
                         },
                         {
@@ -1846,9 +1844,7 @@
                           "columnMatch": "VM Availability Metric (Preview) Timeline",
                           "formatter": 21,
                           "formatOptions": {
-                            "palette": "green",
-                            "linkTarget": "AvailabilityDetails",
-                            "linkIsContextBlade": true
+                            "palette": "green"
                           }
                         },
                         {

--- a/Workbooks/Azure Center for SAP solutions/SAP Inventory Checks/SAP Inventory Checks.workbook
+++ b/Workbooks/Azure Center for SAP solutions/SAP Inventory Checks/SAP Inventory Checks.workbook
@@ -1435,9 +1435,7 @@
                           "columnMatch": "microsoft.compute/virtualmachines--VmAvailabilityMetric Timeline",
                           "formatter": 21,
                           "formatOptions": {
-                            "palette": "green",
-                            "linkTarget": "AvailabilityDetails",
-                            "linkIsContextBlade": true
+                            "palette": "green"
                           }
                         },
                         {
@@ -1856,9 +1854,7 @@
                           "columnMatch": "VM Availability Metric (Preview) Timeline",
                           "formatter": 21,
                           "formatOptions": {
-                            "palette": "green",
-                            "linkTarget": "AvailabilityDetails",
-                            "linkIsContextBlade": true
+                            "palette": "green"
                           }
                         },
                         {


### PR DESCRIPTION
- Removed unnecessary link from VM availability metric column of the "VM Monitoring Key Metrics (Last 24 hours)" tile.

![image](https://github.com/microsoft/Application-Insights-Workbooks/assets/91113392/4ba696e4-71c3-4e9f-a397-3d641cea035b)

## PR Checklist

* [ ] Explain your changes, so people looking at the PR know *what* and *why*, the code changes are the *how*.
* [ ] Validate your changes using one or more of the [testing](../Documentation/Testing.md) methods.

### If adding or updating templates:
* [ ] post a screenshot of templates and/or gallery changes
* [ ] ensure your template has a corresponding gallery entry in the gallery folder
* [ ] If you are adding a new template, add your team and template/gallery file(s) to the CODEOWNERS file. CODEOWNERS entries should be teams, not individuals
* [ ] ensure all steps have meaningful names
* [ ] ensure all parameters and grid columns have display names set so they can be localized
* [ ] ensure that parameters id values are unique __or they will fail PR validation__ (parameter ids are used for localization)
* [ ] ensure that steps names are unique __or they will fail PR validation__ (step names are used for localization)
* [ ] grep `/subscription/` and ensure that your parameters don't have any hardcoded resourceIds __or they will fail PR validation__
* [ ] remove `fallbackResourceIds` and `fromTemplateId` fields from your template workbook __or they will fail PR validation__