### PR TITLE
Update DevOps Security.workbook

### DIFF
--- a/Workbooks/Azure Security Center/DevOps Security/DevOps Security.workbook
+++ b/Workbooks/Azure Security Center/DevOps Security/DevOps Security.workbook
@@ -28,7 +28,8 @@
             "jsonData": "[\r\n { \"value\": \"Yes\", \"label\": \"Yes\"},\r\n {\"value\": \"No\", \"label\": \"No\", \"selected\":true }\r\n]",
             "timeContext": {
               "durationMs": 86400000
-            }
+            },
+            "value": "Yes"
           }
         ],
         "style": "above",
@@ -39,7 +40,7 @@
     {
       "type": 1,
       "content": {
-        "json": "#### Navigate\r\nClick on one of the tabs below to explore each area:\r\n* Overview - Summary view of code, secrets, OSS vulnerabilities, and security coverage\r\n* Posture Management - View of posture management findings in DevOps environments\r\n* Secrets - View of exposed secrets in repositories\r\n* Code - View of code scanning results in repositories\r\n* OSS Vulnerabilities - View of OSS vulnerabilities in repositories\r\n* Infrastructure as Code - View of IaC misconfigurations in repositories\r\n* Threats & Tactics - Summarized view of attack exposure across connected DevOps environments",
+        "json": "#### Navigate\r\nClick on one of the tabs below to explore each area:\r\n* Overview - Summary view of code, secrets, OSS vulnerabilities, and security coverage\r\n* Posture Management - View of posture management findings in DevOps environments\r\n* Secrets - View of exposed secrets in repositories\r\n* Code - View of code scanning results in repositories\r\n* OSS Vulnerabilities - View of OSS vulnerabilities in repositories\r\n* Infrastructure as Code - View of IaC misconfigurations in repositories",
         "style": "info"
       },
       "conditionalVisibility": {
@@ -101,14 +102,6 @@
             "linkTarget": "parameter",
             "linkLabel": "Infrastructure as Code",
             "subTarget": "IaCTab",
-            "style": "link"
-          },
-          {
-            "id": "7059f3ed-1f5b-412f-aeef-5c06da8acdf9",
-            "cellValue": "SelectedTab",
-            "linkTarget": "parameter",
-            "linkLabel": "Threats & Tactics",
-            "subTarget": "ThreatsTab",
             "style": "link"
           }
         ]
@@ -307,7 +300,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "securityresources\r\n| where type == \"microsoft.security/assessments\"\r\n| where name == \"c7a934bf-7be6-407a-84d9-4f20e6e49592\" or name == \"6588c4d4-fbbb-4fb8-be45-7c2de7dc1b3b\"\r\n| extend Resource = tostring(properties.resourceDetails.ResourceName), Status = tostring(properties.status.code), DisplayName = tostring(properties.metadata.displayName), Organization = tostring(split(id, '/')[12]), Project = tostring(split(id, '/')[14]), Repo = tostring(split(id, '/')[16])\r\n| where Status == \"Unhealthy\"\r\n| extend Url = tostring(properties.resourceDetails.NativeResourceId)\r\n| summarize count() by Resource, Organization, Project, Repo, Url\r\n| extend Active = iff(count_ == 2, \"True\", \"False\")\r\n| extend fullUrl = strcat(Url, \"/alerts\")\r\n| project Organization, Project, Repo, Active, fullUrl\r\n| order by Active desc",
+        "query": "securityresources\r\n| where type == \"microsoft.security/assessments\"\r\n| where name == \"c7a934bf-7be6-407a-84d9-4f20e6e49592\"\r\n| project Resource = tostring(properties.resourceDetails.ResourceName), Status = tostring(properties.status.code), DisplayName = tostring(properties.metadata.displayName), Organization = tostring(split(id, '/')[12]), Project = tostring(split(id, '/')[14]), Repository = tostring(split(id, '/')[16]), Url = tostring(properties.resourceDetails.NativeResourceId)\r\n| where Status == \"Unhealthy\"\r\n| extend EnablementUrl = strcat(Url, \"/alerts\")\r\n| project Organization, Project, Repository, EnablementUrl",
         "size": 0,
         "title": "Azure DevOps repositories without GitHub Advanced Security for Azure DevOps enabled",
         "showExportToExcel": true,
@@ -322,47 +315,17 @@
               "columnMatch": "Repo",
               "formatter": 1,
               "formatOptions": {
-                "linkColumn": "fullUrl",
+                "linkColumn": "EnablementUrl",
                 "linkTarget": "Url"
               }
             },
             {
-              "columnMatch": "Active",
-              "formatter": 18,
-              "formatOptions": {
-                "thresholdsOptions": "icons",
-                "thresholdsGrid": [
-                  {
-                    "operator": "==",
-                    "thresholdValue": "True",
-                    "representation": "2",
-                    "text": "{0}{1}"
-                  },
-                  {
-                    "operator": "Default",
-                    "thresholdValue": null,
-                    "representation": "Blank",
-                    "text": "{0}{1}"
-                  }
-                ]
-              },
-              "tooltipFormat": {
-                "tooltip": "Repositories are considered active when unhealthy Infrastructure-as-Code recommendations are present."
-              }
-            },
-            {
-              "columnMatch": "fullUrl",
+              "columnMatch": "EnablementUrl",
               "formatter": 5
             }
           ],
