### PR TITLE
Separating out ASR workbooks as different category

### DIFF
--- a/gallery/workbook/businesscontinuity-insights.json
+++ b/gallery/workbook/businesscontinuity-insights.json
@@ -35,7 +35,13 @@
 					"author": "Microsoft",
 					"description": "View information on user triggered operations on Recovery Services vaults like configuration changes and restores",
 					"name": "User Triggered Operations"
-				},
+				}
+			]
+		},
+		{
+			"id": "Azure Site Recovery",
+			"name": "Azure Site Recovery",
+			"templates": [
 				{
 					"id": "Workbooks/Azure Backup/ASR Job History",
 					"author": "Microsoft",
@@ -48,7 +54,6 @@
 					"description": "View information on ASR Replicated Items",
 					"name": "ASR Replication History"
 				}
-				
 			]
 		}
 	]


### PR DESCRIPTION
Adding a new category for Azure Site Recovery to separate out Azure Site Recovery templates from Azure Backup templates in gallery.

## PR Checklist

* [x] Explain your changes, so people looking at the PR know *what* and *why*, the code changes are the *how*.
* [ ] Validate your changes using one or more of the [testing](../Documentation/Testing.md) methods.

### If adding or updating templates:
* [ ] post a screenshot of templates and/or gallery changes
* [ ] ensure your template has a corresponding gallery entry in the gallery folder
* [ ] If you are adding a new template, add your team and template/gallery file(s) to the CODEOWNERS file. CODEOWNERS entries should be teams, not individuals
* [ ] ensure all steps have meaningful names
* [ ] ensure all parameters and grid columns have display names set so they can be localized
* [ ] ensure that parameters id values are unique __or they will fail PR validation__ (parameter ids are used for localization)
* [ ] ensure that steps names are unique __or they will fail PR validation__ (step names are used for localization)
* [ ] grep `/subscription/` and ensure that your parameters don't have any hardcoded resourceIds __or they will fail PR validation__
* [ ] remove `fallbackResourceIds` and `fromTemplateId` fields from your template workbook __or they will fail PR validation__