### PR TITLE
Add data store connection status

### DIFF
--- a/Workbooks/Database watcher/watcher.workbook
+++ b/Workbooks/Database watcher/watcher.workbook
@@ -49,6 +49,15 @@
             "query": "{\"version\":\"1.0.0\",\"content\":\"{watcherResource}\",\"transformers\":[{\"type\":\"jsonpath\",\"settings\":{\"tablePath\":\"$.properties.datastore.kustoDatabaseName\",\"columns\":[]}}]}",
             "isHiddenWhenLocked": true,
             "queryType": 8
+          },
+          {
+            "id": "0797c608-2ecf-4711-ba9b-6d110f10acd4",
+            "version": "KqlParameterItem/1.0",
+            "name": "watcherDataStoreType",
+            "type": 1,
+            "query": "{\"version\":\"1.0.0\",\"content\":\"{watcherResource}\",\"transformers\":[{\"type\":\"jsonpath\",\"settings\":{\"tablePath\":\"$.properties.datastore.kustoOfferingType\",\"columns\":[]}}]}",
+            "isHiddenWhenLocked": true,
+            "queryType": 8
           }
         ],
         "style": "above",
@@ -74,6 +83,31 @@
               "version": "KqlParameterItem/1.0",
               "parameters": [
                 {
+                  "id": "331dc8bc-f368-4c1c-9ebc-19c7ad38178b",
+                  "version": "KqlParameterItem/1.0",
+                  "name": "decoratedWatcherName",
+                  "type": 1,
+                  "isHiddenWhenLocked": true,
+                  "criteriaData": [
+                    {
+                      "criteriaContext": {
+                        "leftOperand": "watcherName",
+                        "operator": "is Empty",
+                        "rightValType": "param",
+                        "resultValType": "static",
+                        "resultVal": "<Not selected>"
+                      }
+                    },
+                    {
+                      "criteriaContext": {
+                        "operator": "Default",
+                        "resultValType": "param",
+                        "resultVal": "watcherName"
+                      }
+                    }
+                  ]
+                },
+                {
                   "id": "394a23b6-9786-4e1b-bb03-37ef95dbcb1d",
                   "version": "KqlParameterItem/1.0",
                   "name": "dataStore",
@@ -81,7 +115,7 @@
                   "type": 10,
                   "description": "By default, the workbook loads data from the data store of the current database watcher. You can use an alternate data store by entering its Kusto query URI and database name.",
                   "isRequired": true,
-                  "query": "{\"version\":\"1.0.0\",\"content\":\"[{\\\"value\\\":\\\"watcher\\\",\\\"label\\\":\\\"{watcherName}\\\"},{\\\"value\\\":\\\"alternate\\\",\\\"label\\\":\\\"Alternate\\\"}]\",\"transformers\":null}",
+                  "query": "{\"version\":\"1.0.0\",\"content\":\"[{\\\"value\\\":\\\"watcher\\\",\\\"label\\\":\\\"{decoratedWatcherName}\\\"},{\\\"value\\\":\\\"alternate\\\",\\\"label\\\":\\\"Alternate\\\"}]\",\"transformers\":null}",
                   "typeSettings": {
                     "additionalResourceOptions": [],
                     "showDefault": false
@@ -91,7 +125,7 @@
                 }
               ],
               "style": "above",
-              "queryType": 12
+              "queryType": 0
             },
             "customWidth": "30",
             "name": "data_store_parameters"
@@ -238,34 +272,313 @@
               "comparison": "isNotEqualTo"
             },
             "name": "adx_parameters"
