### PR TITLE
Change Azure Stack HCI naming convention to Azure Local

### DIFF
--- a/Workbooks/Windows Virtual Desktop/AtScale/Overview/Overview.workbook
+++ b/Workbooks/Windows Virtual Desktop/AtScale/Overview/Overview.workbook
@@ -892,7 +892,7 @@
                   "type": 3,
                   "content": {
                     "version": "KqlItem/1.0",
-                    "query": "desktopvirtualizationresources\r\n| extend VMRid = tolower(properties.resourceId), Sessions = toint(properties.sessions), hpId = tolower(trim_end(\"/sessionhosts/.+\", id))\r\n| where hpId in~ ({HostPools})\r\n|project id=VMRid, Sessions\r\n| join kind=inner (resources\r\n    | where type =~ \"microsoft.compute/virtualmachines\" or type =~ \"microsoft.hybridcompute/machines\"\r\n    | extend id = tolower(id), location=iff(type =~ \"microsoft.hybridcompute/machines\", \"Azure Stack HCI\", location)\r\n    ) on id\r\n| summarize  Count = count(), Sessions=sum(Sessions) by location\r\n| sort by Count desc, Sessions desc\r\n",
+                    "query": "desktopvirtualizationresources\r\n| extend VMRid = tolower(properties.resourceId), Sessions = toint(properties.sessions), hpId = tolower(trim_end(\"/sessionhosts/.+\", id))\r\n| where hpId in~ ({HostPools})\r\n|project id=VMRid, Sessions\r\n| join kind=inner (resources\r\n    | where type =~ \"microsoft.compute/virtualmachines\" or type =~ \"microsoft.hybridcompute/machines\"\r\n    | extend id = tolower(id), location=iff(type =~ \"microsoft.hybridcompute/machines\", \"Azure Local\", location)\r\n    ) on id\r\n| summarize  Count = count(), Sessions=sum(Sessions) by location\r\n| sort by Count desc, Sessions desc\r\n",
                     "size": 0,
                     "showRefreshButton": true,
                     "queryType": 1,

--- a/Workbooks/Windows Virtual Desktop/shared/Template Versioning Footer/Template Versioning Footer.workbook
+++ b/Workbooks/Windows Virtual Desktop/shared/Template Versioning Footer/Template Versioning Footer.workbook
@@ -13,7 +13,7 @@
             "type": 1,
             "description": "Internal parameter to centralize the template version",
             "isRequired": true,
-            "value": "4.1.0",
+            "value": "4.2.0",
             "isHiddenWhenLocked": true
           }
         ],

--- a/Workbooks/Windows Virtual Desktop/shared/Template Versioning Footer/Template Versioning Footer.workbook
+++ b/Workbooks/Windows Virtual Desktop/shared/Template Versioning Footer/Template Versioning Footer.workbook
@@ -13,7 +13,7 @@
             "type": 1,
             "description": "Internal parameter to centralize the template version",
             "isRequired": true,
-            "value": "4.2.0",
+            "value": "4.3.0",
             "isHiddenWhenLocked": true
           }
         ],


### PR DESCRIPTION
## Summary
On the "Overview" page, change the name from "Azure Stack HCI" to "Azure Local".

## Screenshots
<img width="1720" alt="image" src="https://github.com/user-attachments/assets/2bcf945c-0690-4cb3-9aab-fb108a0b0b7e">

## Validation
https://ms.portal.azure.com/?feature.workbookGalleryBranch=xixiao%2FchangeHCINaming#view/Microsoft_Azure_WVD/WvdManagerMenuBlade/~/insights
