### PR TITLE
Add workbooks for Logic Apps AIS (Integrate)

### DIFF
--- a/Workbooks/Azure Logic Apps/FilteredAPIM/FilteredAPIM.workbook
+++ b/Workbooks/Azure Logic Apps/FilteredAPIM/FilteredAPIM.workbook
@@ -1,0 +1,522 @@
+{
+  "version": "Notebook/1.0",
+  "items": [
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "parameters": [
+          {
+            "id": "accb80c7-9c54-47b5-a316-f83c860ad6ff",
+            "version": "KqlParameterItem/1.0",
+            "name": "TimeRange",
+            "type": 4,
+            "isRequired": true,
+            "typeSettings": {
+              "selectableValues": [
+                {
+                  "durationMs": 300000
+                },
+                {
+                  "durationMs": 900000
+                },
+                {
+                  "durationMs": 1800000
+                },
+                {
+                  "durationMs": 3600000
+                },
+                {
+                  "durationMs": 14400000
+                },
+                {
+                  "durationMs": 43200000
+                },
+                {
+                  "durationMs": 86400000
+                },
+                {
+                  "durationMs": 172800000
+                },
+                {
+                  "durationMs": 259200000
+                },
+                {
+                  "durationMs": 604800000
+                },
+                {
+                  "durationMs": 1209600000
+                },
+                {
+                  "durationMs": 2419200000
+                },
+                {
+                  "durationMs": 2592000000
+                },
+                {
+                  "durationMs": 5184000000
+                },
+                {
+                  "durationMs": 7776000000
+                }
+              ],
+              "allowCustom": true
+            },
+            "value": {
+              "durationMs": 1209600000
+            },
+            "label": "Time range"
+          },
+          {
+            "id": "f6ae972e-aa74-459e-83b9-aaba95c97bcf",
+            "version": "KqlParameterItem/1.0",
+            "name": "Apim",
+            "type": 5,
+            "query": "project id,name,type\r\n| where type == \"microsoft.apimanagement/service\"",
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "queryType": 1,
+            "resourceType": "microsoft.resourcegraph/resources"
+          },
+          {
+            "id": "4d8f9311-bd24-43c8-a692-f111a957be67",
+            "version": "KqlParameterItem/1.0",
+            "name": "ApplicationInsights",
+            "type": 5,
+            "query": "resources\r\n| where type == \"microsoft.insights/components\"",
+            "crossComponentResources": [
+              "value::all"
+            ],
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "queryType": 1,
+            "resourceType": "microsoft.resourcegraph/resources"
+          },
+          {
+            "id": "a0049fee-b07c-4507-9ea3-0bb870e5bf53",
+            "version": "KqlParameterItem/1.0",
+            "name": "Api",
+            "type": 9,
+            "multiSelect": true,
+            "quote": "",
+            "delimiter": ","
+          }
+        ],
+        "style": "pills",
+        "queryType": 0,
+        "resourceType": "microsoft.apimanagement/service"
+      },
+      "conditionalVisibility": {
+        "parameterName": "a",
+        "comparison": "isEqualTo",
+        "value": "b"
+      },
+      "name": "parameters"
+    },
+    {
+      "type": 11,
+      "content": {
+        "version": "LinkItem/1.0",
+        "style": "tabs",
+        "links": [
+          {
+            "id": "cb44da00-4820-4694-adbd-c70e2cc69a27",
+            "cellValue": "tab",
+            "linkTarget": "parameter",
+            "linkLabel": "Timeline",
+            "subTarget": "timeline",
+            "preText": "",
+            "style": "link"
+          },
+          {
+            "id": "cf7438dc-65f6-4816-8c08-a1df486585c2",
+            "cellValue": "tab",
+            "linkTarget": "parameter",
+            "linkLabel": "APIs",
+            "subTarget": "apis",
+            "style": "link"
+          },
+          {
+            "id": "6ddd5c14-7456-4393-9549-9d9b03c70a48",
+            "cellValue": "tab",
+            "linkTarget": "parameter",
+            "linkLabel": "Operations",
+            "subTarget": "operations",
+            "style": "link"
+          }
+        ]
+      },
+      "name": "links"
+    },
+    {
+      "type": 12,
+      "content": {
+        "version": "NotebookGroup/1.0",
+        "groupType": "editable",
+        "items": [
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "let apiFilter = dynamic([{Api}]);\r\nrequests\r\n| where tostring(customDimensions[\"Service Type\"]) == \"API Management\"\r\n| where isnotnull(customDimensions[\"API Name\"]) and isnotnull(customDimensions[\"Operation Name\"])\r\n| extend OperationName = tostring(customDimensions[\"Operation Name\"])\r\n| extend LoggedAPISuffix = strcat(tostring(customDimensions[\"Service ID\"]), \"/apis/\", tostring(customDimensions[\"API Name\"]))\r\n| where apiFilter hassuffix LoggedAPISuffix\r\n| summarize count(tostring(resultCode)) by bin(timestamp, {TimeRange:grain}), LoggedAPISuffix\r\n| render timechart",
+              "size": 0,
+              "title": "Requests",
+              "timeContextFromParameter": "TimeRange",
+              "queryType": 0,
+              "resourceType": "microsoft.insights/components",
+              "crossComponentResources": [
+                "{ApplicationInsights}"
+              ]
+            },
+            "name": "requests"
+          },
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "let apiFilter = dynamic([{Api}]);\r\nrequests\r\n| where tostring(customDimensions[\"Service Type\"]) == \"API Management\"\r\n| where isnotnull(customDimensions[\"API Name\"]) and isnotnull(customDimensions[\"Operation Name\"])\r\n| extend OperationName = tostring(customDimensions[\"Operation Name\"])\r\n| extend LoggedAPISuffix = strcat(tostring(customDimensions[\"Service ID\"]), \"/apis/\", tostring(customDimensions[\"API Name\"]))\r\n| where apiFilter hassuffix LoggedAPISuffix\r\n| summarize avg(duration) by bin(timestamp, {TimeRange:grain})\r\n| render timechart",
+              "size": 0,
+              "aggregation": 3,
+              "title": "Response time",
+              "timeContextFromParameter": "TimeRange",
+              "queryType": 0,
+              "resourceType": "microsoft.insights/components",
+              "crossComponentResources": [
+                "{ApplicationInsights}"
+              ]
+            },
+            "name": "response time"
+          }
+        ]
+      },
+      "conditionalVisibility": {
+        "parameterName": "tab",
+        "comparison": "isEqualTo",
+        "value": "timeline"
+      },
+      "name": "Timeline"
+    },
+    {
+      "type": 12,
+      "content": {
+        "version": "NotebookGroup/1.0",
+        "groupType": "editable",
+        "items": [
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "let apiFilter = dynamic([{Api}]);\r\nrequests\r\n| where tostring(customDimensions[\"Service Type\"]) == \"API Management\"\r\n| where isnotnull(customDimensions[\"API Name\"]) and isnotnull(customDimensions[\"Operation Name\"])\r\n| extend OperationName = tostring(customDimensions[\"Operation Name\"])\r\n| extend ResponseCode = tolong(resultCode)\r\n| extend LoggedAPISuffix = strcat(tostring(customDimensions[\"Service ID\"]), \"/apis/\", tostring(customDimensions[\"API Name\"]))\r\n| where apiFilter hassuffix LoggedAPISuffix\r\n| summarize \r\n    SuccessfullRequests = countif(ResponseCode < 400), \r\n    FailedRequests = countif(ResponseCode == 400 or (ResponseCode >= 500 and ResponseCode < 600)),\r\n    UnauthorizedRequests = countif(ResponseCode == 401 or ResponseCode == 403 or ResponseCode == 429),\r\n    OtherRequests = countif((ResponseCode > 401 and ResponseCode < 500 and ResponseCode != 401 and ResponseCode != 403 and ResponseCode != 429) or ResponseCode > 599 or isempty(ResponseCode)),\r\n    TotalRequests = count(),\r\n    Duration = avg(duration)\r\n  by\r\n    Api = coalesce(LoggedAPISuffix, 'None')\r\n| extend\r\n    AverageDuration = iff(isnan(Duration), 0.0, Duration)\r\n| project-away Duration",
+              "size": 2,
+              "timeContextFromParameter": "TimeRange",
+              "queryType": 0,
+              "resourceType": "microsoft.insights/components",
+              "crossComponentResources": [
+                "{ApplicationInsights}"
+              ],
+              "visualization": "table",
+              "gridSettings": {
+                "formatters": [
+                  {
+                    "columnMatch": "SuccessfullRequests",
+                    "formatter": 0,
+                    "formatOptions": {
+                      "aggregation": "Count"
+                    },
+                    "numberFormat": {
+                      "unit": 17,
+                      "options": {
+                        "style": "decimal"
+                      }
+                    }
+                  },
+                  {
+                    "columnMatch": "FailedRequests",
+                    "formatter": 0,
+                    "formatOptions": {
+                      "aggregation": "Count"
+                    },
+                    "numberFormat": {
+                      "unit": 17,
+                      "options": {
+                        "style": "decimal"
+                      }
+                    }
+                  },
+                  {
+                    "columnMatch": "UnauthorizedRequests",
+                    "formatter": 0,
+                    "formatOptions": {
+                      "aggregation": "Count"
+                    },
+                    "numberFormat": {
+                      "unit": 17,
+                      "options": {
+                        "style": "decimal"
+                      }
+                    }
+                  },
+                  {
+                    "columnMatch": "OtherRequests",
+                    "formatter": 0,
+                    "formatOptions": {
+                      "aggregation": "Count"
+                    },
+                    "numberFormat": {
+                      "unit": 17,
+                      "options": {
+                        "style": "decimal"
+                      }
+                    }
+                  },
+                  {
+                    "columnMatch": "TotalRequests",
+                    "formatter": 0,
+                    "formatOptions": {
+                      "aggregation": "Count"
+                    },
+                    "numberFormat": {
+                      "unit": 17,
+                      "options": {
+                        "style": "decimal"
+                      }
+                    }
+                  },
+                  {
+                    "columnMatch": "AverageResponseTime",
+                    "formatter": 0,
+                    "formatOptions": {
+                      "aggregation": "Average"
+                    },
+                    "numberFormat": {
+                      "unit": 23,
+                      "options": {
+                        "style": "decimal",
+                        "maximumFractionDigits": 2
+                      }
+                    }
+                  },
+                  {
+                    "columnMatch": "AverageServiceResponseTime",
+                    "formatter": 0,
+                    "formatOptions": {
+                      "aggregation": "Average"
+                    },
+                    "numberFormat": {
+                      "unit": 23,
+                      "options": {
+                        "style": "decimal",
+                        "maximumFractionDigits": 2
+                      }
+                    }
+                  },
+                  {
+                    "columnMatch": "DataTransfer",
+                    "formatter": 0,
+                    "formatOptions": {
+                      "aggregation": "Sum"
+                    },
+                    "numberFormat": {
+                      "unit": 2,
+                      "options": {
+                        "style": "decimal",
+                        "maximumFractionDigits": 2
+                      }
+                    }
+                  },
+                  {
+                    "columnMatch": "TimeGenerated",
+                    "formatter": 5
+                  }
+                ]
+              },
+              "sortBy": [],
+              "tileSettings": {
+                "showBorder": false
+              },
+              "mapSettings": {
+                "locInfo": "LatLong"
+              }
+            },
+            "name": "Apis"
+          }
+        ]
+      },
+      "conditionalVisibility": {
+        "parameterName": "tab",
+        "comparison": "isEqualTo",
+        "value": "apis"
+      },
+      "name": "APIs"
+    },
+    {
+      "type": 12,
+      "content": {
+        "version": "NotebookGroup/1.0",
+        "groupType": "editable",
+        "items": [
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "let apiFilter = dynamic([{Api}]);\r\nrequests\r\n| where tostring(customDimensions[\"Service Type\"]) == \"API Management\"\r\n| where isnotnull(customDimensions[\"API Name\"])\r\n| extend OperationName = tostring(customDimensions[\"Operation Name\"])\r\n| extend ResponseCode = tolong(resultCode)\r\n| extend LoggedAPISuffix = strcat(tostring(customDimensions[\"Service ID\"]), \"/apis/\", tostring(customDimensions[\"API Name\"]))\r\n| where apiFilter hassuffix LoggedAPISuffix\r\n| summarize \r\n    SuccessfullRequests = countif(ResponseCode < 400), \r\n    FailedRequests = countif(ResponseCode == 400 or (ResponseCode >= 500 and ResponseCode < 600)),\r\n    UnauthorizedRequests = countif(ResponseCode == 401 or ResponseCode == 403 or ResponseCode == 429),\r\n    OtherRequests = countif((ResponseCode > 401 and ResponseCode < 500 and ResponseCode != 401 and ResponseCode != 403 and ResponseCode != 429) or ResponseCode > 599 or isempty(ResponseCode)),\r\n    TotalRequests = count(),\r\n    Duration = avg(duration)\r\n  by\r\n    Api = coalesce(LoggedAPISuffix, 'None'),\r\n    OperationName = coalesce(OperationName, 'None')\r\n| extend\r\n    AverageDuration = iff(isnan(Duration), 0.0, Duration)\r\n| project-away Duration",
+              "size": 2,
+              "timeContextFromParameter": "TimeRange",
+              "queryType": 0,
+              "resourceType": "microsoft.insights/components",
+              "crossComponentResources": [
+                "{ApplicationInsights}"
+              ],
+              "visualization": "table",
+              "gridSettings": {
+                "formatters": [
+                  {
+                    "columnMatch": "SuccessfullRequests",
+                    "formatter": 0,
+                    "formatOptions": {
+                      "aggregation": "Count"
+                    },
+                    "numberFormat": {
+                      "unit": 17,
+                      "options": {
+                        "style": "decimal"
+                      }
+                    }
+                  },
+                  {
+                    "columnMatch": "FailedRequests",
+                    "formatter": 0,
+                    "formatOptions": {
+                      "aggregation": "Count"
+                    },
+                    "numberFormat": {
+                      "unit": 17,
+                      "options": {
+                        "style": "decimal"
+                      }
+                    }
+                  },
+                  {
+                    "columnMatch": "UnauthorizedRequests",
+                    "formatter": 0,
+                    "formatOptions": {
+                      "aggregation": "Count"
+                    },
+                    "numberFormat": {
+                      "unit": 17,
+                      "options": {
+                        "style": "decimal"
+                      }
+                    }
+                  },
+                  {
+                    "columnMatch": "OtherRequests",
+                    "formatter": 0,
+                    "formatOptions": {
+                      "aggregation": "Count"
+                    },
+                    "numberFormat": {
+                      "unit": 17,
+                      "options": {
+                        "style": "decimal"
+                      }
+                    }
+                  },
+                  {
+                    "columnMatch": "TotalRequests",
+                    "formatter": 0,
+                    "formatOptions": {
+                      "aggregation": "Count"
+                    },
+                    "numberFormat": {
+                      "unit": 17,
+                      "options": {
+                        "style": "decimal"
+                      }
+                    }
+                  },
+                  {
+                    "columnMatch": "AverageResponseTime",
+                    "formatter": 0,
+                    "formatOptions": {
+                      "aggregation": "Average"
+                    },
+                    "numberFormat": {
+                      "unit": 23,
+                      "options": {
+                        "style": "decimal",
+                        "maximumFractionDigits": 2
+                      }
+                    }
+                  },
+                  {
+                    "columnMatch": "AverageServiceResponseTime",
+                    "formatter": 0,
+                    "formatOptions": {
+                      "aggregation": "Average"
+                    },
+                    "numberFormat": {
+                      "unit": 23,
+                      "options": {
+                        "style": "decimal",
+                        "maximumFractionDigits": 2
+                      }
+                    }
+                  },
+                  {
+                    "columnMatch": "DataTransfer",
+                    "formatter": 0,
+                    "numberFormat": {
+                      "unit": 2,
+                      "options": {
+                        "style": "decimal",
+                        "maximumFractionDigits": 2
+                      }
+                    }
+                  }
+                ],
+                "labelSettings": [
+                  {
+                    "columnId": "Api",
+                    "label": "API"
+                  },
+                  {
+                    "columnId": "SuccessfullRequests",
+                    "label": "Successful Requests"
+                  },
+                  {
+                    "columnId": "FailedRequests",
+                    "label": "Failed Requests"
+                  },
+                  {
+                    "columnId": "UnauthorizedRequests",
+                    "label": "Unauthorized Requests"
+                  },
+                  {
+                    "columnId": "OtherRequests",
+                    "label": "Other Requests"
+                  },
+                  {
+                    "columnId": "TotalRequests",
+                    "label": "Total Requests"
+                  }
+                ]
+              },
+              "sortBy": []
+            },
+            "name": "OperationsQuery"
+          }
+        ]
+      },
+      "conditionalVisibility": {
+        "parameterName": "tab",
+        "comparison": "isEqualTo",
+        "value": "operations"
+      },
+      "name": "Operations"
+    }
+  ],
+  "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
+}

