### PR TITLE
[database watcher] Improve the data store inaccessible message

### DIFF
--- a/Workbooks/Database watcher/watcher.workbook
+++ b/Workbooks/Database watcher/watcher.workbook
@@ -238,34 +238,34 @@
               "comparison": "isNotEqualTo"
             },
             "name": "adx_parameters"
-          },
-          {
-            "type": 1,
-            "content": {
-              "json": "Cannot connect to Kusto query URI `{adxClusterUri}`, database `{adxDatabase}`. The Kusto cluster might be stopped or unreachable, specified cluster URI might be invalid, or permissions might be insufficient. [Learn more](https://go.microsoft.com/fwlink/?linkid=2268015) to troubleshoot.",
-              "style": "warning"
-            },
-            "conditionalVisibilities": [
-              {
-                "parameterName": "adxClusterPingResult",
-                "comparison": "isNotEqualTo",
-                "value": "1"
-              },
-              {
-                "parameterName": "adxClusterUri",
-                "comparison": "isNotEqualTo"
-              },
-              {
-                "parameterName": "adxDatabase",
-                "comparison": "isNotEqualTo"
-              }
-            ],
-            "name": "missing_data_bad_permissions_text"
           }
         ],
         "exportParameters": true
       },
       "name": "data_store_group"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "Cannot connect to the query URI `{adxClusterUri}`, database `{adxDatabase}`. The data store might be stopped or unreachable, specified query URI might be invalid, or permissions might be insufficient.\r\n\r\n**Common causes:**\r\n\r\n1. You do not have access to the data store. Ask an administrator to [grant access](https://go.microsoft.com/fwlink/?linkid=2297712).\r\n1. Public connectivity to the Azure Data Explorer cluster is disabled. Learn how to [set up private connectivity](https://go.microsoft.com/fwlink/?linkid=2297583).\r\n\r\n[Learn more](https://go.microsoft.com/fwlink/?linkid=2268015) to troubleshoot other causes.",
+        "style": "warning"
+      },
+      "conditionalVisibilities": [
+        {
+          "parameterName": "adxClusterPingResult",
+          "comparison": "isNotEqualTo",
+          "value": "1"
+        },
+        {
+          "parameterName": "adxClusterUri",
+          "comparison": "isNotEqualTo"
+        },
+        {
+          "parameterName": "adxDatabase",
+          "comparison": "isNotEqualTo"
+        }
+      ],
+      "name": "missing_data_bad_permissions_text"
     },
     {
       "type": 9,


### PR DESCRIPTION
## Summary

- Do not require the user to expand the `Data store` section to see the "data store is inaccessible" message.
- Improve the message to list common causes, with links to relevant documentation.

## Screenshots

![image](https://github.com/user-attachments/assets/7ab7e8b2-0854-4b1f-84d9-2c7209bf1a09)

## Validation

- [x] Validate your changes using one or more of the [testing](https://github.com/microsoft/Application-Insights-Workbooks/blob/master/Documentation/Testing.md) methods.

## Checklist

- [x] Ensure all steps in your template have meaningful names.
- [x] Ensure all parameters and grid columns have display names set so they can be localized.
