### PR TITLE
Add Azure Automation Update Management Tab to AMA Migration Helper Workbook

### DIFF
--- a/Workbooks/Azure Monitor - Agents/Agent Migration Tracker/AMA Migration Helper.workbook
+++ b/Workbooks/Azure Monitor - Agents/Agent Migration Tracker/AMA Migration Helper.workbook
@@ -110,7 +110,7 @@
     {
       "type": 1,
       "content": {
-        "json": "Use this workbook to review the status of migration from [legacy Log Analytics Agents (MMA/OMS)](https://docs.microsoft.com/en-us/azure/azure-monitor/agents/log-analytics-agent) to [Azure Monitor Agent (AMA)](https://docs.microsoft.com/en-us/azure/azure-monitor/agents/azure-monitor-agent-overview?tabs=PowerShellWindows). The legacy agents will not be supported after August, 2024.\r\n\r\n* Select Workspaces view to review the machines connected to the workspace that are running MMA/OMS agents, and the list of solutions/services used. Review the [migration guidance per solution](https://docs.microsoft.com/en-us/azure/azure-monitor/agents/azure-monitor-agent-overview?tabs=PowerShellWindows#supported-services-and-features).\r\n* Select corresponding tabs to look at status of the machine and the agents installed on them.\r\n\r\n*Note: the Time Range selection at the top of this workbook will only affect detection of the heartbeat emitted into the selected workspace(s).*",
+        "json": "Use this workbook to review the status of migration from [legacy Log Analytics Agents (MMA/OMS)](https://docs.microsoft.com/en-us/azure/azure-monitor/agents/log-analytics-agent) to [Azure Monitor Agent (AMA)](https://docs.microsoft.com/en-us/azure/azure-monitor/agents/azure-monitor-agent-overview?tabs=PowerShellWindows). The legacy agents will not be supported after August, 2024.\r\n\r\nYou can also use this workbook to check which log analytics workspaces are being used for [Azure Automation Update Management](https://learn.microsoft.com/en-us/azure/automation/update-management/overview) which will be retired on 31st August 2024. \r\n\r\n* Select Workspaces view to review the machines connected to the workspace that are running MMA/OMS agents, and the list of solutions/services used. Review the [migration guidance per solution](https://docs.microsoft.com/en-us/azure/azure-monitor/agents/azure-monitor-agent-overview?tabs=PowerShellWindows#supported-services-and-features).\r\n* Select corresponding tabs to look at status of the machine and the agents installed on them.\r\n\r\n*Note: the Time Range selection at the top of this workbook will only affect detection of the heartbeat emitted into the selected workspace(s).*",
         "style": "info"
       },
       "name": "workbook-info"
@@ -168,6 +168,14 @@
             "linkTarget": "parameter",
             "linkLabel": "Hybrid without Arc",
             "subTarget": "HybridNoArc",
+            "style": "link"
+          },
+          {
+            "id": "37168904-f778-4c3f-a2a3-2dd238447ed6",
+            "cellValue": "selectedTab",
+            "linkTarget": "parameter",
+            "linkLabel": "Azure Automation Update Management",
+            "subTarget": "AzureAutomationUpdateManagement",
             "style": "link"
           }
         ]
@@ -2413,7 +2421,428 @@
         "value": "HybridNoArc"
       },
       "name": "HybridWithoutArcGroup"