--- a/Workbooks/Azure Logic Apps/FilteredServiceBus/FilteredServiceBus.workbook
+++ b/Workbooks/Azure Logic Apps/FilteredServiceBus/FilteredServiceBus.workbook
@@ -1,0 +1,2654 @@
+{
+  "version": "Notebook/1.0",
+  "items": [
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "crossComponentResources": [
+          "value::all"
+        ],
+        "parameters": [
+          {
+            "id": "448688ba-7539-4780-bba3-7efb5fd5ef81",
+            "version": "KqlParameterItem/1.0",
+            "name": "ServiceBusResource",
+            "type": 5,
+            "query": "resources\r\n| where type == \"microsoft.servicebus/namespaces\"\r\n| where (dynamic(\"{ServiceBus}\")) contains id",
+            "crossComponentResources": [
+              "value::all"
+            ],
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "timeContext": {
+              "durationMs": 86400000
+            },
+            "queryType": 1,
+            "resourceType": "microsoft.resourcegraph/resources",
+            "value": null
+          }
+        ],
+        "style": "pills",
+        "queryType": 1,
+        "resourceType": "microsoft.resourcegraph/resources"
+      },
+      "name": "sb-params-1"
+    },
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "parameters": [
+          {
+            "id": "182d6324-854c-4cc0-802a-de4f3bee9f76",
+            "version": "KqlParameterItem/1.0",
+            "name": "TimeRange",
+            "label": "Time range",
+            "type": 4,
+            "isRequired": true,
+            "value": {
+              "durationMs": 14400000
+            },
+            "typeSettings": {
+              "selectableValues": [
+                {
+                  "durationMs": 300000
+                },
+                {
+                  "durationMs": 900000
+                },
+                {
+                  "durationMs": 1800000
+                },
+                {
+                  "durationMs": 3600000
+                },
+                {
+                  "durationMs": 14400000
+                },
+                {
+                  "durationMs": 43200000
+                },
+                {
+                  "durationMs": 86400000
+                },
+                {
+                  "durationMs": 172800000
+                },
+                {
+                  "durationMs": 259200000
+                },
+                {
+                  "durationMs": 604800000
+                }
+              ],
+              "allowCustom": true
+            }
+          },
+          {
+            "id": "1160772a-8d4d-4a03-89d8-fe741f78a45d",
+            "version": "KqlParameterItem/1.0",
+            "name": "ServiceBusDictionaryFromUX",
+            "type": 1,
+            "value": "{ \t\"/subscriptions/test\": [\"test\", \"test\"], \t\"SB2\": [\"x\"] }"
+          },
+          {
+            "id": "a90e3519-65de-4775-9398-a02ff9cdad4c",
+            "version": "KqlParameterItem/1.0",
+            "name": "TopicsAndQueues",
+            "type": 9,
+            "multiSelect": true,
+            "quote": "'",
+            "delimiter": ",",
+            "query": "{\"version\":\"1.0.0\",\"content\":\"{ServiceBusDictionaryFromUX}\",\"transformers\":[{\"type\":\"jsonpath\",\"settings\":{\"tablePath\":\"$[\\\"{ServiceBusResource:id}\\\"]\",\"columns\":[]}}]}",
+            "queryType": 8
+          }
+        ],
+        "style": "above",
+        "queryType": 8
+      },
+      "name": "sb-params-2",
+      "styleSettings": {
+        "margin": "15px 0 0 0"
+      }
+    },
+    {
+      "type": 11,
+      "content": {
+        "version": "LinkItem/1.0",
+        "style": "tabs",
+        "links": [
+          {
+            "id": "0570ec01-d6bf-495e-a637-8baa17e5c3e3",
+            "cellValue": "selectedTab",
+            "linkTarget": "parameter",
+            "linkLabel": "Overview",
+            "subTarget": "Overview",
+            "style": "link"
+          },
+          {
+            "id": "0339c6cd-e2cb-459b-a09f-1c83640bdac9",
+            "cellValue": "selectedTab",
+            "linkTarget": "parameter",
+            "linkLabel": "Requests",
+            "subTarget": "Requests",
+            "style": "link"
+          },
+          {
+            "id": "6a954fb7-3294-43a5-8377-b44e6cf6ccba",
+            "cellValue": "selectedTab",
+            "linkTarget": "parameter",
+            "linkLabel": "Messages",
+            "subTarget": "Messages",
+            "style": "link"
+          }
+        ]
+      },
+      "name": "sbtabs",
+      "styleSettings": {
+        "margin": "-15px 0px -15px 0px"
+      }
+    },
+    {
+      "type": 12,
+      "content": {
+        "version": "NotebookGroup/1.0",
+        "groupType": "editable",
+        "items": [
+          {
+            "type": 12,
+            "content": {
+              "version": "NotebookGroup/1.0",
+              "groupType": "editable",
+              "items": [
+                {
+                  "type": 10,
+                  "content": {
+                    "chartId": "workbookcd69dced-b884-486e-bba0-793500f1fffe",
+                    "version": "MetricsItem/2.0",
+                    "size": 4,
+                    "chartType": -1,
+                    "resourceType": "microsoft.servicebus/namespaces",
+                    "metricScope": 0,
+                    "resourceParameter": "ServiceBusResource",
+                    "resourceIds": [
+                      "{ServiceBusResource}"
+                    ],
+                    "timeContextFromParameter": "TimeRange",
+                    "timeContext": {
+                      "durationMs": 14400000
+                    },
+                    "metrics": [
+                      {
+                        "namespace": "microsoft.servicebus/namespaces",
+                        "metric": "microsoft.servicebus/namespaces--ActiveConnections",
+                        "aggregation": 1,
+                        "columnName": "Active Connections (Sum)"
+                      },
+                      {
+                        "namespace": "microsoft.servicebus/namespaces",
+                        "metric": "microsoft.servicebus/namespaces--ConnectionsOpened",
+                        "aggregation": 1,
+                        "columnName": "Connections Opened (Sum)"
+                      },
+                      {
+                        "namespace": "microsoft.servicebus/namespaces",
+                        "metric": "microsoft.servicebus/namespaces--SuccessfulRequests",
+                        "aggregation": 1,
+                        "columnName": "Successful Requests (Sum)"
+                      },
+                      {
+                        "namespace": "microsoft.servicebus/namespaces",
+                        "metric": "microsoft.servicebus/namespaces--ThrottledRequests",
+                        "aggregation": 1,
+                        "columnName": "Throttled Requests (Sum)"
+                      },
+                      {
+                        "namespace": "microsoft.servicebus/namespaces",
+                        "metric": "microsoft.servicebus/namespaces--IncomingMessages",
+                        "aggregation": 1,
+                        "columnName": "Incoming Messages (Sum)"
+                      }
+                    ],
+                    "gridFormatType": 1,
+                    "tileSettings": {
+                      "titleContent": {
+                        "columnMatch": "Metric",
+                        "formatter": 1,
+                        "formatOptions": {}
+                      },
+                      "leftContent": {
+                        "columnMatch": "Value",
+                        "formatter": 12,
+                        "formatOptions": {
+                          "palette": "auto"
+                        },
+                        "numberFormat": {
+                          "unit": 17,
+                          "options": {
+                            "maximumSignificantDigits": 3,
+                            "maximumFractionDigits": 2
+                          }
+                        }
+                      },
+                      "showBorder": false
+                    },
+                    "filters": [
+                      {
+                        "id": "1",
+                        "key": "EntityName",
+                        "operator": 0,
+                        "valueParam": "TopicsAndQueues"
+                      }
+                    ],
+                    "gridSettings": {
+                      "rowLimit": 10000
+                    }
+                  },
+                  "name": "Summary Metrics"
+                },
+                {
+                  "type": 10,
+                  "content": {
+                    "chartId": "workbookbed4014b-7f7f-46fa-a61f-77e3221dd950",
+                    "version": "MetricsItem/2.0",
+                    "size": 0,
+                    "chartType": 2,
+                    "resourceType": "microsoft.servicebus/namespaces",
+                    "metricScope": 0,
+                    "resourceParameter": "ServiceBusResource",
+                    "resourceIds": [
+                      "{ServiceBusResource}"
+                    ],
+                    "timeContextFromParameter": "TimeRange",
+                    "timeContext": {
+                      "durationMs": 14400000
+                    },
+                    "metrics": [
+                      {
+                        "namespace": "microsoft.servicebus/namespaces",
+                        "metric": "microsoft.servicebus/namespaces--ActiveConnections",
+                        "aggregation": 1
+                      }
+                    ],
+                    "title": "Active Connections",
+                    "gridSettings": {
+                      "rowLimit": 10000
+                    }
+                  },
+                  "customWidth": "50",
+                  "showPin": true,
+                  "name": "Active Connections",
+                  "styleSettings": {
+                    "margin": "0 0 20px 0"
+                  }
+                },
+                {
+                  "type": 10,
+                  "content": {
+                    "chartId": "workbook31386dcc-67c5-43f4-8c51-4575a032886d",
+                    "version": "MetricsItem/2.0",
+                    "size": 0,
+                    "chartType": 2,
+                    "resourceType": "microsoft.servicebus/namespaces",
+                    "metricScope": 0,
+                    "resourceParameter": "ServiceBusResource",
+                    "resourceIds": [
+                      "{ServiceBusResource}"
+                    ],
+                    "timeContextFromParameter": "TimeRange",
+                    "timeContext": {
+                      "durationMs": 14400000
+                    },
+                    "metrics": [
+                      {
+                        "namespace": "microsoft.servicebus/namespaces",
+                        "metric": "microsoft.servicebus/namespaces--ConnectionsOpened",
+                        "aggregation": 1
+                      },
+                      {
+                        "namespace": "microsoft.servicebus/namespaces",
+                        "metric": "microsoft.servicebus/namespaces--ConnectionsClosed",
+                        "aggregation": 1
+                      }
+                    ],
+                    "title": "Connections Opened & Connections Closed",
+                    "filters": [
+                      {
+                        "id": "1",
+                        "key": "EntityName",
+                        "operator": 0,
+                        "valueParam": "TopicsAndQueues"
+                      }
+                    ],
+                    "gridSettings": {
+                      "rowLimit": 10000
+                    }
+                  },
+                  "customWidth": "50",
+                  "showPin": true,
+                  "name": "Connections Opened & Connections Closed",
+                  "styleSettings": {
+                    "margin": "0 0 20px 0"
+                  }
+                },
+                {
+                  "type": 10,
+                  "content": {
+                    "chartId": "workbookc1fd942c-b24b-4902-adc1-6e9975bc8ced",
+                    "version": "MetricsItem/2.0",
+                    "size": 0,
+                    "chartType": 2,
+                    "resourceType": "microsoft.servicebus/namespaces",
+                    "metricScope": 0,
+                    "resourceParameter": "ServiceBusResource",
+                    "resourceIds": [
+                      "{ServiceBusResource}"
+                    ],
+                    "timeContextFromParameter": "TimeRange",
+                    "timeContext": {
+                      "durationMs": 14400000
+                    },
+                    "metrics": [
+                      {
+                        "namespace": "microsoft.servicebus/namespaces",
+                        "metric": "microsoft.servicebus/namespaces--SuccessfulRequests",
+                        "aggregation": 1
+                      }
+                    ],
+                    "title": "Successful Requests",
+                    "filters": [
+                      {
+                        "id": "1",
+                        "key": "EntityName",
+                        "operator": 0,
+                        "valueParam": "TopicsAndQueues"
+                      }
+                    ],
+                    "gridSettings": {
+                      "rowLimit": 10000
+                    }
+                  },
+                  "customWidth": "50",
+                  "name": "Successful vs Throttled Requests",
+                  "styleSettings": {
+                    "margin": "0 0 20px 0"
+                  }
+                },
+                {
+                  "type": 10,
+                  "content": {
+                    "chartId": "workbookc1fd942c-b24b-4902-adc1-6e9975bc8ced",
+                    "version": "MetricsItem/2.0",
+                    "size": 0,
+                    "chartType": 2,
+                    "resourceType": "microsoft.servicebus/namespaces",
+                    "metricScope": 0,
+                    "resourceParameter": "ServiceBusResource",
+                    "resourceIds": [
+                      "{ServiceBusResource}"
+                    ],
+                    "timeContextFromParameter": "TimeRange",
+                    "timeContext": {
+                      "durationMs": 14400000
+                    },
+                    "metrics": [
+                      {
+                        "namespace": "microsoft.servicebus/namespaces",
+                        "metric": "microsoft.servicebus/namespaces--ThrottledRequests",
+                        "aggregation": 1
+                      }
+                    ],
+                    "title": "Throttled Requests",
+                    "filters": [
+                      {
+                        "id": "1",
+                        "key": "EntityName",
+                        "operator": 0,
+                        "valueParam": "TopicsAndQueues"
+                      }
+                    ],
+                    "gridSettings": {
+                      "rowLimit": 10000
+                    }
+                  },
+                  "customWidth": "50",
+                  "name": "Throttled Requests",
+                  "styleSettings": {
+                    "margin": "0 0 20px 0"
+                  }
+                },
+                {
+                  "type": 10,
+                  "content": {
+                    "chartId": "workbook87e7ac24-1637-40ca-8bf4-bf8f9d25a23c",
+                    "version": "MetricsItem/2.0",
+                    "size": 0,
+                    "chartType": 2,
+                    "resourceType": "microsoft.servicebus/namespaces",
+                    "metricScope": 0,
+                    "resourceParameter": "ServiceBusResource",
+                    "resourceIds": [
+                      "{ServiceBusResource}"
+                    ],
+                    "timeContextFromParameter": "TimeRange",
+                    "timeContext": {
+                      "durationMs": 14400000
+                    },
+                    "metrics": [
+                      {
+                        "namespace": "microsoft.servicebus/namespaces",
+                        "metric": "microsoft.servicebus/namespaces--IncomingMessages",
+                        "aggregation": 1
+                      },
+                      {
+                        "namespace": "microsoft.servicebus/namespaces",
+                        "metric": "microsoft.servicebus/namespaces--OutgoingMessages",
+                        "aggregation": 1
+                      }
+                    ],
+                    "title": "Incoming & Outgoing Messages",
+                    "filters": [
+                      {
+                        "id": "1",
+                        "key": "EntityName",
+                        "operator": 0,
+                        "valueParam": "TopicsAndQueues"
+                      }
+                    ],
+                    "gridSettings": {
+                      "rowLimit": 10000
+                    }
+                  },
+                  "customWidth": "50",
+                  "name": "Incoming & Outgoing Messages",
+                  "styleSettings": {
+                    "margin": "0 0 20px 0"
+                  }
+                }
+              ]
+            },
+            "conditionalVisibility": {
+              "parameterName": "selectedTab",
+              "comparison": "isEqualTo",
+              "value": "Overview"
+            },
+            "name": "Overview Tab"
+          },
+          {
+            "type": 12,
+            "content": {
+              "version": "NotebookGroup/1.0",
+              "groupType": "editable",
+              "items": [
+                {
+                  "type": 10,
+                  "content": {
+                    "chartId": "workbook317adf9d-7012-4a5e-8d72-c8cfdcaa9f96",
+                    "version": "MetricsItem/2.0",
+                    "size": 4,
+                    "chartType": -1,
+                    "resourceType": "microsoft.servicebus/namespaces",
+                    "metricScope": 0,
+                    "resourceParameter": "ServiceBusResource",
+                    "resourceIds": [
+                      "{ServiceBusResource}"
+                    ],
+                    "timeContextFromParameter": "TimeRange",
+                    "timeContext": {
+                      "durationMs": 0
+                    },
+                    "metrics": [
+                      {
+                        "namespace": "microsoft.servicebus/namespaces",
+                        "metric": "microsoft.servicebus/namespaces--IncomingRequests",
+                        "aggregation": 1,
+                        "columnName": "Incoming Requests (Sum)"
+                      },
+                      {
+                        "namespace": "microsoft.servicebus/namespaces",
+                        "metric": "microsoft.servicebus/namespaces--SuccessfulRequests",
+                        "aggregation": 1,
+                        "columnName": "Successful Requests (Sum)"
+                      },
+                      {
+                        "namespace": "microsoft.servicebus/namespaces",
+                        "metric": "microsoft.servicebus/namespaces--ServerErrors",
+                        "aggregation": 1,
+                        "columnName": "Server Errors (Sum)"
+                      },
+                      {
+                        "namespace": "microsoft.servicebus/namespaces",
+                        "metric": "microsoft.servicebus/namespaces--UserErrors",
+                        "aggregation": 1,
+                        "columnName": "User Errors (Sum)"
+                      },
+                      {
+                        "namespace": "microsoft.servicebus/namespaces",
+                        "metric": "microsoft.servicebus/namespaces--ThrottledRequests",
+                        "aggregation": 1,
+                        "columnName": "Throttled Requests (Sum)"
+                      }
+                    ],
+                    "gridFormatType": 1,
+                    "tileSettings": {
+                      "titleContent": {
+                        "columnMatch": "Metric",
+                        "formatter": 1,
+                        "formatOptions": {}
+                      },
+                      "leftContent": {
+                        "columnMatch": "Value",
+                        "formatter": 12,
+                        "formatOptions": {
+                          "palette": "auto"
+                        },
+                        "numberFormat": {
+                          "unit": 17,
+                          "options": {
+                            "maximumSignificantDigits": 3,
+                            "maximumFractionDigits": 2
+                          }
+                        }
+                      },
+                      "showBorder": false
+                    },
+                    "filters": [
+                      {
+                        "id": "1",
+                        "key": "EntityName",
+                        "operator": 0,
+                        "valueParam": "TopicsAndQueues"
+                      }
+                    ],
+                    "gridSettings": {
+                      "rowLimit": 10000
+                    }
+                  },
+                  "name": "Summary Metrics"
+                },
+                {
+                  "type": 10,
+                  "content": {
+                    "chartId": "workbookb787c19d-e2b5-4147-93af-2c7abd825275",
+                    "version": "MetricsItem/2.0",
+                    "size": 1,
+                    "chartType": 0,
+                    "resourceType": "microsoft.servicebus/namespaces",
+                    "metricScope": 0,
+                    "resourceParameter": "ServiceBusResource",
+                    "resourceIds": [
+                      "{ServiceBusResource}"
+                    ],
+                    "timeContextFromParameter": "TimeRange",
+                    "timeContext": {
+                      "durationMs": 0
+                    },
+                    "metrics": [
+                      {
+                        "namespace": "microsoft.servicebus/namespaces",
+                        "metric": "microsoft.servicebus/namespaces--IncomingRequests",
+                        "aggregation": 1,
+                        "splitBy": "EntityName",
+                        "splitBySortOrder": 2,
+                        "splitByLimit": 5
+                      },
+                      {
+                        "namespace": "microsoft.servicebus/namespaces",
+                        "metric": "microsoft.servicebus/namespaces--SuccessfulRequests",
+                        "aggregation": 1,
+                        "splitBy": "EntityName",
+                        "splitBySortOrder": 2,
+                        "splitByLimit": 5
+                      },
+                      {
+                        "namespace": "microsoft.servicebus/namespaces",
+                        "metric": "microsoft.servicebus/namespaces--ServerErrors",
+                        "aggregation": 1,
+                        "splitBy": "EntityName",
+                        "splitBySortOrder": 2,
+                        "splitByLimit": 5
+                      },
+                      {
+                        "namespace": "microsoft.servicebus/namespaces",
+                        "metric": "microsoft.servicebus/namespaces--UserErrors",
+                        "aggregation": 1,
+                        "splitBy": "EntityName",
+                        "splitBySortOrder": 2,
+                        "splitByLimit": 5
+                      },
+                      {
+                        "namespace": "microsoft.servicebus/namespaces",
+                        "metric": "microsoft.servicebus/namespaces--ThrottledRequests",
+                        "aggregation": 1,
+                        "splitBy": "EntityName",
+                        "splitBySortOrder": 2,
+                        "splitByLimit": 5
+                      }
+                    ],
+                    "title": "Summary Metrics - Resource & Segment",
+                    "gridFormatType": 2,
+                    "filters": [
+                      {
+                        "id": "1",
+                        "key": "EntityName",
+                        "operator": 0,
+                        "valueParam": "TopicsAndQueues"
+                      }
+                    ],
+                    "gridSettings": {
+                      "formatters": [
+                        {
+                          "columnMatch": "$gen_group",
+                          "formatter": 13,
+                          "formatOptions": {
+                            "linkTarget": null,
+                            "showIcon": true
+                          }
+                        },
+                        {
+                          "columnMatch": "Subscription",
+                          "formatter": 5,
+                          "formatOptions": {}
+                        },
+                        {
+                          "columnMatch": "Name",
+                          "formatter": 5,
+                          "formatOptions": {}
+                        },
+                        {
+                          "columnMatch": "Segment",
+                          "formatter": 5,
+                          "formatOptions": {}
+                        },
+                        {
+                          "columnMatch": "microsoft.servicebus/namespaces--IncomingRequests",
+                          "formatter": 8,
+                          "formatOptions": {
+                            "min": 0,
+                            "palette": "blue",
+                            "aggregation": "Sum"
+                          },
+                          "numberFormat": {
+                            "unit": 17,
+                            "options": {
+                              "style": "decimal",
+                              "useGrouping": false,
+                              "maximumFractionDigits": 1
+                            },
+                            "emptyValCustomText": "-"
+                          }
+                        },
+                        {
+                          "columnMatch": "microsoft.servicebus/namespaces--IncomingRequests Timeline",
+                          "formatter": 21,
+                          "formatOptions": {
+                            "min": 0,
+                            "palette": "blue",
+                            "aggregation": "Sum"
+                          },
+                          "numberFormat": {
+                            "unit": 17,
+                            "options": {
+                              "style": "decimal",
+                              "maximumFractionDigits": 1
+                            },
+                            "emptyValCustomText": "-"
+                          }
+                        },
+                        {
+                          "columnMatch": "microsoft.servicebus/namespaces--SuccessfulRequests",
+                          "formatter": 8,
+                          "formatOptions": {
+                            "min": 0,
+                            "palette": "blue",
+                            "aggregation": "Sum"
+                          },
+                          "numberFormat": {
+                            "unit": 17,
+                            "options": {
+                              "style": "decimal",
+                              "maximumFractionDigits": 1
+                            },
+                            "emptyValCustomText": "-"
+                          }
+                        },
+                        {
+                          "columnMatch": "microsoft.servicebus/namespaces--SuccessfulRequests Timeline",
+                          "formatter": 21,
+                          "formatOptions": {
+                            "min": 0,
+                            "palette": "blue",
+                            "aggregation": "Sum"
+                          },
+                          "numberFormat": {
+                            "unit": 17,
+                            "options": {
+                              "style": "decimal",
+                              "maximumFractionDigits": 1
+                            },
+                            "emptyValCustomText": "-"
+                          }
+                        },
+                        {
+                          "columnMatch": "microsoft.servicebus/namespaces--ServerErrors",
+                          "formatter": 4,
+                          "formatOptions": {
+                            "min": 0,
+                            "palette": "blue",
+                            "aggregation": "Sum"
+                          },
+                          "numberFormat": {
+                            "unit": 17,
+                            "options": {
+                              "style": "decimal",
+                              "maximumFractionDigits": 1
+                            },
+                            "emptyValCustomText": "-"
+                          }
+                        },
+                        {
+                          "columnMatch": "microsoft.servicebus/namespaces--ServerErrors Timeline",
+                          "formatter": 5,
+                          "formatOptions": {}
+                        },
+                        {
+                          "columnMatch": "microsoft.servicebus/namespaces--UserErrors",
+                          "formatter": 4,
+                          "formatOptions": {
+                            "min": 0,
+                            "palette": "blue",
+                            "aggregation": "Sum"
+                          },
+                          "numberFormat": {
+                            "unit": 17,
+                            "options": {
+                              "style": "decimal",
+                              "maximumFractionDigits": 1
+                            },
+                            "emptyValCustomText": "-"
+                          }
+                        },
+                        {
+                          "columnMatch": "microsoft.servicebus/namespaces--UserErrors Timeline",
+                          "formatter": 5,
+                          "formatOptions": {}
+                        },
+                        {
+                          "columnMatch": "microsoft.servicebus/namespaces--ThrottledRequests",
+                          "formatter": 4,
+                          "formatOptions": {
+                            "min": 0,
+                            "palette": "blue",
+                            "aggregation": "Sum"
+                          },
+                          "numberFormat": {
+                            "unit": 17,
+                            "options": {
+                              "style": "decimal",
+                              "maximumFractionDigits": 1
+                            },
+                            "emptyValCustomText": "-"
+                          }
+                        },
+                        {
+                          "columnMatch": "microsoft.servicebus/namespaces--ThrottledRequests Timeline",
+                          "formatter": 5,
+                          "formatOptions": {}
+                        }
+                      ],
+                      "rowLimit": 10000,
+                      "hierarchySettings": {
+                        "treeType": 1,
+                        "groupBy": [
+                          "Name"
+                        ],
+                        "expandTopLevel": true,
+                        "finalBy": "Segment"
+                      },
+                      "labelSettings": [
+                        {
+                          "columnId": "microsoft.servicebus/namespaces--IncomingRequests",
+                          "label": "Incoming Requests (Sum)"
+                        },
+                        {
+                          "columnId": "microsoft.servicebus/namespaces--IncomingRequests Timeline",
+                          "label": "Incoming Requests (Sum) Timeline"
+                        },
+                        {
+                          "columnId": "microsoft.servicebus/namespaces--SuccessfulRequests",
+                          "label": "Successful Requests (Sum)"
+                        },
+                        {
+                          "columnId": "microsoft.servicebus/namespaces--SuccessfulRequests Timeline",
+                          "label": "Successful Requests (Sum) Timeline"
+                        },
+                        {
+                          "columnId": "microsoft.servicebus/namespaces--ServerErrors",
+                          "label": "Server Errors. (Sum)"
+                        },
+                        {
+                          "columnId": "microsoft.servicebus/namespaces--ServerErrors Timeline",
+                          "label": "Server Errors. (Sum) Timeline"
+                        },
+                        {
+                          "columnId": "microsoft.servicebus/namespaces--UserErrors",
+                          "label": "User Errors. (Sum)"
+                        },
+                        {
+                          "columnId": "microsoft.servicebus/namespaces--UserErrors Timeline",
+                          "label": "User Errors. (Sum) Timeline"
+                        },
+                        {
+                          "columnId": "microsoft.servicebus/namespaces--ThrottledRequests",
+                          "label": "Throttled Requests. (Sum)"
+                        },
+                        {
+                          "columnId": "microsoft.servicebus/namespaces--ThrottledRequests Timeline",
+                          "label": "Throttled Requests. (Sum) Timeline"
+                        }
+                      ]
+                    }
+                  },
+                  "name": "Summary Metrics - Resource & Segment"
+                },
+                {
+                  "type": 10,
+                  "content": {
+                    "chartId": "workbook40ac9447-01b4-44bb-8de7-b7ca3e1d2377",
+                    "version": "MetricsItem/2.0",
+                    "size": 0,
+                    "chartType": 2,
+                    "resourceType": "microsoft.servicebus/namespaces",
+                    "metricScope": 0,
+                    "resourceParameter": "ServiceBusResource",
+                    "resourceIds": [
+                      "{ServiceBusResource}"
+                    ],
+                    "timeContextFromParameter": "TimeRange",
+                    "timeContext": {
+                      "durationMs": 0
+                    },
+                    "metrics": [
+                      {
+                        "namespace": "microsoft.servicebus/namespaces",
+                        "metric": "microsoft.servicebus/namespaces--IncomingRequests",
+                        "aggregation": 1,
+                        "splitBy": null
+                      }
+                    ],
+                    "title": "Incoming Requests",
+                    "filters": [
+                      {
+                        "id": "1",
+                        "key": "EntityName",
+                        "operator": 0,
+                        "valueParam": "TopicsAndQueues"
+                      }
+                    ],
+                    "gridSettings": {
+                      "rowLimit": 10000
+                    }
+                  },
+                  "customWidth": "50",
+                  "name": "Incoming Requests",
+                  "styleSettings": {
+                    "margin": "0 0 20px 0"
+                  }
+                },
+                {
+                  "type": 10,
+                  "content": {
+                    "chartId": "workbook40ac9447-01b4-44bb-8de7-b7ca3e1d2377",
+                    "version": "MetricsItem/2.0",
+                    "size": 0,
+                    "chartType": 2,
+                    "resourceType": "microsoft.servicebus/namespaces",
+                    "metricScope": 0,
+                    "resourceParameter": "ServiceBusResource",
+                    "resourceIds": [
+                      "{ServiceBusResource}"
+                    ],
+                    "timeContextFromParameter": "TimeRange",
+                    "timeContext": {
+                      "durationMs": 0
+                    },
+                    "metrics": [
+                      {
+                        "namespace": "microsoft.servicebus/namespaces",
+                        "metric": "microsoft.servicebus/namespaces--IncomingRequests",
+                        "aggregation": 1,
+                        "splitBy": "EntityName"
+                      }
+                    ],
+                    "title": "Incoming Requests - by Segment",
+                    "filters": [
+                      {
+                        "id": "1",
+                        "key": "EntityName",
+                        "operator": 0,
+                        "valueParam": "TopicsAndQueues"
+                      }
+                    ],
+                    "gridSettings": {
+                      "rowLimit": 10000
+                    }
+                  },
+                  "customWidth": "50",
+                  "name": "Incoming Requests - by Segment",
+                  "styleSettings": {
+                    "margin": "0 0 20px 0"
+                  }
+                },
+                {
+                  "type": 10,
+                  "content": {
+                    "chartId": "workbook40ac9447-01b4-44bb-8de7-b7ca3e1d2377",
+                    "version": "MetricsItem/2.0",
+                    "size": 0,
+                    "chartType": 2,
+                    "resourceType": "microsoft.servicebus/namespaces",
+                    "metricScope": 0,
+                    "resourceParameter": "ServiceBusResource",
+                    "resourceIds": [
+                      "{ServiceBusResource}"
+                    ],
+                    "timeContextFromParameter": "TimeRange",
+                    "timeContext": {
+                      "durationMs": 0
+                    },
+                    "metrics": [
+                      {
+                        "namespace": "microsoft.servicebus/namespaces",
+                        "metric": "microsoft.servicebus/namespaces--SuccessfulRequests",
+                        "aggregation": 1,
+                        "splitBy": null
+                      }
+                    ],
+                    "title": "Successful Requests",
+                    "filters": [
+                      {
+                        "id": "1",
+                        "key": "EntityName",
+                        "operator": 0,
+                        "valueParam": "TopicsAndQueues"
+                      }
+                    ],
+                    "gridSettings": {
+                      "rowLimit": 10000
+                    }
+                  },
+                  "customWidth": "50",
+                  "name": "Successful Requests",
+                  "styleSettings": {
+                    "margin": "0 0 20px 0"
+                  }
+                },
+                {
+                  "type": 10,
+                  "content": {
+                    "chartId": "workbook40ac9447-01b4-44bb-8de7-b7ca3e1d2377",
+                    "version": "MetricsItem/2.0",
+                    "size": 0,
+                    "chartType": 2,
+                    "resourceType": "microsoft.servicebus/namespaces",
+                    "metricScope": 0,
+                    "resourceParameter": "ServiceBusResource",
+                    "resourceIds": [
+                      "{ServiceBusResource}"
+                    ],
+                    "timeContextFromParameter": "TimeRange",
+                    "timeContext": {
+                      "durationMs": 0
+                    },
+                    "metrics": [
+                      {
+                        "namespace": "microsoft.servicebus/namespaces",
+                        "metric": "microsoft.servicebus/namespaces--SuccessfulRequests",
+                        "aggregation": 1,
+                        "splitBy": "EntityName"
+                      }
+                    ],
+                    "title": "Successful Requests - By Segment",
+                    "filters": [
+                      {
+                        "id": "1",
+                        "key": "EntityName",
+                        "operator": 0,
+                        "valueParam": "TopicsAndQueues"
+                      }
+                    ],
+                    "gridSettings": {
+                      "rowLimit": 10000
+                    }
+                  },
+                  "customWidth": "50",
+                  "name": "Successful Requests - By Segment",
+                  "styleSettings": {
+                    "margin": "0 0 20px 0"
+                  }
+                },
+                {
+                  "type": 10,
+                  "content": {
+                    "chartId": "workbook40ac9447-01b4-44bb-8de7-b7ca3e1d2377",
+                    "version": "MetricsItem/2.0",
+                    "size": 0,
+                    "chartType": 2,
+                    "resourceType": "microsoft.servicebus/namespaces",
+                    "metricScope": 0,
+                    "resourceParameter": "ServiceBusResource",
+                    "resourceIds": [
+                      "{ServiceBusResource}"
+                    ],
+                    "timeContextFromParameter": "TimeRange",
+                    "timeContext": {
+                      "durationMs": 0
+                    },
+                    "metrics": [
+                      {
+                        "namespace": "microsoft.servicebus/namespaces",
+                        "metric": "microsoft.servicebus/namespaces--ServerErrors",
+                        "aggregation": 1,
+                        "splitBy": null
+                      }
+                    ],
+                    "title": "Server Errors",
+                    "filters": [
+                      {
+                        "id": "1",
+                        "key": "EntityName",
+                        "operator": 0,
+                        "valueParam": "TopicsAndQueues"
+                      }
+                    ],
+                    "gridSettings": {
+                      "rowLimit": 10000
+                    }
+                  },
+                  "customWidth": "50",
+                  "name": "Server Errors",
+                  "styleSettings": {
+                    "margin": "0 0 20px 0"
+                  }
+                },
+                {
+                  "type": 10,
+                  "content": {
+                    "chartId": "workbook40ac9447-01b4-44bb-8de7-b7ca3e1d2377",
+                    "version": "MetricsItem/2.0",
+                    "size": 0,
+                    "chartType": 2,
+                    "resourceType": "microsoft.servicebus/namespaces",
+                    "metricScope": 0,
+                    "resourceParameter": "ServiceBusResource",
+                    "resourceIds": [
+                      "{ServiceBusResource}"
+                    ],
+                    "timeContextFromParameter": "TimeRange",
+                    "timeContext": {
+                      "durationMs": 0
+                    },
+                    "metrics": [
+                      {
+                        "namespace": "microsoft.servicebus/namespaces",
+                        "metric": "microsoft.servicebus/namespaces--ServerErrors",
+                        "aggregation": 1,
+                        "splitBy": "EntityName"
+                      }
+                    ],
+                    "title": "Server Errors - By Segment",
+                    "filters": [
+                      {
+                        "id": "1",
+                        "key": "EntityName",
+                        "operator": 0,
+                        "valueParam": "TopicsAndQueues"
+                      }
+                    ],
+                    "gridSettings": {
+                      "rowLimit": 10000
+                    }
+                  },
+                  "customWidth": "50",
+                  "name": "Server Errors - By Segment",
+                  "styleSettings": {
+                    "margin": "0 0 20px 0"
+                  }
+                },
+                {
+                  "type": 10,
+                  "content": {
+                    "chartId": "workbook40ac9447-01b4-44bb-8de7-b7ca3e1d2377",
+                    "version": "MetricsItem/2.0",
+                    "size": 0,
+                    "chartType": 2,
+                    "resourceType": "microsoft.servicebus/namespaces",
+                    "metricScope": 0,
+                    "resourceParameter": "ServiceBusResource",
+                    "resourceIds": [
+                      "{ServiceBusResource}"
+                    ],
+                    "timeContextFromParameter": "TimeRange",
+                    "timeContext": {
+                      "durationMs": 0
+                    },
+                    "metrics": [
+                      {
+                        "namespace": "microsoft.servicebus/namespaces",
+                        "metric": "microsoft.servicebus/namespaces--UserErrors",
+                        "aggregation": 1,
+                        "splitBy": null
+                      }
+                    ],
+                    "title": "User Errors",
+                    "filters": [
+                      {
+                        "id": "1",
+                        "key": "EntityName",
+                        "operator": 0,
+                        "valueParam": "TopicsAndQueues"
+                      }
+                    ],
+                    "gridSettings": {
+                      "rowLimit": 10000
+                    }
+                  },
+                  "customWidth": "50",
+                  "name": "User Errors",
+                  "styleSettings": {
+                    "margin": "0 0 20px 0"
+                  }
+                },
+                {
+                  "type": 10,
+                  "content": {
+                    "chartId": "workbook40ac9447-01b4-44bb-8de7-b7ca3e1d2377",
+                    "version": "MetricsItem/2.0",
+                    "size": 0,
+                    "chartType": 2,
+                    "resourceType": "microsoft.servicebus/namespaces",
+                    "metricScope": 0,
+                    "resourceParameter": "ServiceBusResource",
+                    "resourceIds": [
+                      "{ServiceBusResource}"
+                    ],
+                    "timeContextFromParameter": "TimeRange",
+                    "timeContext": {
+                      "durationMs": 0
+                    },
+                    "metrics": [
+                      {
+                        "namespace": "microsoft.servicebus/namespaces",
+                        "metric": "microsoft.servicebus/namespaces--UserErrors",
+                        "aggregation": 1,
+                        "splitBy": "EntityName"
+                      }
+                    ],
+                    "title": "User Errors - By Segment",
+                    "filters": [
+                      {
+                        "id": "1",
+                        "key": "EntityName",
+                        "operator": 0,
+                        "valueParam": "TopicsAndQueues"
+                      }
+                    ],
+                    "gridSettings": {
+                      "rowLimit": 10000
+                    }
+                  },
+                  "customWidth": "50",
+                  "name": "User Errors - By Segment",
+                  "styleSettings": {
+                    "margin": "0 0 20px 0"
+                  }
+                },
+                {
+                  "type": 10,
+                  "content": {
+                    "chartId": "workbook40ac9447-01b4-44bb-8de7-b7ca3e1d2377",
+                    "version": "MetricsItem/2.0",
+                    "size": 0,
+                    "chartType": 2,
+                    "resourceType": "microsoft.servicebus/namespaces",
+                    "metricScope": 0,
+                    "resourceParameter": "ServiceBusResource",
+                    "resourceIds": [
+                      "{ServiceBusResource}"
+                    ],
+                    "timeContextFromParameter": "TimeRange",
+                    "timeContext": {
+                      "durationMs": 0
+                    },
+                    "metrics": [
+                      {
+                        "namespace": "microsoft.servicebus/namespaces",
+                        "metric": "microsoft.servicebus/namespaces--ThrottledRequests",
+                        "aggregation": 1,
+                        "splitBy": null
+                      }
+                    ],
+                    "title": "Throttled Requests",
+                    "filters": [
+                      {
+                        "id": "1",
+                        "key": "EntityName",
+                        "operator": 0,
+                        "valueParam": "TopicsAndQueues"
+                      }
+                    ],
+                    "gridSettings": {
+                      "rowLimit": 10000
+                    }
+                  },
+                  "customWidth": "50",
+                  "name": "Throttled Requests",
+                  "styleSettings": {
+                    "margin": "0 0 20px 0"
+                  }
+                },
+                {
+                  "type": 10,
+                  "content": {
+                    "chartId": "workbook40ac9447-01b4-44bb-8de7-b7ca3e1d2377",
+                    "version": "MetricsItem/2.0",
+                    "size": 0,
+                    "chartType": 2,
+                    "resourceType": "microsoft.servicebus/namespaces",
+                    "metricScope": 0,
+                    "resourceParameter": "ServiceBusResource",
+                    "resourceIds": [
+                      "{ServiceBusResource}"
+                    ],
+                    "timeContextFromParameter": "TimeRange",
+                    "timeContext": {
+                      "durationMs": 0
+                    },
+                    "metrics": [
+                      {
+                        "namespace": "microsoft.servicebus/namespaces",
+                        "metric": "microsoft.servicebus/namespaces--ThrottledRequests",
+                        "aggregation": 1,
+                        "splitBy": "EntityName"
+                      }
+                    ],
+                    "title": "Throttled Requests - By Segment",
+                    "gridSettings": {
+                      "rowLimit": 10000
+                    }
+                  },
+                  "customWidth": "50",
+                  "name": "Throttled Requests - By Segment",
+                  "styleSettings": {
+                    "margin": "0 0 20px 0"
+                  }
+                }
+              ]
+            },
+            "conditionalVisibility": {
+              "parameterName": "selectedTab",
+              "comparison": "isEqualTo",
+              "value": "Requests"
+            },
+            "name": "Requests Tab"
+          },
+          {
+            "type": 12,
+            "content": {
+              "version": "NotebookGroup/1.0",
+              "groupType": "editable",
+              "items": [
+                {
+                  "type": 10,
+                  "content": {
+                    "chartId": "workbook166063ac-eae0-4d36-88a5-c7c326d068b3",
+                    "version": "MetricsItem/2.0",
+                    "size": 4,
+                    "chartType": -1,
+                    "resourceType": "microsoft.servicebus/namespaces",
+                    "metricScope": 0,
+                    "resourceParameter": "ServiceBusResource",
+                    "resourceIds": [
+                      "{ServiceBusResource}"
+                    ],
+                    "timeContextFromParameter": "TimeRange",
+                    "timeContext": {
+                      "durationMs": 0
+                    },
+                    "metrics": [
+                      {
+                        "namespace": "microsoft.servicebus/namespaces",
+                        "metric": "microsoft.servicebus/namespaces--IncomingMessages",
+                        "aggregation": 1,
+                        "columnName": "Incoming Mesages (Sum)"
+                      },
+                      {
+                        "namespace": "microsoft.servicebus/namespaces",
+                        "metric": "microsoft.servicebus/namespaces--OutgoingMessages",
+                        "aggregation": 1,
+                        "columnName": "Outgoing Messages (Sum)"
+                      },
+                      {
+                        "namespace": "microsoft.servicebus/namespaces",
+                        "metric": "microsoft.servicebus/namespaces--Messages",
+                        "aggregation": 4,
+                        "columnName": "Messages in Queue/Topic (Avg)"
+                      },
+                      {
+                        "namespace": "microsoft.servicebus/namespaces",
+                        "metric": "microsoft.servicebus/namespaces--ActiveMessages",
+                        "aggregation": 4,
+                        "columnName": "Active Messages in Queue/Topic (Avg)"
+                      },
+                      {
+                        "namespace": "microsoft.servicebus/namespaces",
+                        "metric": "microsoft.servicebus/namespaces--ScheduledMessages",
+                        "aggregation": 4,
+                        "columnName": "Scheduled Messages in Queue/Topic (Avg)"
+                      },
+                      {
+                        "namespace": "microsoft.servicebus/namespaces",
+                        "metric": "microsoft.servicebus/namespaces--DeadletteredMessages",
+                        "aggregation": 4,
+                        "columnName": "Dead-Lettered Messages (Sum)"
+                      }
+                    ],
+                    "gridFormatType": 1,
+                    "tileSettings": {
+                      "titleContent": {
+                        "columnMatch": "Metric",
+                        "formatter": 1,
+                        "formatOptions": {}
+                      },
+                      "leftContent": {
+                        "columnMatch": "Value",
+                        "formatter": 12,
+                        "formatOptions": {
+                          "palette": "auto"
+                        },
+                        "numberFormat": {
+                          "unit": 17,
+                          "options": {
+                            "maximumSignificantDigits": 3,
+                            "maximumFractionDigits": 2
+                          }
+                        }
+                      },
+                      "showBorder": false,
+                      "size": "auto"
+                    },
+                    "filters": [
+                      {
+                        "id": "1",
+                        "key": "EntityName",
+                        "operator": 0,
+                        "valueParam": "TopicsAndQueues"
+                      }
+                    ],
+                    "gridSettings": {
+                      "rowLimit": 10000
+                    }
+                  },
+                  "name": "Summary Metrics"
+                },
+                {
+                  "type": 10,
+                  "content": {
+                    "chartId": "workbookb787c19d-e2b5-4147-93af-2c7abd825275",
+                    "version": "MetricsItem/2.0",
+                    "size": 1,
+                    "chartType": 0,
+                    "resourceType": "microsoft.servicebus/namespaces",
+                    "metricScope": 0,
+                    "resourceParameter": "ServiceBusResource",
+                    "resourceIds": [
+                      "{ServiceBusResource}"
+                    ],
+                    "timeContextFromParameter": "TimeRange",
+                    "timeContext": {
+                      "durationMs": 0
+                    },
+                    "metrics": [
+                      {
+                        "namespace": "microsoft.servicebus/namespaces",
+                        "metric": "microsoft.servicebus/namespaces--IncomingMessages",
+                        "aggregation": 1,
+                        "splitBy": "EntityName",
+                        "splitBySortOrder": 2,
+                        "splitByLimit": 5
+                      },
+                      {
+                        "namespace": "microsoft.servicebus/namespaces",
+                        "metric": "microsoft.servicebus/namespaces--OutgoingMessages",
+                        "aggregation": 1,
+                        "splitBy": "EntityName",
+                        "splitBySortOrder": 2,
+                        "splitByLimit": 5
+                      },
+                      {
+                        "namespace": "microsoft.servicebus/namespaces",
+                        "metric": "microsoft.servicebus/namespaces--Messages",
+                        "aggregation": 4,
+                        "splitBy": "EntityName",
+                        "splitBySortOrder": 2,
+                        "splitByLimit": 5
+                      },
+                      {
+                        "namespace": "microsoft.servicebus/namespaces",
+                        "metric": "microsoft.servicebus/namespaces--ActiveMessages",
+                        "aggregation": 4,
+                        "splitBy": "EntityName",
+                        "splitBySortOrder": 2,
+                        "splitByLimit": 5
+                      },
+                      {
+                        "namespace": "microsoft.servicebus/namespaces",
+                        "metric": "microsoft.servicebus/namespaces--ScheduledMessages",
+                        "aggregation": 4,
+                        "splitBy": "EntityName",
+                        "splitBySortOrder": 2,
+                        "splitByLimit": 5
+                      },
+                      {
+                        "namespace": "microsoft.servicebus/namespaces",
+                        "metric": "microsoft.servicebus/namespaces--DeadletteredMessages",
+                        "aggregation": 4
+                      }
+                    ],
+                    "title": "Summary Metrics - Resource & Segment",
+                    "gridFormatType": 2,
+                    "filters": [
+                      {
+                        "id": "1",
+                        "key": "EntityName",
+                        "operator": 0,
+                        "valueParam": "TopicsAndQueues"
+                      }
+                    ],
+                    "gridSettings": {
+                      "formatters": [
+                        {
+                          "columnMatch": "$gen_group",
+                          "formatter": 13,
+                          "formatOptions": {
+                            "linkTarget": null,
+                            "showIcon": true
+                          }
+                        },
+                        {
+                          "columnMatch": "Subscription",
+                          "formatter": 5,
+                          "formatOptions": {}
+                        },
+                        {
+                          "columnMatch": "Name",
+                          "formatter": 5,
+                          "formatOptions": {}
+                        },
+                        {
+                          "columnMatch": "Segment",
+                          "formatter": 5,
+                          "formatOptions": {}
+                        },
+                        {
+                          "columnMatch": "microsoft.servicebus/namespaces--IncomingMessages",
+                          "formatter": 8,
+                          "formatOptions": {
+                            "min": 0,
+                            "palette": "blue",
+                            "aggregation": "Sum"
+                          },
+                          "numberFormat": {
+                            "unit": 17,
+                            "options": {
+                              "style": "decimal",
+                              "useGrouping": false,
+                              "maximumFractionDigits": 1
+                            },
+                            "emptyValCustomText": "-"
+                          }
+                        },
+                        {
+                          "columnMatch": "microsoft.servicebus/namespaces--IncomingMessages Timeline",
+                          "formatter": 21,
+                          "formatOptions": {
+                            "min": 0,
+                            "palette": "blue",
+                            "aggregation": "Sum"
+                          },
+                          "numberFormat": {
+                            "unit": 17,
+                            "options": {
+                              "style": "decimal",
+                              "maximumFractionDigits": 1
+                            },
+                            "emptyValCustomText": "-"
+                          }
+                        },
+                        {
+                          "columnMatch": "microsoft.servicebus/namespaces--OutgoingMessages",
+                          "formatter": 8,
+                          "formatOptions": {
+                            "min": 0,
+                            "palette": "blue",
+                            "aggregation": "Sum"
+                          },
+                          "numberFormat": {
+                            "unit": 17,
+                            "options": {
+                              "style": "decimal",
+                              "maximumFractionDigits": 1
+                            },
+                            "emptyValCustomText": "-"
+                          }
+                        },
+                        {
+                          "columnMatch": "microsoft.servicebus/namespaces--OutgoingMessages Timeline",
+                          "formatter": 5,
+                          "formatOptions": {}
+                        },
+                        {
+                          "columnMatch": "microsoft.servicebus/namespaces--Messages",
+                          "formatter": 4,
+                          "formatOptions": {
+                            "palette": "blue",
+                            "aggregation": "Sum"
+                          },
+                          "numberFormat": {
+                            "unit": 17,
+                            "options": {
+                              "style": "decimal",
+                              "maximumFractionDigits": 1
+                            },
+                            "emptyValCustomText": "-"
+                          }
+                        },
+                        {
+                          "columnMatch": "microsoft.servicebus/namespaces--Messages Timeline",
+                          "formatter": 5,
+                          "formatOptions": {
+                            "aggregation": "Sum"
+                          },
+                          "numberFormat": {
+                            "unit": 17,
+                            "options": {
+                              "style": "decimal",
+                              "maximumFractionDigits": 1
+                            }
+                          }
+                        },
+                        {
+                          "columnMatch": "microsoft.servicebus/namespaces--ActiveMessages",
+                          "formatter": 4,
+                          "formatOptions": {
+                            "min": 0,
+                            "palette": "blue",
+                            "aggregation": "Sum"
+                          },
+                          "numberFormat": {
+                            "unit": 17,
+                            "options": {
+                              "style": "decimal",
+                              "maximumFractionDigits": 1
+                            },
+                            "emptyValCustomText": "-"
+                          }
+                        },
+                        {
+                          "columnMatch": "microsoft.servicebus/namespaces--ActiveMessages Timeline",
+                          "formatter": 5,
+                          "formatOptions": {}
+                        },
+                        {
+                          "columnMatch": "microsoft.servicebus/namespaces--ScheduledMessages",
+                          "formatter": 4,
+                          "formatOptions": {
+                            "min": 0,
+                            "palette": "blue",
+                            "aggregation": "Sum"
+                          },
+                          "numberFormat": {
+                            "unit": 17,
+                            "options": {
+                              "style": "decimal",
+                              "maximumFractionDigits": 1
+                            },
+                            "emptyValCustomText": "-"
+                          }
+                        },
+                        {
+                          "columnMatch": "microsoft.servicebus/namespaces--ScheduledMessages Timeline",
+                          "formatter": 5,
+                          "formatOptions": {}
+                        },
+                        {
+                          "columnMatch": "microsoft.servicebus/namespaces--DeadletteredMessages",
+                          "formatter": 4,
+                          "formatOptions": {
+                            "min": 0,
+                            "palette": "blue",
+                            "aggregation": "Sum"
+                          },
+                          "numberFormat": {
+                            "unit": 17,
+                            "options": {
+                              "style": "decimal",
+                              "maximumFractionDigits": 1
+                            },
+                            "emptyValCustomText": "-"
+                          }
+                        },
+                        {
+                          "columnMatch": "microsoft.servicebus/namespaces--DeadletteredMessages Timeline",
+                          "formatter": 5,
+                          "formatOptions": {}
+                        },
+                        {
+                          "columnMatch": "microsoft.servicebus/namespaces--IncomingRequests",
+                          "formatter": 5,
+                          "formatOptions": {
+                            "aggregation": "Sum"
+                          },
+                          "numberFormat": {
+                            "unit": 17,
+                            "options": {
+                              "style": "decimal",
+                              "maximumFractionDigits": 1
+                            }
+                          }
+                        },
+                        {
+                          "columnMatch": "microsoft.servicebus/namespaces--IncomingRequests Timeline",
+                          "formatter": 5,
+                          "formatOptions": {
+                            "aggregation": "Sum"
+                          },
+                          "numberFormat": {
+                            "unit": 17,
+                            "options": {
+                              "style": "decimal",
+                              "useGrouping": true,
+                              "maximumFractionDigits": 1
+                            }
+                          }
+                        },
+                        {
+                          "columnMatch": "microsoft.servicebus/namespaces--SuccessfulRequests",
+                          "formatter": 5,
+                          "formatOptions": {
+                            "aggregation": "Sum"
+                          },
+                          "numberFormat": {
+                            "unit": 17,
+                            "options": {
+                              "style": "decimal",
+                              "useGrouping": false,
+                              "maximumFractionDigits": 1
+                            }
+                          }
+                        },
+                        {
+                          "columnMatch": "microsoft.servicebus/namespaces--SuccessfulRequests Timeline",
+                          "formatter": 5,
+                          "formatOptions": {
+                            "aggregation": "Sum"
+                          },
+                          "numberFormat": {
+                            "unit": 17,
+                            "options": {
+                              "style": "decimal",
+                              "maximumFractionDigits": 1
+                            }
+                          }
+                        },
+                        {
+                          "columnMatch": "microsoft.servicebus/namespaces--ServerErrors",
+                          "formatter": 5,
+                          "formatOptions": {
+                            "aggregation": "Sum"
+                          },
+                          "numberFormat": {
+                            "unit": 17,
+                            "options": {
+                              "style": "decimal",
+                              "maximumFractionDigits": 1
+                            }
+                          }
+                        },
+                        {
+                          "columnMatch": "microsoft.servicebus/namespaces--ServerErrors Timeline",
+                          "formatter": 5,
+                          "formatOptions": {}
+                        },
+                        {
+                          "columnMatch": "microsoft.servicebus/namespaces--UserErrors",
+                          "formatter": 5,
+                          "formatOptions": {
+                            "aggregation": "Sum"
+                          },
+                          "numberFormat": {
+                            "unit": 17,
+                            "options": {
+                              "style": "decimal",
+                              "maximumFractionDigits": 1
+                            }
+                          }
+                        },
+                        {
+                          "columnMatch": "microsoft.servicebus/namespaces--UserErrors Timeline",
+                          "formatter": 5,
+                          "formatOptions": {}
+                        },
+                        {
+                          "columnMatch": "microsoft.servicebus/namespaces--ThrottledRequests",
+                          "formatter": 5,
+                          "formatOptions": {
+                            "aggregation": "Sum"
+                          },
+                          "numberFormat": {
+                            "unit": 17,
+                            "options": {
+                              "style": "decimal",
+                              "maximumFractionDigits": 1
+                            }
+                          }
+                        },
+                        {
+                          "columnMatch": "microsoft.servicebus/namespaces--ThrottledRequests Timeline",
+                          "formatter": 5,
+                          "formatOptions": {}
+                        }
+                      ],
+                      "rowLimit": 10000,
+                      "hierarchySettings": {
+                        "treeType": 1,
+                        "groupBy": [
+                          "Name"
+                        ],
+                        "expandTopLevel": true,
+                        "finalBy": "Segment"
+                      },
+                      "labelSettings": [
+                        {
+                          "columnId": "microsoft.servicebus/namespaces--IncomingMessages",
+                          "label": "Incoming Messages (Sum)"
+                        },
+                        {
+                          "columnId": "microsoft.servicebus/namespaces--IncomingMessages Timeline",
+                          "label": "Incoming Messages (Sum) Timeline"
+                        },
+                        {
+                          "columnId": "microsoft.servicebus/namespaces--OutgoingMessages",
+                          "label": "Outgoing Messages (Sum)"
+                        },
+                        {
+                          "columnId": "microsoft.servicebus/namespaces--OutgoingMessages Timeline",
+                          "label": "Outgoing Messages (Sum) Timeline"
+                        },
+                        {
+                          "columnId": "microsoft.servicebus/namespaces--Messages",
+                          "label": "Count of messages in a Queue/Topic. (Average)"
+                        },
+                        {
+                          "columnId": "microsoft.servicebus/namespaces--Messages Timeline",
+                          "label": "Count of messages in a Queue/Topic. (Average) Timeline"
+                        },
+                        {
+                          "columnId": "microsoft.servicebus/namespaces--ActiveMessages",
+                          "label": "Count of active messages in a Queue/Topic. (Average)"
+                        },
+                        {
+                          "columnId": "microsoft.servicebus/namespaces--ActiveMessages Timeline",
+                          "label": "Count of active messages in a Queue/Topic. (Average) Timeline"
+                        },
+                        {
+                          "columnId": "microsoft.servicebus/namespaces--ScheduledMessages",
+                          "label": "Count of scheduled messages in a Queue/Topic. (Average)"
+                        },
+                        {
+                          "columnId": "microsoft.servicebus/namespaces--ScheduledMessages Timeline",
+                          "label": "Count of scheduled messages in a Queue/Topic. (Average) Timeline"
+                        },
+                        {
+                          "columnId": "microsoft.servicebus/namespaces--DeadletteredMessages",
+                          "label": "Count of dead-lettered messages in a Queue/Topic. (Average)"
+                        },
+                        {
+                          "columnId": "microsoft.servicebus/namespaces--DeadletteredMessages Timeline",
+                          "label": "Count of dead-lettered messages in a Queue/Topic. (Average) Timeline"
+                        }
+                      ]
+                    }
+                  },
+                  "name": "Summary Metrics - Resource & Segment"
+                },
+                {
+                  "type": 10,
+                  "content": {
+                    "chartId": "workbookcdb54091-e8c8-4b3a-ae28-fa277d00fe31",
+                    "version": "MetricsItem/2.0",
+                    "size": 0,
+                    "chartType": 2,
+                    "resourceType": "microsoft.servicebus/namespaces",
+                    "metricScope": 0,
+                    "resourceParameter": "ServiceBusResource",
+                    "resourceIds": [
+                      "{ServiceBusResource}"
+                    ],
+                    "timeContextFromParameter": "TimeRange",
+                    "timeContext": {
+                      "durationMs": 0
+                    },
+                    "metrics": [
+                      {
+                        "namespace": "microsoft.servicebus/namespaces",
+                        "metric": "microsoft.servicebus/namespaces--IncomingMessages",
+                        "aggregation": 1,
+                        "splitBy": null
+                      }
+                    ],
+                    "title": "Incoming Messages",
+                    "filters": [
+                      {
+                        "id": "1",
+                        "key": "EntityName",
+                        "operator": 0,
+                        "valueParam": "TopicsAndQueues"
+                      }
+                    ],
+                    "gridSettings": {
+                      "rowLimit": 10000
+                    }
+                  },
+                  "customWidth": "50",
+                  "name": "Incoming Messages",
+                  "styleSettings": {
+                    "margin": "0 0 20px 0"
+                  }
+                },
+                {
+                  "type": 10,
+                  "content": {
+                    "chartId": "workbook19356bdc-cfd5-47c7-8e70-05bbd3f39558",
+                    "version": "MetricsItem/2.0",
+                    "size": 0,
+                    "chartType": 2,
+                    "resourceType": "microsoft.servicebus/namespaces",
+                    "metricScope": 0,
+                    "resourceParameter": "ServiceBusResource",
+                    "resourceIds": [
+                      "{ServiceBusResource}"
+                    ],
+                    "timeContextFromParameter": "TimeRange",
+                    "timeContext": {
+                      "durationMs": 0
+                    },
+                    "metrics": [
+                      {
+                        "namespace": "microsoft.servicebus/namespaces",
+                        "metric": "microsoft.servicebus/namespaces--IncomingMessages",
+                        "aggregation": 1,
+                        "splitBy": "EntityName"
+                      }
+                    ],
+                    "title": "Incoming Messages - by Segment",
+                    "gridFormatType": 1,
+                    "filters": [
+                      {
+                        "id": "1",
+                        "key": "EntityName",
+                        "operator": 0,
+                        "valueParam": "TopicsAndQueues"
+                      }
+                    ],
+                    "showExpandCollapseGrid": true,
+                    "gridSettings": {
+                      "formatters": [
+                        {
+                          "columnMatch": "$gen_group",
+                          "formatter": 13,
+                          "formatOptions": {
+                            "linkTarget": "Resource",
+                            "showIcon": true
+                          }
+                        },
+                        {
+                          "columnMatch": "Subscription",
+                          "formatter": 5,
+                          "formatOptions": {}
+                        },
+                        {
+                          "columnMatch": "Name",
+                          "formatter": 5,
+                          "formatOptions": {}
+                        },
+                        {
+                          "columnMatch": "Segment",
+                          "formatter": 5,
+                          "formatOptions": {}
+                        },
+                        {
+                          "columnMatch": "microsoft.servicebus/namespaces--IncomingMessages",
+                          "formatter": 8,
+                          "formatOptions": {
+                            "min": 0,
+                            "palette": "blue",
+                            "aggregation": "Sum"
+                          },
+                          "numberFormat": {
+                            "unit": 17,
+                            "options": {
+                              "style": "decimal",
+                              "useGrouping": false,
+                              "maximumFractionDigits": 1
+                            },
+                            "emptyValCustomText": "-"
+                          }
+                        },
+                        {
+                          "columnMatch": "microsoft.servicebus/namespaces--IncomingMessages Timeline",
+                          "formatter": 21,
+                          "formatOptions": {
+                            "min": 0,
+                            "palette": "blue",
+                            "aggregation": "Sum"
+                          }
+                        },
+                        {
+                          "columnMatch": "microsoft.servicebus/namespaces--OutgoingMessages",
+                          "formatter": 8,
+                          "formatOptions": {
+                            "min": 0,
+                            "palette": "blue",
+                            "aggregation": "Sum"
+                          },
+                          "numberFormat": {
+                            "unit": 17,
+                            "options": {
+                              "style": "decimal",
+                              "maximumFractionDigits": 1
+                            },
+                            "emptyValCustomText": "-"
+                          }
+                        },
+                        {
+                          "columnMatch": "microsoft.servicebus/namespaces--OutgoingMessages Timeline",
+                          "formatter": 5,
+                          "formatOptions": {}
+                        },
+                        {
+                          "columnMatch": "microsoft.servicebus/namespaces--Messages",
+                          "formatter": 4,
+                          "formatOptions": {
+                            "min": 0,
+                            "palette": "blue",
+                            "aggregation": "Sum"
+                          },
+                          "numberFormat": {
+                            "unit": 17,
+                            "options": {
+                              "style": "decimal",
+                              "maximumFractionDigits": 1
+                            }
+                          }
+                        },
+                        {
+                          "columnMatch": "microsoft.servicebus/namespaces--Messages Timeline",
+                          "formatter": 5,
+                          "formatOptions": {}
+                        },
+                        {
+                          "columnMatch": "Scheduled messages in a Queue/Topic",
+                          "formatter": 4,
+                          "formatOptions": {
+                            "min": 0,
+                            "palette": "blue",
+                            "aggregation": "Sum"
+                          },
+                          "numberFormat": {
+                            "unit": 17,
+                            "options": {
+                              "style": "decimal",
+                              "maximumFractionDigits": 1
+                            },
+                            "emptyValCustomText": "-"
+                          }
+                        },
+                        {
+                          "columnMatch": "Scheduled messages in a Queue/Topic Timeline",
+                          "formatter": 5,
+                          "formatOptions": {}
+                        },
+                        {
+                          "columnMatch": "microsoft.servicebus/namespaces--ActiveConnections",
+                          "formatter": 5,
+                          "formatOptions": {},
+                          "numberFormat": {
+                            "unit": 0,
+                            "options": {
+                              "style": "decimal",
+                              "useGrouping": false
+                            }
+                          }
+                        },
+                        {
+                          "columnMatch": "microsoft.servicebus/namespaces--ActiveConnections Timeline",
+                          "formatter": 5,
+                          "formatOptions": {}
+                        },
+                        {
+                          "columnMatch": "microsoft.servicebus/namespaces--ScheduledMessages",
+                          "formatter": 4,
+                          "formatOptions": {
+                            "min": 0,
+                            "palette": "blue",
+                            "aggregation": "Sum"
+                          },
+                          "numberFormat": {
+                            "unit": 17,
+                            "options": {
+                              "style": "decimal",
+                              "useGrouping": false,
+                              "maximumFractionDigits": 1
+                            },
+                            "emptyValCustomText": "-"
+                          }
+                        },
+                        {
+                          "columnMatch": "microsoft.servicebus/namespaces--ScheduledMessages Timeline",
+                          "formatter": 5,
+                          "formatOptions": {}
+                        },
+                        {
+                          "columnMatch": "microsoft.eventhub/namespaces--IncomingMessages",
+                          "formatter": 8,
+                          "formatOptions": {
+                            "min": 0,
+                            "palette": "blue",
+                            "aggregation": "Sum"
+                          },
+                          "numberFormat": {
+                            "unit": 17,
+                            "options": {
+                              "style": "decimal",
+                              "useGrouping": false,
+                              "maximumFractionDigits": 1
+                            },
+                            "emptyValCustomText": "-"
+                          }
+                        },
+                        {
+                          "columnMatch": "microsoft.eventhub/namespaces--IncomingMessages Timeline",
+                          "formatter": 21,
+                          "formatOptions": {
+                            "min": 0,
+                            "palette": "blue",
+                            "aggregation": "Sum"
+                          }
+                        },
+                        {
+                          "columnMatch": "microsoft.eventhub/namespaces--OutgoingMessages",
+                          "formatter": 8,
+                          "formatOptions": {
+                            "min": 0,
+                            "palette": "blue",
+                            "aggregation": "Sum"
+                          },
+                          "numberFormat": {
+                            "unit": 17,
+                            "options": {
+                              "style": "decimal",
+                              "maximumFractionDigits": 1
+                            },
+                            "emptyValCustomText": "-"
+                          }
+                        },
+                        {
+                          "columnMatch": "microsoft.eventhub/namespaces--OutgoingMessages Timeline",
+                          "formatter": 21,
+                          "formatOptions": {
+                            "min": 0,
+                            "palette": "blue",
+                            "aggregation": "Sum"
+                          }
+                        },
+                        {
+                          "columnMatch": "microsoft.eventhub/namespaces--CapturedMessages",
+                          "formatter": 1,
+                          "formatOptions": {},
+                          "numberFormat": {
+                            "unit": 0,
+                            "options": {
+                              "style": "decimal"
+                            },
+                            "emptyValCustomText": "-"
+                          }
+                        },
+                        {
+                          "columnMatch": "microsoft.eventhub/namespaces--CapturedMessages Timeline",
+                          "formatter": 5,
+                          "formatOptions": {}
+                        },
+                        {
+                          "columnMatch": "microsoft.eventhub/namespaces--CaptureBacklog",
+                          "formatter": 1,
+                          "formatOptions": {},
+                          "numberFormat": {
+                            "unit": 0,
+                            "options": {
+                              "style": "decimal"
+                            },
+                            "emptyValCustomText": "-"
+                          }
+                        },
+                        {
+                          "columnMatch": "microsoft.eventhub/namespaces--CaptureBacklog Timeline",
+                          "formatter": 5,
+                          "formatOptions": {}
+                        },
+                        {
+                          "columnMatch": ".*\\/Incoming Messages$",
+                          "formatter": 1,
+                          "formatOptions": {}
+                        },
+                        {
+                          "columnMatch": ".*\\/Outgoing Messages$",
+                          "formatter": 1,
+                          "formatOptions": {}
+                        },
+                        {
+                          "columnMatch": ".*\\/Count of messages in a Queue/Topic.$",
+                          "formatter": 1,
+                          "formatOptions": {}
+                        }
+                      ],
+                      "rowLimit": 10000,
+                      "filter": true,
+                      "hierarchySettings": {
+                        "treeType": 1,
+                        "groupBy": [
+                          "Subscription",
+                          "Name"
+                        ],
+                        "expandTopLevel": true,
+                        "finalBy": "Segment"
+                      },
+                      "labelSettings": [
+                        {
+                          "columnId": "microsoft.servicebus/namespaces--IncomingMessages",
+                          "label": "Incoming Messages (Sum)"
+                        },
+                        {
+                          "columnId": "microsoft.servicebus/namespaces--IncomingMessages Timeline",
+                          "label": "Incoming Messages (Sum) Timeline"
+                        }
+                      ]
+                    },
+                    "sortBy": [],
+                    "showExportToExcel": true
+                  },
+                  "customWidth": "50",
+                  "showPin": true,
+                  "name": "Incoming Messages - by Segment",
+                  "styleSettings": {
+                    "margin": "0 0 20px 0"
+                  }
+                },
+                {
+                  "type": 10,
+                  "content": {
+                    "chartId": "workbookcdb54091-e8c8-4b3a-ae28-fa277d00fe31",
+                    "version": "MetricsItem/2.0",
+                    "size": 0,
+                    "chartType": 2,
+                    "resourceType": "microsoft.servicebus/namespaces",
+                    "metricScope": 0,
+                    "resourceParameter": "ServiceBusResource",
+                    "resourceIds": [
+                      "{ServiceBusResource}"
+                    ],
+                    "timeContextFromParameter": "TimeRange",
+                    "timeContext": {
+                      "durationMs": 0
+                    },
+                    "metrics": [
+                      {
+                        "namespace": "microsoft.servicebus/namespaces",
+                        "metric": "microsoft.servicebus/namespaces--OutgoingMessages",
+                        "aggregation": 1,
+                        "splitBy": null
+                      }
+                    ],
+                    "title": "Outgoing Messages",
+                    "filters": [
+                      {
+                        "id": "1",
+                        "key": "EntityName",
+                        "operator": 0,
+                        "valueParam": "TopicsAndQueues"
+                      }
+                    ],
+                    "gridSettings": {
+                      "rowLimit": 10000
+                    }
+                  },
+                  "customWidth": "50",
+                  "name": "Outgoing Messages",
+                  "styleSettings": {
+                    "margin": "0 0 20px 0"
+                  }
+                },
+                {
+                  "type": 10,
+                  "content": {
+                    "chartId": "workbookcdb54091-e8c8-4b3a-ae28-fa277d00fe31",
+                    "version": "MetricsItem/2.0",
+                    "size": 0,
+                    "chartType": 2,
+                    "resourceType": "microsoft.servicebus/namespaces",
+                    "metricScope": 0,
+                    "resourceParameter": "ServiceBusResource",
+                    "resourceIds": [
+                      "{ServiceBusResource}"
+                    ],
+                    "timeContextFromParameter": "TimeRange",
+                    "timeContext": {
+                      "durationMs": 0
+                    },
+                    "metrics": [
+                      {
+                        "namespace": "microsoft.servicebus/namespaces",
+                        "metric": "microsoft.servicebus/namespaces--OutgoingMessages",
+                        "aggregation": 1,
+                        "splitBy": "EntityName"
+                      }
+                    ],
+                    "title": "Outgoing Messages - By Segment",
+                    "filters": [
+                      {
+                        "id": "1",
+                        "key": "EntityName",
+                        "operator": 0,
+                        "valueParam": "TopicsAndQueues"
+                      }
+                    ],
+                    "gridSettings": {
+                      "rowLimit": 10000
+                    }
+                  },
+                  "customWidth": "50",
+                  "name": "Outgoing Messages - By Segment",
+                  "styleSettings": {
+                    "margin": "0 0 20px 0"
+                  }
+                },
+                {
+                  "type": 10,
+                  "content": {
+                    "chartId": "workbook184841f8-94c9-46ae-86b8-56d63b72cc32",
+                    "version": "MetricsItem/2.0",
+                    "size": 0,
+                    "chartType": 2,
+                    "resourceType": "microsoft.servicebus/namespaces",
+                    "metricScope": 0,
+                    "resourceParameter": "ServiceBusResource",
+                    "resourceIds": [
+                      "{ServiceBusResource}"
+                    ],
+                    "timeContextFromParameter": "TimeRange",
+                    "timeContext": {
+                      "durationMs": 0
+                    },
+                    "metrics": [
+                      {
+                        "namespace": "microsoft.servicebus/namespaces",
+                        "metric": "microsoft.servicebus/namespaces--Messages",
+                        "aggregation": 4,
+                        "splitBy": null
+                      }
+                    ],
+                    "title": "Messages in a Queue/Topic",
+                    "filters": [
+                      {
+                        "id": "1",
+                        "key": "EntityName",
+                        "operator": 0,
+                        "valueParam": "TopicsAndQueues"
+                      }
+                    ],
+                    "gridSettings": {
+                      "rowLimit": 10000
+                    }
+                  },
+                  "customWidth": "50",
+                  "name": "Messages in a Queue/Topic",
+                  "styleSettings": {
+                    "margin": "0 0 20px 0"
+                  }
+                },
+                {
+                  "type": 10,
+                  "content": {
+                    "chartId": "workbook184841f8-94c9-46ae-86b8-56d63b72cc32",
+                    "version": "MetricsItem/2.0",
+                    "size": 0,
+                    "chartType": 2,
+                    "resourceType": "microsoft.servicebus/namespaces",
+                    "metricScope": 0,
+                    "resourceParameter": "ServiceBusResource",
+                    "resourceIds": [
+                      "{ServiceBusResource}"
+                    ],
+                    "timeContextFromParameter": "TimeRange",
+                    "timeContext": {
+                      "durationMs": 0
+                    },
+                    "metrics": [
+                      {
+                        "namespace": "microsoft.servicebus/namespaces",
+                        "metric": "microsoft.servicebus/namespaces--Messages",
+                        "aggregation": 4,
+                        "splitBy": "EntityName"
+                      }
+                    ],
+                    "title": "Messages in a Queue/Topic - By Segment",
+                    "filters": [
+                      {
+                        "id": "1",
+                        "key": "EntityName",
+                        "operator": 0,
+                        "valueParam": "TopicsAndQueues"
+                      }
+                    ],
+                    "gridSettings": {
+                      "rowLimit": 10000
+                    }
+                  },
+                  "customWidth": "50",
+                  "name": "Messages in a Queue/Topic - By Segment",
+                  "styleSettings": {
+                    "margin": "0 0 20px 0"
+                  }
+                },
+                {
+                  "type": 10,
+                  "content": {
+                    "chartId": "workbook1deffc6a-4449-4f59-9563-ded959b82e30",
+                    "version": "MetricsItem/2.0",
+                    "size": 0,
+                    "chartType": 2,
+                    "resourceType": "microsoft.servicebus/namespaces",
+                    "metricScope": 0,
+                    "resourceParameter": "ServiceBusResource",
+                    "resourceIds": [
+                      "{ServiceBusResource}"
+                    ],
+                    "timeContextFromParameter": "TimeRange",
+                    "timeContext": {
+                      "durationMs": 0
+                    },
+                    "metrics": [
+                      {
+                        "namespace": "microsoft.servicebus/namespaces",
+                        "metric": "microsoft.servicebus/namespaces--ActiveMessages",
+                        "aggregation": 4,
+                        "splitBy": null
+                      }
+                    ],
+                    "title": "Active Messages in a Queue/Topic",
+                    "filters": [
+                      {
+                        "id": "1",
+                        "key": "EntityName",
+                        "operator": 0,
+                        "valueParam": "TopicsAndQueues"
+                      }
+                    ],
+                    "gridSettings": {
+                      "rowLimit": 10000
+                    }
+                  },
+                  "customWidth": "50",
+                  "name": "Active Messages in a Queue/Topic",
+                  "styleSettings": {
+                    "margin": "0 0 20px 0"
+                  }
+                },
+                {
+                  "type": 10,
+                  "content": {
+                    "chartId": "workbook1deffc6a-4449-4f59-9563-ded959b82e30",
+                    "version": "MetricsItem/2.0",
+                    "size": 0,
+                    "chartType": 2,
+                    "resourceType": "microsoft.servicebus/namespaces",
+                    "metricScope": 0,
+                    "resourceParameter": "ServiceBusResource",
+                    "resourceIds": [
+                      "{ServiceBusResource}"
+                    ],
+                    "timeContextFromParameter": "TimeRange",
+                    "timeContext": {
+                      "durationMs": 0
+                    },
+                    "metrics": [
+                      {
+                        "namespace": "microsoft.servicebus/namespaces",
+                        "metric": "microsoft.servicebus/namespaces--ActiveMessages",
+                        "aggregation": 4,
+                        "splitBy": "EntityName"
+                      }
+                    ],
+                    "title": "Active Messages in a Queue/Topic - By Segment",
+                    "filters": [
+                      {
+                        "id": "1",
+                        "key": "EntityName",
+                        "operator": 0,
+                        "valueParam": "TopicsAndQueues"
+                      }
+                    ],
+                    "gridSettings": {
+                      "rowLimit": 10000
+                    }
+                  },
+                  "customWidth": "50",
+                  "name": "Active Messages in a Queue/Topic - By Segment",
+                  "styleSettings": {
+                    "margin": "0 0 20px 0"
+                  }
+                },
+                {
+                  "type": 10,
+                  "content": {
+                    "chartId": "workbookca87107b-15ec-4c94-b64e-a15f9ad2bddf",
+                    "version": "MetricsItem/2.0",
+                    "size": 0,
+                    "chartType": 2,
+                    "resourceType": "microsoft.servicebus/namespaces",
+                    "metricScope": 0,
+                    "resourceParameter": "ServiceBusResource",
+                    "resourceIds": [
+                      "{ServiceBusResource}"
+                    ],
+                    "timeContextFromParameter": "TimeRange",
+                    "timeContext": {
+                      "durationMs": 0
+                    },
+                    "metrics": [
+                      {
+                        "namespace": "microsoft.servicebus/namespaces",
+                        "metric": "microsoft.servicebus/namespaces--ScheduledMessages",
+                        "aggregation": 4,
+                        "splitBy": null
+                      }
+                    ],
+                    "title": "Scheduled Messages in a Queue/Topic",
+                    "filters": [
+                      {
+                        "id": "1",
+                        "key": "EntityName",
+                        "operator": 0,
+                        "valueParam": "TopicsAndQueues"
+                      }
+                    ],
+                    "gridSettings": {
+                      "rowLimit": 10000
+                    }
+                  },
+                  "customWidth": "50",
+                  "name": "Scheduled Messages in a Queue/Topic",
+                  "styleSettings": {
+                    "margin": "0 0 20px 0"
+                  }
+                },
+                {
+                  "type": 10,
+                  "content": {
+                    "chartId": "workbookca87107b-15ec-4c94-b64e-a15f9ad2bddf",
+                    "version": "MetricsItem/2.0",
+                    "size": 0,
+                    "chartType": 2,
+                    "resourceType": "microsoft.servicebus/namespaces",
+                    "metricScope": 0,
+                    "resourceParameter": "ServiceBusResource",
+                    "resourceIds": [
+                      "{ServiceBusResource}"
+                    ],
+                    "timeContextFromParameter": "TimeRange",
+                    "timeContext": {
+                      "durationMs": 0
+                    },
+                    "metrics": [
+                      {
+                        "namespace": "microsoft.servicebus/namespaces",
+                        "metric": "microsoft.servicebus/namespaces--ScheduledMessages",
+                        "aggregation": 4,
+                        "splitBy": "EntityName"
+                      }
+                    ],
+                    "title": "Scheduled Messages in a Queue/Topic - By Segment",
+                    "filters": [
+                      {
+                        "id": "1",
+                        "key": "EntityName",
+                        "operator": 0,
+                        "valueParam": "TopicsAndQueues"
+                      }
+                    ],
+                    "gridSettings": {
+                      "rowLimit": 10000
+                    }
+                  },
+                  "customWidth": "50",
+                  "name": "Scheduled Messages in a Queue/Topic - By Segment",
+                  "styleSettings": {
+                    "margin": "0 0 20px 0"
+                  }
+                },
+                {
+                  "type": 10,
+                  "content": {
+                    "chartId": "workbooke9640ed0-78e9-48ce-b87c-1f921075a476",
+                    "version": "MetricsItem/2.0",
+                    "size": 0,
+                    "chartType": 2,
+                    "resourceType": "microsoft.servicebus/namespaces",
+                    "metricScope": 0,
+                    "resourceParameter": "ServiceBusResource",
+                    "resourceIds": [
+                      "{ServiceBusResource}"
+                    ],
+                    "timeContextFromParameter": "TimeRange",
+                    "timeContext": {
+                      "durationMs": 0
+                    },
+                    "metrics": [
+                      {
+                        "namespace": "microsoft.servicebus/namespaces",
+                        "metric": "microsoft.servicebus/namespaces--DeadletteredMessages",
+                        "aggregation": 4,
+                        "splitBy": null
+                      }
+                    ],
+                    "title": "Dead-Lettered Messages in a Queue/Topic",
+                    "filters": [
+                      {
+                        "id": "1",
+                        "key": "EntityName",
+                        "operator": 0,
+                        "valueParam": "TopicsAndQueues"
+                      }
+                    ],
+                    "gridSettings": {
+                      "rowLimit": 10000
+                    }
+                  },
+                  "customWidth": "50",
+                  "name": "Dead-Lettered Messages in a Queue/Topic",
+                  "styleSettings": {
+                    "margin": "0 0 20px 0"
+                  }
+                },
+                {
+                  "type": 10,
+                  "content": {
+                    "chartId": "workbooke9640ed0-78e9-48ce-b87c-1f921075a476",
+                    "version": "MetricsItem/2.0",
+                    "size": 0,
+                    "chartType": 2,
+                    "resourceType": "microsoft.servicebus/namespaces",
+                    "metricScope": 0,
+                    "resourceParameter": "ServiceBusResource",
+                    "resourceIds": [
+                      "{ServiceBusResource}"
+                    ],
+                    "timeContextFromParameter": "TimeRange",
+                    "timeContext": {
+                      "durationMs": 0
+                    },
+                    "metrics": [
+                      {
+                        "namespace": "microsoft.servicebus/namespaces",
+                        "metric": "microsoft.servicebus/namespaces--DeadletteredMessages",
+                        "aggregation": 4,
+                        "splitBy": "EntityName"
+                      }
+                    ],
+                    "title": "Dead-Lettered Messages in a Queue/Topic - By Segment",
+                    "filters": [
+                      {
+                        "id": "1",
+                        "key": "EntityName",
+                        "operator": 0,
+                        "valueParam": "TopicsAndQueues"
+                      }
+                    ],
+                    "gridSettings": {
+                      "rowLimit": 10000
+                    }
+                  },
+                  "customWidth": "50",
+                  "name": "Dead-Lettered Messages in a Queue/Topic - By Segment",
+                  "styleSettings": {
+                    "margin": "0 0 20px 0"
+                  }
+                }
+              ]
+            },
+            "conditionalVisibility": {
+              "parameterName": "selectedTab",
+              "comparison": "isEqualTo",
+              "value": "Messages"
+            },
+            "name": "Messages Tab"
+          }
+        ]
+      },
+      "name": "Service Bus Resources"
+    }
+  ],
+  "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
+}

