### PR TITLE
Update Email_Insights.workbook. Per-Instance table should use actual timestamp

### DIFF
--- a/Workbooks/Communication Services/Email_Insights/Email_Insights.workbook
+++ b/Workbooks/Communication Services/Email_Insights/Email_Insights.workbook
@@ -956,7 +956,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "ACSEmailStatusUpdateOperational \r\n| where OperationName == \"DeliveryStatusUpdate\" and isnotempty(DeliveryStatus) and DeliveryStatus != \"OutForDelivery\"\r\n| where ('{email_mailfrom:value}' == \"All senders\") or (strcat(SenderUsername, '@', SenderDomain) == '{email_mailfrom:value}')\r\n| project    Id=CorrelationId, [\"Mail To Address\"]=RecipientId, [\"Mail From Address\"]=strcat(SenderUsername, \"@\", SenderDomain), DeliveryStatus, Status=iff(DeliveryStatus == \"Delivered\", \"success\", \"error\"), [\"Date Sent\"]=bin(TimeGenerated, 1d)",
+        "query": "ACSEmailStatusUpdateOperational \r\n| where OperationName == \"DeliveryStatusUpdate\" and isnotempty(DeliveryStatus) and DeliveryStatus != \"OutForDelivery\"\r\n| where ('{email_mailfrom:value}' == \"All senders\") or (strcat(SenderUsername, '@', SenderDomain) == '{email_mailfrom:value}')\r\n| project    Id=CorrelationId, [\"Mail To Address\"]=RecipientId, [\"Mail From Address\"]=strcat(SenderUsername, \"@\", SenderDomain), DeliveryStatus, Status=iff(DeliveryStatus == \"Delivered\", \"success\", \"error\"), [\"Date Sent\"]=TimeGenerated",
         "size": 0,
         "title": "Per-recipient Delivery Details",
         "timeContextFromParameter": "email_time",


### PR DESCRIPTION
The issue is in the query used to generate this chart.  The Date Sent column is using the bin() function to round to the nearest time bucket.  This instance level chart should use actual timestamps

This: ["Date Sent"]=bin(TimeGenerated, 1d)
Should be: ["Date Sent"]=TimeGenerated
![image](https://github.com/microsoft/Application-Insights-Workbooks/assets/89162957/40bd717b-6623-4c19-a81f-9af7ae1a2f09)

## PR Checklist

* [ ] Explain your changes, so people looking at the PR know *what* and *why*, the code changes are the *how*.
* [ ] Validate your changes using one or more of the [testing](../Documentation/Testing.md) methods.

### If adding or updating templates:
* [ ] post a screenshot of templates and/or gallery changes
* [ ] ensure your template has a corresponding gallery entry in the gallery folder
* [ ] If you are adding a new template, add your team and template/gallery file(s) to the CODEOWNERS file. CODEOWNERS entries should be teams, not individuals
* [ ] ensure all steps have meaningful names
* [ ] ensure all parameters and grid columns have display names set so they can be localized
* [ ] ensure that parameters id values are unique __or they will fail PR validation__ (parameter ids are used for localization)
* [ ] ensure that steps names are unique __or they will fail PR validation__ (step names are used for localization)
* [ ] grep `/subscription/` and ensure that your parameters don't have any hardcoded resourceIds __or they will fail PR validation__
* [ ] remove `fallbackResourceIds` and `fromTemplateId` fields from your template workbook __or they will fail PR validation__