+    },
+    {
+      "type": 12,
+      "content": {
+        "version": "NotebookGroup/1.0",
+        "groupType": "editable",
+        "items": [
+          {
+            "type": 1,
+            "content": {
+              "json": "# Azure Automation Update Management Overview"
+            },
+            "name": "AutomationAccountOverviewHeader"
+          },
+          {
+            "type": 1,
+            "content": {
+              "json": "On 31 August 2024, both Automation Update Management and the Log Analytics agent it uses will be retired. Migrate to Azure Update Manager before that. Refer to guidance on migrating to Azure Update Manager [here](https://learn.microsoft.com/en-us/azure/update-manager/guidance-migration-automation-update-management-azure-update-manager?WT.mc_id=Portal-Microsoft_Azure_Automation).",
+              "style": "warning"
+            },
+            "name": "AutomationAccount-select-warning"
+          },
+          {
+            "type": 9,
+            "content": {
+              "version": "KqlParameterItem/1.0",
+              "crossComponentResources": [
+                "{Subscription}"
+              ],
+              "parameters": [
+                {
+                  "id": "16ae0ffa-3747-4c57-8f87-e2388c68c56b",
+                  "version": "KqlParameterItem/1.0",
+                  "name": "wsid",
+                  "label": "Workspace",
+                  "type": 5,
+                  "description": "Select the workspace from the drop down to fetch linked automation accounts using updates solution",
+                  "isRequired": true,
+                  "query": "resources\r\n| where type == \"microsoft.operationalinsights/workspaces\"\r\n| extend id = tolower(id)\r\n| where id in~ ({Workspace})\r\n| join kind=leftouter  ( \r\nresourcecontainers\r\n| where type == \"microsoft.resources/subscriptions\"\r\n| project subscriptionId, subname = name\r\n) on subscriptionId\r\n| project subscriptionId, subname, id, name, location, resourceGroup\r\n| order by subscriptionId\r\n| join kind=inner (\r\n resources\r\n| where type == \"microsoft.operationsmanagement/solutions\"\r\n| extend workspace = tostring(properties.workspaceResourceId)\r\n| extend workspace = tolower(workspace)\r\n| where workspace in~ ({Workspace})\r\n| where name contains \"Updates\"\r\n) on $left.id == $right.workspace\r\n| project value = id, label = name, group = strcat('🔑 ', subname)",
+                  "crossComponentResources": [
+                    "{Subscription}"
+                  ],
+                  "typeSettings": {
+                    "additionalResourceOptions": []
+                  },
+                  "timeContext": {
+                    "durationMs": 86400000
+                  },
+                  "queryType": 1,
+                  "resourceType": "microsoft.resourcegraph/resources"
+                },
+                {
+                  "id": "8748c312-ad8e-48af-88fe-67a81c4eb447",
+                  "version": "KqlParameterItem/1.0",
+                  "name": "aaid",
+                  "label": "Automation account",
+                  "type": 1,
+                  "description": "Automation account.",
+                  "isRequired": true,
+                  "query": "{\"version\":\"ARMEndpoint/1.0\",\"data\":null,\"headers\":[],\"method\":\"GET\",\"path\":\"/{wsid}/linkedServices/Automation\",\"urlParams\":[{\"key\":\"api-version\",\"value\":\"2020-08-01\"}],\"batchDisabled\":false,\"transformers\":[{\"type\":\"jsonpath\",\"settings\":{\"tablePath\":\"properties.resourceId\",\"columns\":[]}}]}",
+                  "timeContext": {
+                    "durationMs": 86400000
+                  },
+                  "queryType": 12
+                }
+              ],
+              "style": "pills",
+              "queryType": 1,
+              "resourceType": "microsoft.resourcegraph/resources"
+            },
+            "customWidth": "100",
+            "name": "AutomationAccountSelectionParam",
+            "styleSettings": {
+              "margin": "0px",
+              "maxWidth": "100"
+            }
+          },
+          {
+            "type": 11,
+            "content": {
+              "version": "LinkItem/1.0",
+              "style": "nav",
+              "links": [
+                {
+                  "id": "8e9d87e8-4bf0-4530-995a-59830b6d26ea",
+                  "linkTarget": "OpenBlade",
+                  "linkLabel": "Migrate Now",
+                  "style": "primary",
+                  "bladeOpenContext": {
+                    "bladeName": "UpdateCenterMigrationBlade",
+                    "extensionName": "Microsoft_Azure_Automation",
+                    "bladeJsonParameters": "{\n  \"automationAccountId\": \"{aaid}\"\n}"
+                  }
+                }
+              ]
+            },
+            "name": "MigrateNowLink"
+          },
+          {
+            "type": 12,
+            "content": {
+              "version": "NotebookGroup/1.0",
+              "groupType": "editable",
+              "items": [
+                {
+                  "type": 9,
+                  "content": {
+                    "version": "KqlParameterItem/1.0",
+                    "crossComponentResources": [
+                      "{Subscription}"
+                    ],
+                    "parameters": [
+                      {
+                        "id": "df6dfea5-53cc-46d5-a767-42d8d0aea4d4",
+                        "version": "KqlParameterItem/1.0",
+                        "name": "workspaceid",
+                        "type": 5,
+                        "description": "Used to pass Workspace from previous step",
+                        "query": "resources\r\n| where type == \"microsoft.operationalinsights/workspaces\"\r\n| where id =~ '{wsid}'",
+                        "crossComponentResources": [
+                          "{Subscription}"
+                        ],
+                        "isHiddenWhenLocked": true,
+                        "typeSettings": {
+                          "resourceTypeFilter": {
+                            "microsoft.operationalinsights/workspaces": true
+                          },
+                          "additionalResourceOptions": []
+                        },
+                        "timeContext": {
+                          "durationMs": 86400000
+                        },
+                        "queryType": 1,
+                        "resourceType": "microsoft.resourcegraph/resources"
+                      }
+                    ],
+                    "style": "above",
+                    "queryType": 1,
+                    "resourceType": "microsoft.resourcegraph/resources"
+                  },
+                  "name": "workspace-hidden-param"
+                },
+                {
+                  "type": 11,
+                  "content": {
+                    "version": "LinkItem/1.0",
+                    "style": "tabs",
+                    "links": [
+                      {
+                        "id": "be489620-96ea-4464-85eb-e541d20c42f3",
+                        "cellValue": "selectedTab",
+                        "linkTarget": "parameter",
+                        "linkLabel": "Machines",
+                        "subTarget": "Machines",
+                        "style": "link"
+                      },
+                      {
+                        "id": "11da3fe4-5f48-4f7e-bde0-35f230841df3",
+                        "cellValue": "selectedTab",
+                        "linkTarget": "parameter",
+                        "linkLabel": "Deployment schedules ",
+                        "subTarget": "Schedules",
+                        "style": "link"
+                      }
+                    ]
+                  },
+                  "name": "Automation-Tabs"
+                },
+                {
+                  "type": 12,
+                  "content": {
+                    "version": "NotebookGroup/1.0",
+                    "groupType": "editable",
+                    "items": [
+                      {
+                        "type": 3,
+                        "content": {
+                          "version": "KqlItem/1.0",
+                          "query": "Heartbeat\r\n| where Solutions contains \"updates\"\r\n| extend ResourceType = iff(ResourceType == \"virtualMachines\", \"microsoft.compute/virtualmachines\", iff(ResourceType == \"machines\", \"microsoft.hybridcompute/machines\", ResourceType))\r\n| distinct Computer, ResourceId, ResourceType, OSType\r\n",
+                          "size": 1,
+                          "showAnalytics": true,
+                          "showRefreshButton": true,
+                          "showExportToExcel": true,
+                          "queryType": 0,
+                          "resourceType": "microsoft.operationalinsights/workspaces",
+                          "crossComponentResources": [
+                            "{workspaceid}"
+                          ],
+                          "gridSettings": {
+                            "rowLimit": 10000,
+                            "filter": true,
+                            "labelSettings": [
+                              {
+                                "columnId": "Computer",
+                                "label": "Machine name"
+                              },
+                              {
+                                "columnId": "ResourceId",
+                                "label": "Resource Id"
+                              },
+                              {
+                                "columnId": "ResourceType",
+                                "label": "Resource type"
+                              }
+                            ]
+                          }
+                        },
+                        "conditionalVisibility": {
+                          "parameterName": "selectedTab",
+                          "comparison": "isEqualTo",
+                          "value": "MachinesDataFromLA"
+                        },
+                        "name": "Machines data from Log Analytics Workspace",
+                        "styleSettings": {
+                          "showBorder": true
+                        }
+                      },
+                      {
+                        "type": 3,
+                        "content": {
+                          "version": "KqlItem/1.0",
+                          "query": "\r\n((resources\r\n| where type =~ \"microsoft.compute/virtualmachines\"\r\n| where properties.storageProfile.osDisk.osType in~ ('Linux','Windows')\r\n| extend os = tolower(properties.storageProfile.osDisk.osType)\r\n| extend patchSettingsObject = iff(os == \"windows\", properties.osProfile.windowsConfiguration.patchSettings, properties.osProfile.linuxConfiguration.patchSettings)\r\n| extend conf = tostring(patchSettingsObject.patchMode)\r\n| extend conf = iff (conf =~ \"AutomaticByPlatform\",\r\niff(isnotnull(patchSettingsObject.automaticByPlatformSettings.bypassPlatformSafetyChecksOnUserSchedule) and patchSettingsObject.automaticByPlatformSettings.bypassPlatformSafetyChecksOnUserSchedule == true, \"AutomaticByPlatformWithUserManagedSchedules\", \"AutomaticByPlatformUsingAutoGuestPatching\"),conf)\r\n| extend assessMode = tostring(patchSettingsObject.assessmentMode)\r\n| extend periodicAssessment = iff(assessMode =~ \"AutomaticByPlatform\", \"Yes\", \"No\")\r\n| extend status=tostring(properties.extended.instanceView.powerState.displayStatus)\r\n| extend imageRef = strcat(tolower(tostring(properties.storageProfile.imageReference.publisher)), \":\", tolower(tostring(properties.storageProfile.imageReference.offer)), \":\", tolower(tostring(properties.storageProfile.imageReference.sku)))\r\n| extend isMarketplace = (isnotnull(properties.storageProfile.imageReference.publisher) and isnotnull(properties.storageProfile.imageReference.offer) and isnotnull(properties.storageProfile.imageReference.sku))\r\n| extend isNotInCRPAllowList = (isnotnull(properties.storageProfile.imageReference.publisher) and isnotnull(properties.storageProfile.imageReference.offer) and isnotnull(properties.storageProfile.imageReference.sku)) and not(iff(os =~ \"windows\", (imageRef in ('microsoftwindowsserver:microsoftserveroperatingsystems-previews:windows-server-vnext-azure-edition-core','microsoftwindowsserver:windowsserver:2008-r2-sp1','microsoftwindowsserver:windowsserver:2012-r2-datacenter','microsoftwindowsserver:windowsserver:2012-r2-datacenter-gensecond','microsoftwindowsserver:windowsserver:2012-r2-datacenter-smalldisk','microsoftwindowsserver:windowsserver:2012-r2-datacenter-smalldisk-g2','microsoftwindowsserver:windowsserver:2016-datacenter','microsoftwindowsserver:windowsserver:2016-datacenter-gensecond','microsoftwindowsserver:windowsserver:2016-datacenter-server-core','microsoftwindowsserver:windowsserver:2016-datacenter-smalldisk','microsoftwindowsserver:windowsserver:2016-datacenter-with-containers','microsoftwindowsserver:windowsserver:2019-datacenter','microsoftwindowsserver:windowsserver:2019-datacenter-core','microsoftwindowsserver:windowsserver:2019-datacenter-gensecond','microsoftwindowsserver:windowsserver:2019-datacenter-smalldisk','microsoftwindowsserver:windowsserver:2019-datacenter-smalldisk-g2','microsoftwindowsserver:windowsserver:2019-datacenter-with-containers','microsoftwindowsserver:windowsserver:2022-datacenter','microsoftwindowsserver:windowsserver:2022-datacenter-azure-edition','microsoftwindowsserver:windowsserver:2022-datacenter-azure-edition-core','microsoftwindowsserver:windowsserver:2022-datacenter-azure-edition-core-smalldisk','microsoftwindowsserver:windowsserver:2022-datacenter-azure-edition-hotpatch','microsoftwindowsserver:windowsserver:2022-datacenter-azure-edition-hotpatch-smalldisk','microsoftwindowsserver:windowsserver:2022-datacenter-azure-edition-smalldisk','microsoftwindowsserver:windowsserver:2022-datacenter-core','microsoftwindowsserver:windowsserver:2022-datacenter-core-g2','microsoftwindowsserver:windowsserver:2022-datacenter-g2','microsoftwindowsserver:windowsserver:2022-datacenter-smalldisk','microsoftwindowsserver:windowsserver:2022-datacenter-smalldisk-g2','microsoftwindowsserver:windowsserverhotpatch-previews:windows-server-2022-azure-edition-hotpatch','microsoftazuresiterecovery:process-server:windows-2012-r2-datacenter','microsoftdynamicsax:dynamics:pre-req-ax7-onebox-v4','microsoftdynamicsax:dynamics:pre-req-ax7-onebox-v5','microsoftdynamicsax:dynamics:pre-req-ax7-onebox-v6','microsoftdynamicsax:dynamics:pre-req-ax7-onebox-v7','microsoftdynamicsax:dynamics:pre-req-ax7-onebox-u8','microsoftsqlserver:sql2016sp1-ws2016:standard','microsoftsqlserver:sql2016sp2-ws2016:standard','microsoftsqlserver:sql2017-ws2016:enterprise','microsoftsqlserver:sql2017-ws2016:standard','microsoftsqlserver:sql2019-ws2019:enterprise','microsoftsqlserver:sql2019-ws2019:sqldev','microsoftsqlserver:sql2019-ws2019:standard','microsoftsqlserver:sql2019-ws2019:standard-gen2') or imageRef matches regex 'microsoftwindowsserver:windowsserver:.+|microsoftbiztalkserver:biztalk-server:.+|microsoftdynamicsax:dynamics:.+|microsoftpowerbi:.+:*|microsoftsharepoint:microsoftsharepointserver:.+|microsoftsqlserver:.+:*|microsoftvisualstudio:visualstudio.+:*-ws2012r2|microsoftvisualstudio:visualstudio.+:*-ws2016|microsoftvisualstudio:visualstudio.+:*-ws2019|microsoftvisualstudio:visualstudio.+:*-ws2022|microsoftwindowsserver:windows-cvm:.+|microsoftwindowsserver:windowsserverdotnet:.+|microsoftwindowsserver:windowsserver-gen2preview:.+|microsoftwindowsserver:windowsserversemiannual:.+|microsoftwindowsserver:windowsserverupgrade:.+|microsoftwindowsserverhpcpack:windowsserverhpcpack:.+'), not(imageRef in ('redhat:rhel:74-gen2','redhat:rhel-ha:7.4','redhat:rhel-ha:7.5','redhat:rhel-ha:7.6','redhat:rhel-ha:8.1','redhat:rhel-sap:7.4','redhat:rhel-sap:7.5','redhat:rhel-sap:7.7','redhat:rhel-sap-ha:7.5','redhat:rhel-ha:81_gen2') or imageRef matches regex 'openlogic:centos:8.+|openlogic:centos-hpc:.+|microsoftsqlserver:sql2019-sles.+:*|microsoftsqlserver:sql2019-rhel7:.+|microsoftsqlserver:sql2017-rhel7:.+|microsoft-ads:.+:*|suse:sles-sap-15-.+-byos:gen*') and (imageRef in ('canonical:ubuntuserver:16.04-lts','canonical:ubuntuserver:16.04.0-lts','canonical:ubuntuserver:18.04-lts','canonical:ubuntuserver:18_04-lts-gen2','canonical:0001-com-ubuntu-pro-bionic:pro-18_04-lts','canonical:0001-com-ubuntu-pro-focal:pro-20_04-lts','canonical:0001-com-ubuntu-pro-focal:pro-20_04-lts-gen2','canonical:0001-com-ubuntu-pro-jammy:pro-22_04-lts-gen2','canonical:0001-com-ubuntu-server-focal:20_04-lts','canonical:0001-com-ubuntu-server-focal:20_04-lts-gen2','canonical:0001-com-ubuntu-server-jammy:22_04-lts','canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen2','microsoftcblmariner:cbl-mariner:cbl-mariner-1','microsoftcblmariner:cbl-mariner:1-gen2','microsoftcblmariner:cbl-mariner:cbl-mariner-2','microsoftcblmariner:cbl-mariner:cbl-mariner-2-gen2','microsoft-aks:aks:aks-engine-ubuntu-1804-202112','microsoft-dsvm:aml-workstation:ubuntu-20','microsoft-dsvm:aml-workstation:ubuntu-20-gen2','openlogic:centos:7.2','openlogic:centos:7.3','openlogic:centos:7.4','openlogic:centos:7.5','openlogic:centos:7.6','openlogic:centos:7.7','openlogic:centos:7_8','openlogic:centos:7_9','openlogic:centos:7_9-gen2','openlogic:centos:8.0','openlogic:centos:8_1','openlogic:centos:8_2','openlogic:centos:8_3','openlogic:centos:8_4','openlogic:centos:8_5','openlogic:centos-lvm:7-lvm','openlogic:centos-lvm:8-lvm','redhat:rhel:7.2','redhat:rhel:7.3','redhat:rhel:7.4','redhat:rhel:7.5','redhat:rhel:7.6','redhat:rhel:7.7','redhat:rhel:7.8','redhat:rhel:7_9','redhat:rhel:7-lvm','redhat:rhel:7-raw','redhat:rhel:8','redhat:rhel:8.1','redhat:rhel:81gen2','redhat:rhel:8.2','redhat:rhel:82gen2','redhat:rhel:8_3','redhat:rhel:83-gen2','redhat:rhel:8_4','redhat:rhel:84-gen2','redhat:rhel:8_5','redhat:rhel:85-gen2','redhat:rhel:8_6','redhat:rhel:86-gen2','redhat:rhel:8_7','redhat:rhel:8_8','redhat:rhel:8-lvm','redhat:rhel:8-lvm-gen2','redhat:rhel-raw:8-raw','redhat:rhel-raw:8-raw-gen2','redhat:rhel:9_0','redhat:rhel:9_1','redhat:rhel:9-lvm','redhat:rhel:9-lvm-gen2','suse:sles-12-sp5:gen1','suse:sles-12-sp5:gen2','suse:sles-15-sp2:gen1','suse:sles-15-sp2:gen2','canonical:0001-com-ubuntu-pro-jammy:pro-22_04-lts','openlogic:centos-hpc:7.1','openlogic:centos-hpc:7.3','oracle:oracle-linux:8','oracle:oracle-linux:8-ci','oracle:oracle-linux:81','oracle:oracle-linux:81-ci','oracle:oracle-linux:81-gen2','oracle:oracle-linux:ol82','oracle:oracle-linux:ol8_2-gen2','oracle:oracle-linux:ol82-gen2','oracle:oracle-linux:ol83-lvm','oracle:oracle-linux:ol83-lvm-gen2','oracle:oracle-linux:ol84-lvm','oracle:oracle-linux:ol84-lvm-gen2','openlogic:centos-ci:7-ci','openlogic:centos-lvm:7-lvm-gen2','oracle:oracle-database:oracle_db_21','oracle:oracle-database-19-3:oracle-database-19-0904','redhat:rhel-sap-apps:90sapapps-gen2','redhat:rhel-sap-ha:90sapha-gen2','suse:sle-hpc-15-sp4:gen1','suse:sle-hpc-15-sp4:gen2','suse:sles:12-sp4-gen2','suse:sles-15-sp1-sapcal:gen1','suse:sles-15-sp1-sapcal:gen2','suse:sles-15-sp2-basic:gen2','suse:sles-15-sp2-hpc:gen2','suse:sles-15-sp3-sapcal:gen1','suse:sles-15-sp3-sapcal:gen2','suse:sles-15-sp4:gen1','suse:sles-15-sp4:gen2','suse:sles-15-sp4-basic:gen1','suse:sles-15-sp4-basic:gen2','suse:sles-15-sp4-sapcal:gen1','suse:sles-byos:12-sp4','suse:sles-byos:12-sp4-gen2','suse:sles-sap:12-sp4','suse:sles-sap:12-sp4-gen2','suse:sles-sap-byos:12-sp4','suse:sles-sap-byos:12-sp4-gen2','suse:sles-sap-byos:gen2-12-sp4','suse:sles-sapcal:12-sp3','suse:sles-standard:12-sp4-gen2') or imageRef matches regex 'canonical:.+:*|microsoftsqlserver:.+:*|openlogic:centos:7.+|oracle:oracle-database-.+:18.*|oracle:oracle-linux:7.+|oracle:oracle-linux:ol7.+|oracle:oracle-linux:ol8.+|oracle:oracle-linux:ol9.+|redhat:rhel:7.+|redhat:rhel:8.+|redhat:rhel:9.+|redhat:rhel-ha:8.+|redhat:rhel-raw:7.+|redhat:rhel-raw:8.+|redhat:rhel-raw:9.+|redhat:rhel-sap:7.+|redhat:rhel-sap-apps:7.+|redhat:rhel-sap-apps:8.+|redhat:rhel-sap-.+:9_0|redhat:rhel-sap-ha:7.+|redhat:rhel-sap-ha:8.+|suse:opensuse-leap-15-.+:gen*|suse:sles-12-sp5-.+:gen*|oracle:oracle-linux:ol9-lvm.+|suse:sles-sap-12-sp5.+:gen*|suse:sles-sap-15-.+:gen*')))\r\n| extend imageRef = iff (isMarketplace, imageRef, \"\")\r\n| extend publisher = iff(isnotnull(properties.storageProfile.imageReference.publisher), properties.storageProfile.imageReference.publisher, \"-\")\r\n| extend offer = iff(isnotnull(properties.storageProfile.imageReference.offer), properties.storageProfile.imageReference.offer, \"-\")\r\n| extend plan = iff(isnotnull(properties.storageProfile.imageReference.sku), properties.storageProfile.imageReference.sku, \"-\")\r\n| project id, joinId = tolower(id), subscriptionId, type, name, machineProperties=properties, os, conf, periodicAssessment, status, resourceGroup, location, tags, imageRef, isNotInCRPAllowList, publisher, offer, plan)\r\n| union (resources\r\n| where type =~ \"microsoft.hybridcompute/machines\"\r\n| where properties.osName in~ ('Linux','Windows') or properties.osType in~ ('Linux','Windows')\r\n| extend os = tolower(coalesce(properties.osName, properties.osType))\r\n| extend assessMode = iff(os == \"windows\", tostring(properties.osProfile.windowsConfiguration.patchSettings.assessmentMode), tostring(properties.osProfile.linuxConfiguration.patchSettings.assessmentMode))\r\n| extend periodicAssessment = iff(assessMode =~ \"AutomaticByPlatform\", \"Yes\", \"No\")\r\n| extend status=tostring(properties.status)\r\n| project id, joinId = tolower(id), subscriptionId, type, name, machineProperties=properties, os, conf = \"\", periodicAssessment, status, resourceGroup, location, tags, imageRef = \"N/A\", isNotInCRPAllowList = false, publisher = \"-\", offer = \"-\", plan = \"-\"))\r\n| join kind = leftouter(\r\nresources\r\n| where type =~ \"Microsoft.SqlVirtualMachine/sqlVirtualMachines\"\r\n| project resourceId = tolower(properties.virtualMachineResourceId), sqlType = type\r\n) on $left.joinId == $right.resourceId\r\n| extend type = iff(isnotempty(sqlType), sqlType, type)\r\n| project-away resourceId, sqlType\r\n| where type in~ ('microsoft.compute/virtualmachines','microsoft.hybridcompute/machines','microsoft.sqlvirtualmachine/sqlvirtualmachines')\r\n| join kind=leftouter(\r\nresources\r\n| where type =~ \"microsoft.hybridcompute/machines/licenseProfiles\"\r\n| extend machineId = tolower(tostring(trim_end(@\"/w+/(w|.)+\", id)))\r\n| extend licenseId = tolower(tostring(properties.esuProfile.assignedLicense))\r\n) on $left.joinId == $right.machineId\r\n| join kind=leftouter (\r\n resources\r\n| where type =~ \"microsoft.hybridcompute/licenses\"\r\n| extend licenseId = tolower(id)\r\n| extend licenseProps = properties\r\n) on licenseId\r\n| extend esuStatus = case(\r\n(machineProperties.licenseProfile.esuProfile.esuEligibility !~ \"Eligible\"), 'N/A',\r\n(machineProperties.licenseProfile.esuProfile.licenseAssignmentState =~ 'Assigned' and licenseProps.licenseDetails.state =~ 'Activated') or machineProperties.licenseProfile.esuProfile.esuKeyState =~ 'Active', 'Enabled',\r\n(machineProperties.licenseProfile.esuProfile.licenseAssignmentState =~ 'NotAssigned' or licenseProps.licenseDetails.state =~ 'Deactivated') and machineProperties.licenseProfile.esuProfile.esuKeyState =~ 'Inactive', 'Not Enabled',\r\n'Unknown'\r\n)\r\n| join kind=leftouter ((patchassessmentresources  // resources filters i.e resource-group or location\r\n| where type in~ (\"microsoft.compute/virtualmachines/patchassessmentresults\", \"microsoft.hybridcompute/machines/patchassessmentresults\")\r\n| where properties.status =~ \"Succeeded\" or properties.status =~ \"Inprogress\" or (isnotnull(properties.configurationStatus.vmGuestPatchReadiness.detectedVMGuestPatchSupportState) and (properties.configurationStatus.vmGuestPatchReadiness.detectedVMGuestPatchSupportState =~ \"Unsupported\"))\r\n| parse id with resourceId \"/patchAssessmentResults\" *\r\n| extend resourceId=tolower(resourceId)\r\n| project resourceId, assessmentDataProperties=properties)) on $left.joinId == $right.resourceId\r\n| extend isUnsupported = isNotInCRPAllowList or (isnotnull(assessmentDataProperties.configurationStatus.vmGuestPatchReadiness.detectedVMGuestPatchSupportState) and (assessmentDataProperties.configurationStatus.vmGuestPatchReadiness.detectedVMGuestPatchSupportState =~ \"Unsupported\"))\r\n| extend patchOrchestration =\r\n    iff(\r\n        conf == \"AutomaticByOS\", \"Windows Automatic Update\",\r\n        iff(\r\n            conf == \"AutomaticByPlatformWithUserManagedSchedules\", \"Customer Managed Schedules\",\r\n            iff(\r\n                conf == \"AutomaticByPlatformUsingAutoGuestPatching\", \"Azure Managed - Safe Deployment\",\r\n                iff(\r\n                    conf == \"ImageDefault\", \"Image Default\",\r\n                    iff(\r\n                        conf == \"Manual\", \"Manual\",\r\n                        \"N/A\"\r\n                    )\r\n                )\r\n            )\r\n        )\r\n    )\r\n| order by tolower(tostring(name)) asc\r\n| extend supported = iff(isUnsupported == 1, \"False\", \"True\")\r\n| extend resourceIdParams = url_encode(strcat(\"[\", '\"', id, '\"', \"]\"))\r\n| extend subscriptionIdParams = url_encode(strcat(\"[\", '\"', subscriptionId, '\"',  \"]\"))\r\n| extend updateSettingsLink = strcat(\"https://ms.portal.azure.com/#view/Microsoft_Azure_Automation/UpdateCenterUpdateSettingsBlade/ids~/\", resourceIdParams, \"/subs~/\", subscriptionIdParams, \"/source/UpdateMgmtV2MenuBlade\")\r\n| project id, location, patchOrchestration, periodicAssessment, vMStatus=status,  supported, esuStatus, subscriptionId, updateSettingsLink",
+                          "size": 0,
+                          "queryType": 1,
+                          "resourceType": "microsoft.resourcegraph/resources",
+                          "crossComponentResources": [
+                            "value::all"
+                          ],
+                          "gridSettings": {
+                            "formatters": [
+                              {
+                                "columnMatch": "test",
+                                "formatter": 7,
+                                "formatOptions": {
+                                  "linkTarget": "Url"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        "conditionalVisibility": {
+                          "parameterName": "selectedTab",
+                          "comparison": "isEqualTo",
+                          "value": "MachinesDataFromARG"
+                        },
+                        "name": "Machines data from Azure Resource Graph"
+                      },
+                      {
+                        "type": 3,
+                        "content": {
+                          "version": "KqlItem/1.0",
+                          "query": "{\"version\":\"Merge/1.0\",\"merges\":[{\"id\":\"9c899097-e682-45c7-b453-42a6e7380079\",\"mergeType\":\"innerunique\",\"leftTable\":\"Machines data from Log Analytics Workspace\",\"rightTable\":\"Machines data from Azure Resource Graph\",\"leftColumn\":\"ResourceId\",\"rightColumn\":\"id\"}],\"projectRename\":[{\"originalName\":\"[Machines data from Log Analytics Workspace].Computer\",\"mergedName\":\"Machine Name\",\"fromId\":\"9c899097-e682-45c7-b453-42a6e7380079\"},{\"originalName\":\"[Machines data from Log Analytics Workspace].ResourceId\",\"mergedName\":\"Resource Id\",\"fromId\":\"9c899097-e682-45c7-b453-42a6e7380079\"},{\"originalName\":\"[Machines data from Log Analytics Workspace].ResourceType\",\"mergedName\":\"Resource Type\",\"fromId\":\"9c899097-e682-45c7-b453-42a6e7380079\"},{\"originalName\":\"[Machines data from Log Analytics Workspace].OSType\",\"mergedName\":\"OS Type\",\"fromId\":\"9c899097-e682-45c7-b453-42a6e7380079\"},{\"originalName\":\"[Machines data from Azure Resource Graph].supported\",\"mergedName\":\"Azure Update Manager Supported\",\"fromId\":\"unknown\"},{\"originalName\":\"[Machines data from Azure Resource Graph].esuStatus\",\"mergedName\":\"Esu Status\",\"fromId\":\"9c899097-e682-45c7-b453-42a6e7380079\"},{\"originalName\":\"[Machines data from Azure Resource Graph].location\",\"mergedName\":\"Location\",\"fromId\":\"9c899097-e682-45c7-b453-42a6e7380079\"},{\"originalName\":\"[Machines data from Azure Resource Graph].patchOrchestration\",\"mergedName\":\"Patch Orchestration\",\"fromId\":\"9c899097-e682-45c7-b453-42a6e7380079\"},{\"originalName\":\"[Machines data from Azure Resource Graph].periodicAssessment\",\"mergedName\":\"Periodic Assessment\",\"fromId\":\"9c899097-e682-45c7-b453-42a6e7380079\"},{\"originalName\":\"[Machines data from Azure Resource Graph].vMStatus\",\"mergedName\":\"Status\",\"fromId\":\"9c899097-e682-45c7-b453-42a6e7380079\"},{\"originalName\":\"[Machines data from Azure Resource Graph].subscriptionId\",\"mergedName\":\"SubId\",\"fromId\":\"unknown\"},{\"originalName\":\"[Machines data from Azure Resource Graph].updateSettingsLink\",\"mergedName\":\"Update Settings\",\"fromId\":\"unknown\"},{\"originalName\":\"[Machines data from Azure Resource Graph].id\"},{\"originalName\":\"[Machines data from Azure Resource Graph].updateSettings\"},{\"originalName\":\"[Machines data from Azure Resource Graph].rid\"},{\"originalName\":\"[Machines data from Azure Resource Graph].test\"}]}",
+                          "size": 3,
+                          "title": "Azure virtual machines and Arc-enabled servers",
+                          "noDataMessage": "No heartbeats for machines having updates solution in automation account.",
+                          "queryType": 7,
+                          "gridSettings": {
+                            "formatters": [
+                              {
+                                "columnMatch": "Resource Id",
+                                "formatter": 13,
+                                "formatOptions": {
+                                  "linkColumn": "Resource Id",
+                                  "linkTarget": "OpenBlade",
+                                  "subTarget": "",
+                                  "showIcon": true,
+                                  "bladeOpenContext": {
+                                    "bladeName": "UpdateMgmtV2MenuBlade",
+                                    "extensionName": "Microsoft_Azure_Automation",
+                                    "bladeParameters": [
+                                      {
+                                        "name": "machineResourceId",
+                                        "source": "column",
+                                        "value": "Resource Id"
+                                      }
+                                    ]
+                                  }
+                                }
+                              },
+                              {
+                                "columnMatch": "Resource Type",
+                                "formatter": 16,
+                                "formatOptions": {
+                                  "showIcon": true
+                                }
+                              },
+                              {
+                                "columnMatch": "SubId",
+                                "formatter": 5
+                              },
+                              {
+                                "columnMatch": "Update Settings",
+                                "formatter": 7,
+                                "formatOptions": {
+                                  "linkTarget": "OpenBlade",
+                                  "linkLabel": "Change Update Settings",
+                                  "bladeOpenContext": {
+                                    "bladeName": "UpdateCenterUpdateSettingsBlade",
+                                    "extensionName": "Microsoft_Azure_Automation",
+                                    "bladeJsonParameters": "{\n  \"ids\": [\n\t\t\"[\"Resource Id\"]\"\n  ],\n  \"subs\": [\n    \"[\"SubId\"]\"\n  ],\n  \"source\": \"UpdateMgmtV2MenuBlade\"\n}"
+                                  }
+                                }
+                              }
+                            ],
+                            "rowLimit": 10000
+                          }
+                        },
+                        "conditionalVisibility": {
+                          "parameterName": "selectedTab",
+                          "comparison": "isEqualTo",
+                          "value": "Machines"
+                        },
+                        "name": "Azure virtual machines and Arc-enabled servers"
+                      },
+                      {
+                        "type": 3,
+                        "content": {
+                          "version": "KqlItem/1.0",
+                          "query": "{\"version\":\"Merge/1.0\",\"merges\":[{\"id\":\"9c899097-e682-45c7-b453-42a6e7380079\",\"mergeType\":\"leftanti\",\"leftTable\":\"Machines data from Log Analytics Workspace\",\"rightTable\":\"Machines data from Azure Resource Graph\",\"leftColumn\":\"ResourceId\",\"rightColumn\":\"id\"}],\"projectRename\":[{\"originalName\":\"[Machines data from Log Analytics Workspace].Computer\",\"mergedName\":\"Machine name\",\"fromId\":\"9c899097-e682-45c7-b453-42a6e7380079\"},{\"originalName\":\"[Machines data from Log Analytics Workspace].OSType\",\"mergedName\":\"OSType\",\"fromId\":\"9c899097-e682-45c7-b453-42a6e7380079\"},{\"originalName\":\"[Added column]\",\"mergedName\":\"Take Action\",\"fromId\":null,\"isNewItem\":true,\"newItemData\":[{\"criteriaContext\":{\"leftOperand\":\"Machine name\",\"operator\":\"isNotNull\",\"rightValType\":\"column\",\"resultValType\":\"static\",\"resultVal\":\"Add non-Azure machines to Azure Arc\"}},{\"criteriaContext\":{\"operator\":\"Default\",\"rightValType\":\"column\",\"resultValType\":\"column\"}}]},{\"originalName\":\"[Machines data from Azure Resource Graph].id\"},{\"originalName\":\"[Machines data from Azure Resource Graph].supported\"},{\"originalName\":\"[Machines data from Log Analytics Workspace].ResourceId\"},{\"originalName\":\"[Machines data from Log Analytics Workspace].ResourceType\"}]}",
+                          "size": 3,
+                          "title": "Non-azure machines",
+                          "noDataMessage": "No heartbeats for machines having updates solution in automation account.",
+                          "queryType": 7,
+                          "gridSettings": {
+                            "formatters": [
+                              {
+                                "columnMatch": "Take Action",
+                                "formatter": 7,
+                                "formatOptions": {
+                                  "linkTarget": "OpenBlade",
+                                  "bladeOpenContext": {
+                                    "bladeName": "ARGBrowseResourcesInMenu",
+                                    "extensionName": "HubsExtension",
+                                    "bladeJsonParameters": "{\n  \"resourceType\": \"Microsoft.HybridCompute/machines\"\n}"
+                                  }
+                                }
+                              }
+                            ],
+                            "rowLimit": 10000
+                          }
+                        },
+                        "conditionalVisibility": {
+                          "parameterName": "selectedTab",
+                          "comparison": "isEqualTo",
+                          "value": "Machines"
+                        },
+                        "showPin": false,
+                        "name": "Non-azure machines"
+                      },
+                      {
+                        "type": 3,
+                        "content": {
+                          "version": "KqlItem/1.0",
+                          "query": "{\"version\":\"ARMEndpoint/1.0\",\"data\":null,\"headers\":[],\"method\":\"GETARRAY\",\"path\":\"/{aaid}/softwareupdateconfigurations/\",\"urlParams\":[{\"key\":\"api-version\",\"value\":\"2023-11-01\"}],\"batchDisabled\":false,\"transformers\":[{\"type\":\"jsonpath\",\"settings\":{\"tablePath\":\"\",\"columns\":[{\"path\":\"name\",\"columnid\":\"Name\"},{\"path\":\"properties.nextRun\",\"columnid\":\" Next run time\",\"columnType\":\"datetime\"},{\"path\":\"properties.updateConfiguration.operatingSystem\",\"columnid\":\"Operating system\",\"columnType\":\"string\"},{\"path\":\"properties.frequency\",\"columnid\":\"Recurrence\",\"columnType\":\"string\",\"substringRegexMatch\":\"OneTime\",\"substringReplace\":\"One Time\"},{\"path\":\"properties.updateConfiguration.duration\",\"columnid\":\"Maintenance window\",\"substringRegexMatch\":\"{TimeRange:durationISO}\"},{\"path\":\"id\",\"columnid\":\"ResourceId\"}]}}]}",
+                          "size": 0,
+                          "noDataMessage": "No schedules present in automation account.",
+                          "queryType": 12,
+                          "gridSettings": {
+                            "formatters": [
+                              {
+                                "columnMatch": "Name",
+                                "formatter": 13,
+                                "formatOptions": {
+                                  "linkTarget": "OpenBlade",
+                                  "showIcon": true,
+                                  "bladeOpenContext": {
+                                    "bladeName": "EditUpdateDeploymentBlade",
+                                    "extensionName": "Microsoft_Azure_Automation",
+                                    "bladeJsonParameters": "{\n  \"softwareUpdateConfigurationId\": \"[\"ResourceId\"]\",\n  \"automationAccountId\": \"{aaid}\",\n  \"workspaceId\": \"{wsid}\",\n  \"osType\": 0,\n  \"virtualMachineUniqueId\": null,\n  \"virtualMachineResourceId\": null\n}"
+                                  }
+                                }
+                              },
+                              {
+                                "columnMatch": " Next run time",
+                                "formatter": 6,
+                                "dateFormat": {
+                                  "showUtcTime": null,
+                                  "formatName": "shortDateTimePattern"
+                                }
+                              },
+                              {
+                                "columnMatch": "ResourceId",
+                                "formatter": 5
+                              }
+                            ],
+                            "rowLimit": 10000
+                          },
+                          "tileSettings": {
+                            "showBorder": false
+                          }
+                        },
+                        "conditionalVisibility": {
+                          "parameterName": "selectedTab",
+                          "comparison": "isEqualTo",
+                          "value": "Schedules"
+                        },
+                        "name": "Schedules in Automation Account"
+                      }
+                    ]
+                  },
+                  "name": "AutomationAccount-MachinesAndSchedules-Group"
+                }
+              ]
+            },
+            "conditionalVisibility": {
+              "parameterName": "wsid",
+              "comparison": "isNotEqualTo"
+            },
+            "name": "automationaccountspecific-group"
+          }
+        ]
+      },
+      "conditionalVisibility": {
+        "parameterName": "selectedTab",
+        "comparison": "isEqualTo",
+        "value": "AzureAutomationUpdateManagement"
+      },
+      "name": "Automation Account"
     }
+  ],
+  "fallbackResourceIds": [
+    "azure monitor"
   ],
   "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
 }


### PR DESCRIPTION
Add Azure Automation Update Management Tab to AMA Migration Helper Workbook

## PR Checklist

* [x] Explain your changes, so people looking at the PR know *what* and *why*, the code changes are the *how*.
- Adding Azure Automation Update Management Tab in the Workbook.
- Update Top-Level Banner to include info about the new Tab.
- In this Tab, Customers will be able to select a Workspace that has "Updates" Solution Enabled.
- Once the Workspace is selected, it will auto-populate the Automation Account.
- Then it will fetch info about all Machines with Updates Solution Enabled Reporting to Log Analytics Workspace.
- Then we will additionally fetch info about Azure and Arc-Enabled Machines from ARG.
- Join the data from above two queries to present two tables in Machines Tab. One Table will have all Azure and Arc Machines while the other table will have all Non-Azure Machines which are not arc-enabled. Please refer to columns in the table for details. Most of them are self-explanatory and similar to what we show in Azure Update Manager.
- In the Deployment Schedules Tab, we fetch information about all the deployment schedules under the automation account.
- Add a Migrate Now button that will take them to Update Management Migration Blade.

* [x] Validate your changes using one or more of the [testing](../Documentation/Testing.md) methods.
- Changes Tested using Workbook in Portal. 

### If adding or updating templates:
* [x] post a screenshot of templates and/or gallery changes
![image](https://github.com/microsoft/Application-Insights-Workbooks/assets/105488792/cb01f61f-1474-4847-aff5-0bbe87b134f9)
![image](https://github.com/microsoft/Application-Insights-Workbooks/assets/105488792/d4244d4e-7a60-41cb-9e65-c6225cb6ca40)
* [x] ensure your template has a corresponding gallery entry in the gallery folder
* [x] If you are adding a new template, add your team and template/gallery file(s) to the CODEOWNERS file. CODEOWNERS entries should be teams, not individuals
* [x] ensure all steps have meaningful names
* [x] ensure all parameters and grid columns have display names set so they can be localized
* [x] ensure that parameters id values are unique __or they will fail PR validation__ (parameter ids are used for localization)
* [x] ensure that steps names are unique __or they will fail PR validation__ (step names are used for localization)
* [x] grep `/subscription/` and ensure that your parameters don't have any hardcoded resourceIds __or they will fail PR validation__
* [x] remove `fallbackResourceIds` and `fromTemplateId` fields from your template workbook __or they will fail PR validation__