-          "rowLimit": 5000,
-          "filter": true,
-          "labelSettings": [
-            {
-              "columnId": "Active",
-              "comment": "An active Azure DevOps repository is defined when IaC findings are found using MDSO"
-            }
-          ]
+          "rowLimit": 10000,
+          "filter": true
         }
       },
       "conditionalVisibility": {
@@ -616,7 +579,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "securityresources\r\n| where type == \"microsoft.security/assessments/subassessments\"\r\n| extend assessmentKey = extract(\".*assessments/(.+?)/.*\",1,  id)\r\n| where assessmentKey == \"b5ef903f-8655-473b-9784-4f749eeb25c6\" or assessmentKey == \"dd98425c-1407-40cc-8a2c-da5d0a2f80da\"\r\n| extend Source = tostring(properties.resourceDetails.source)\r\n| extend Repo = tostring(iff(Source == 'GitHub', split(id,'/')[14], split(id,'/')[16])), Project = tostring(iff(Source == 'AzureDevOps', split(id,'/')[14], 'N/A')), Organization = tostring(iff(Source == 'GitHub', split(id,'/')[12], split(id,'/')[12]))\r\n| extend VulId = tostring(properties.id), Severity = tostring(properties.status.severity), Status = tostring(properties.status.code), \r\nSecret = tostring(iff(Source == 'GitHub', properties.description, properties.displayName)), Location = tostring(properties.additionalData.data.Locations_Url), File = tostring(properties.additionalData.data.File), AlertUrl = tostring(properties.additionalData.data.Html_Url), Line = tostring(properties.additionalData.data.Line), Info = \"Info\"\r\n| project Source, Organization, Project, Repo, Status, Secret, Location, File, AlertUrl, Line, Info, properties\r\n| order by ['Source'] asc",
+        "query": "securityresources\r\n| where type == \"microsoft.security/assessments/subassessments\"\r\n| extend assessmentKey = extract(\".*assessments/(.+?)/.*\",1,  id)\r\n| where assessmentKey == \"b5ef903f-8655-473b-9784-4f749eeb25c6\" or assessmentKey == \"dd98425c-1407-40cc-8a2c-da5d0a2f80da\"\r\n| extend Source = tostring(properties.resourceDetails.source)\r\n| extend Repo = tostring(iff(Source == 'GitHub', split(id,'/')[14], split(id,'/')[16])), Project = tostring(iff(Source == 'AzureDevOps', split(id,'/')[14], 'N/A')), Organization = tostring(iff(Source == 'GitHub', split(id,'/')[12], split(id,'/')[12])),\r\n    Finding = tostring(properties.status.description),\r\n    Status = tostring(properties.status.code),\r\n    RuleID = tostring(properties.additionalData.data.Rule_id),\r\n    Time = tostring(properties.timeGenerated),\r\n    Secret = tostring(iff(Source == 'GitHub', properties.description, properties.displayName)),\r\n    Details = \"info\"\r\n| extend Creation_Date_Raw = tostring(properties.additionalData.data.Creation_Date)\r\n| extend Creation_Date_Trimmed = trim('\\\"', tostring(Creation_Date_Raw)) \r\n| extend Creation_Date = todatetime(Creation_Date_Trimmed) \r\n| extend CreatedAt = iff(Source =~ \"AzureDevOps\", Creation_Date, todatetime(Time))\r\n| project Source, Organization, Project, Repo, Secret, properties, CreatedAt, Details",
         "size": 0,
         "title": "Secret scanning",
         "showExportToExcel": true,
@@ -628,6 +591,26 @@
         ],
         "gridSettings": {
           "formatters": [
+            {
+              "columnMatch": "Secret",
+              "formatter": 1,
+              "formatOptions": {
+                "customColumnWidthSetting": "36.8571ch"
+              }
+            },
+            {
+              "columnMatch": "properties",
+              "formatter": 5
+            },
+            {
+              "columnMatch": "Details",
+              "formatter": 1,
+              "formatOptions": {
+                "linkColumn": "properties",
+                "linkTarget": "CellDetails",
+                "linkIsContextBlade": true
+              }
+            },
             {
               "columnMatch": "Status",
               "formatter": 18,
@@ -662,13 +645,6 @@
               }
             },
             {
-              "columnMatch": "Secret",
-              "formatter": 1,
-              "formatOptions": {
-                "customColumnWidthSetting": "36.8571ch"
-              }
-            },
-            {
               "columnMatch": "Location",
               "formatter": 5
             },
@@ -682,41 +658,6 @@
               "formatOptions": {
                 "linkTarget": "Url",
                 "linkLabel": "Link"
-              }
-            },
-            {
-              "columnMatch": "Line",
-              "formatter": 5
-            },
-            {
-              "columnMatch": "Info",
-              "formatter": 5,
-              "formatOptions": {
-                "linkTarget": "GenericDetails",
-                "linkIsContextBlade": true
-              }
-            },
-            {
-              "columnMatch": "properties",
-              "formatter": 5
-            },
-            {
-              "columnMatch": "Severity",
-              "formatter": 1
-            },
-            {
-              "columnMatch": "Repository",
-              "formatter": 18,
-              "formatOptions": {
-                "thresholdsOptions": "icons",
-                "thresholdsGrid": [
-                  {
-                    "operator": "Default",
-                    "thresholdValue": null,
-                    "representation": "resource",
-                    "text": "{0}{1}"
-                  }
-                ]
               }
             }
           ],
@@ -836,7 +777,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "securityresources\r\n| where type == \"microsoft.security/assessments/subassessments\"\r\n| extend assessmentKey = extract(\".*assessments/(.+?)/.*\",1,  id)\r\n| where assessmentKey == \"99232bb2-9b21-4bbb-8e3c-763673b9923d\" or assessmentKey == \"18aa4e75-776a-4296-97f0-fe1cf10d679c\"\r\n| extend Source = tostring(properties.resourceDetails.source)\r\n| extend Repo = tostring(iff(Source == 'GitHub', split(id,'/')[14], split(id,'/')[16])), Project = tostring(iff(Source == 'AzureDevOps', split(id,'/')[14], 'N/A')), Organization = tostring(iff(Source == 'GitHub', split(id,'/')[12], split(id,'/')[12])),\r\n    Finding = tostring(properties.status.description),\r\n    Status = tostring(properties.status.code),\r\n    Severity = tostring(properties.status.severity),\r\n    Tool = tostring(iff(Source == 'GitHub', properties.additionalData.data.Tool_name, properties.additionalData.data.ToolName)),\r\n    RuleID = tostring(properties.additionalData.data.Rule_id),\r\n    Branch = tostring(properties.additionalData.data.Branch),\r\n    Details = \"info\"\r\n| extend AlertUrl = tostring(iff(Source =~ \"GitHub\", properties.additionalData.data.Html_Url, iff(Tool =~ \"CodeQL\", properties.additionalData.data.Html_Url, properties.additionalData.data.Build_Url)))\r\n| extend SeveritySort = case(\r\n    Severity == \"High\", 1,\r\n    Severity == \"Medium\", 2,\r\n    Severity == \"Low\", 3,\r\n    4\r\n)\r\n| order by SeveritySort asc, Severity asc\r\n| project-away SeveritySort\r\n| project Severity, Source, Organization, Project, Repo, Finding, Tool, properties, AlertUrl, Details",
+        "query": "securityresources\r\n| where type == \"microsoft.security/assessments/subassessments\"\r\n| extend assessmentKey = extract(\".*assessments/(.+?)/.*\",1,  id)\r\n| where assessmentKey == \"99232bb2-9b21-4bbb-8e3c-763673b9923d\" or assessmentKey == \"18aa4e75-776a-4296-97f0-fe1cf10d679c\"\r\n| project properties, id\r\n| extend Source = tostring(properties.resourceDetails.source)\r\n| extend Repo = tostring(iff(Source == 'GitHub', split(id,'/')[14], split(id,'/')[16])), Project = tostring(iff(Source == 'AzureDevOps', split(id,'/')[14], 'N/A')), Organization = tostring(iff(Source == 'GitHub', split(id,'/')[12], split(id,'/')[12])),\r\n    Finding = tostring(properties.status.description),\r\n    Status = tostring(properties.status.code),\r\n    Severity = tostring(properties.status.severity),\r\n    Tool = tostring(iff(Source =~ 'GitHub', properties.additionalData.data.Tool_name, properties.additionalData.data.ToolName)),\r\n    RuleID = tostring(properties.additionalData.data.Rule_id), Details = \"info\"\r\n| extend Branch = iff(Source =~ 'AzureDevOps' and Tool == 'CodeQL', 'N/A - Default Only', tostring(properties.additionalData.data.Branch)), Time = tostring(properties.timeGenerated)\r\n| extend Creation_Date_Raw = tostring(properties.additionalData.data.Creation_Date)\r\n| extend Creation_Date_Trimmed = trim('\\\"', tostring(Creation_Date_Raw)) \r\n| extend Creation_Date = todatetime(Creation_Date_Trimmed) \r\n| extend CreatedAt = iff(Source =~ \"AzureDevOps\", Creation_Date, todatetime(Time))\r\n| extend SeveritySort = case(\r\n    Severity == \"High\", 1,\r\n    Severity == \"Medium\", 2,\r\n    Severity == \"Low\", 3,\r\n    4\r\n)\r\n| order by SeveritySort asc, Severity asc\r\n| project-away SeveritySort\r\n| project Severity, Source, Organization, Project, Repo, Finding, Tool, properties, Branch, CreatedAt, Details",
         "size": 0,
         "title": "Code scanning by severity",
         "showExportToExcel": true,