--- a/Workbooks/Azure Logic Apps/Integration Environment/IntegrationEnvironment.workbook
+++ b/Workbooks/Azure Logic Apps/Integration Environment/IntegrationEnvironment.workbook
@@ -1,0 +1,318 @@
+{
+  "version": "Notebook/1.0",
+  "items": [
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "crossComponentResources": [
+          "{Subscription}"
+        ],
+        "parameters": [
+          {
+            "id": "54b50e2a-ec77-46d3-8a2e-05f1a6d83ea1",
+            "version": "KqlParameterItem/1.0",
+            "name": "Subscription",
+            "type": 6,
+            "isRequired": true,
+            "isGlobal": true,
+            "query": "Resources\r\n| where type =~ 'microsoft.insights/components'\r\n| summarize Count = count() by subscriptionId\r\n|order by Count desc\r\n| project value = subscriptionId, label = subscriptionId, selected = Count > 1",
+            "crossComponentResources": [
+              "value::all"
+            ],
+            "typeSettings": {
+              "additionalResourceOptions": [],
+              "showDefault": false
+            },
+            "timeContext": {
+              "durationMs": 86400000
+            },
+            "queryType": 1,
+            "resourceType": "microsoft.resourcegraph/resources"
+          },
+          {
+            "id": "441bf375-dd40-4b8d-98ed-64778257264c",
+            "version": "KqlParameterItem/1.0",
+            "name": "LogicApps",
+            "label": "Logic App",
+            "type": 5,
+            "description": "List of Logic App Resources",
+            "multiSelect": true,
+            "quote": "",
+            "delimiter": ",",
+            "typeSettings": {
+              "resourceTypeFilter": {
+                "microsoft.web/sites": true
+              },
+              "additionalResourceOptions": [],
+              "showDefault": false
+            },
+            "timeContext": {
+              "durationMs": 0
+            },
+            "timeContextFromParameter": "TimeRange"
+          },
+          {
+            "id": "dd64683e-e6a3-40ed-81ea-61befbdf9cfe",
+            "version": "KqlParameterItem/1.0",
+            "name": "ServiceBus",
+            "type": 5,
+            "multiSelect": true,
+            "quote": "",
+            "delimiter": ",",
+            "query": "where type in~('microsoft.ServiceBus/namespaces')\r\n|order by name asc\r\n| project value = id, label = name",
+            "crossComponentResources": [
+              "{Subscription}"
+            ],
+            "typeSettings": {
+              "resourceTypeFilter": {
+                "microsoft.servicebus/namespaces": true
+              },
+              "additionalResourceOptions": [],
+              "showDefault": false
+            },
+            "timeContext": {
+              "durationMs": 0
+            },
+            "timeContextFromParameter": "TimeRange",
+            "queryType": 1,
+            "resourceType": "microsoft.resourcegraph/resources"
+          },
+          {
+            "id": "d45a5b30-7c31-499d-9bbf-5610272d09d9",
+            "version": "KqlParameterItem/1.0",
+            "name": "Apim",
+            "type": 5,
+            "multiSelect": true,
+            "quote": "",
+            "delimiter": ",",
+            "query": "where type in~('microsoft.ApiManagement/service')\r\n|order by name asc\r\n| project value = id, label = name",
+            "crossComponentResources": [
+              "{Subscription}"
+            ],
+            "typeSettings": {
+              "resourceTypeFilter": {
+                "microsoft.apimanagement/service": true
+              },
+              "additionalResourceOptions": [],
+              "showDefault": false
+            },
+            "timeContext": {
+              "durationMs": 0
+            },
+            "timeContextFromParameter": "TimeRange",
+            "queryType": 1,
+            "resourceType": "microsoft.resourcegraph/resources"
+          },
+          {
+            "id": "39b09059-63e0-4bf3-aa90-68402abbc933",
+            "version": "KqlParameterItem/1.0",
+            "name": "Api",
+            "type": 9,
+            "multiSelect": true,
+            "quote": "",
+            "delimiter": ","
+          },
+          {
+            "id": "2b3852db-cb61-41fb-8995-1763efb2b528",
+            "version": "KqlParameterItem/1.0",
+            "name": "Topics",
+            "type": 9,
+            "multiSelect": true,
+            "quote": "",
+            "delimiter": ","
+          },
+          {
+            "id": "a7d8047a-2b86-4c09-926c-6d31a4956494",
+            "version": "KqlParameterItem/1.0",
+            "name": "Queues",
+            "type": 9,
+            "multiSelect": true,
+            "quote": "",
+            "delimiter": ","
+          },
+          {
+            "id": "3475b40c-71f0-41fd-afb9-eb0a7415b8d3",
+            "version": "KqlParameterItem/1.0",
+            "name": "ServiceBusDictionaryFromUX",
+            "type": 1
+          }
+        ],
+        "style": "above",
+        "queryType": 1,
+        "resourceType": "microsoft.resourcegraph/resources"
+      },
+      "conditionalVisibility": {
+        "parameterName": "selectedTab",
+        "comparison": "isEqualTo",
+        "value": "4"
+      },
+      "name": "integration-parameters"
+    },
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "parameters": [
+          {
+            "id": "c5e98b1a-2f0c-40fa-b112-7b4ae712d5c4",
+            "version": "KqlParameterItem/1.0",
+            "name": "TimeRange",
+            "type": 4,
+            "isRequired": true,
+            "typeSettings": {
+              "selectableValues": [
+                {
+                  "durationMs": 300000
+                },
+                {
+                  "durationMs": 900000
+                },
+                {
+                  "durationMs": 1800000
+                },
+                {
+                  "durationMs": 3600000
+                },
+                {
+                  "durationMs": 14400000
+                },
+                {
+                  "durationMs": 43200000
+                },
+                {
+                  "durationMs": 86400000
+                },
+                {
+                  "durationMs": 172800000
+                },
+                {
+                  "durationMs": 259200000
+                },
+                {
+                  "durationMs": 604800000
+                },
+                {
+                  "durationMs": 1209600000
+                },
+                {
+                  "durationMs": 2419200000
+                },
+                {
+                  "durationMs": 2592000000
+                }
+              ],
+              "allowCustom": true
+            },
+            "value": {
+              "durationMs": 604800000
+            }
+          },
+          {
+            "id": "50490e9d-fa9d-4e8f-a019-5ca34c6bde43",
+            "version": "KqlParameterItem/1.0",
+            "name": "ApplicationInsights",
+            "type": 5,
+            "isRequired": true,
+            "query": "resources\r\n| where type has \"microsoft.insights/components\"",
+            "crossComponentResources": [
+              "value::all"
+            ],
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "timeContext": {
+              "durationMs": 86400000
+            },
+            "queryType": 1,
+            "resourceType": "microsoft.resourcegraph/resources"
+          }
+        ],
+        "style": "pills",
+        "queryType": 0,
+        "resourceType": "microsoft.operationalinsights/workspaces"
+      },
+      "name": "integration-parameters-2"
+    },
+    {
+      "type": 11,
+      "content": {
+        "version": "LinkItem/1.0",
+        "style": "tabs",
+        "links": [
+          {
+            "id": "8acd942d-abe7-4fca-b4f1-e06b1b850bd6",
+            "cellValue": "selectedTab",
+            "linkTarget": "parameter",
+            "linkLabel": "Logic Apps",
+            "subTarget": "1",
+            "style": "link"
+          },
+          {
+            "id": "ab7cb679-e9f2-49d0-b1db-05d0f4f198d4",
+            "cellValue": "selectedTab",
+            "linkTarget": "parameter",
+            "linkLabel": "Service Bus",
+            "subTarget": "2",
+            "style": "link"
+          },
+          {
+            "id": "afd14644-cf2c-43c0-9858-37d11290cae2",
+            "cellValue": "selectedTab",
+            "linkTarget": "parameter",
+            "linkLabel": "APIM",
+            "subTarget": "3",
+            "style": "link"
+          }
+        ]
+      },
+      "name": "integration-tabs"
+    },
+    {
+      "type": 12,
+      "content": {
+        "version": "NotebookGroup/1.0",
+        "groupType": "template",
+        "loadFromTemplateId": "community-Workbooks/Azure Logic Apps/FilteredAPIM",
+        "items": []
+      },
+      "conditionalVisibility": {
+        "parameterName": "selectedTab",
+        "comparison": "isEqualTo",
+        "value": "3"
+      },
+      "name": "apim-template"
+    },
+    {
+      "type": 12,
+      "content": {
+        "version": "NotebookGroup/1.0",
+        "groupType": "template",
+        "loadFromTemplateId": "community-Workbooks/Azure Logic Apps/FilteredServiceBus",
+        "items": []
+      },
+      "conditionalVisibility": {
+        "parameterName": "selectedTab",
+        "comparison": "isEqualTo",
+        "value": "2"
+      },
+      "name": "sb-template"
+    },
+    {
+      "type": 12,
+      "content": {
+        "version": "NotebookGroup/1.0",
+        "groupType": "template",
+        "loadFromTemplateId": "community-Workbooks/Azure Logic Apps/IntegrationLogicApps",
+        "items": []
+      },
+      "conditionalVisibility": {
+        "parameterName": "selectedTab",
+        "comparison": "isEqualTo",
+        "value": "1"
+      },
+      "name": "la-template"
+    }
+  ],
+  "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
+}