+          },
+          {
+            "type": 9,
+            "content": {
+              "version": "KqlParameterItem/1.0",
+              "parameters": [
+                {
+                  "id": "4d1aef87-cfcf-4dcb-93c9-77f5e405a902",
+                  "version": "KqlParameterItem/1.0",
+                  "name": "noWatcherResourceIdText",
+                  "type": 1,
+                  "isHiddenWhenLocked": true,
+                  "typeSettings": {
+                    "multiLineText": true,
+                    "editorLanguage": "markdown"
+                  },
+                  "timeContext": {
+                    "durationMs": 86400000
+                  },
+                  "value": "A watcher is not selected."
+                },
+                {
+                  "id": "20a4ed56-5b4e-4e25-8bbc-74fffe94fcf6",
+                  "version": "KqlParameterItem/1.0",
+                  "name": "noDataStoreText",
+                  "type": 1,
+                  "query": "{\"version\":\"1.0.0\",\"content\":\"{\\\"Text\\\":\\\"Watcher `{watcherName}` does not have a data store.\\\"}\",\"transformers\":null}",
+                  "isHiddenWhenLocked": true,
+                  "typeSettings": {
+                    "multiLineText": true,
+                    "editorLanguage": "markdown"
+                  },
+                  "timeContext": {
+                    "durationMs": 86400000
+                  },
+                  "queryType": 8
+                },
+                {
+                  "version": "KqlParameterItem/1.0",
+                  "name": "noKustoQueryUriText",
+                  "type": 1,
+                  "isHiddenWhenLocked": true,
+                  "typeSettings": {
+                    "multiLineText": true,
+                    "editorLanguage": "markdown"
+                  },
+                  "timeContext": {
+                    "durationMs": 86400000
+                  },
+                  "value": "The Kusto query URI is not specified.",
+                  "id": "d0acaf74-9bee-4904-817b-99ba086d6239"
+                },
+                {
+                  "version": "KqlParameterItem/1.0",
+                  "name": "noKustoDatabaseText",
+                  "type": 1,
+                  "isHiddenWhenLocked": true,
+                  "typeSettings": {
+                    "multiLineText": true,
+                    "editorLanguage": "markdown"
+                  },
+                  "timeContext": {
+                    "durationMs": 86400000
+                  },
+                  "value": "The Kusto database is not specified.",
+                  "id": "24c3fc88-c326-4aaa-9508-f357e3e839c3"
+                },
+                {
+                  "id": "add7ef86-d620-42e6-8819-6038864e9b7a",
+                  "version": "KqlParameterItem/1.0",
+                  "name": "dataStoreTypeName",
+                  "type": 1,
+                  "isHiddenWhenLocked": true,
+                  "criteriaData": [
+                    {
+                      "criteriaContext": {
+                        "leftOperand": "watcherDataStoreType",
+                        "operator": "==",
+                        "rightValType": "static",
+                        "rightVal": "adx",
+                        "resultValType": "static",
+                        "resultVal": "on an Azure Data Explorer cluster"
+                      }
+                    },
+                    {
+                      "criteriaContext": {
+                        "leftOperand": "watcherDataStoreType",
+                        "operator": "==",
+                        "rightValType": "static",
+                        "rightVal": "free",
+                        "resultValType": "static",
+                        "resultVal": "on a free Azure Data Explorer cluster"
+                      }
+                    },
+                    {
+                      "criteriaContext": {
+                        "leftOperand": "watcherDataStoreType",
+                        "operator": "==",
+                        "rightValType": "static",
+                        "rightVal": "fabric",
+                        "resultValType": "static",
+                        "resultVal": "in Real-Time Analytics in Microsoft Fabric"
+                      }
+                    },
+                    {
+                      "criteriaContext": {
+                        "operator": "Default",
+                        "resultValType": "static",
+                        "resultVal": "of unknown type"
+                      }
+                    }
+                  ],
+                  "timeContext": {
+                    "durationMs": 86400000
+                  }
+                },
+                {
+                  "id": "e8a51676-5feb-41f1-b5ca-d2c0d5a2555c",
+                  "version": "KqlParameterItem/1.0",
+                  "name": "successfulDataStoreConnectionText",
+                  "type": 1,
+                  "query": "{\"version\":\"1.0.0\",\"content\":\"{\\\"Text\\\":\\\"Connected to a data store {dataStoreTypeName}.\\\"}\",\"transformers\":null}",
+                  "isHiddenWhenLocked": true,
+                  "typeSettings": {
+                    "multiLineText": true,
+                    "editorLanguage": "markdown"
+                  },
+                  "timeContext": {
+                    "durationMs": 86400000
+                  },
+                  "queryType": 8
+                },
+                {
+                  "id": "0f567986-9058-4d5c-8043-00f192274f27",
+                  "version": "KqlParameterItem/1.0",
+                  "name": "dataStoreStatusText",
+                  "type": 1,
+                  "isHiddenWhenLocked": true,
+                  "criteriaData": [
+                    {
+                      "criteriaContext": {
+                        "leftOperand": "watcherResourceId",
+                        "operator": "is Empty",
+                        "rightValType": "param",
+                        "resultValType": "param",
+                        "resultVal": "noWatcherResourceIdText"
+                      }
+                    },
+                    {
+                      "criteriaContext": {
+                        "leftOperand": "watcherDataStoreType",
+                        "operator": "is Empty",
+                        "rightValType": "param",
+                        "resultValType": "param",
+                        "resultVal": "noDataStoreText"
+                      }
+                    },
+                    {
+                      "criteriaContext": {
+                        "leftOperand": "adxClusterUri",
+                        "operator": "is Empty",
+                        "rightValType": "param",
+                        "resultValType": "param",
+                        "resultVal": "noKustoQueryUriText"
+                      }
+                    },
+                    {
+                      "criteriaContext": {
+                        "leftOperand": "adxDatabase",
+                        "operator": "is Empty",
+                        "rightValType": "param",
+                        "resultValType": "param",
+                        "resultVal": "noKustoDatabaseText"
+                      }
+                    },
+                    {
+                      "criteriaContext": {
+                        "leftOperand": "adxClusterPingResult",
+                        "operator": "==",
+                        "rightValType": "static",
+                        "rightVal": "1",
+                        "resultValType": "param",
+                        "resultVal": "successfulDataStoreConnectionText"
+                      }
+                    },
+                    {
+                      "criteriaContext": {
+                        "operator": "Default",
+                        "resultValType": "static",
+                        "resultVal": ""
+                      }
+                    }
+                  ],
+                  "timeContext": {
+                    "durationMs": 86400000
+                  }
+                },
+                {
+                  "id": "f0fde190-0fd4-4f4c-aea4-201ae72568d3",
+                  "version": "KqlParameterItem/1.0",
+                  "name": "dataStoreStatusStyle",
+                  "type": 1,
+                  "isHiddenWhenLocked": true,
+                  "criteriaData": [
+                    {
+                      "criteriaContext": {
+                        "leftOperand": "watcherResourceId",
+                        "operator": "is Empty",
+                        "rightValType": "param",
+                        "resultValType": "static",
+                        "resultVal": "Info"
+                      }
+                    },
+                    {
+                      "criteriaContext": {
+                        "leftOperand": "watcherDataStoreType",
+                        "operator": "is Empty",
+                        "rightValType": "param",
+                        "resultValType": "static",
+                        "resultVal": "Info"
+                      }
+                    },
+                    {
+                      "criteriaContext": {
+                        "leftOperand": "adxClusterUri",
+                        "operator": "is Empty",
+                        "rightValType": "param",
+                        "resultValType": "static",
+                        "resultVal": "Info"
+                      }
+                    },
+                    {
+                      "criteriaContext": {
+                        "leftOperand": "adxDatabase",
+                        "operator": "is Empty",
+                        "rightValType": "param",
+                        "resultValType": "static",
+                        "resultVal": "Info"
+                      }
+                    },
+                    {
+                      "criteriaContext": {
+                        "leftOperand": "adxClusterPingResult",
+                        "operator": "==",
+                        "rightValType": "static",
+                        "rightVal": "1",
+                        "resultValType": "static",
+                        "resultVal": "Success"
+                      }
+                    },
+                    {
+                      "criteriaContext": {
+                        "operator": "Default",
+                        "resultValType": "static",
+                        "resultVal": "Plain"
+                      }
+                    }
+                  ],
+                  "timeContext": {
+                    "durationMs": 86400000
+                  }
+                }
+              ],
+              "style": "pills",
+              "queryType": 8
+            },
+            "conditionalVisibility": {
+              "parameterName": "alwaysHidden",
+              "comparison": "isNotEqualTo"
+            },
+            "name": "adx_connection_status_parameters"
+          },
+          {
+            "type": 1,
+            "content": {
+              "json": "{dataStoreStatusText}",
+              "style": "{dataStoreStatusStyle}"
+            },
+            "name": "data_store_connection_status_text"
+          },
+          {
+            "type": 1,
+            "content": {
+              "json": "Cannot connect to Kusto query URI `{adxClusterUri}`, database `{adxDatabase}`. The data store might be stopped or unreachable, specified query URI might be invalid, or permissions might be insufficient.\r\n\r\n**Common causes:**\r\n\r\n1. You do not have access to the data store. Ask an administrator to [grant access](https://go.microsoft.com/fwlink/?linkid=2297712).\r\n1. Public connectivity to the Azure Data Explorer cluster is disabled. Learn how to [set up private connectivity](https://go.microsoft.com/fwlink/?linkid=2297583).\r\n\r\n[Learn more](https://go.microsoft.com/fwlink/?linkid=2268015) to troubleshoot other causes.",
+              "style": "warning"
+            },
+            "conditionalVisibilities": [
+              {
+                "parameterName": "adxClusterPingResult",
+                "comparison": "isNotEqualTo",
+                "value": "1"
+              },
+              {
+                "parameterName": "adxClusterUri",
+                "comparison": "isNotEqualTo"
+              },
+              {
+                "parameterName": "adxDatabase",
+                "comparison": "isNotEqualTo"
+              }
+            ],
+            "name": "missing_data_bad_permissions_text"
           }
         ],
         "exportParameters": true
       },
       "name": "data_store_group"
