### PR TITLE
Email Insights page should let customers know to setup Diagnostic settings to start capturing logs

### DIFF
--- a/Workbooks/Communication Services/Email_Insights/Email_Insights.workbook
+++ b/Workbooks/Communication Services/Email_Insights/Email_Insights.workbook
@@ -351,6 +351,7 @@
         "version": "KqlItem/1.0",
         "query": "let all = ACSEmailStatusUpdateOperational \r\n| where OperationName == \"DeliveryStatusUpdate\" and isnotempty(DeliveryStatus) and DeliveryStatus != \"OutForDelivery\"\r\n| where ('{email_mailfrom:value}' == \"All senders\") or (strcat(SenderUsername, '@', SenderDomain) == '{email_mailfrom:value}')\r\n| project DeliveryStatus, ts=bin(TimeGenerated, iif(\"{email_time_bucket:label}\" == \"<unset>\", 4h, totimespan(\"{email_time_bucket:value}\")));\r\nall | summarize \r\n        total=count(),\r\n        success=countif(DeliveryStatus == \"Delivered\"),\r\n        failures=countif(DeliveryStatus != \"Delivered\")\r\n        by ts",
         "size": 0,
+        "noDataMessage": "__NOTE:__ In the table above, if collection name is set to an empty value, this is because throughput is shared among collections within your database.",
         "timeContextFromParameter": "email_time",
         "queryType": 0,
         "resourceType": "microsoft.communication/communicationservices",

--- a/Workbooks/Communication Services/Overview/Overview.workbook
+++ b/Workbooks/Communication Services/Overview/Overview.workbook
@@ -3590,6 +3590,7 @@
               "version": "KqlItem/1.0",
               "query": "let all = ACSEmailStatusUpdateOperational \r\n| where OperationName == \"DeliveryStatusUpdate\" and isnotempty(DeliveryStatus) and DeliveryStatus != \"OutForDelivery\"\r\n| where ('{email_mailfrom:value}' == \"All senders\") or (strcat(SenderUsername, '@', SenderDomain) == '{email_mailfrom:value}')\r\n| project DeliveryStatus, ts=bin(TimeGenerated, iif(\"{time_granularity:label}\" == \"<unset>\", 4h, totimespan(\"{time_granularity:value}\")));\r\nall | summarize \r\n        total=count(),\r\n        success=countif(DeliveryStatus == \"Delivered\"),\r\n        failures=countif(DeliveryStatus != \"Delivered\")\r\n        by ts",
               "size": 0,
+              "noDataMessage": "__NOTE:__ In the table above, if collection name is set to an empty value, this is because throughput is shared among collections within your database.",
               "timeContextFromParameter": "time_range",
               "queryType": 0,
               "resourceType": "microsoft.communication/communicationservices",


### PR DESCRIPTION
Today if the customer does not have any diagnostic setting enabled to capture logs, the insights tab does not show any data

CSS has asked that we should either have some text here that lets customers know that they have to go setup Diagnostic settings to start capturing logs which will power data shown in this insights tab, or explicitly provide a link to the customer directly to the Diagnostic blade.

![image](https://github.com/user-attachments/assets/2e716078-e274-40fd-99bd-72a33ff9435f)
![image](https://github.com/user-attachments/assets/0ba34e98-9c43-4199-9df7-dbb2d36ba30c)
