### PR TITLE
Improve spark area contrast, fix tooltips

### DIFF
--- a/Workbooks/Database watcher/Azure SQL Database/elastic pool/databases/databases.workbook
+++ b/Workbooks/Database watcher/Azure SQL Database/elastic pool/databases/databases.workbook
@@ -220,7 +220,7 @@
             "formatOptions": {
               "min": 0,
               "max": 100,
-              "palette": "purple"
+              "palette": "blueDarkDark"
             },
             "tooltipFormat": {
               "tooltip": "Average CPU utilization over selected time range"
@@ -1461,10 +1461,10 @@
             "formatOptions": {
               "min": 0,
               "max": 100,
-              "palette": "purple"
+              "palette": "blueDarkDark"
             },
             "tooltipFormat": {
-              "tooltip": "Average Data IO utilization over selected time range"
+              "tooltip": "Average data IO utilization over selected time range"
             }
           },
           "nodeIdField": "database_name",
@@ -1614,7 +1614,7 @@
               "emptyValCustomText": "N/A"
             },
             "tooltipFormat": {
-              "tooltip": "Average Data IO percentage for selected time range. Shows \"N/A\" if the number of samples is insufficient."
+              "tooltip": "Average log write percentage for selected time range. Shows \"N/A\" if the number of samples is insufficient."
             }
           },
           "bottomContent": {
@@ -1623,10 +1623,10 @@
             "formatOptions": {
               "min": 0,
               "max": 100,
-              "palette": "purple"
+              "palette": "blueDarkDark"
             },
             "tooltipFormat": {
-              "tooltip": "Average Data IO utilization over selected time range"
+              "tooltip": "Average log write utilization over selected time range"
             }
           },
           "nodeIdField": "database_name",