--- a/Workbooks/Azure Logic Apps/IntegrationLogicApps/IntegrationLogicApps.workbook
+++ b/Workbooks/Azure Logic Apps/IntegrationLogicApps/IntegrationLogicApps.workbook
@@ -1,0 +1,51 @@
+{
+  "version": "Notebook/1.0",
+  "items": [
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "crossComponentResources": [
+          "value::all"
+        ],
+        "parameters": [
+          {
+            "id": "b6b15514-a980-4f8a-8c16-abe1a3c588d1",
+            "version": "KqlParameterItem/1.0",
+            "name": "LogicApp",
+            "type": 5,
+            "isRequired": true,
+            "query": "resources\r\n| where type == \"microsoft.web/sites\" and kind has \"workflowapp\"\r\n| where (dynamic(\"{LogicApps}\")) contains id",
+            "crossComponentResources": [
+              "value::all"
+            ],
+            "typeSettings": {
+              "additionalResourceOptions": [],
+              "showDefault": false
+            },
+            "timeContext": {
+              "durationMs": 86400000
+            },
+            "queryType": 1,
+            "resourceType": "microsoft.resourcegraph/resources"
+          }
+        ],
+        "style": "pills",
+        "queryType": 1,
+        "resourceType": "microsoft.resourcegraph/resources"
+      },
+      "name": "la-parameters"
+    },
+    {
+      "type": 12,
+      "content": {
+        "version": "NotebookGroup/1.0",
+        "groupType": "template",
+        "loadFromTemplateId": "community-Workbooks/Azure Logic Apps/LA Standard Metrics",
+        "items": []
+      },
+      "name": "embedded-la-metrics"
+    }
+  ],
+  "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
+}


