### PR TITLE
Use byte units and separators for tempdb consumption

### DIFF
--- a/Workbooks/Database watcher/Azure SQL Database/database/activity/activity.workbook
+++ b/Workbooks/Database watcher/Azure SQL Database/database/activity/activity.workbook
@@ -718,16 +718,30 @@
             },
             {
               "columnMatch": "tempdb_allocations_kb",
-              "formatter": 0,
+              "formatter": 2,
               "formatOptions": {
                 "customColumnWidthSetting": "22ch"
+              },
+              "numberFormat": {
+                "unit": 3,
+                "options": {
+                  "style": "decimal",
+                  "useGrouping": true
+                }
               }
             },
             {
               "columnMatch": "tempdb_current_kb",
-              "formatter": 0,
+              "formatter": 2,
               "formatOptions": {
                 "customColumnWidthSetting": "19ch"
+              },
+              "numberFormat": {
+                "unit": 3,
+                "options": {
+                  "style": "decimal",
+                  "useGrouping": true
+                }
               }
             },
             {

--- a/Workbooks/Database watcher/Azure SQL Database/elastic pool/activity/activity.workbook
+++ b/Workbooks/Database watcher/Azure SQL Database/elastic pool/activity/activity.workbook
@@ -672,16 +672,30 @@
             },
             {
               "columnMatch": "tempdb_allocations_kb",
-              "formatter": 0,
+              "formatter": 2,
               "formatOptions": {
                 "customColumnWidthSetting": "22ch"
+              },
+              "numberFormat": {
+                "unit": 3,
+                "options": {
+                  "style": "decimal",
+                  "useGrouping": true
+                }
               }
             },
             {
               "columnMatch": "tempdb_current_kb",
-              "formatter": 0,
+              "formatter": 2,
               "formatOptions": {
                 "customColumnWidthSetting": "19ch"
+              },
+              "numberFormat": {
+                "unit": 3,
+                "options": {
+                  "style": "decimal",
+                  "useGrouping": true
+                }
               }
             },
             {

--- a/Workbooks/Database watcher/Azure SQL Managed Instance/instance/activity/activity.workbook
+++ b/Workbooks/Database watcher/Azure SQL Managed Instance/instance/activity/activity.workbook
@@ -720,16 +720,30 @@
             },
             {
               "columnMatch": "tempdb_allocations_kb",
-              "formatter": 0,
+              "formatter": 2,
               "formatOptions": {
                 "customColumnWidthSetting": "22ch"
+              },
+              "numberFormat": {
+                "unit": 3,
+                "options": {
+                  "style": "decimal",
+                  "useGrouping": true
+                }
               }
             },
             {
               "columnMatch": "tempdb_current_kb",
-              "formatter": 0,
+              "formatter": 2,
               "formatOptions": {
                 "customColumnWidthSetting": "19ch"
+              },
+              "numberFormat": {
+                "unit": 3,
+                "options": {
+                  "style": "decimal",
+                  "useGrouping": true
+                }
               }
             },
             {

--- a/Workbooks/Database watcher/SQL Server/instance/activity/activity.workbook
+++ b/Workbooks/Database watcher/SQL Server/instance/activity/activity.workbook
@@ -720,16 +720,30 @@
             },
             {
               "columnMatch": "tempdb_allocations_kb",
-              "formatter": 0,
+              "formatter": 2,
               "formatOptions": {
                 "customColumnWidthSetting": "22ch"
+              },
+              "numberFormat": {
+                "unit": 3,
+                "options": {
+                  "style": "decimal",
+                  "useGrouping": true
+                }
               }
             },
             {
               "columnMatch": "tempdb_current_kb",
-              "formatter": 0,
+              "formatter": 2,
               "formatOptions": {
                 "customColumnWidthSetting": "19ch"
+              },
+              "numberFormat": {
+                "unit": 3,
+                "options": {
+                  "style": "decimal",
+                  "useGrouping": true
+                }
               }
             },
             {


### PR DESCRIPTION
## Summary

### Problem

The tempdb allocation and consumption columns in the Activity grid are displayed as plain numbers.

### Solution

Use byte units and grouping separators.

## Screenshots

![image](https://github.com/user-attachments/assets/9d877a3c-81f6-4d29-a7a2-b47b204cdef7)

## Validation

- [x] Validate your changes using one or more of the [testing](https://github.com/microsoft/Application-Insights-Workbooks/blob/master/Documentation/Testing.md) methods.
  
  Make sure you've tested your template content. Fixing things while in PR is trivial. Hotfixing it later is very expensive; at the current time at least 3 teams are involved in a hotfix!

## Checklist

- [x] If you are adding a new template, gallery, or folder, add your team and folder/file(s) to the CODEOWNERS file at the root of the repo. CODEOWNERS entries should be teams, not individuals.
      When done correctly, this means that from then on *your* team does reviews of *your* things, not the workbooks team.
- [x] Ensure all steps in your template have meaningful names.
- [x] Ensure all parameters and grid columns have display names set so they can be localized.
