### PR TITLE
Update Overview.workbook update datetime column

### DIFF
--- a/Workbooks/Communication Services/Overview/Overview.workbook
+++ b/Workbooks/Communication Services/Overview/Overview.workbook
@@ -4810,7 +4810,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "ACSEmailStatusUpdateOperational \r\n| where OperationName == \"DeliveryStatusUpdate\" and isnotempty(DeliveryStatus) and DeliveryStatus != \"OutForDelivery\"\r\n| where ('{email_mailfrom:value}' == \"All senders\") or (strcat(SenderUsername, '@', SenderDomain) == '{email_mailfrom:value}')\r\n| project    Id=CorrelationId, [\"Mail To Address\"]=RecipientId, [\"Mail From Address\"]=strcat(SenderUsername, \"@\", SenderDomain), DeliveryStatus, Status=iff(DeliveryStatus == \"Delivered\", \"success\", \"error\"), [\"Date Sent\"]=bin(TimeGenerated, 1d)",
+              "query": "ACSEmailStatusUpdateOperational \r\n| where OperationName == \"DeliveryStatusUpdate\" and isnotempty(DeliveryStatus) and DeliveryStatus != \"OutForDelivery\"\r\n| where ('{email_mailfrom:value}' == \"All senders\") or (strcat(SenderUsername, '@', SenderDomain) == '{email_mailfrom:value}')\r\n| project    Id=CorrelationId, [\"Mail To Address\"]=RecipientId, [\"Mail From Address\"]=strcat(SenderUsername, \"@\", SenderDomain), DeliveryStatus, Status=iff(DeliveryStatus == \"Delivered\", \"success\", \"error\"), [\"Date Sent\"]=TimeGenerated",
               "size": 0,
               "title": "Per-recipient Delivery Details",
               "timeContextFromParameter": "time_range",


### PR DESCRIPTION
We have an issue in our Azure Communications Email Service Insights Workbook where our per-instance table shows an aggregated date (bin()). The issue is in the query used to generate this chart. The Date Sent column is using the bin() function to round to the nearest time bucket. This instance level chart should use actual timestamps

## PR Checklist

* [ ] Explain your changes, so people looking at the PR know *what* and *why*, the code changes are the *how*.
* [ ] Validate your changes using one or more of the [testing](../Documentation/Testing.md) methods.

### If adding or updating templates:
* [ ] post a screenshot of templates and/or gallery changes
* [ ] ensure your template has a corresponding gallery entry in the gallery folder
* [ ] If you are adding a new template, add your team and template/gallery file(s) to the CODEOWNERS file. CODEOWNERS entries should be teams, not individuals
* [ ] ensure all steps have meaningful names
* [ ] ensure all parameters and grid columns have display names set so they can be localized
* [ ] ensure that parameters id values are unique __or they will fail PR validation__ (parameter ids are used for localization)
* [ ] ensure that steps names are unique __or they will fail PR validation__ (step names are used for localization)
* [ ] grep `/subscription/` and ensure that your parameters don't have any hardcoded resourceIds __or they will fail PR validation__
* [ ] remove `fallbackResourceIds` and `fromTemplateId` fields from your template workbook __or they will fail PR validation__