### PR TITLE
Contribute workbook for Azure Logic Apps

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -127,6 +127,8 @@
 /Workbooks/Azure*Private*MEC/** @microsoft/azure-private-mec-workbooks
 /Workbooks/Azure*API*Management/** @microsoft/azure-api-management
 
+/Workbooks/Azure*Logic*Apps/** @Azure/azure-logicapps-team
+
 # Section for gallery files
 /gallery/workbook/WaaSUpdateInsights.json @microsoft/update-compliance-workbooks
 /gallery/workbook/Azure*Monitor.json @microsoft/applicationinsights-devtools

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -127,7 +127,7 @@
 /Workbooks/Azure*Private*MEC/** @microsoft/azure-private-mec-workbooks
 /Workbooks/Azure*API*Management/** @microsoft/azure-api-management
 
-/Workbooks/Azure*Logic*Apps/** @Azure/azure-logicapps-team
+/Workbooks/Azure*Logic*Apps/** @microsoft/azure-logic-apps-admin
 
 # Section for gallery files
 /gallery/workbook/WaaSUpdateInsights.json @microsoft/update-compliance-workbooks

--- a/Workbooks/Azure Logic Apps/LA Standard Metrics/LAStandardMetrics.json
+++ b/Workbooks/Azure Logic Apps/LA Standard Metrics/LAStandardMetrics.json
@@ -101,7 +101,7 @@
         "queryType": 0,
         "resourceType": "microsoft.web/sites"
       },
-      "name": "parameters - 0 - Copy"
+      "name": "parameters"
     },
     {
       "type": 11,
@@ -135,7 +135,7 @@
           }
         ]
       },
-      "name": "links - 17"
+      "name": "tabs"
     },
     {
       "type": 12,
@@ -158,7 +158,7 @@
               ],
               "timeContextFromParameter": "TimeRange",
               "timeContext": {
-                "durationMs": 604800000
+                "durationMs": 0
               },
               "metrics": [
                 {
@@ -530,7 +530,7 @@
               ],
               "timeContextFromParameter": "TimeRange",
               "timeContext": {
-                "durationMs": 604800000
+                "durationMs": 0
               },
               "metrics": [
                 {
@@ -894,7 +894,7 @@
         "comparison": "isEqualTo",
         "value": "Workflows"
       },
-      "name": "workflowTabGroup2"
+      "name": "workflowTabGroup"
     },
     {
       "type": 12,
@@ -917,7 +917,7 @@
               ],
               "timeContextFromParameter": "TimeRange",
               "timeContext": {
-                "durationMs": 604800000
+                "durationMs": 0
               },
               "metrics": [
                 {
@@ -1118,7 +1118,7 @@
               }
             },
             "showPin": false,
-            "name": "query - 5"
+            "name": "overviewTilesInverted"
           },
           {
             "type": 10,
@@ -1135,7 +1135,7 @@
               ],
               "timeContextFromParameter": "TimeRange",
               "timeContext": {
-                "durationMs": 604800000
+                "durationMs": 0
               },
               "metrics": [
                 {
@@ -1376,7 +1376,7 @@
                     ],
                     "timeContextFromParameter": "TimeRange",
                     "timeContext": {
-                      "durationMs": 604800000
+                      "durationMs": 0
                     },
                     "metrics": [
                       {
@@ -1419,7 +1419,7 @@
                     }
                   },
                   "customWidth": "30",
-                  "name": "metric - 12"
+                  "name": "runStatusGraph"
                 },
                 {
                   "type": 10,
@@ -1436,7 +1436,7 @@
                     ],
                     "timeContextFromParameter": "TimeRange",
                     "timeContext": {
-                      "durationMs": 604800000
+                      "durationMs": 0
                     },
                     "metrics": [
                       {
@@ -1479,7 +1479,7 @@
                     }
                   },
                   "customWidth": "30",
-                  "name": "metric - 12 - Copy - Copy"
+                  "name": "actionStatusGraph"
                 },
                 {
                   "type": 10,
@@ -1496,7 +1496,7 @@
                     ],
                     "timeContextFromParameter": "TimeRange",
                     "timeContext": {
-                      "durationMs": 604800000
+                      "durationMs": 0
                     },
                     "metrics": [
                       {
@@ -1539,7 +1539,7 @@
                     }
                   },
                   "customWidth": "30",
-                  "name": "metric - 12 - Copy"
+                  "name": "triggerStatusGraph"
                 }
               ]
             },
@@ -1580,13 +1580,14 @@
               ],
               "timeContextFromParameter": "TimeRange",
               "timeContext": {
-                "durationMs": 604800000
+                "durationMs": 0
               },
               "metrics": [
                 {
                   "namespace": "microsoft.web/sites",
                   "metric": "microsoft.web/sites--WorkflowJobExecutionDelay",
                   "aggregation": 7,
+                  "splitBy": null,
                   "columnName": "Workflow Job Count"
                 }
               ],
@@ -1596,7 +1597,7 @@
               }
             },
             "customWidth": "50",
-            "name": "metric - 10 - Copy"
+            "name": "workflow-job-count-graph"
           },
           {
             "type": 10,
@@ -1613,13 +1614,14 @@
               ],
               "timeContextFromParameter": "TimeRange",
               "timeContext": {
-                "durationMs": 604800000
+                "durationMs": 0
               },
               "metrics": [
                 {
                   "namespace": "microsoft.web/sites",
                   "metric": "microsoft.web/sites--WorkflowJobExecutionDelay",
-                  "aggregation": 4
+                  "aggregation": 4,
+                  "splitBy": null
                 }
               ],
               "title": "Workflow Job Execution Delay",
@@ -1628,7 +1630,7 @@
               }
             },
             "customWidth": "50",
-            "name": "metric - 10"
+            "name": "workflow-job-execution-delay-graph"
           },
           {
             "type": 10,
@@ -1645,13 +1647,14 @@
               ],
               "timeContextFromParameter": "TimeRange",
               "timeContext": {
-                "durationMs": 604800000
+                "durationMs": 0
               },
               "metrics": [
                 {
                   "namespace": "microsoft.web/sites",
                   "metric": "microsoft.web/sites--InstanceCount",
                   "aggregation": 3,
+                  "splitBy": null,
                   "columnName": "Instance count"
                 }
               ],
@@ -1660,7 +1663,7 @@
                 "rowLimit": 10000
               }
             },
-            "name": "metric - 11"
+            "name": "workflow-instance-count-graph"
           },
           {
             "type": 10,
@@ -1677,13 +1680,14 @@
               ],
               "timeContextFromParameter": "TimeRange",
               "timeContext": {
-                "durationMs": 604800000
+                "durationMs": 0
               },
               "metrics": [
                 {
                   "namespace": "microsoft.web/sites",
                   "metric": "microsoft.web/sites--AverageMemoryWorkingSet",
                   "aggregation": 4,
+                  "splitBy": null,
                   "columnName": "Avg Memory Working Set"
                 }
               ],
@@ -1692,7 +1696,7 @@
                 "rowLimit": 10000
               }
             },
-            "name": "metric - 5"
+            "name": "memory-graph"
           },
           {
             "type": 1,
@@ -1717,7 +1721,7 @@
               ],
               "timeContextFromParameter": "TimeRange",
               "timeContext": {
-                "durationMs": 604800000
+                "durationMs": 0
               },
               "metrics": [
                 {
@@ -1801,7 +1805,7 @@
                 "rowLimit": 10000
               }
             },
-            "name": "metric - 3 - Copy - Copy"
+            "name": "asp-memory-graph"
           },
           {
             "type": 10,
@@ -1818,7 +1822,7 @@
               ],
               "timeContextFromParameter": "TimeRange",
               "timeContext": {
-                "durationMs": 604800000
+                "durationMs": 0
               },
               "metrics": [
                 {
@@ -1902,7 +1906,7 @@
                 "rowLimit": 10000
               }
             },
-            "name": "metric - 3 - Copy"
+            "name": "asp-cpu-graph"
           }
         ]
       },
@@ -1913,6 +1917,9 @@
       },
       "name": "capacityTabGroup"
     }
+  ],
+  "fallbackResourceIds": [
+    "/subscriptions/f34b22a3-2202-4fb1-b040-1332bd928c84/resourceGroups/karansin/providers/Microsoft.Web/sites/basic-logic-app"
   ],
   "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
 }

--- a/Workbooks/Azure Logic Apps/LA Standard Metrics/LAStandardMetrics.json
+++ b/Workbooks/Azure Logic Apps/LA Standard Metrics/LAStandardMetrics.json
@@ -1,0 +1,1918 @@
+{
+  "version": "Notebook/1.0",
+  "items": [
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "parameters": [
+          {
+            "id": "bb1ff9c7-9c8e-4bb1-807e-e981af905baf",
+            "version": "KqlParameterItem/1.0",
+            "name": "LogicApp",
+            "type": 5,
+            "isRequired": true,
+            "isHiddenWhenLocked": true,
+            "typeSettings": {
+              "resourceTypeFilter": {
+                "microsoft.web/sites": true
+              },
+              "additionalResourceOptions": [
+                "value::1"
+              ],
+              "showDefault": false,
+              "componentIdOnly": true
+            },
+            "defaultValue": "value::1"
+          },
+          {
+            "id": "c5bdfde8-aac0-417d-a288-435782ed94e8",
+            "version": "KqlParameterItem/1.0",
+            "name": "AppServicePlan",
+            "type": 5,
+            "isRequired": true,
+            "query": "{\"version\":\"ARMEndpoint/1.0\",\"data\":null,\"headers\":[],\"method\":\"GET\",\"path\":\"{LogicApp:id}?api-version=2023-01-01\",\"urlParams\":[],\"batchDisabled\":false,\"transformers\":[{\"type\":\"jsonpath\",\"settings\":{\"tablePath\":\"$.properties.serverFarmId\",\"columns\":[]}}]}",
+            "isHiddenWhenLocked": true,
+            "typeSettings": {
+              "additionalResourceOptions": [
+                "value::1"
+              ],
+              "showDefault": false
+            },
+            "defaultValue": "value::1",
+            "queryType": 12
+          },
+          {
+            "id": "5ab687d2-41e2-4128-8ab6-6ff43908a8d4",
+            "version": "KqlParameterItem/1.0",
+            "name": "TimeRange",
+            "type": 4,
+            "isRequired": true,
+            "typeSettings": {
+              "selectableValues": [
+                {
+                  "durationMs": 300000
+                },
+                {
+                  "durationMs": 900000
+                },
+                {
+                  "durationMs": 1800000
+                },
+                {
+                  "durationMs": 3600000
+                },
+                {
+                  "durationMs": 14400000
+                },
+                {
+                  "durationMs": 43200000
+                },
+                {
+                  "durationMs": 86400000
+                },
+                {
+                  "durationMs": 172800000
+                },
+                {
+                  "durationMs": 259200000
+                },
+                {
+                  "durationMs": 604800000
+                },
+                {
+                  "durationMs": 1209600000
+                },
+                {
+                  "durationMs": 2419200000
+                },
+                {
+                  "durationMs": 2592000000
+                }
+              ],
+              "allowCustom": true
+            },
+            "value": {
+              "durationMs": 604800000
+            }
+          }
+        ],
+        "style": "pills",
+        "queryType": 0,
+        "resourceType": "microsoft.web/sites"
+      },
+      "name": "parameters - 0 - Copy"
+    },
+    {
+      "type": 11,
+      "content": {
+        "version": "LinkItem/1.0",
+        "style": "tabs",
+        "links": [
+          {
+            "id": "4e1c17b0-9ca8-45c7-81d5-dccc6844e39f",
+            "cellValue": "tabParam",
+            "linkTarget": "parameter",
+            "linkLabel": "Overview",
+            "subTarget": "Overview",
+            "style": "link"
+          },
+          {
+            "id": "8cecb4e5-2cfa-432a-a644-7dc4c6eb1dae",
+            "cellValue": "tabParam",
+            "linkTarget": "parameter",
+            "linkLabel": "Workflows",
+            "subTarget": "Workflows",
+            "style": "link"
+          },
+          {
+            "id": "983fe583-e399-451f-8c4b-59973db5b4ca",
+            "cellValue": "tabParam",
+            "linkTarget": "parameter",
+            "linkLabel": "Compute",
+            "subTarget": "Capacity",
+            "style": "link"
+          }
+        ]
+      },
+      "name": "links - 17"
+    },
+    {
+      "type": 12,
+      "content": {
+        "version": "NotebookGroup/1.0",
+        "groupType": "editable",
+        "items": [
+          {
+            "type": 10,
+            "content": {
+              "chartId": "workbook6f55d7e4-d957-4ca8-bb76-2818dc440087",
+              "version": "MetricsItem/2.0",
+              "size": 0,
+              "chartType": 0,
+              "resourceType": "microsoft.web/sites",
+              "metricScope": 0,
+              "resourceParameter": "LogicApp",
+              "resourceIds": [
+                "{LogicApp}"
+              ],
+              "timeContextFromParameter": "TimeRange",
+              "timeContext": {
+                "durationMs": 604800000
+              },
+              "metrics": [
+                {
+                  "namespace": "microsoft.web/sites",
+                  "metric": "microsoft.web/sites--WorkflowRunsCompleted",
+                  "aggregation": 1,
+                  "splitBy": "workflowName",
+                  "splitBySortOrder": -1,
+                  "splitByLimit": 10000,
+                  "columnName": "Runs Succeeded",
+                  "filters": [
+                    {
+                      "key": "status",
+                      "operator": 0,
+                      "values": [
+                        "Succeeded"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "namespace": "microsoft.web/sites",
+                  "metric": "microsoft.web/sites--WorkflowActionsCompleted",
+                  "aggregation": 7,
+                  "splitBy": "workflowName",
+                  "splitBySortOrder": -1,
+                  "splitByLimit": 10000,
+                  "columnName": "Actions Succeeded",
+                  "filters": [
+                    {
+                      "key": "status",
+                      "operator": 0,
+                      "values": [
+                        "Succeeded"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "namespace": "microsoft.web/sites",
+                  "metric": "microsoft.web/sites--WorkflowTriggersCompleted",
+                  "aggregation": 7,
+                  "splitBy": "workflowName",
+                  "splitBySortOrder": -1,
+                  "splitByLimit": 10000,
+                  "columnName": "Triggers Succeeded",
+                  "filters": [
+                    {
+                      "key": "status",
+                      "operator": 0,
+                      "values": [
+                        "Succeeded"
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "title": "Succeeded runs, actions, triggers",
+              "gridFormatType": 2,
+              "resourceLimit": 10000,
+              "gridSettings": {
+                "formatters": [
+                  {
+                    "columnMatch": "Subscription",
+                    "formatter": 5
+                  },
+                  {
+                    "columnMatch": "Name",
+                    "formatter": 5,
+                    "formatOptions": {
+                      "linkTarget": "Resource"
+                    }
+                  },
+                  {
+                    "columnMatch": "Runs Failure Rate",
+                    "formatter": 18,
+                    "formatOptions": {
+                      "thresholdsOptions": "icons",
+                      "thresholdsGrid": [
+                        {
+                          "operator": "!=",
+                          "thresholdValue": "0",
+                          "representation": "2",
+                          "text": "{0}{1}"
+                        },
+                        {
+                          "operator": "is Empty",
+                          "representation": "more",
+                          "text": "{0}{1}"
+                        },
+                        {
+                          "operator": "Default",
+                          "thresholdValue": null,
+                          "representation": "success",
+                          "text": "{0}{1}"
+                        }
+                      ]
+                    },
+                    "numberFormat": {
+                      "unit": 1,
+                      "options": {
+                        "style": "decimal"
+                      }
+                    }
+                  },
+                  {
+                    "columnMatch": "Runs Failure Rate Timeline",
+                    "formatter": 5
+                  },
+                  {
+                    "columnMatch": "Runs Succeeded",
+                    "formatter": 1,
+                    "numberFormat": {
+                      "unit": 0,
+                      "options": null
+                    }
+                  },
+                  {
+                    "columnMatch": "Runs Succeeded Timeline",
+                    "formatter": 10,
+                    "formatOptions": {
+                      "palette": "green"
+                    }
+                  },
+                  {
+                    "columnMatch": "Actions Failure Rate",
+                    "formatter": 18,
+                    "formatOptions": {
+                      "thresholdsOptions": "icons",
+                      "thresholdsGrid": [
+                        {
+                          "operator": "!=",
+                          "thresholdValue": "0",
+                          "representation": "2",
+                          "text": "{0}{1}"
+                        },
+                        {
+                          "operator": "is Empty",
+                          "representation": "more",
+                          "text": "{0}{1}"
+                        },
+                        {
+                          "operator": "Default",
+                          "thresholdValue": null,
+                          "representation": "success",
+                          "text": "{0}{1}"
+                        }
+                      ]
+                    },
+                    "numberFormat": {
+                      "unit": 1,
+                      "options": {
+                        "style": "decimal"
+                      }
+                    }
+                  },
+                  {
+                    "columnMatch": "Actions Failure Rate Timeline",
+                    "formatter": 5
+                  },
+                  {
+                    "columnMatch": "Actions Succeeded",
+                    "formatter": 1,
+                    "numberFormat": {
+                      "unit": 0,
+                      "options": null
+                    }
+                  },
+                  {
+                    "columnMatch": "Actions Succeeded Timeline",
+                    "formatter": 10,
+                    "formatOptions": {
+                      "palette": "green"
+                    }
+                  },
+                  {
+                    "columnMatch": "Triggers Failure Rate",
+                    "formatter": 18,
+                    "formatOptions": {
+                      "thresholdsOptions": "icons",
+                      "thresholdsGrid": [
+                        {
+                          "operator": "!=",
+                          "thresholdValue": "0",
+                          "representation": "2",
+                          "text": "{0}{1}"
+                        },
+                        {
+                          "operator": "is Empty",
+                          "representation": "more",
+                          "text": "{0}{1}"
+                        },
+                        {
+                          "operator": "Default",
+                          "thresholdValue": null,
+                          "representation": "success",
+                          "text": "{0}{1}"
+                        }
+                      ]
+                    },
+                    "numberFormat": {
+                      "unit": 1,
+                      "options": {
+                        "style": "decimal"
+                      }
+                    }
+                  },
+                  {
+                    "columnMatch": "Triggers Failure Rate Timeline",
+                    "formatter": 5
+                  },
+                  {
+                    "columnMatch": "Triggers Succeeded",
+                    "formatter": 1,
+                    "numberFormat": {
+                      "unit": 0,
+                      "options": null
+                    }
+                  },
+                  {
+                    "columnMatch": "Triggers Succeeded Timeline",
+                    "formatter": 10,
+                    "formatOptions": {
+                      "palette": "green"
+                    }
+                  },
+                  {
+                    "columnMatch": "Runs Completed",
+                    "formatter": 1,
+                    "numberFormat": {
+                      "unit": 0,
+                      "options": null
+                    }
+                  },
+                  {
+                    "columnMatch": "Runs Completed Timeline",
+                    "formatter": 10,
+                    "formatOptions": {
+                      "palette": "green"
+                    }
+                  },
+                  {
+                    "columnMatch": "Actions Completed",
+                    "formatter": 1,
+                    "numberFormat": {
+                      "unit": 0,
+                      "options": null
+                    }
+                  },
+                  {
+                    "columnMatch": "Actions Completed Timeline",
+                    "formatter": 10,
+                    "formatOptions": {
+                      "palette": "green"
+                    }
+                  },
+                  {
+                    "columnMatch": "Triggers Completed",
+                    "formatter": 1,
+                    "numberFormat": {
+                      "unit": 0,
+                      "options": null
+                    }
+                  },
+                  {
+                    "columnMatch": "Triggers Completed Timeline",
+                    "formatter": 10,
+                    "formatOptions": {
+                      "palette": "green"
+                    }
+                  },
+                  {
+                    "columnMatch": ".*\\/Runs Completed$",
+                    "formatter": 1
+                  },
+                  {
+                    "columnMatch": "microsoft.web/sites--WorkflowActionsCompleted Timeline",
+                    "formatter": 5
+                  },
+                  {
+                    "columnMatch": "microsoft.web/sites--WorkflowActionsCompleted",
+                    "formatter": 1,
+                    "numberFormat": {
+                      "unit": 0,
+                      "options": null
+                    }
+                  },
+                  {
+                    "columnMatch": "microsoft.web/sites--WorkflowTriggersCompleted Timeline",
+                    "formatter": 5
+                  },
+                  {
+                    "columnMatch": "microsoft.web/sites--WorkflowTriggersCompleted",
+                    "formatter": 1,
+                    "numberFormat": {
+                      "unit": 0,
+                      "options": null
+                    }
+                  },
+                  {
+                    "columnMatch": "microsoft.web/sites--WorkflowRunsFailureRate Timeline",
+                    "formatter": 5
+                  },
+                  {
+                    "columnMatch": "microsoft.web/sites--WorkflowRunsFailureRate",
+                    "formatter": 1,
+                    "numberFormat": {
+                      "unit": 1,
+                      "options": null
+                    }
+                  }
+                ],
+                "rowLimit": 10000,
+                "filter": true,
+                "labelSettings": [
+                  {
+                    "columnId": "Subscription",
+                    "label": "Subscription"
+                  },
+                  {
+                    "columnId": "Name",
+                    "label": "Name"
+                  },
+                  {
+                    "columnId": "Segment",
+                    "label": "Status"
+                  },
+                  {
+                    "columnId": "Runs Succeeded",
+                    "label": "Runs Succeeded"
+                  },
+                  {
+                    "columnId": "Runs Succeeded Timeline",
+                    "label": "Runs Succeeded Timeline"
+                  },
+                  {
+                    "columnId": "Actions Succeeded",
+                    "label": "Actions Succeeded"
+                  },
+                  {
+                    "columnId": "Actions Succeeded Timeline",
+                    "label": "Actions Succeeded Timeline"
+                  },
+                  {
+                    "columnId": "Triggers Succeeded",
+                    "label": "Triggers Succeeded"
+                  },
+                  {
+                    "columnId": "Triggers Succeeded Timeline",
+                    "label": "Triggers Succeeded Timeline"
+                  }
+                ]
+              }
+            },
+            "name": "succeeded-workflows"
+          },
+          {
+            "type": 10,
+            "content": {
+              "chartId": "workbook6f55d7e4-d957-4ca8-bb76-2818dc440087",
+              "version": "MetricsItem/2.0",
+              "size": 0,
+              "chartType": 0,
+              "resourceType": "microsoft.web/sites",
+              "metricScope": 0,
+              "resourceParameter": "LogicApp",
+              "resourceIds": [
+                "{LogicApp}"
+              ],
+              "timeContextFromParameter": "TimeRange",
+              "timeContext": {
+                "durationMs": 604800000
+              },
+              "metrics": [
+                {
+                  "namespace": "microsoft.web/sites",
+                  "metric": "microsoft.web/sites--WorkflowRunsCompleted",
+                  "aggregation": 1,
+                  "splitBy": "workflowName",
+                  "splitBySortOrder": -1,
+                  "splitByLimit": 10000,
+                  "columnName": "Runs Failed",
+                  "filters": [
+                    {
+                      "key": "status",
+                      "operator": 0,
+                      "values": [
+                        "Failed"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "namespace": "microsoft.web/sites",
+                  "metric": "microsoft.web/sites--WorkflowActionsCompleted",
+                  "aggregation": 7,
+                  "splitBy": "workflowName",
+                  "splitBySortOrder": -1,
+                  "splitByLimit": 10000,
+                  "columnName": "Actions Failed",
+                  "filters": [
+                    {
+                      "key": "status",
+                      "operator": 0,
+                      "values": [
+                        "Failed"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "namespace": "microsoft.web/sites",
+                  "metric": "microsoft.web/sites--WorkflowTriggersCompleted",
+                  "aggregation": 7,
+                  "splitBy": "workflowName",
+                  "splitBySortOrder": -1,
+                  "splitByLimit": 10000,
+                  "columnName": "Triggers Failed",
+                  "filters": [
+                    {
+                      "key": "status",
+                      "operator": 0,
+                      "values": [
+                        "Failed"
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "title": "Failed runs, actions, triggers",
+              "gridFormatType": 2,
+              "resourceLimit": 10000,
+              "gridSettings": {
+                "formatters": [
+                  {
+                    "columnMatch": "Subscription",
+                    "formatter": 5
+                  },
+                  {
+                    "columnMatch": "Name",
+                    "formatter": 5,
+                    "formatOptions": {
+                      "linkTarget": "Resource"
+                    }
+                  },
+                  {
+                    "columnMatch": "Runs Failure Rate",
+                    "formatter": 18,
+                    "formatOptions": {
+                      "thresholdsOptions": "icons",
+                      "thresholdsGrid": [
+                        {
+                          "operator": "!=",
+                          "thresholdValue": "0",
+                          "representation": "2",
+                          "text": "{0}{1}"
+                        },
+                        {
+                          "operator": "is Empty",
+                          "representation": "more",
+                          "text": "{0}{1}"
+                        },
+                        {
+                          "operator": "Default",
+                          "thresholdValue": null,
+                          "representation": "success",
+                          "text": "{0}{1}"
+                        }
+                      ]
+                    },
+                    "numberFormat": {
+                      "unit": 1,
+                      "options": {
+                        "style": "decimal"
+                      }
+                    }
+                  },
+                  {
+                    "columnMatch": "Runs Failure Rate Timeline",
+                    "formatter": 5
+                  },
+                  {
+                    "columnMatch": "Runs Failed",
+                    "formatter": 1,
+                    "numberFormat": {
+                      "unit": 0,
+                      "options": null
+                    }
+                  },
+                  {
+                    "columnMatch": "Runs Failed Timeline",
+                    "formatter": 10,
+                    "formatOptions": {
+                      "palette": "redBright"
+                    }
+                  },
+                  {
+                    "columnMatch": "Actions Failure Rate",
+                    "formatter": 18,
+                    "formatOptions": {
+                      "thresholdsOptions": "icons",
+                      "thresholdsGrid": [
+                        {
+                          "operator": "!=",
+                          "thresholdValue": "0",
+                          "representation": "2",
+                          "text": "{0}{1}"
+                        },
+                        {
+                          "operator": "is Empty",
+                          "representation": "more",
+                          "text": "{0}{1}"
+                        },
+                        {
+                          "operator": "Default",
+                          "thresholdValue": null,
+                          "representation": "success",
+                          "text": "{0}{1}"
+                        }
+                      ]
+                    },
+                    "numberFormat": {
+                      "unit": 1,
+                      "options": {
+                        "style": "decimal"
+                      }
+                    }
+                  },
+                  {
+                    "columnMatch": "Actions Failure Rate Timeline",
+                    "formatter": 5
+                  },
+                  {
+                    "columnMatch": "Actions Failed",
+                    "formatter": 1,
+                    "numberFormat": {
+                      "unit": 0,
+                      "options": null
+                    }
+                  },
+                  {
+                    "columnMatch": "Actions Failed Timeline",
+                    "formatter": 10,
+                    "formatOptions": {
+                      "palette": "redBright"
+                    }
+                  },
+                  {
+                    "columnMatch": "Triggers Failure Rate",
+                    "formatter": 18,
+                    "formatOptions": {
+                      "thresholdsOptions": "icons",
+                      "thresholdsGrid": [
+                        {
+                          "operator": "!=",
+                          "thresholdValue": "0",
+                          "representation": "2",
+                          "text": "{0}{1}"
+                        },
+                        {
+                          "operator": "is Empty",
+                          "representation": "more",
+                          "text": "{0}{1}"
+                        },
+                        {
+                          "operator": "Default",
+                          "thresholdValue": null,
+                          "representation": "success",
+                          "text": "{0}{1}"
+                        }
+                      ]
+                    },
+                    "numberFormat": {
+                      "unit": 1,
+                      "options": {
+                        "style": "decimal"
+                      }
+                    }
+                  },
+                  {
+                    "columnMatch": "Triggers Failure Rate Timeline",
+                    "formatter": 5
+                  },
+                  {
+                    "columnMatch": "Triggers Failed",
+                    "formatter": 1,
+                    "numberFormat": {
+                      "unit": 0,
+                      "options": null
+                    }
+                  },
+                  {
+                    "columnMatch": "Triggers Failed Timeline",
+                    "formatter": 10,
+                    "formatOptions": {
+                      "palette": "redBright"
+                    }
+                  },
+                  {
+                    "columnMatch": "Triggers Completed",
+                    "formatter": 1,
+                    "numberFormat": {
+                      "unit": 0,
+                      "options": null
+                    }
+                  },
+                  {
+                    "columnMatch": "Triggers Completed Timeline",
+                    "formatter": 10,
+                    "formatOptions": {
+                      "palette": "redBright"
+                    }
+                  },
+                  {
+                    "columnMatch": "Runs Completed",
+                    "formatter": 1,
+                    "numberFormat": {
+                      "unit": 0,
+                      "options": null
+                    }
+                  },
+                  {
+                    "columnMatch": "Runs Completed Timeline",
+                    "formatter": 10,
+                    "formatOptions": {
+                      "palette": "redBright"
+                    }
+                  },
+                  {
+                    "columnMatch": "Actions Completed",
+                    "formatter": 1,
+                    "numberFormat": {
+                      "unit": 0,
+                      "options": null
+                    }
+                  },
+                  {
+                    "columnMatch": "Actions Completed Timeline",
+                    "formatter": 10,
+                    "formatOptions": {
+                      "palette": "redBright"
+                    }
+                  },
+                  {
+                    "columnMatch": ".*\\/Runs Completed$",
+                    "formatter": 1
+                  },
+                  {
+                    "columnMatch": "microsoft.web/sites--WorkflowActionsCompleted Timeline",
+                    "formatter": 5
+                  },
+                  {
+                    "columnMatch": "microsoft.web/sites--WorkflowActionsCompleted",
+                    "formatter": 1,
+                    "numberFormat": {
+                      "unit": 0,
+                      "options": null
+                    }
+                  },
+                  {
+                    "columnMatch": "microsoft.web/sites--WorkflowTriggersCompleted Timeline",
+                    "formatter": 5
+                  },
+                  {
+                    "columnMatch": "microsoft.web/sites--WorkflowTriggersCompleted",
+                    "formatter": 1,
+                    "numberFormat": {
+                      "unit": 0,
+                      "options": null
+                    }
+                  },
+                  {
+                    "columnMatch": "microsoft.web/sites--WorkflowRunsFailureRate Timeline",
+                    "formatter": 5
+                  },
+                  {
+                    "columnMatch": "microsoft.web/sites--WorkflowRunsFailureRate",
+                    "formatter": 1,
+                    "numberFormat": {
+                      "unit": 1,
+                      "options": null
+                    }
+                  }
+                ],
+                "rowLimit": 10000,
+                "filter": true,
+                "labelSettings": [
+                  {
+                    "columnId": "Subscription",
+                    "label": "Subscription"
+                  },
+                  {
+                    "columnId": "Name",
+                    "label": "Name"
+                  },
+                  {
+                    "columnId": "Segment",
+                    "label": "Status"
+                  },
+                  {
+                    "columnId": "Runs Failed",
+                    "label": "Runs Failed"
+                  },
+                  {
+                    "columnId": "Runs Failed Timeline",
+                    "label": "Runs Failed Timeline"
+                  },
+                  {
+                    "columnId": "Actions Failed",
+                    "label": "Actions Failed"
+                  },
+                  {
+                    "columnId": "Actions Failed Timeline",
+                    "label": "Actions Failed Timeline"
+                  },
+                  {
+                    "columnId": "Triggers Failed",
+                    "label": "Triggers Failed"
+                  },
+                  {
+                    "columnId": "Triggers Failed Timeline",
+                    "label": "Triggers Failed Timeline"
+                  }
+                ]
+              }
+            },
+            "name": "failed-workflows"
+          }
+        ]
+      },
+      "conditionalVisibility": {
+        "parameterName": "tabParam",
+        "comparison": "isEqualTo",
+        "value": "Workflows"
+      },
+      "name": "workflowTabGroup2"
+    },
+    {
+      "type": 12,
+      "content": {
+        "version": "NotebookGroup/1.0",
+        "groupType": "editable",
+        "items": [
+          {
+            "type": 10,
+            "content": {
+              "chartId": "workbookfdb51157-37d9-4d38-9149-c660b8c00cc2",
+              "version": "MetricsItem/2.0",
+              "size": 4,
+              "chartType": -1,
+              "resourceType": "microsoft.web/sites",
+              "metricScope": 0,
+              "resourceParameter": "LogicApp",
+              "resourceIds": [
+                "{LogicApp}"
+              ],
+              "timeContextFromParameter": "TimeRange",
+              "timeContext": {
+                "durationMs": 604800000
+              },
+              "metrics": [
+                {
+                  "namespace": "microsoft.web/sites",
+                  "metric": "microsoft.web/sites--WorkflowRunsFailureRate",
+                  "aggregation": 1,
+                  "columnName": "Workflow Runs Success Rate"
+                },
+                {
+                  "namespace": "microsoft.web/sites",
+                  "metric": "microsoft.web/sites--WorkflowActionsFailureRate",
+                  "aggregation": 1,
+                  "columnName": "Workflow Actions Success Rate"
+                },
+                {
+                  "namespace": "microsoft.web/sites",
+                  "metric": "microsoft.web/sites--WorkflowTriggersFailureRate",
+                  "aggregation": 1,
+                  "columnName": "Workflow Triggers Success Rate"
+                }
+              ],
+              "gridFormatType": 1,
+              "tileSettings": {
+                "titleContent": {
+                  "columnMatch": "Metric",
+                  "formatter": 1
+                },
+                "leftContent": {
+                  "columnMatch": "Value",
+                  "formatter": 18,
+                  "formatOptions": {
+                    "thresholdsOptions": "icons",
+                    "thresholdsGrid": [
+                      {
+                        "operator": "!=",
+                        "thresholdValue": "0",
+                        "representation": "2",
+                        "text": "{0}{1}"
+                      },
+                      {
+                        "operator": "Default",
+                        "thresholdValue": null,
+                        "representation": "success",
+                        "text": "{0}{1}"
+                      }
+                    ]
+                  },
+                  "numberFormat": {
+                    "unit": 1,
+                    "options": {
+                      "style": "decimal",
+                      "useGrouping": false,
+                      "maximumFractionDigits": 2,
+                      "maximumSignificantDigits": 3
+                    }
+                  }
+                },
+                "showBorder": true,
+                "size": "auto"
+              },
+              "mapSettings": {
+                "locInfo": "AzureResource",
+                "sizeSettings": "Value",
+                "sizeAggregation": "Sum",
+                "legendMetric": "Value",
+                "legendAggregation": "Sum",
+                "itemColorSettings": {
+                  "type": "heatmap",
+                  "colorAggregation": "Sum",
+                  "nodeColorField": "Value",
+                  "heatmapPalette": "greenRed"
+                },
+                "locInfoColumn": "Name"
+              },
+              "graphSettings": {
+                "type": 0,
+                "topContent": {
+                  "columnMatch": "Subscription",
+                  "formatter": 1
+                },
+                "centerContent": {
+                  "columnMatch": "Value",
+                  "formatter": 1,
+                  "numberFormat": {
+                    "unit": 17,
+                    "options": {
+                      "maximumSignificantDigits": 3,
+                      "maximumFractionDigits": 2
+                    }
+                  }
+                }
+              },
+              "gridSettings": {
+                "formatters": [
+                  {
+                    "columnMatch": "Subscription",
+                    "formatter": 5
+                  },
+                  {
+                    "columnMatch": "Name",
+                    "formatter": 13,
+                    "formatOptions": {
+                      "linkTarget": "Resource"
+                    }
+                  },
+                  {
+                    "columnMatch": "Metric",
+                    "formatter": 1
+                  },
+                  {
+                    "columnMatch": "Aggregation",
+                    "formatter": 5
+                  },
+                  {
+                    "columnMatch": "Value",
+                    "formatter": 1
+                  },
+                  {
+                    "columnMatch": "Timeline",
+                    "formatter": 9
+                  }
+                ],
+                "rowLimit": 10000,
+                "labelSettings": [
+                  {
+                    "columnId": "Subscription",
+                    "label": "Subscription"
+                  },
+                  {
+                    "columnId": "Name",
+                    "label": "Name"
+                  },
+                  {
+                    "columnId": "Segment",
+                    "label": "Workflow"
+                  }
+                ]
+              }
+            },
+            "conditionalVisibilities": [
+              {
+                "parameterName": "tabParam",
+                "comparison": "isEqualTo",
+                "value": "Overview"
+              },
+              {
+                "parameterName": "A",
+                "comparison": "isEqualTo",
+                "value": "B"
+              }
+            ],
+            "name": "overviewTiles"
+          },
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "{\"version\":\"Merge/1.0\",\"merges\":[{\"id\":\"69b77d53-cda4-4c8b-b412-9164dc11d04a\",\"mergeType\":\"table\",\"leftTable\":\"overviewTiles\"}],\"projectRename\":[{\"originalName\":\"[overviewTiles].Subscription\",\"mergedName\":\"Subscription\",\"fromId\":\"69b77d53-cda4-4c8b-b412-9164dc11d04a\"},{\"originalName\":\"[overviewTiles].Name\",\"mergedName\":\"Name\",\"fromId\":\"69b77d53-cda4-4c8b-b412-9164dc11d04a\"},{\"originalName\":\"[overviewTiles].Namespace\",\"mergedName\":\"Namespace\",\"fromId\":\"69b77d53-cda4-4c8b-b412-9164dc11d04a\"},{\"originalName\":\"[overviewTiles].Metric\",\"mergedName\":\"Metric\",\"fromId\":\"69b77d53-cda4-4c8b-b412-9164dc11d04a\"},{\"originalName\":\"[overviewTiles].Metric ID\",\"mergedName\":\"Metric ID\",\"fromId\":\"69b77d53-cda4-4c8b-b412-9164dc11d04a\"},{\"originalName\":\"[overviewTiles].Aggregation\",\"mergedName\":\"Aggregation\",\"fromId\":\"69b77d53-cda4-4c8b-b412-9164dc11d04a\"},{\"originalName\":\"[overviewTiles].Segment Field\",\"mergedName\":\"Segment Field\",\"fromId\":\"69b77d53-cda4-4c8b-b412-9164dc11d04a\"},{\"originalName\":\"[overviewTiles].Segment\",\"mergedName\":\"Status\",\"fromId\":\"69b77d53-cda4-4c8b-b412-9164dc11d04a\"},{\"originalName\":\"[overviewTiles].Value\",\"mergedName\":\"Value\",\"fromId\":\"69b77d53-cda4-4c8b-b412-9164dc11d04a\"},{\"originalName\":\"[overviewTiles].Timeline\",\"mergedName\":\"Timeline\",\"fromId\":\"69b77d53-cda4-4c8b-b412-9164dc11d04a\"},{\"originalName\":\"[Added column]\",\"mergedName\":\"Inverted\",\"fromId\":null,\"isNewItem\":true,\"newItemData\":[{\"criteriaContext\":{\"operator\":\"Default\",\"rightValType\":\"column\",\"resultValType\":\"expression\",\"resultVal\":\"100 - [\\\"Value\\\"]\"}}]}]}",
+              "size": 4,
+              "queryType": 7,
+              "visualization": "tiles",
+              "tileSettings": {
+                "titleContent": {
+                  "columnMatch": "Metric",
+                  "formatter": 1
+                },
+                "leftContent": {
+                  "columnMatch": "Inverted",
+                  "formatter": 18,
+                  "formatOptions": {
+                    "thresholdsOptions": "icons",
+                    "thresholdsGrid": [
+                      {
+                        "operator": "!=",
+                        "thresholdValue": "100",
+                        "representation": "2",
+                        "text": "{0}{1}"
+                      },
+                      {
+                        "operator": "Default",
+                        "thresholdValue": null,
+                        "representation": "success",
+                        "text": "{0}{1}"
+                      }
+                    ]
+                  },
+                  "numberFormat": {
+                    "unit": 1,
+                    "options": {
+                      "style": "decimal",
+                      "maximumFractionDigits": 2,
+                      "maximumSignificantDigits": 3
+                    }
+                  }
+                },
+                "showBorder": true,
+                "size": "auto"
+              }
+            },
+            "showPin": false,
+            "name": "query - 5"
+          },
+          {
+            "type": 10,
+            "content": {
+              "chartId": "workbook8efd5fd5-7b72-4297-beb3-8d5e2412d012",
+              "version": "MetricsItem/2.0",
+              "size": 1,
+              "chartType": 0,
+              "resourceType": "microsoft.web/sites",
+              "metricScope": 0,
+              "resourceParameter": "LogicApp",
+              "resourceIds": [
+                "{LogicApp}"
+              ],
+              "timeContextFromParameter": "TimeRange",
+              "timeContext": {
+                "durationMs": 604800000
+              },
+              "metrics": [
+                {
+                  "namespace": "microsoft.web/sites",
+                  "metric": "microsoft.web/sites--WorkflowRunsCompleted",
+                  "aggregation": 7,
+                  "splitBy": "status",
+                  "splitBySortOrder": -1,
+                  "splitByLimit": 50
+                },
+                {
+                  "namespace": "microsoft.web/sites",
+                  "metric": "microsoft.web/sites--WorkflowActionsCompleted",
+                  "aggregation": 7,
+                  "splitBy": "status",
+                  "splitBySortOrder": -1,
+                  "splitByLimit": 50
+                },
+                {
+                  "namespace": "microsoft.web/sites",
+                  "metric": "microsoft.web/sites--WorkflowTriggersCompleted",
+                  "aggregation": 7,
+                  "splitBy": "status",
+                  "splitBySortOrder": -1,
+                  "splitByLimit": 50
+                }
+              ],
+              "title": "Overview",
+              "gridFormatType": 2,
+              "tileSettings": {
+                "showBorder": false,
+                "titleContent": {
+                  "columnMatch": "Name",
+                  "formatter": 13
+                },
+                "leftContent": {
+                  "columnMatch": "Value",
+                  "formatter": 12,
+                  "formatOptions": {
+                    "palette": "auto"
+                  },
+                  "numberFormat": {
+                    "unit": 17,
+                    "options": {
+                      "maximumSignificantDigits": 3,
+                      "maximumFractionDigits": 2
+                    }
+                  }
+                }
+              },
+              "mapSettings": {
+                "locInfo": "AzureResource",
+                "sizeSettings": "Value",
+                "sizeAggregation": "Sum",
+                "legendMetric": "Value",
+                "legendAggregation": "Sum",
+                "itemColorSettings": {
+                  "type": "heatmap",
+                  "colorAggregation": "Sum",
+                  "nodeColorField": "Value",
+                  "heatmapPalette": "greenRed"
+                },
+                "locInfoColumn": "Name"
+              },
+              "graphSettings": {
+                "type": 0,
+                "topContent": {
+                  "columnMatch": "Subscription",
+                  "formatter": 1
+                },
+                "centerContent": {
+                  "columnMatch": "Value",
+                  "formatter": 1,
+                  "numberFormat": {
+                    "unit": 17,
+                    "options": {
+                      "maximumSignificantDigits": 3,
+                      "maximumFractionDigits": 2
+                    }
+                  }
+                }
+              },
+              "gridSettings": {
+                "formatters": [
+                  {
+                    "columnMatch": "Subscription",
+                    "formatter": 5
+                  },
+                  {
+                    "columnMatch": "Name",
+                    "formatter": 5,
+                    "formatOptions": {
+                      "linkTarget": "Resource"
+                    }
+                  },
+                  {
+                    "columnMatch": "Segment",
+                    "formatter": 0,
+                    "tooltipFormat": {
+                      "tooltip": "Status"
+                    }
+                  },
+                  {
+                    "columnMatch": "microsoft.web/sites--WorkflowRunsCompleted",
+                    "formatter": 1,
+                    "numberFormat": {
+                      "unit": 0,
+                      "options": {
+                        "style": "decimal"
+                      }
+                    }
+                  },
+                  {
+                    "columnMatch": "microsoft.web/sites--WorkflowRunsCompleted Timeline",
+                    "formatter": 5
+                  },
+                  {
+                    "columnMatch": "microsoft.web/sites--WorkflowTriggersCompleted",
+                    "formatter": 1,
+                    "numberFormat": {
+                      "unit": 0,
+                      "options": null
+                    }
+                  },
+                  {
+                    "columnMatch": "microsoft.web/sites--WorkflowTriggersCompleted Timeline",
+                    "formatter": 5
+                  },
+                  {
+                    "columnMatch": "microsoft.web/sites--WorkflowActionsCompleted",
+                    "formatter": 1,
+                    "numberFormat": {
+                      "unit": 0,
+                      "options": null
+                    }
+                  },
+                  {
+                    "columnMatch": "microsoft.web/sites--WorkflowActionsCompleted Timeline",
+                    "formatter": 5
+                  },
+                  {
+                    "columnMatch": "Metric",
+                    "formatter": 1
+                  },
+                  {
+                    "columnMatch": "Aggregation",
+                    "formatter": 5
+                  },
+                  {
+                    "columnMatch": "Value",
+                    "formatter": 1
+                  },
+                  {
+                    "columnMatch": "Timeline",
+                    "formatter": 9
+                  },
+                  {
+                    "columnMatch": ".*\\/Workflow Runs Completed Count$",
+                    "formatter": 1
+                  },
+                  {
+                    "columnMatch": ".*\\/Workflow Triggers Completed Count$",
+                    "formatter": 1
+                  },
+                  {
+                    "columnMatch": ".*\\/Workflow Action Completed Count$",
+                    "formatter": 1
+                  }
+                ],
+                "rowLimit": 10000,
+                "labelSettings": [
+                  {
+                    "columnId": "Subscription",
+                    "label": "Subscription"
+                  },
+                  {
+                    "columnId": "Name",
+                    "label": "Name"
+                  },
+                  {
+                    "columnId": "Segment",
+                    "label": "Status"
+                  },
+                  {
+                    "columnId": "microsoft.web/sites--WorkflowRunsCompleted",
+                    "label": "Runs"
+                  },
+                  {
+                    "columnId": "microsoft.web/sites--WorkflowRunsCompleted Timeline",
+                    "label": "Workflow Runs Completed Count (Count) Timeline"
+                  },
+                  {
+                    "columnId": "microsoft.web/sites--WorkflowActionsCompleted",
+                    "label": "Actions"
+                  },
+                  {
+                    "columnId": "microsoft.web/sites--WorkflowActionsCompleted Timeline",
+                    "label": "Workflow Action Completed Count (Count) Timeline"
+                  },
+                  {
+                    "columnId": "microsoft.web/sites--WorkflowTriggersCompleted",
+                    "label": "Triggers"
+                  },
+                  {
+                    "columnId": "microsoft.web/sites--WorkflowTriggersCompleted Timeline",
+                    "label": "Workflow Triggers Completed Count (Count) Timeline"
+                  }
+                ]
+              },
+              "sortBy": []
+            },
+            "customWidth": "50",
+            "conditionalVisibility": {
+              "parameterName": "tabParam",
+              "comparison": "isEqualTo",
+              "value": "Overview"
+            },
+            "name": "overviewTable"
+          },
+          {
+            "type": 12,
+            "content": {
+              "version": "NotebookGroup/1.0",
+              "groupType": "editable",
+              "items": [
+                {
+                  "type": 10,
+                  "content": {
+                    "chartId": "workbooke90ebf1f-87f4-45f1-9bcb-77897f04e8e8",
+                    "version": "MetricsItem/2.0",
+                    "size": 0,
+                    "chartType": 2,
+                    "resourceType": "microsoft.web/sites",
+                    "metricScope": 0,
+                    "resourceParameter": "LogicApp",
+                    "resourceIds": [
+                      "{LogicApp}"
+                    ],
+                    "timeContextFromParameter": "TimeRange",
+                    "timeContext": {
+                      "durationMs": 604800000
+                    },
+                    "metrics": [
+                      {
+                        "namespace": "microsoft.web/sites",
+                        "metric": "microsoft.web/sites--WorkflowRunsCompleted",
+                        "aggregation": 7,
+                        "splitBy": "status"
+                      }
+                    ],
+                    "title": "Run status",
+                    "gridSettings": {
+                      "formatters": [
+                        {
+                          "columnMatch": "Subscription",
+                          "formatter": 5
+                        },
+                        {
+                          "columnMatch": "Name",
+                          "formatter": 13,
+                          "formatOptions": {
+                            "linkTarget": "Resource"
+                          }
+                        },
+                        {
+                          "columnMatch": ".*\\/Workflow Action Completed Count$",
+                          "formatter": 1
+                        }
+                      ],
+                      "rowLimit": 10000,
+                      "labelSettings": [
+                        {
+                          "columnId": "Subscription",
+                          "label": "Subscription"
+                        },
+                        {
+                          "columnId": "Name",
+                          "label": "Name"
+                        }
+                      ]
+                    }
+                  },
+                  "customWidth": "30",
+                  "name": "metric - 12"
+                },
+                {
+                  "type": 10,
+                  "content": {
+                    "chartId": "workbooke90ebf1f-87f4-45f1-9bcb-77897f04e8e8",
+                    "version": "MetricsItem/2.0",
+                    "size": 0,
+                    "chartType": 2,
+                    "resourceType": "microsoft.web/sites",
+                    "metricScope": 0,
+                    "resourceParameter": "LogicApp",
+                    "resourceIds": [
+                      "{LogicApp}"
+                    ],
+                    "timeContextFromParameter": "TimeRange",
+                    "timeContext": {
+                      "durationMs": 604800000
+                    },
+                    "metrics": [
+                      {
+                        "namespace": "microsoft.web/sites",
+                        "metric": "microsoft.web/sites--WorkflowActionsCompleted",
+                        "aggregation": 7,
+                        "splitBy": "status"
+                      }
+                    ],
+                    "title": "Action status",
+                    "gridSettings": {
+                      "formatters": [
+                        {
+                          "columnMatch": "Subscription",
+                          "formatter": 5
+                        },
+                        {
+                          "columnMatch": "Name",
+                          "formatter": 13,
+                          "formatOptions": {
+                            "linkTarget": "Resource"
+                          }
+                        },
+                        {
+                          "columnMatch": ".*\\/Workflow Action Completed Count$",
+                          "formatter": 1
+                        }
+                      ],
+                      "rowLimit": 10000,
+                      "labelSettings": [
+                        {
+                          "columnId": "Subscription",
+                          "label": "Subscription"
+                        },
+                        {
+                          "columnId": "Name",
+                          "label": "Name"
+                        }
+                      ]
+                    }
+                  },
+                  "customWidth": "30",
+                  "name": "metric - 12 - Copy - Copy"
+                },
+                {
+                  "type": 10,
+                  "content": {
+                    "chartId": "workbooke90ebf1f-87f4-45f1-9bcb-77897f04e8e8",
+                    "version": "MetricsItem/2.0",
+                    "size": 0,
+                    "chartType": 2,
+                    "resourceType": "microsoft.web/sites",
+                    "metricScope": 0,
+                    "resourceParameter": "LogicApp",
+                    "resourceIds": [
+                      "{LogicApp}"
+                    ],
+                    "timeContextFromParameter": "TimeRange",
+                    "timeContext": {
+                      "durationMs": 604800000
+                    },
+                    "metrics": [
+                      {
+                        "namespace": "microsoft.web/sites",
+                        "metric": "microsoft.web/sites--WorkflowTriggersCompleted",
+                        "aggregation": 7,
+                        "splitBy": "status"
+                      }
+                    ],
+                    "title": "Trigger status",
+                    "gridSettings": {
+                      "formatters": [
+                        {
+                          "columnMatch": "Subscription",
+                          "formatter": 5
+                        },
+                        {
+                          "columnMatch": "Name",
+                          "formatter": 13,
+                          "formatOptions": {
+                            "linkTarget": "Resource"
+                          }
+                        },
+                        {
+                          "columnMatch": ".*\\/Workflow Action Completed Count$",
+                          "formatter": 1
+                        }
+                      ],
+                      "rowLimit": 10000,
+                      "labelSettings": [
+                        {
+                          "columnId": "Subscription",
+                          "label": "Subscription"
+                        },
+                        {
+                          "columnId": "Name",
+                          "label": "Name"
+                        }
+                      ]
+                    }
+                  },
+                  "customWidth": "30",
+                  "name": "metric - 12 - Copy"
+                }
+              ]
+            },
+            "conditionalVisibility": {
+              "parameterName": "tabParam",
+              "comparison": "isEqualTo",
+              "value": "Overview"
+            },
+            "name": "overviewLineCharts"
+          }
+        ]
+      },
+      "conditionalVisibility": {
+        "parameterName": "tabParam",
+        "comparison": "isEqualTo",
+        "value": "Overview"
+      },
+      "name": "overviewTabGroup"
+    },
+    {
+      "type": 12,
+      "content": {
+        "version": "NotebookGroup/1.0",
+        "groupType": "editable",
+        "items": [
+          {
+            "type": 10,
+            "content": {
+              "chartId": "workbooke63fdb25-9d13-42e6-825a-692e368abbbb",
+              "version": "MetricsItem/2.0",
+              "size": 0,
+              "chartType": 2,
+              "resourceType": "microsoft.web/sites",
+              "metricScope": 0,
+              "resourceParameter": "LogicApp",
+              "resourceIds": [
+                "{LogicApp}"
+              ],
+              "timeContextFromParameter": "TimeRange",
+              "timeContext": {
+                "durationMs": 604800000
+              },
+              "metrics": [
+                {
+                  "namespace": "microsoft.web/sites",
+                  "metric": "microsoft.web/sites--WorkflowJobExecutionDelay",
+                  "aggregation": 7,
+                  "columnName": "Workflow Job Count"
+                }
+              ],
+              "title": "Workflow Job Count",
+              "gridSettings": {
+                "rowLimit": 10000
+              }
+            },
+            "customWidth": "50",
+            "name": "metric - 10 - Copy"
+          },
+          {
+            "type": 10,
+            "content": {
+              "chartId": "workbooke63fdb25-9d13-42e6-825a-692e368abbbb",
+              "version": "MetricsItem/2.0",
+              "size": 0,
+              "chartType": 2,
+              "resourceType": "microsoft.web/sites",
+              "metricScope": 0,
+              "resourceParameter": "LogicApp",
+              "resourceIds": [
+                "{LogicApp}"
+              ],
+              "timeContextFromParameter": "TimeRange",
+              "timeContext": {
+                "durationMs": 604800000
+              },
+              "metrics": [
+                {
+                  "namespace": "microsoft.web/sites",
+                  "metric": "microsoft.web/sites--WorkflowJobExecutionDelay",
+                  "aggregation": 4
+                }
+              ],
+              "title": "Workflow Job Execution Delay",
+              "gridSettings": {
+                "rowLimit": 10000
+              }
+            },
+            "customWidth": "50",
+            "name": "metric - 10"
+          },
+          {
+            "type": 10,
+            "content": {
+              "chartId": "workbookcbe77ede-2979-46ed-a87d-8741be5edf8e",
+              "version": "MetricsItem/2.0",
+              "size": 0,
+              "chartType": 2,
+              "resourceType": "microsoft.web/sites",
+              "metricScope": 0,
+              "resourceParameter": "LogicApp",
+              "resourceIds": [
+                "{LogicApp}"
+              ],
+              "timeContextFromParameter": "TimeRange",
+              "timeContext": {
+                "durationMs": 604800000
+              },
+              "metrics": [
+                {
+                  "namespace": "microsoft.web/sites",
+                  "metric": "microsoft.web/sites--InstanceCount",
+                  "aggregation": 3,
+                  "columnName": "Instance count"
+                }
+              ],
+              "title": "Instance count",
+              "gridSettings": {
+                "rowLimit": 10000
+              }
+            },
+            "name": "metric - 11"
+          },
+          {
+            "type": 10,
+            "content": {
+              "chartId": "workbook7fe2f5b9-d00a-414a-8a0e-8683576267c8",
+              "version": "MetricsItem/2.0",
+              "size": 0,
+              "chartType": 4,
+              "resourceType": "microsoft.web/sites",
+              "metricScope": 0,
+              "resourceParameter": "LogicApp",
+              "resourceIds": [
+                "{LogicApp}"
+              ],
+              "timeContextFromParameter": "TimeRange",
+              "timeContext": {
+                "durationMs": 604800000
+              },
+              "metrics": [
+                {
+                  "namespace": "microsoft.web/sites",
+                  "metric": "microsoft.web/sites--AverageMemoryWorkingSet",
+                  "aggregation": 4,
+                  "columnName": "Avg Memory Working Set"
+                }
+              ],
+              "title": "Average memory working set",
+              "gridSettings": {
+                "rowLimit": 10000
+              }
+            },
+            "name": "metric - 5"
+          },
+          {
+            "type": 1,
+            "content": {
+              "json": "The metrics below refer to your app service plan: {AppServicePlan:id}",
+              "style": "info"
+            },
+            "name": "text - 6"
+          },
+          {
+            "type": 10,
+            "content": {
+              "chartId": "workbook8efd5fd5-7b72-4297-beb3-8d5e2412d012",
+              "version": "MetricsItem/2.0",
+              "size": 1,
+              "chartType": 4,
+              "resourceType": "microsoft.web/serverfarms",
+              "metricScope": 0,
+              "resourceParameter": "AppServicePlan",
+              "resourceIds": [
+                "{AppServicePlan}"
+              ],
+              "timeContextFromParameter": "TimeRange",
+              "timeContext": {
+                "durationMs": 604800000
+              },
+              "metrics": [
+                {
+                  "namespace": "microsoft.web/serverfarms",
+                  "metric": "microsoft.web/serverfarms--MemoryPercentage",
+                  "aggregation": 4,
+                  "splitBy": "Instance"
+                }
+              ],
+              "title": "Memory % by instance",
+              "gridFormatType": 1,
+              "tileSettings": {
+                "showBorder": false,
+                "titleContent": {
+                  "columnMatch": "Name",
+                  "formatter": 13
+                },
+                "leftContent": {
+                  "columnMatch": "Value",
+                  "formatter": 12,
+                  "formatOptions": {
+                    "palette": "auto"
+                  },
+                  "numberFormat": {
+                    "unit": 17,
+                    "options": {
+                      "maximumSignificantDigits": 3,
+                      "maximumFractionDigits": 2
+                    }
+                  }
+                }
+              },
+              "graphSettings": {
+                "type": 0,
+                "topContent": {
+                  "columnMatch": "Subscription",
+                  "formatter": 1
+                },
+                "centerContent": {
+                  "columnMatch": "Value",
+                  "formatter": 1,
+                  "numberFormat": {
+                    "unit": 17,
+                    "options": {
+                      "maximumSignificantDigits": 3,
+                      "maximumFractionDigits": 2
+                    }
+                  }
+                }
+              },
+              "gridSettings": {
+                "formatters": [
+                  {
+                    "columnMatch": "Subscription",
+                    "formatter": 5
+                  },
+                  {
+                    "columnMatch": "Name",
+                    "formatter": 13,
+                    "formatOptions": {
+                      "linkTarget": "Resource"
+                    }
+                  },
+                  {
+                    "columnMatch": "Metric",
+                    "formatter": 1
+                  },
+                  {
+                    "columnMatch": "Aggregation",
+                    "formatter": 5
+                  },
+                  {
+                    "columnMatch": "Value",
+                    "formatter": 1
+                  },
+                  {
+                    "columnMatch": "Timeline",
+                    "formatter": 9
+                  }
+                ],
+                "rowLimit": 10000
+              }
+            },
+            "name": "metric - 3 - Copy - Copy"
+          },
+          {
+            "type": 10,
+            "content": {
+              "chartId": "workbook8efd5fd5-7b72-4297-beb3-8d5e2412d012",
+              "version": "MetricsItem/2.0",
+              "size": 1,
+              "chartType": 4,
+              "resourceType": "microsoft.web/serverfarms",
+              "metricScope": 0,
+              "resourceParameter": "AppServicePlan",
+              "resourceIds": [
+                "{AppServicePlan}"
+              ],
+              "timeContextFromParameter": "TimeRange",
+              "timeContext": {
+                "durationMs": 604800000
+              },
+              "metrics": [
+                {
+                  "namespace": "microsoft.web/serverfarms",
+                  "metric": "microsoft.web/serverfarms--CpuPercentage",
+                  "aggregation": 4,
+                  "splitBy": "Instance"
+                }
+              ],
+              "title": "CPU % by instance",
+              "gridFormatType": 1,
+              "tileSettings": {
+                "showBorder": false,
+                "titleContent": {
+                  "columnMatch": "Name",
+                  "formatter": 13
+                },
+                "leftContent": {
+                  "columnMatch": "Value",
+                  "formatter": 12,
+                  "formatOptions": {
+                    "palette": "auto"
+                  },
+                  "numberFormat": {
+                    "unit": 17,
+                    "options": {
+                      "maximumSignificantDigits": 3,
+                      "maximumFractionDigits": 2
+                    }
+                  }
+                }
+              },
+              "graphSettings": {
+                "type": 0,
+                "topContent": {
+                  "columnMatch": "Subscription",
+                  "formatter": 1
+                },
+                "centerContent": {
+                  "columnMatch": "Value",
+                  "formatter": 1,
+                  "numberFormat": {
+                    "unit": 17,
+                    "options": {
+                      "maximumSignificantDigits": 3,
+                      "maximumFractionDigits": 2
+                    }
+                  }
+                }
+              },
+              "gridSettings": {
+                "formatters": [
+                  {
+                    "columnMatch": "Subscription",
+                    "formatter": 5
+                  },
+                  {
+                    "columnMatch": "Name",
+                    "formatter": 13,
+                    "formatOptions": {
+                      "linkTarget": "Resource"
+                    }
+                  },
+                  {
+                    "columnMatch": "Metric",
+                    "formatter": 1
+                  },
+                  {
+                    "columnMatch": "Aggregation",
+                    "formatter": 5
+                  },
+                  {
+                    "columnMatch": "Value",
+                    "formatter": 1
+                  },
+                  {
+                    "columnMatch": "Timeline",
+                    "formatter": 9
+                  }
+                ],
+                "rowLimit": 10000
+              }
+            },
+            "name": "metric - 3 - Copy"
+          }
+        ]
+      },
+      "conditionalVisibility": {
+        "parameterName": "tabParam",
+        "comparison": "isEqualTo",
+        "value": "Capacity"
+      },
+      "name": "capacityTabGroup"
+    }
+  ],
+  "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
+}

--- a/Workbooks/Azure Logic Apps/LA Standard Metrics/LAStandardMetrics.json
+++ b/Workbooks/Azure Logic Apps/LA Standard Metrics/LAStandardMetrics.json
@@ -1918,8 +1918,5 @@
       "name": "capacityTabGroup"
     }
   ],
-  "fallbackResourceIds": [
-    "/subscriptions/f34b22a3-2202-4fb1-b040-1332bd928c84/resourceGroups/karansin/providers/Microsoft.Web/sites/basic-logic-app"
-  ],
   "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
 }


### PR DESCRIPTION
This is a workbook for Azure Logic Apps standard that will be referenced from the LA portal in the insights blade.

It was tested by deploying to a custom gallery, and then via `enableWorkbooks` + `apply` on the resource. There are three tabs, describing overview, workflows, and compute.

Please help advise:
- For CODEOWNERS, will an @azure team work? Or do we need to provide a @microsoft one?
- Do we need a gallery file update for our scenario? Or is contributing the workbook sufficient if we reference it directly from the built-in blade?

Feel free to ping me at `karansin`

https://github.com/microsoft/Application-Insights-Workbooks/assets/7775527/d476e644-77d5-4ff9-b9c8-12289b0403b0

## PR Checklist

* [x] Explain your changes, so people looking at the PR know *what* and *why*, the code changes are the *how*.
* [x] Validate your changes using one or more of the [testing](../Documentation/Testing.md) methods.

### If adding or updating templates:
* [x] post a screenshot of templates and/or gallery changes
* [ ] ensure your template has a corresponding gallery entry in the gallery folder
* [ ] If you are adding a new template, add your team and template/gallery file(s) to the CODEOWNERS file. CODEOWNERS entries should be teams, not individuals
* [x] ensure all steps have meaningful names
* [x] ensure all parameters and grid columns have display names set so they can be localized
* [x] ensure that parameters id values are unique __or they will fail PR validation__ (parameter ids are used for localization)
* [x] ensure that steps names are unique __or they will fail PR validation__ (step names are used for localization)
* [x] grep `/subscription/` and ensure that your parameters don't have any hardcoded resourceIds __or they will fail PR validation__
* [x] remove `fallbackResourceIds` and `fromTemplateId` fields from your template workbook __or they will fail PR validation__