-    },
-    {
-      "type": 1,
-      "content": {
-        "json": "Cannot connect to Kusto query URI `{adxClusterUri}`, database `{adxDatabase}`. The data store might be stopped or unreachable, specified query URI might be invalid, or permissions might be insufficient.\r\n\r\n**Common causes:**\r\n\r\n1. You do not have access to the data store. Ask an administrator to [grant access](https://go.microsoft.com/fwlink/?linkid=2297712).\r\n1. Public connectivity to the Azure Data Explorer cluster is disabled. Learn how to [set up private connectivity](https://go.microsoft.com/fwlink/?linkid=2297583).\r\n\r\n[Learn more](https://go.microsoft.com/fwlink/?linkid=2268015) to troubleshoot other causes.",
-        "style": "warning"
-      },
-      "conditionalVisibilities": [
-        {
-          "parameterName": "adxClusterPingResult",
-          "comparison": "isNotEqualTo",
-          "value": "1"
-        },
-        {
-          "parameterName": "adxClusterUri",
-          "comparison": "isNotEqualTo"
-        },
-        {
-          "parameterName": "adxDatabase",
-          "comparison": "isNotEqualTo"
-        }
-      ],
-      "name": "missing_data_bad_permissions_text"
     },
     {
       "type": 9,


### PR DESCRIPTION
## Summary

- Add text in the `Data store` group to provide data store connection status and informational messages to explain why connection to the data store isn't attempted.
- Revert a previous change and move the "data store inaccessible" message back into the `Data store` group, to avoid showing it incorrectly while the connection is still being opened.
 
## Screenshots

![image](https://github.com/user-attachments/assets/c09aee02-960b-4972-80b9-d9d7ae586256)
![image](https://github.com/user-attachments/assets/88cee673-7019-46cd-b04a-e5f8ef5c82b3)
![image](https://github.com/user-attachments/assets/2c3c64dd-baa1-432f-865f-467fc974549c)

## Validation

- [x] Validate your changes using one or more of the [testing](https://github.com/microsoft/Application-Insights-Workbooks/blob/master/Documentation/Testing.md) methods.
  
  Make sure you've tested your template content. Fixing things while in PR is trivial. Hotfixing it later is very expensive; at the current time at least 3 teams are involved in a hotfix!

## Checklist

- [x] If you are adding a new template, gallery, or folder, add your team and folder/file(s) to the CODEOWNERS file at the root of the repo. CODEOWNERS entries should be teams, not individuals.
      When done correctly, this means that from then on *your* team does reviews of *your* things, not the workbooks team.
- [x] Ensure all steps in your template have meaningful names.
- [x] Ensure all parameters and grid columns have display names set so they can be localized.