--- a/Workbooks/Database watcher/Azure SQL Database/estate/estate.workbook
+++ b/Workbooks/Database watcher/Azure SQL Database/estate/estate.workbook
@@ -2155,7 +2155,7 @@
             "formatOptions": {
               "min": 0,
               "max": 100,
-              "palette": "purple"
+              "palette": "blueDarkDark"
             },
             "tooltipFormat": {
               "tooltip": "Average CPU utilization over selected time range"
@@ -2342,7 +2342,7 @@
               "emptyValCustomText": "N/A"
             },
             "tooltipFormat": {
-              "tooltip": "Average CPU percentage for selected time range. Shows \"N/A\" if the number of samples is insufficient."
+              "tooltip": "Average instance CPU percentage for selected time range. Shows \"N/A\" if the number of samples is insufficient."
             }
           },
           "bottomContent": {
@@ -2351,10 +2351,10 @@
             "formatOptions": {
               "min": 0,
               "max": 100,
-              "palette": "purple"
+              "palette": "blueDarkDark"
             },
             "tooltipFormat": {
-              "tooltip": "Average CPU utilization over selected time range"
+              "tooltip": "Average instance CPU utilization over selected time range"
             }
           },
           "hivesContent": {
@@ -2537,7 +2537,7 @@
               "emptyValCustomText": "N/A"
             },
             "tooltipFormat": {
-              "tooltip": "Average CPU percentage for selected time range. Shows \"N/A\" if the number of samples is insufficient."
+              "tooltip": "Average data IO percentage for selected time range. Shows \"N/A\" if the number of samples is insufficient."
             }
           },
           "bottomContent": {
@@ -2546,10 +2546,10 @@
             "formatOptions": {
               "min": 0,
               "max": 100,
-              "palette": "purple"
+              "palette": "blueDarkDark"
             },
             "tooltipFormat": {
-              "tooltip": "Average CPU utilization over selected time range"
+              "tooltip": "Average data IO utilization over selected time range"
             }
           },
           "hivesContent": {
@@ -2732,7 +2732,7 @@
               "emptyValCustomText": "N/A"
             },
             "tooltipFormat": {
-              "tooltip": "Average CPU percentage for selected time range. Shows \"N/A\" if the number of samples is insufficient."
+              "tooltip": "Average log write percentage for selected time range. Shows \"N/A\" if the number of samples is insufficient."
             }
           },
           "bottomContent": {
@@ -2741,10 +2741,10 @@
             "formatOptions": {
               "min": 0,
               "max": 100,
-              "palette": "purple"
+              "palette": "blueDarkDark"
             },
             "tooltipFormat": {
-              "tooltip": "Average CPU utilization over selected time range"
+              "tooltip": "Average log write utilization over selected time range"
             }
           },
           "hivesContent": {
@@ -2927,7 +2927,7 @@
               "emptyValCustomText": "N/A"
             },
             "tooltipFormat": {
-              "tooltip": "Average CPU percentage for selected time range. Shows \"N/A\" if the number of samples is insufficient."
+              "tooltip": "Average worker percentage for selected time range. Shows \"N/A\" if the number of samples is insufficient."
             }
           },
           "bottomContent": {
@@ -2936,10 +2936,10 @@
             "formatOptions": {
               "min": 0,
               "max": 100,
-              "palette": "purple"
+              "palette": "blueDarkDark"
             },
             "tooltipFormat": {
-              "tooltip": "Average CPU utilization over selected time range"
+              "tooltip": "Average worker utilization over selected time range"
             }
           },
           "hivesContent": {
@@ -3892,7 +3892,7 @@
             "formatOptions": {
               "min": 0,
               "max": 100,
-              "palette": "purple"
+              "palette": "blueDarkDark"
             },
             "tooltipFormat": {
               "tooltip": "Average CPU utilization over selected time range"
@@ -4083,7 +4083,7 @@
             "formatOptions": {
               "min": 0,
               "max": 100,
-              "palette": "purple"
+              "palette": "blueDarkDark"
             },
             "tooltipFormat": {
               "tooltip": "Average instance CPU utilization over selected time range"
@@ -4273,7 +4273,7 @@
             "formatOptions": {
               "min": 0,
               "max": 100,
-              "palette": "purple"
+              "palette": "blueDarkDark"
             },
             "tooltipFormat": {
               "tooltip": "Average data IO utilization over selected time range"
@@ -4463,7 +4463,7 @@
             "formatOptions": {
               "min": 0,
               "max": 100,
-              "palette": "purple"
+              "palette": "blueDarkDark"
             },
             "tooltipFormat": {
               "tooltip": "Average log write utilization over selected time range"
@@ -4653,7 +4653,7 @@
             "formatOptions": {
               "min": 0,
               "max": 100,
-              "palette": "purple"
+              "palette": "blueDarkDark"
             },
             "tooltipFormat": {
               "tooltip": "Average worker utilization over selected time range"

--- a/Workbooks/Database watcher/Azure SQL Managed Instance/estate/estate.workbook
+++ b/Workbooks/Database watcher/Azure SQL Managed Instance/estate/estate.workbook
@@ -1516,7 +1516,7 @@
             "formatOptions": {
               "min": 0,
               "max": 100,
-              "palette": "purple"
+              "palette": "blueDarkDark"
             },
             "tooltipFormat": {
               "tooltip": "Average CPU utilization over selected time range"
@@ -1710,7 +1710,7 @@
             "formatOptions": {
               "min": 0,
               "max": 100,
-              "palette": "purple"
+              "palette": "blueDarkDark"
             },
             "tooltipFormat": {
               "tooltip": "Average log write utilization over selected time range"
@@ -1904,7 +1904,7 @@
             "formatOptions": {
               "min": 0,
               "max": 100,
-              "palette": "purple"
+              "palette": "blueDarkDark"
             },
             "tooltipFormat": {
               "tooltip": "Average worker utilization over selected time range"

--- a/Workbooks/Database watcher/SQL Server/estate/estate.workbook
+++ b/Workbooks/Database watcher/SQL Server/estate/estate.workbook
@@ -1615,7 +1615,7 @@
             "formatOptions": {
               "min": 0,
               "max": 100,
-              "palette": "purple"
+              "palette": "blueDarkDark"
             },
             "tooltipFormat": {
               "tooltip": "Average CPU utilization over selected time range"


### PR DESCRIPTION
## Summary

- Use a darker color for spark areas to improve contrast on heatmap dashboards
- Fix copy/paste bugs in tooltips on heatmap dashboards

## Screenshots

![image](https://github.com/user-attachments/assets/d64462ec-f693-41b0-aec9-49ee6a7a7383)

- [x] If you added a template to a gallery, show a screenshot of it in the gallery view (which verifies its shows up where you expected).

  It is also good to show a screenshot of template content, so people can see what you expect it to look like, compared to what they see when they might run it themselves.

## Validation

- [x] Validate your changes using one or more of the [testing](https://github.com/microsoft/Application-Insights-Workbooks/blob/master/Documentation/Testing.md) methods.
  
  Make sure you've tested your template content. Fixing things while in PR is trivial. Hotfixing it later is very expensive; at the current time at least 3 teams are involved in a hotfix!

## Checklist

- [x] If you are adding a new template, gallery, or folder, add your team and folder/file(s) to the CODEOWNERS file at the root of the repo. CODEOWNERS entries should be teams, not individuals.
      When done correctly, this means that from then on *your* team does reviews of *your* things, not the workbooks team.
- [x] Ensure all steps in your template have meaningful names.
- [x] Ensure all parameters and grid columns have display names set so they can be localized.
