### PR TITLE
Add trailing whitespace file path validation

### DIFF
--- a/test/jsonValidationTest.js
+++ b/test/jsonValidationTest.js
@@ -26,6 +26,7 @@ const LocKeys = [
     "markDown" // specific to cohorts
 ];
 
+const TrailingWhitespaceSlashRegex = /\s\/|\/\s|\s\\|\\\s/;
 
 const GallerySchema = "https://raw.githubusercontent.com/microsoft/Application-Insights-Workbooks/master/schema/gallery.json";
 const GalleryVersion = "TemplateGallery/1.0";
@@ -169,6 +170,7 @@ function validateJsonStringAndGetObject(file) {
     // also validate the file name. 
     // * it can have either / or \ but not both.
     // * it cannnot have & or ? or #
+    // * it cannot have a trailing whitespace after before or after the slash
     if (file.indexOf("/") !== -1 && file.indexOf("\\") !== -1) {
         assert.fail("Filename contains both '/' and '\\' characters: '" + file + "'")
     } else {
@@ -177,6 +179,10 @@ function validateJsonStringAndGetObject(file) {
                 assert.fail("Filename contains invalid '" + c + "' character: '" + file + "'");
             }
         });
+    }
+
+    if (!TrailingWhitespaceSlashRegex.test(file)) {
+        assert.fail("Invalid file path: " + file + ". Trailing whitespace found before or after '/' or '\\'.");
     }
 
     let json = fs.readFileSync(file, 'utf8');


### PR DESCRIPTION
Github seems to allow trailing whitespaces when creating file paths using the Github UI. Ensure as part of validating template paths that there are no trailing whitespaces before or after slashes.