@@ -857,19 +798,19 @@
               "formatter": 5
             },
             {
-              "columnMatch": "Details",
-              "formatter": 11,
-              "formatOptions": {
-                "linkTarget": "GenericDetails",
-                "linkIsContextBlade": true
-              }
-            },
-            {
               "columnMatch": "AlertUrl",
               "formatter": 7,
               "formatOptions": {
                 "linkTarget": "Url",
                 "linkLabel": "Link"
+              }
+            },
+            {
+              "columnMatch": "Details",
+              "formatter": 11,
+              "formatOptions": {
+                "linkTarget": "GenericDetails",
+                "linkIsContextBlade": true
               }
             },
             {
@@ -1009,7 +950,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "securityresources\r\n| where type == \"microsoft.security/assessments/subassessments\"\r\n| extend assessmentKey = extract(\".*assessments/(.+?)/.*\",1,  id)\r\n| where assessmentKey == \"2ea72208-8558-4011-8dcd-d93375a4003d\" or assessmentKey == \"945f7b1c-8def-4ab3-a44d-1416060104b3\"\r\n| extend Source = tostring(properties.resourceDetails.source)\r\n| extend Repo = tostring(iff(Source == 'GitHub', split(id,'/')[14], split(id,'/')[16])), Project = tostring(iff(Source == 'AzureDevOps', split(id,'/')[14], 'N/A')), Organization = tostring(iff(Source == 'GitHub', split(id,'/')[12], split(id,'/')[12])),\r\n    Finding = tostring(properties.status.description),\r\n    Status = tostring(properties.status.code),\r\n    Severity = tostring(properties.status.severity),\r\n    RuleID = tostring(properties.additionalData.data.Rule_id),\r\n    Branch = tostring(properties.additionalData.data.Branch),\r\n    Package = tostring(properties.additionalData.data.securityVulnerability__package__ecosystem),\r\n    Summary = tostring(properties.additionalData.data.securityAdvisory__summary),\r\n    AlertUrl = tostring(properties.additionalData.data.securityAdvisory__permalink),\r\n    CVE = tostring(properties.additionalData.data.SecurityAdvisoryCVE),\r\n    timeGenerated = todatetime(properties.timeGenerated),\r\n    Details = \"info\"\r\n| extend SeveritySort = case(\r\n    Severity == \"High\", 1,\r\n    Severity == \"Medium\", 2,\r\n    Severity == \"Low\", 3,\r\n    4\r\n)\r\n| order by SeveritySort asc, Severity asc\r\n| project-away SeveritySort\r\n| project Severity, Source, Organization, Project, Repo, CVE, Package, Finding, properties, AlertUrl, Details",
+        "query": "securityresources\r\n| where type == \"microsoft.security/assessments/subassessments\"\r\n| extend assessmentKey = extract(\".*assessments/(.+?)/.*\",1,  id)\r\n| where assessmentKey == \"2ea72208-8558-4011-8dcd-d93375a4003d\" or assessmentKey == \"945f7b1c-8def-4ab3-a44d-1416060104b3\"\r\n| extend Source = tostring(properties.resourceDetails.source)\r\n| extend Repo = tostring(iff(Source == 'GitHub', split(id,'/')[14], split(id,'/')[16])), Project = tostring(iff(Source == 'AzureDevOps', split(id,'/')[14], 'N/A')), Organization = tostring(iff(Source == 'GitHub', split(id,'/')[12], split(id,'/')[12])),\r\n    Finding = tostring(properties.status.description),\r\n    Status = tostring(properties.status.code),\r\n    Severity = tostring(properties.status.severity),\r\n    RuleID = tostring(properties.additionalData.data.Rule_id),\r\n    Branch = tostring(iff(Source == 'GitHub', 'N/A - Default', properties.additionalData.data.Branch)),\r\n    Creation_Date = tostring(properties.additionalData.data.Creation_Date),\r\n    Package = tostring(properties.additionalData.data.securityVulnerability__package__ecosystem),\r\n    Summary = tostring(properties.additionalData.data.securityAdvisory__summary),\r\n    AlertUrl = tostring(properties.additionalData.data.securityAdvisory__permalink),\r\n    CVE = tostring(properties.additionalData.data.SecurityAdvisoryCVE),\r\n    timeGenerated = todatetime(properties.timeGenerated),\r\n    createdAtGH = tostring(properties.additionalData.data.createdAt),\r\n    Details = \"info\"\r\n| extend Creation_Date_Raw = tostring(properties.additionalData.data.Creation_Date)\r\n| extend Creation_Date_Trimmed = trim('\\\"', tostring(Creation_Date_Raw)) \r\n| extend Creation_Date = todatetime(Creation_Date_Trimmed) \r\n| extend CreatedTime = iff(Source =~ \"AzureDevOps\", Creation_Date, todatetime(createdAtGH))\r\n| extend SeveritySort = case(\r\n    Severity == \"High\", 1,\r\n    Severity == \"Medium\", 2,\r\n    Severity == \"Low\", 3,\r\n    4\r\n)\r\n| order by SeveritySort asc, Severity asc\r\n| project-away SeveritySort\r\n| project Severity, Source, Organization, Project, Repo, CVE, Package, Finding, properties, AlertUrl, Details, Branch, CreatedTime",
         "size": 0,
         "title": "Open source vulnerabilities",
         "showExportToExcel": true,
@@ -1179,7 +1120,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "securityresources\r\n| where type == \"microsoft.security/assessments/subassessments\"\r\n| extend assessmentKey = extract(\".*assessments/(.+?)/.*\",1,  id)\r\n| where assessmentKey == \"6588c4d4-fbbb-4fb8-be45-7c2de7dc1b3b\" or assessmentKey == \"d9be0ff8-3eb0-4348-82f6-c1e735f85983\"\r\n| extend Source = tostring(properties.resourceDetails.source)\r\n| extend Repo = tostring(iff(Source == 'GitHub', split(id,'/')[14], split(id,'/')[16])), Project = tostring(iff(Source == 'AzureDevOps', split(id,'/')[14], 'N/A')), Organization = tostring(iff(Source == 'GitHub', split(id,'/')[12], split(id,'/')[12])),\r\n    Finding = tostring(properties.status.description),\r\n    Status = tostring(properties.status.code),\r\n    Severity = tostring(properties.status.severity),\r\n    Tool = tostring(iff(Source == 'GitHub', properties.additionalData.data.Tool_name, properties.additionalData.data.ToolName)),\r\n    RuleID = tostring(properties.additionalData.data.Rule_id),\r\n    Branch = tostring(properties.additionalData.data.Branch),\r\n    Details = \"info\"\r\n| extend AlertUrl = tostring(iff(Source =~ \"GitHub\", properties.additionalData.data.Html_Url, properties.additionalData.data.Build_Url))\r\n| extend SeveritySort = case(\r\n    Severity == \"High\", 1,\r\n    Severity == \"Medium\", 2,\r\n    Severity == \"Low\", 3,\r\n    4\r\n)\r\n| order by SeveritySort asc, Severity asc\r\n| project-away SeveritySort\r\n| project Severity, Source, Organization, Project, Repo, Finding, Tool, properties, AlertUrl, Details",
+        "query": "securityresources\r\n| where type == \"microsoft.security/assessments/subassessments\"\r\n| extend assessmentKey = extract(\".*assessments/(.+?)/.*\",1,  id)\r\n| where assessmentKey == \"6588c4d4-fbbb-4fb8-be45-7c2de7dc1b3b\" or assessmentKey == \"d9be0ff8-3eb0-4348-82f6-c1e735f85983\"\r\n| extend Source = tostring(properties.resourceDetails.source)\r\n| extend Repo = tostring(iff(Source == 'GitHub', split(id,'/')[14], split(id,'/')[16])), Project = tostring(iff(Source == 'AzureDevOps', split(id,'/')[14], 'N/A')), Organization = tostring(iff(Source == 'GitHub', split(id,'/')[12], split(id,'/')[12])),\r\n    Finding = tostring(properties.status.description),\r\n    Status = tostring(properties.status.code),\r\n    Severity = tostring(properties.status.severity),\r\n    Tool = tostring(iff(Source == 'GitHub', properties.additionalData.data.Tool_name, properties.additionalData.data.ToolName)),\r\n    RuleID = tostring(properties.additionalData.data.Rule_id),\r\n    Branch = tostring(properties.additionalData.data.Branch),\r\n    Time = tostring(properties.timeGenerated),\r\n    Details = \"info\"\r\n| extend Creation_Date_Raw = tostring(properties.additionalData.data.Creation_Date)\r\n| extend Creation_Date_Trimmed = trim('\\\"', tostring(Creation_Date_Raw)) \r\n| extend Creation_Date = todatetime(Creation_Date_Trimmed) \r\n| extend CreatedAt = iff(Source =~ \"AzureDevOps\", Creation_Date, todatetime(Time))\r\n| extend SeveritySort = case(\r\n    Severity == \"High\", 1,\r\n    Severity == \"Medium\", 2,\r\n    Severity == \"Low\", 3,\r\n    4\r\n)\r\n| order by SeveritySort asc, Severity asc\r\n| project-away SeveritySort\r\n| project Severity, Source, Organization, Project, Repo, Finding, Tool, properties, Branch, CreatedAt, Details",
         "size": 0,
         "showExportToExcel": true,
         "exportToExcelOptions": "all",
@@ -1236,174 +1177,6 @@
       }
     },
     {
-      "type": 3,
-      "content": {
-        "version": "KqlItem/1.0",
-        "query": "securityresources\r\n| where type == \"microsoft.security/assessments\"\r\n| where name == \"b6ad173c-0cc6-4d44-b954-8217c8837a8e\" \r\n                or name == \"5a2b692f-9ccc-4519-b6bd-47125dd51884\" \r\n                or name == \"c64e7cfb-6d64-4227-8c23-b4fa5c72957b\" \r\n                or name == \"b5ef903f-8655-473b-9784-4f749eeb25c6\" \r\n                or name == \"99232bb2-9b21-4bbb-8e3c-763673b9923d\" \r\n                or name == \"6588c4d4-fbbb-4fb8-be45-7c2de7dc1b3b\"\r\n                or name == \"2ea72208-8558-4011-8dcd-d93375a4003d\"\r\n                or name == \"dd98425c-1407-40cc-8a2c-da5d0a2f80da\" \r\n                or name == \"18aa4e75-776a-4296-97f0-fe1cf10d679c\" \r\n                or name == \"d9be0ff8-3eb0-4348-82f6-c1e735f85983\"\r\n                or name == \"945f7b1c-8def-4ab3-a44d-1416060104b3\"\r\n| extend Repository = tostring(split(id, '/')[12]), \r\n    Threats = tostring(strcat_array(properties.metadata.threats,\",\")), \r\n    Tactics = tostring(strcat_array(properties.metadata.tactics,\",\")),\r\n        Status = tostring(properties.status.code)\r\n| where Status == \"Unhealthy\"\r\n| project Repository, Threats, Tactics\r\n| summarize count() by Threats",
-        "size": 0,
-        "title": "Threats & tactics",
-        "queryType": 1,
-        "resourceType": "microsoft.resourcegraph/resources",
-        "crossComponentResources": [
-          "value::all"
-        ],
-        "visualization": "piechart"
-      },
-      "conditionalVisibility": {
-        "parameterName": "SelectedTab",
-        "comparison": "isEqualTo",
-        "value": "ThreatsTab"
-      },
-      "customWidth": "33",
-      "name": "ThreatsandTacticsGraph"
-    },
-    {
-      "type": 3,
-      "content": {
-        "version": "KqlItem/1.0",
-        "query": "securityresources\r\n| where type == \"microsoft.security/assessments\"\r\n| where name == \"b6ad173c-0cc6-4d44-b954-8217c8837a8e\" \r\n                or name == \"5a2b692f-9ccc-4519-b6bd-47125dd51884\" \r\n                or name == \"c64e7cfb-6d64-4227-8c23-b4fa5c72957b\" \r\n                or name == \"b5ef903f-8655-473b-9784-4f749eeb25c6\" \r\n                or name == \"99232bb2-9b21-4bbb-8e3c-763673b9923d\" \r\n                or name == \"6588c4d4-fbbb-4fb8-be45-7c2de7dc1b3b\"\r\n                or name == \"2ea72208-8558-4011-8dcd-d93375a4003d\"\r\n                or name == \"dd98425c-1407-40cc-8a2c-da5d0a2f80da\" \r\n                or name == \"18aa4e75-776a-4296-97f0-fe1cf10d679c\" \r\n                or name == \"d9be0ff8-3eb0-4348-82f6-c1e735f85983\"\r\n                or name == \"945f7b1c-8def-4ab3-a44d-1416060104b3\"\r\n| extend Repository = tostring(split(id, '/')[12]), \r\n    Threats = tostring(strcat_array(properties.metadata.threats,\",\")), \r\n    Tactics = tostring(strcat_array(properties.metadata.tactics,\",\")),\r\n    Status = tostring(properties.status.code)\r\n| where Status == \"Unhealthy\"\r\n| project Repository, Threats, Tactics\r\n| summarize count(Threats) by Repository",
-        "size": 0,
-        "title": " Threats & tactics by repository",
-        "queryType": 1,
-        "resourceType": "microsoft.resourcegraph/resources",
-        "crossComponentResources": [
-          "value::all"
-        ],
-        "visualization": "barchart",
-        "chartSettings": {
-          "showMetrics": false,
-          "showLegend": true,
-          "customThresholdLine": "5",
-          "customThresholdLineStyle": 1
-        }
-      },
-      "conditionalVisibility": {
-        "parameterName": "SelectedTab",
-        "comparison": "isEqualTo",
-        "value": "ThreatsTab"
-      },
-      "customWidth": "66",
-      "name": "ThreatandTacticsChart"
-    },
-    {
-      "type": 3,
-      "content": {
-        "version": "KqlItem/1.0",
-        "query": "securityresources\r\n| where type == \"microsoft.security/assessments\"\r\n| where name == \"b6ad173c-0cc6-4d44-b954-8217c8837a8e\" \r\n                or name == \"5a2b692f-9ccc-4519-b6bd-47125dd51884\" \r\n                or name == \"c64e7cfb-6d64-4227-8c23-b4fa5c72957b\" \r\n                or name == \"b5ef903f-8655-473b-9784-4f749eeb25c6\" \r\n                or name == \"99232bb2-9b21-4bbb-8e3c-763673b9923d\" \r\n                or name == \"6588c4d4-fbbb-4fb8-be45-7c2de7dc1b3b\"\r\n                or name == \"2ea72208-8558-4011-8dcd-d93375a4003d\"\r\n                or name == \"dd98425c-1407-40cc-8a2c-da5d0a2f80da\" \r\n                or name == \"18aa4e75-776a-4296-97f0-fe1cf10d679c\" \r\n                or name == \"d9be0ff8-3eb0-4348-82f6-c1e735f85983\"\r\n                or name == \"945f7b1c-8def-4ab3-a44d-1416060104b3\"\r\n| extend Status = tostring(properties.status.code)\r\n| where Status == 'Unhealthy'\r\n| extend Repository = tostring(split(id, '/')[12]), \r\n        Threats = tostring(strcat_array(properties.metadata.threats,\",\")), \r\n        Tactics = tostring(strcat_array(properties.metadata.tactics,\",\")), \r\n        Techniques = tostring(strcat_array(properties.metadata.techniques,\",\")),\r\n        Details = \"info\"\r\n| project Repository, Threats, Tactics, Techniques, properties, Details",
-        "size": 0,
-        "queryType": 1,
-        "resourceType": "microsoft.resourcegraph/resources",
-        "crossComponentResources": [
-          "value::all"
-        ],
-        "visualization": "table",
-        "gridSettings": {
-          "formatters": [
-            {
-              "columnMatch": "Threats",
-              "formatter": 1
-            },
-            {
-              "columnMatch": "Tactics",
-              "formatter": 1
-            },
-            {
-              "columnMatch": "properties",
-              "formatter": 5
-            },
-            {
-              "columnMatch": "Details",
-              "formatter": 11,
-              "formatOptions": {
-                "linkTarget": "GenericDetails",
-                "linkIsContextBlade": true
-              }
-            }
-          ],
-          "hierarchySettings": {
-            "treeType": 1,
-            "groupBy": [
-              "Repository"
-            ]
-          }
-        },
-        "sortBy": [],
-        "tileSettings": {
-          "showBorder": false,
-          "titleContent": {
-            "columnMatch": "Threats",
-            "formatter": 1
-          },
-          "leftContent": {
-            "columnMatch": "count_",
-            "formatter": 12,
-            "formatOptions": {
-              "palette": "auto"
-            },
-            "numberFormat": {
-              "unit": 17,
-              "options": {
-                "maximumSignificantDigits": 3,
-                "maximumFractionDigits": 2
-              }
-            }
-          }
-        },
-        "graphSettings": {
-          "type": 0,
-          "topContent": {
-            "columnMatch": "Threats",
-            "formatter": 1
-          },
-          "centerContent": {
-            "columnMatch": "count_",
-            "formatter": 1,
-            "numberFormat": {
-              "unit": 17,
-              "options": {
-                "maximumSignificantDigits": 3,
-                "maximumFractionDigits": 2
-              }
-            }
-          }
-        },
-        "chartSettings": {
-          "seriesLabelSettings": [
-            {
-              "seriesName": "[\"MissingCoverage\",\"ThreatResistance\"]",
-              "color": "blue"
-            },
-            {
-              "seriesName": "[\"AccountBreach\"]",
-              "color": "magenta"
-            },
-            {
-              "color": "purple"
-            }
-          ]
-        },
-        "mapSettings": {
-          "locInfo": "LatLong",
-          "sizeSettings": "count_",
-          "sizeAggregation": "Sum",
-          "legendMetric": "count_",
-          "legendAggregation": "Sum",
-          "itemColorSettings": {
-            "type": "heatmap",
-            "colorAggregation": "Sum",
-            "nodeColorField": "count_",
-            "heatmapPalette": "greenRed"
-          }
-        }
-      },
-      "conditionalVisibility": {
-        "parameterName": "SelectedTab",
-        "comparison": "isEqualTo",
-        "value": "ThreatsTab"
-      },
-      "name": "ThreatsAndTactics"
-    },
-    {
       "type": 12,
       "content": {
         "version": "NotebookGroup/1.0",
@@ -1413,7 +1186,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "securityresources\r\n    | where type == \"microsoft.security/assessments\"\r\n    | extend assessmentKey = tostring(name)\r\n    | where assessmentKey in (\"9245366d-393f-49c5-b8e6-258b1b1c2daa\", \"a887e860-40ff-4b57-9ef9-5177a11091ac\", \"d5711372-9b5f-4926-a711-13dcf51565a6\", \"2c2c801e-6279-4d88-a419-af73f0eff4fb\", \"6855e9b1-c493-4a43-a6d1-74f30e72c5af\", \"909d299a-1736-456d-aef5-63688b230bfd\", \"17f3ad34-4f87-4463-a11d-6c6d7a84c486\", \"90901cb2-c497-4389-b63a-d3a562e15847\", \"bd041c7b-95db-4aaf-8bc4-fd9875ecdddf\", \"48f93272-e99c-47be-8087-091c71be9897\", \"2815b95f-f872-4d51-9709-54c1c7133d7b\", \"497e771e-d309-4e36-9bbd-353defd2658a\")\r\n    | extend source = trim(' ', tolower(tostring(properties.resourceDetails.Source)))\r\n    | extend resourceId = trim(' ', tolower(tostring( extract('^(.+)/providers/Microsoft.Security/assessments/.+$',1,id))))\r\n    | extend status = trim(\" \", tostring(properties.status.code)), cause = trim(\" \", tostring(properties.status.cause)), Severity = tostring(properties.metadata.severity)\r\n    | extend displayName = tostring(properties.displayName), affectedResourceUrl = properties.additionalData.AffectedResource_Url, Resource = tostring(properties.additionalData.AffectedResource), Project = tostring(iff(properties.resourceDetails.Source == \"AzureDevOps\", tostring(properties.additionalData.AdoProject), \"N/A\")), Org = tostring(iff(properties.resourceDetails.Source == \"AzureDevOps\", properties.additionalData.AdoOrg, properties.additionalData.GitHubOrg)), Finding = tostring(properties.additionalData.Finding), Severity = tostring(properties.metadata.severity), firstEvaluationDate = todatetime(properties.status.firstEvaluationDate), statusChangeDate = todatetime(properties.status.statusChangeDate), type = tostring(properties.resourceDetails.ResourceType)\r\n    | extend resourceType = tostring(iff(properties.resourceDetails.Source == \"AzureDevOps\", split(type,'/')[5], properties.additionalData.AffectedResourceCategory))\r\n    | summarize count() by status",
+              "query": "securityresources\r\n    | where type == \"microsoft.security/assessments\"\r\n    | extend assessmentKey = tostring(name)\r\n    | where assessmentKey in (\"9245366d-393f-49c5-b8e6-258b1b1c2daa\", \"a887e860-40ff-4b57-9ef9-5177a11091ac\", \"d5711372-9b5f-4926-a711-13dcf51565a6\", \"2c2c801e-6279-4d88-a419-af73f0eff4fb\", \"6855e9b1-c493-4a43-a6d1-74f30e72c5af\", \"909d299a-1736-456d-aef5-63688b230bfd\", \"17f3ad34-4f87-4463-a11d-6c6d7a84c486\", \"90901cb2-c497-4389-b63a-d3a562e15847\", \"bd041c7b-95db-4aaf-8bc4-fd9875ecdddf\", \"48f93272-e99c-47be-8087-091c71be9897\", \"2815b95f-f872-4d51-9709-54c1c7133d7b\", \"497e771e-d309-4e36-9bbd-353defd2658a\", \"470742ea-324a-406c-b91f-fc1da6a27c0c\", \"98b5895a-0ad8-4ed9-8c9d-d654f5bda816\", \"9f4a17ee-7a02-4978-b968-8c36b74ac8e3\", \"6331fad3-a7a2-497d-b616-52672057e0f3\", \"98e858ed-6e88-4698-b538-f51b31ad57f6\", \"a9621d26-9d8c-4cd6-8ad0-84501eb88f17\", \"20be7df7-9ebb-4fb4-95a9-3ae19b78b80a\")\r\n    | extend source = trim(' ', tolower(tostring(properties.resourceDetails.Source)))\r\n    | extend resourceId = trim(' ', tolower(tostring( extract('^(.+)/providers/Microsoft.Security/assessments/.+$',1,id))))\r\n    | extend status = trim(\" \", tostring(properties.status.code)), cause = trim(\" \", tostring(properties.status.cause)), Severity = tostring(properties.metadata.severity)\r\n    | extend displayName = tostring(properties.displayName), affectedResourceUrl = properties.additionalData.AffectedResource_Url, Resource = tostring(properties.additionalData.AffectedResource), Project = tostring(iff(properties.resourceDetails.Source == \"AzureDevOps\", tostring(properties.additionalData.AdoProject), \"N/A\")), Org = tostring(iff(properties.resourceDetails.Source == \"AzureDevOps\", properties.additionalData.AdoOrg, properties.additionalData.GitHubOrg)), Finding = tostring(properties.additionalData.Finding), Severity = tostring(properties.metadata.severity), firstEvaluationDate = todatetime(properties.status.firstEvaluationDate), statusChangeDate = todatetime(properties.status.statusChangeDate), type = tostring(properties.resourceDetails.ResourceType)\r\n    | extend resourceType = tostring(iff(properties.resourceDetails.Source == \"AzureDevOps\", split(type,'/')[5], properties.additionalData.AffectedResourceCategory))\r\n    | summarize count() by status",
               "size": 0,
               "title": "Posture management findings by status",
               "queryType": 1,
@@ -1442,7 +1215,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "securityresources\r\n    | where type == \"microsoft.security/assessments\"\r\n    | extend assessmentKey = tostring(name)\r\n    | where assessmentKey in (\"9245366d-393f-49c5-b8e6-258b1b1c2daa\", \"a887e860-40ff-4b57-9ef9-5177a11091ac\", \"d5711372-9b5f-4926-a711-13dcf51565a6\", \"2c2c801e-6279-4d88-a419-af73f0eff4fb\", \"6855e9b1-c493-4a43-a6d1-74f30e72c5af\", \"909d299a-1736-456d-aef5-63688b230bfd\", \"17f3ad34-4f87-4463-a11d-6c6d7a84c486\", \"90901cb2-c497-4389-b63a-d3a562e15847\", \"bd041c7b-95db-4aaf-8bc4-fd9875ecdddf\", \"48f93272-e99c-47be-8087-091c71be9897\", \"2815b95f-f872-4d51-9709-54c1c7133d7b\", \"497e771e-d309-4e36-9bbd-353defd2658a\")\r\n    | extend source = trim(' ', tolower(tostring(properties.resourceDetails.Source)))\r\n    | extend resourceId = trim(' ', tolower(tostring( extract('^(.+)/providers/Microsoft.Security/assessments/.+$',1,id))))\r\n    | extend status = trim(\" \", tostring(properties.status.code)), cause = trim(\" \", tostring(properties.status.cause)), Severity = tostring(properties.metadata.severity)\r\n    | extend displayName = tostring(properties.displayName), affectedResourceUrl = properties.additionalData.AffectedResource_Url, Resource = tostring(properties.additionalData.AffectedResource), Project = tostring(iff(properties.resourceDetails.Source == \"AzureDevOps\", tostring(properties.additionalData.AdoProject), \"N/A\")), Org = tostring(iff(properties.resourceDetails.Source == \"AzureDevOps\", properties.additionalData.AdoOrg, properties.additionalData.GitHubOrg)), Finding = tostring(properties.additionalData.Finding), Severity = tostring(properties.metadata.severity), firstEvaluationDate = todatetime(properties.status.firstEvaluationDate), statusChangeDate = todatetime(properties.status.statusChangeDate), type = tostring(properties.resourceDetails.ResourceType)\r\n    | extend resourceType = tostring(iff(properties.resourceDetails.Source == \"AzureDevOps\", split(type,'/')[5], properties.additionalData.AffectedResourceCategory))\r\n    | where status == \"Unhealthy\"\r\n    | summarize count() by resourceType",
+              "query": "securityresources\r\n    | where type == \"microsoft.security/assessments\"\r\n    | extend assessmentKey = tostring(name)\r\n    | where assessmentKey in (\"9245366d-393f-49c5-b8e6-258b1b1c2daa\", \"a887e860-40ff-4b57-9ef9-5177a11091ac\", \"d5711372-9b5f-4926-a711-13dcf51565a6\", \"2c2c801e-6279-4d88-a419-af73f0eff4fb\", \"6855e9b1-c493-4a43-a6d1-74f30e72c5af\", \"909d299a-1736-456d-aef5-63688b230bfd\", \"17f3ad34-4f87-4463-a11d-6c6d7a84c486\", \"90901cb2-c497-4389-b63a-d3a562e15847\", \"bd041c7b-95db-4aaf-8bc4-fd9875ecdddf\", \"48f93272-e99c-47be-8087-091c71be9897\", \"2815b95f-f872-4d51-9709-54c1c7133d7b\", \"497e771e-d309-4e36-9bbd-353defd2658a\", \"470742ea-324a-406c-b91f-fc1da6a27c0c\", \"98b5895a-0ad8-4ed9-8c9d-d654f5bda816\", \"9f4a17ee-7a02-4978-b968-8c36b74ac8e3\", \"6331fad3-a7a2-497d-b616-52672057e0f3\", \"98e858ed-6e88-4698-b538-f51b31ad57f6\", \"a9621d26-9d8c-4cd6-8ad0-84501eb88f17\", \"20be7df7-9ebb-4fb4-95a9-3ae19b78b80a\")\r\n    | extend source = trim(' ', tolower(tostring(properties.resourceDetails.Source)))\r\n    | extend resourceId = trim(' ', tolower(tostring( extract('^(.+)/providers/Microsoft.Security/assessments/.+$',1,id))))\r\n    | extend status = trim(\" \", tostring(properties.status.code)), cause = trim(\" \", tostring(properties.status.cause)), Severity = tostring(properties.metadata.severity)\r\n    | extend displayName = tostring(properties.displayName), affectedResourceUrl = properties.additionalData.AffectedResource_Url, Resource = tostring(properties.additionalData.AffectedResource), Project = tostring(iff(properties.resourceDetails.Source == \"AzureDevOps\", tostring(properties.additionalData.AdoProject), \"N/A\")), Org = tostring(iff(properties.resourceDetails.Source == \"AzureDevOps\", properties.additionalData.AdoOrg, properties.additionalData.GitHubOrg)), Finding = tostring(properties.additionalData.Finding), Severity = tostring(properties.metadata.severity), firstEvaluationDate = todatetime(properties.status.firstEvaluationDate), statusChangeDate = todatetime(properties.status.statusChangeDate), type = tostring(properties.resourceDetails.ResourceType)\r\n    | extend resourceType = tostring(iff(properties.resourceDetails.Source == \"AzureDevOps\", split(type,'/')[5], properties.additionalData.AffectedResourceCategory))\r\n    | where status == \"Unhealthy\"\r\n    | summarize count() by resourceType",
               "size": 0,
               "title": "Posture management findings by resource type",
               "queryType": 1,
@@ -1459,7 +1232,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "securityresources\r\n    | where type == \"microsoft.security/assessments\"\r\n    | extend assessmentKey = tostring(name)\r\n    | where assessmentKey in (\"9245366d-393f-49c5-b8e6-258b1b1c2daa\", \"a887e860-40ff-4b57-9ef9-5177a11091ac\", \"d5711372-9b5f-4926-a711-13dcf51565a6\", \"2c2c801e-6279-4d88-a419-af73f0eff4fb\", \"6855e9b1-c493-4a43-a6d1-74f30e72c5af\", \"909d299a-1736-456d-aef5-63688b230bfd\", \"17f3ad34-4f87-4463-a11d-6c6d7a84c486\", \"90901cb2-c497-4389-b63a-d3a562e15847\", \"bd041c7b-95db-4aaf-8bc4-fd9875ecdddf\", \"48f93272-e99c-47be-8087-091c71be9897\", \"2815b95f-f872-4d51-9709-54c1c7133d7b\", \"497e771e-d309-4e36-9bbd-353defd2658a\")\r\n    | project source = trim(' ', tolower(tostring(properties.resourceDetails.Source))), resourceId = trim(' ', tolower(tostring( extract('^(.+)/providers/Microsoft.Security/assessments/.+$',1,id)))), status = trim(\" \", tostring(properties.status.code)), displayName = trim(\" \", tostring(properties.displayName)), Severity = tostring(properties.metadata.severity)\r\n    | summarize Healthy = countif(status == \"Healthy\"), Unhealthy = countif(status == \"Unhealthy\") by displayName, Severity\r\n    | order by Severity asc",
+              "query": "securityresources\r\n    | where type == \"microsoft.security/assessments\"\r\n    | extend assessmentKey = tostring(name)\r\n    | where assessmentKey in (\"9245366d-393f-49c5-b8e6-258b1b1c2daa\", \"a887e860-40ff-4b57-9ef9-5177a11091ac\", \"d5711372-9b5f-4926-a711-13dcf51565a6\", \"2c2c801e-6279-4d88-a419-af73f0eff4fb\", \"6855e9b1-c493-4a43-a6d1-74f30e72c5af\", \"909d299a-1736-456d-aef5-63688b230bfd\", \"17f3ad34-4f87-4463-a11d-6c6d7a84c486\", \"90901cb2-c497-4389-b63a-d3a562e15847\", \"bd041c7b-95db-4aaf-8bc4-fd9875ecdddf\", \"48f93272-e99c-47be-8087-091c71be9897\", \"2815b95f-f872-4d51-9709-54c1c7133d7b\", \"497e771e-d309-4e36-9bbd-353defd2658a\", \"470742ea-324a-406c-b91f-fc1da6a27c0c\", \"98b5895a-0ad8-4ed9-8c9d-d654f5bda816\", \"9f4a17ee-7a02-4978-b968-8c36b74ac8e3\", \"6331fad3-a7a2-497d-b616-52672057e0f3\", \"98e858ed-6e88-4698-b538-f51b31ad57f6\", \"a9621d26-9d8c-4cd6-8ad0-84501eb88f17\", \"20be7df7-9ebb-4fb4-95a9-3ae19b78b80a\")\r\n    | project source = trim(' ', tolower(tostring(properties.resourceDetails.Source))), resourceId = trim(' ', tolower(tostring( extract('^(.+)/providers/Microsoft.Security/assessments/.+$',1,id)))), status = trim(\" \", tostring(properties.status.code)), displayName = trim(\" \", tostring(properties.displayName)), Severity = tostring(properties.metadata.severity)\r\n    | summarize Healthy = countif(status == \"Healthy\"), Unhealthy = countif(status == \"Unhealthy\") by displayName, Severity\r\n    | order by Severity asc",
               "size": 3,
               "title": "DevOps Posture Management Findings",
               "exportedParameters": [
@@ -1611,69 +1384,6 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "securityresources\r\n    | where type == \"microsoft.security/assessments\"\r\n    | extend assessmentKey = tostring(name)\r\n    | project source = trim(' ', tolower(tostring(properties.resourceDetails.Source))), resourceId = trim(' ', tolower(tostring( extract('^(.+)/providers/Microsoft.Security/assessments/.+$',1,id)))), status = trim(\" \", tostring(properties.status.code)), displayName = trim(\" \", tostring(properties.displayName)), description = tostring(properties.status.description)\r\n    | where displayName == '{displayName}'\r\n    | project description",
-              "size": 3,
-              "title": "Description",
-              "queryType": 1,
-              "resourceType": "microsoft.resourcegraph/resources",
-              "crossComponentResources": [
-                "value::all"
-              ],
-              "visualization": "card",
-              "textSettings": {
-                "style": "markdown"
-              }
-            },
-            "conditionalVisibility": {
-              "parameterName": "nameSelected",
-              "comparison": "isNotEqualTo",
-              "value": "false"
-            },
-            "name": "Description"
-          },
-          {
-            "type": 3,
-            "content": {
-              "version": "KqlItem/1.0",
-              "query": "securityresources\r\n    | where type == \"microsoft.security/assessments\"\r\n    | extend assessmentKey = tostring(name), source = trim(' ', tolower(tostring(properties.resourceDetails.Source)))\r\n    | project resourceId = trim(' ', tolower(tostring( extract('^(.+)/providers/Microsoft.Security/assessments/.+$',1,id)))), status = trim(\" \", tostring(properties.status.code)), displayName = trim(\" \", tostring(properties.displayName)), tostring(properties.status.description), remediation = tostring(properties.metadata.remediationDescription)\r\n    | where displayName == '{displayName}'\r\n    | project remediation",
-              "size": 3,
-              "title": "Remediation Guidance",
-              "queryType": 1,
-              "resourceType": "microsoft.resourcegraph/resources",
-              "crossComponentResources": [
-                "value::all"
-              ],
-              "visualization": "card",
-              "gridSettings": {
-                "formatters": [
-                  {
-                    "columnMatch": "remediation",
-                    "formatter": 1
-                  }
-                ]
-              },
-              "textSettings": {
-                "style": "markdown"
-              }
-            },
-            "conditionalVisibilities": [
-              {
-                "parameterName": "SelectedTab",
-                "comparison": "isEqualTo",
-                "value": "Hardening"
-              },
-              {
-                "parameterName": "nameSelected",
-                "comparison": "isNotEqualTo",
-                "value": "false"
-              }
-            ],
-            "name": "Remediation Guidance"
-          },
-          {
-            "type": 3,
-            "content": {
-              "version": "KqlItem/1.0",
               "query": "securityresources\r\n    | where type == \"microsoft.security/assessments\"\r\n    | extend assessmentKey = tostring(name)\r\n    | extend source = trim(' ', tolower(tostring(properties.resourceDetails.Source))), resourceId = trim(' ', tolower(tostring( extract('^(.+)/providers/Microsoft.Security/assessments/.+$',1,id)))), status = trim(\" \", tostring(properties.status.code)), displayName = trim(\" \", tostring(properties.displayName)), Cause = trim(\" \", tostring(properties.status.cause))\r\n    | where status == \"Unhealthy\"\r\n    | where displayName == '{displayName}'\r\n    | extend affectedResourceUrl = tostring(properties.resourceDetails.NativeResourceId), Resource = tostring(properties.additionalData.AffectedResource), Project = tostring(iff(properties.resourceDetails.Source == \"AzureDevOps\", tostring(properties.additionalData.AdoProject), \"N/A\")), Org = tostring(iff(properties.resourceDetails.Source == \"AzureDevOps\", properties.additionalData.AdoOrg, properties.additionalData.GitHubOrg)), Severity = tostring(properties.metadata.severity), firstEvaluationDate = todatetime(properties.status.firstEvaluationDate), statusChangeDate = todatetime(properties.status.statusChangeDate), type = tostring(properties.resourceDetails.ResourceType)\r\n    | extend resourceType = tostring(iff(properties.resourceDetails.Source == \"AzureDevOps\", split(type,'/')[5], properties.additionalData.AffectedResourceCategory))\r\n    | extend Details = \"info\"\r\n    | project resourceType, Org, Project, Resource, Cause, DiscoveredDate = format_datetime(firstEvaluationDate, 'yyyy-MM-dd'), ChangedDate = format_datetime(statusChangeDate, 'yyyy-MM-dd'), affectedResourceUrl, Details, properties\r\n    | order by Org asc",
               "size": 0,
               "title": "Affected Resources",
@@ -1809,7 +1519,7 @@
                 "value": "Hardening"
               },
               {
-                "parameterName": "causeSelected",
+                "parameterName": "nameSelected",
                 "comparison": "isNotEqualTo",
                 "value": "false"
               }
@@ -1818,6 +1528,69 @@
             "styleSettings": {
               "showBorder": true
             }
+          },
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "securityresources\r\n    | where type == \"microsoft.security/assessments\"\r\n    | extend assessmentKey = tostring(name)\r\n    | project source = trim(' ', tolower(tostring(properties.resourceDetails.Source))), resourceId = trim(' ', tolower(tostring( extract('^(.+)/providers/Microsoft.Security/assessments/.+$',1,id)))), status = trim(\" \", tostring(properties.status.code)), displayName = trim(\" \", tostring(properties.displayName)), description = tostring(properties.status.description)\r\n    | where displayName == '{displayName}'\r\n    | project description",
+              "size": 3,
+              "title": "Description",
+              "queryType": 1,
+              "resourceType": "microsoft.resourcegraph/resources",
+              "crossComponentResources": [
+                "value::all"
+              ],
+              "visualization": "card",
+              "textSettings": {
+                "style": "markdown"
+              }
+            },
+            "conditionalVisibility": {
+              "parameterName": "nameSelected",
+              "comparison": "isNotEqualTo",
+              "value": "false"
+            },
+            "name": "Description"
+          },
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "securityresources\r\n    | where type == \"microsoft.security/assessments\"\r\n    | extend assessmentKey = tostring(name), source = trim(' ', tolower(tostring(properties.resourceDetails.Source)))\r\n    | project resourceId = trim(' ', tolower(tostring( extract('^(.+)/providers/Microsoft.Security/assessments/.+$',1,id)))), status = trim(\" \", tostring(properties.status.code)), displayName = trim(\" \", tostring(properties.displayName)), tostring(properties.status.description), remediation = tostring(properties.metadata.remediationDescription)\r\n    | where displayName == '{displayName}'\r\n    | project remediation",
+              "size": 3,
+              "title": "Remediation Guidance",
+              "queryType": 1,
+              "resourceType": "microsoft.resourcegraph/resources",
+              "crossComponentResources": [
+                "value::all"
+              ],
+              "visualization": "card",
+              "gridSettings": {
+                "formatters": [
+                  {
+                    "columnMatch": "remediation",
+                    "formatter": 1
+                  }
+                ]
+              },
+              "textSettings": {
+                "style": "markdown"
+              }
+            },
+            "conditionalVisibilities": [
+              {
+                "parameterName": "SelectedTab",
+                "comparison": "isEqualTo",
+                "value": "Hardening"
+              },
+              {
+                "parameterName": "nameSelected",
+                "comparison": "isNotEqualTo",
+                "value": "false"
+              }
+            ],
+            "name": "Remediation Guidance"
           }
         ]
       },
@@ -1828,9 +1601,6 @@
       },
       "name": "Hardening"
     }
-  ],
-  "fallbackResourceIds": [
-    "Azure Security Center"
   ],
   "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
 }


### PR DESCRIPTION
I added the "CreatedAt" field to the Secrets tab too. 
Creation_Date property is not the same for ADO and GitHub findings. I added in the following logic to account for that and removed the quotation marks around it: 
| extend Creation_Date_Raw = tostring(properties.additionalData.data.Creation_Date)
| extend Creation_Date_Trimmed = trim('\"', tostring(Creation_Date_Raw)) 
| extend Creation_Date = todatetime(Creation_Date_Trimmed) 
| extend TimeGenerated = iff(Source =~ "AzureDevOps", Creation_Date, todatetime(Time))
For Branch, we do not receive the Branch property for CodeQL findings from ADO. I added in the following logic to account for that:
| extend  Branch = iff(Source =~ 'AzureDevOps' and Tool == 'CodeQL', 'N/A - Default Only', tostring(properties.additionalData.data.Branch))
Some general updates that I've been meaning to push out but haven't had the chance.