### PR DESCRIPTION
## PR Checklist

This PR adds a 'report' workbook for integration spaces. These will be referenced using the WorkbookViewerBlade in a new Insights tab.

Integration spaces allow users to group several resources together, so the workbook embeds information about the enclosed logic apps, APIMs, and ServiceBus instances. The inner workbooks were generated by adding entity-filtering to the existing workbooks for those resources (users configure specific entities as part of their integration space). Each resource has its own workbook file, and the top-level workbook includes the others as templates.

Users must select the application insights instance connected to their resource. This should be improved in the future as we find a way to enforce it programmatically in UX; but until then, this will get the experience out.

Here are some screenshots of this tested via GitHub branch:

![image](https://github.com/microsoft/Application-Insights-Workbooks/assets/7775527/0f3426b8-79b6-4358-9d5a-e1a9eece92ee)
![image](https://github.com/microsoft/Application-Insights-Workbooks/assets/7775527/59992c37-a5cc-40bc-995c-d8686c838115)
![image](https://github.com/microsoft/Application-Insights-Workbooks/assets/7775527/f1bbe615-65f4-4243-8ee2-42a361426a3b)

* [x] Explain your changes, so people looking at the PR know *what* and *why*, the code changes are the *how*.
* [x] Validate your changes using one or more of the [testing](../Documentation/Testing.md) methods.

### If adding or updating templates:
* [x] post a screenshot of templates and/or gallery changes
* [ ] ensure your template has a corresponding gallery entry in the gallery folder
* [ ] If you are adding a new template, add your team and template/gallery file(s) to the CODEOWNERS file. CODEOWNERS entries should be teams, not individuals
* [ ] ensure all steps have meaningful names
* [ ] ensure all parameters and grid columns have display names set so they can be localized
* [ ] ensure that parameters id values are unique __or they will fail PR validation__ (parameter ids are used for localization)
* [ ] ensure that steps names are unique __or they will fail PR validation__ (step names are used for localization)
* [ ] grep `/subscription/` and ensure that your parameters don't have any hardcoded resourceIds __or they will fail PR validation__
* [ ] remove `fallbackResourceIds` and `fromTemplateId` fields from your template workbook __or they will fail PR validation__