### PR TITLE
[database watcher] Add data store size grid

### DIFF
--- a/Workbooks/Database watcher/watcher.workbook
+++ b/Workbooks/Database watcher/watcher.workbook
@@ -635,6 +635,15 @@
                   "query": "{\"version\":\"AzureDataExplorerQuery/1.0\",\"queryText\":\".show databases\\r\\n| where DatabaseName =~ @\\\"{adxDatabase}\\\" // ADX\\r\\n        or\\r\\n        (PrettyName =~ @\\\"{adxDatabase}\\\" and isnotempty(toguid(DatabaseName))) // Fabric Kusto\\r\\n| project 1\",\"clusterName\":\"{adxClusterUri}\",\"databaseName\":\"\"}",
                   "isHiddenWhenLocked": true,
                   "queryType": 9
+                },
+                {
+                  "id": "1051cf8a-cecc-45b0-ac25-5ab65b869292",
+                  "version": "KqlParameterItem/1.0",
+                  "name": "dataStoreSizeProperties",
+                  "type": 1,
+                  "query": "{\"version\":\"AzureDataExplorerQuery/1.0\",\"queryText\":\".show database extents\\r\\n| summarize uncompressed_size_bytes = sum(OriginalSize),\\r\\n            compressed_size_bytes = sum(CompressedSize)\\r\\n| extend freeKustoWarning = iif(\\\"{watcherDataStoreType}\\\" == \\\"free\\\" and uncompressed_size_bytes > 85899345920, true, false) // Greater than 80 GiB\\r\\n| project uncompressed_size_bytes, compressed_size_bytes, 1formatted_uncompressed_size = format_bytes(uncompressed_size_bytes), 2formatted_compressed_size = format_bytes(compressed_size_bytes), freeKustoWarning\\r\\n| project dynamic_to_json(pack_all())\",\"clusterName\":\"{adxClusterUri}\",\"databaseName\":\"{adxDatabase}\"}",
+                  "isHiddenWhenLocked": true,
+                  "queryType": 9
                 }
               ],
               "style": "pills",
@@ -947,6 +956,102 @@
               }
             ],
             "name": "missing_data_bad_permissions_text"
+          },
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "{\"version\":\"1.0.0\",\"content\":\"{dataStoreSizeProperties}\",\"transformers\":null}",
+              "size": 3,
+              "title": "Data size",
+              "showExportToExcel": true,
+              "queryType": 8,
+              "visualization": "table",
+              "gridSettings": {
+                "formatters": [
+                  {
+                    "columnMatch": "1formatted_uncompressed_size",
+                    "formatter": 18,
+                    "formatOptions": {
+                      "thresholdsOptions": "icons",
+                      "thresholdsGrid": [
+                        {
+                          "sourceColumn": "freeKustoWarning",
+                          "operator": "==",
+                          "thresholdValue": "true",
+                          "representation": "2",
+                          "text": "{0}{1}",
+                          "tooltipFormat": {
+                            "tooltip": "Size is approaching or has reached the limit of a free Azure Data Explorer cluster"
+                          }
+                        },
+                        {
+                          "operator": "Default",
+                          "thresholdValue": null,
+                          "representation": "Blank",
+                          "text": "{0}{1}"
+                        }
+                      ]
+                    },
+                    "tooltipFormat": {
+                      "tooltip": "The original ingested data size"
+                    }
+                  },
+                  {
+                    "columnMatch": "2formatted_compressed_size",
+                    "formatter": 22,
+                    "formatOptions": {
+                      "compositeBarSettings": {
+                        "labelText": "[\"2formatted_compressed_size\"]",
+                        "columnSettings": [
+                          {
+                            "columnName": "compressed_size_bytes",
+                            "color": "pink"
+                          },
+                          {
+                            "columnName": "uncompressed_size_bytes",
+                            "color": "blue"
+                          }
+                        ],
+                        "noRowsScaling": true
+                      }
+                    },
+                    "tooltipFormat": {
+                      "tooltip": "Stored data size after applying columnstore compression"
+                    }
+                  },
+                  {
+                    "columnMatch": "compressed_size_bytes",
+                    "formatter": 5
+                  },
+                  {
+                    "columnMatch": "freeKustoWarning",
+                    "formatter": 5
+                  },
+                  {
+                    "columnMatch": "uncompressed_size_bytes",
+                    "formatter": 5
+                  }
+                ],
+                "labelSettings": [
+                  {
+                    "columnId": "1formatted_uncompressed_size",
+                    "label": "Uncompressed"
+                  },
+                  {
+                    "columnId": "2formatted_compressed_size",
+                    "label": "Compressed"
+                  }
+                ]
+              }
+            },
+            "customWidth": "30",
+            "conditionalVisibility": {
+              "parameterName": "adxClusterPingResult",
+              "comparison": "isEqualTo",
+              "value": "1"
+            },
+            "name": "data_store_size"
           }
         ],
         "exportParameters": true

--- a/Workbooks/Database watcher/watcher.workbook
+++ b/Workbooks/Database watcher/watcher.workbook
@@ -982,7 +982,7 @@
                           "representation": "2",
                           "text": "{0}{1}",
                           "tooltipFormat": {
-                            "tooltip": "Size is approaching or has reached the limit of a free Azure Data Explorer cluster"
+                            "tooltip": "Database size is approaching or has reached the limit of a free Azure Data Explorer cluster. The limit might be reached sooner if there are other databases on the same cluster."
                           }
                         },
                         {
@@ -994,7 +994,7 @@
                       ]
                     },
                     "tooltipFormat": {
-                      "tooltip": "The original ingested data size"
+                      "tooltip": "Originally ingested data size before compression"
                     }
                   },
                   {


### PR DESCRIPTION
## Summary

Add a grid in the `Data store` group to show the total uncompressed and compressed size of data in the data store. For free ADX, show a warning if the size approaches the storage limit.

## Screenshots

![image](https://github.com/user-attachments/assets/6bd738cd-f419-4734-844f-0578e3d41ac9)

## Validation

- [x] Validate your changes using one or more of the [testing](https://github.com/microsoft/Application-Insights-Workbooks/blob/master/Documentation/Testing.md) methods.
  
## Checklist

- [x] If you are adding a new template, gallery, or folder, add your team and folder/file(s) to the CODEOWNERS file at the root of the repo. CODEOWNERS entries should be teams, not individuals.
      When done correctly, this means that from then on *your* team does reviews of *your* things, not the workbooks team.
- [x] Ensure all steps in your template have meaningful names.
- [x] Ensure all parameters and grid columns have display names set so they can be localized.
