### PR TITLE
[database watcher] Add info messages when top queries aren't shown for known reasons

### DIFF
--- a/Workbooks/Database watcher/Azure SQL Database/database/database.workbook
+++ b/Workbooks/Database watcher/Azure SQL Database/database/database.workbook
@@ -6168,17 +6168,17 @@
           "value": "1"
         },
         {
+          "parameterName": "sqldb_database_properties",
+          "comparison": "isEqualTo",
+          "value": "1"
+        },
+        {
           "parameterName": "serverName",
           "comparison": "isNotEqualTo"
         },
         {
           "parameterName": "databaseName",
           "comparison": "isNotEqualTo"
-        },
-        {
-          "parameterName": "haReplica",
-          "comparison": "isEqualTo",
-          "value": "false"
         }
       ],
       "name": "top_queries_group"

--- a/Workbooks/Database watcher/Azure SQL Database/database/top queries/top queries.workbook
+++ b/Workbooks/Database watcher/Azure SQL Database/database/top queries/top queries.workbook
@@ -76,7 +76,7 @@
     {
       "type": 1,
       "content": {
-        "json": "Top query data in the selected time range might be missing or incomplete because the [Query Store](https://go.microsoft.com/fwlink/?linkid=2213253) state is other than `READ_WRITE`:\r\n\r\n| Query Store state |\r\n|:--|\r\n{qdsMissingDataWarningText}\r\n\r\nFor more information, see [Best practices for managing Query Store](https://go.microsoft.com/fwlink/?linkid=2198632).",
+        "json": "Top query data in the selected time range might be missing or incomplete because the [Query Store](https://go.microsoft.com/fwlink/?linkid=2213253) state is other than `READ_WRITE`. For more information, see [Best practices for managing Query Store](https://go.microsoft.com/fwlink/?linkid=2198632).\r\n\r\n| Query Store state |\r\n|:--|\r\n{qdsMissingDataWarningText}",
         "style": "info"
       },
       "conditionalVisibilities": [

--- a/Workbooks/Database watcher/Azure SQL Database/database/top queries/top queries.workbook
+++ b/Workbooks/Database watcher/Azure SQL Database/database/top queries/top queries.workbook
@@ -12,7 +12,7 @@
             "name": "qdsStartTime",
             "type": 1,
             "isRequired": true,
-            "query": "{\"version\":\"AzureDataExplorerQuery/1.0\",\"queryText\":\"union\\r\\n(\\r\\n// The most recent interval that is earlier than the end of time range.\\r\\n// This may be earlier than the start of time range by at most 2h.\\r\\nsqldb_database_query_runtime_stats\\r\\n| where interval_start_time between (({timeRange:start} - 2h) .. {timeRange:end})\\r\\n| where logical_server_name =~ @\\\"{serverName}\\\"\\r\\n| where database_name == @\\\"{databaseName}\\\"\\r\\n| summarize interval_start_time = max(interval_start_time)\\r\\n),\\r\\n(\\r\\n// earliest interval start within time range\\r\\nsqldb_database_query_runtime_stats\\r\\n| where interval_end_time >= {timeRange:start} and interval_start_time <= {timeRange:end}\\r\\n| where logical_server_name =~ @\\\"{serverName}\\\"\\r\\n| where database_name == @\\\"{databaseName}\\\"\\r\\n| summarize interval_start_time = min(interval_start_time)\\r\\n)\\r\\n// return the earliest of these times as start of QDS range\\r\\n// if there isn't a complete QDS interval within time range, this will show the most recent available interval outside of the range\\r\\n| summarize qds_start_time = min(interval_start_time)\\r\\n\",\"clusterName\":\"{adxClusterUri}\",\"databaseName\":\"{adxDatabase}\"}",
+            "query": "{\"version\":\"AzureDataExplorerQuery/1.0\",\"queryText\":\"union\\r\\n(\\r\\n// The most recent interval that is earlier than the end of time range.\\r\\n// This may be earlier than the start of time range by at most 2h.\\r\\nsqldb_database_query_runtime_stats\\r\\n| where interval_start_time between (({timeRange:start} - 2h) .. {timeRange:end})\\r\\n| where logical_server_name =~ @\\\"{serverName}\\\"\\r\\n| where database_name == @\\\"{databaseName}\\\"\\r\\n| where \\\"{replicaType}\\\" == \\\"Primary\\\"\\r\\n| summarize interval_start_time = max(interval_start_time)\\r\\n),\\r\\n(\\r\\n// earliest interval start within time range\\r\\nsqldb_database_query_runtime_stats\\r\\n| where interval_end_time >= {timeRange:start} and interval_start_time <= {timeRange:end}\\r\\n| where logical_server_name =~ @\\\"{serverName}\\\"\\r\\n| where database_name == @\\\"{databaseName}\\\"\\r\\n| where \\\"{replicaType}\\\" == \\\"Primary\\\"\\r\\n| summarize interval_start_time = min(interval_start_time)\\r\\n)\\r\\n// return the earliest of these times as start of QDS range\\r\\n// if there isn't a complete QDS interval within time range, this will show the most recent available interval outside of the range\\r\\n| summarize qds_start_time = min(interval_start_time)\\r\\n\",\"clusterName\":\"{adxClusterUri}\",\"databaseName\":\"{adxDatabase}\"}",
             "isHiddenWhenLocked": true,
             "queryType": 9
           },
@@ -22,7 +22,7 @@
             "name": "qdsEndTime",
             "type": 1,
             "isRequired": true,
-            "query": "{\"version\":\"AzureDataExplorerQuery/1.0\",\"queryText\":\"union\\r\\n(\\r\\n// The most recent interval that is earlier than the end of time range.\\r\\n// This may be earlier than the start of time range by at most 2h.\\r\\nsqldb_database_query_runtime_stats\\r\\n| where interval_end_time between (({timeRange:start} - 2h) .. {timeRange:end})\\r\\n| where logical_server_name =~ @\\\"{serverName}\\\"\\r\\n| where database_name == @\\\"{databaseName}\\\"\\r\\n| summarize interval_end_time = max(interval_end_time)\\r\\n),\\r\\n(\\r\\n// latest interval end within time range\\r\\nsqldb_database_query_runtime_stats\\r\\n| where interval_end_time >= {timeRange:start} and interval_start_time <= {timeRange:end}\\r\\n| where logical_server_name =~ @\\\"{serverName}\\\"\\r\\n| where database_name == @\\\"{databaseName}\\\"\\r\\n| summarize interval_end_time = max(interval_end_time)\\r\\n)\\r\\n// return the latest of these times as end of QDS range\\r\\n// if there isn't a complete QDS interval within time range, this will show the latest available interval\\r\\n| summarize qds_end_time = datetime_add(\\\"second\\\", 1, max(interval_end_time)) // make-series treats the end of interval as not inclusive, fudge by 1 second\\r\\n\",\"clusterName\":\"{adxClusterUri}\",\"databaseName\":\"{adxDatabase}\"}",
+            "query": "{\"version\":\"AzureDataExplorerQuery/1.0\",\"queryText\":\"union\\r\\n(\\r\\n// The most recent interval that is earlier than the end of time range.\\r\\n// This may be earlier than the start of time range by at most 2h.\\r\\nsqldb_database_query_runtime_stats\\r\\n| where interval_end_time between (({timeRange:start} - 2h) .. {timeRange:end})\\r\\n| where logical_server_name =~ @\\\"{serverName}\\\"\\r\\n| where database_name == @\\\"{databaseName}\\\"\\r\\n| where \\\"{replicaType}\\\" == \\\"Primary\\\"\\r\\n| summarize interval_end_time = max(interval_end_time)\\r\\n),\\r\\n(\\r\\n// latest interval end within time range\\r\\nsqldb_database_query_runtime_stats\\r\\n| where interval_end_time >= {timeRange:start} and interval_start_time <= {timeRange:end}\\r\\n| where logical_server_name =~ @\\\"{serverName}\\\"\\r\\n| where database_name == @\\\"{databaseName}\\\"\\r\\n| where \\\"{replicaType}\\\" == \\\"Primary\\\"\\r\\n| summarize interval_end_time = max(interval_end_time)\\r\\n)\\r\\n// return the latest of these times as end of QDS range\\r\\n// if there isn't a complete QDS interval within time range, this will show the latest available interval\\r\\n| summarize qds_end_time = datetime_add(\\\"second\\\", 1, max(interval_end_time)) // make-series treats the end of interval as not inclusive, fudge by 1 second\\r\\n\",\"clusterName\":\"{adxClusterUri}\",\"databaseName\":\"{adxDatabase}\"}",
             "isHiddenWhenLocked": true,
             "queryType": 9
           },
@@ -35,6 +35,15 @@
             "isHiddenWhenLocked": true,
             "queryType": 9,
             "id": "597f2e25-7cb4-416e-aaa8-d156dccd25b4"
+          },
+          {
+            "id": "621902c6-c42c-4102-bd83-08f58a7c4a3a",
+            "version": "KqlParameterItem/1.0",
+            "name": "qdsMissingDataWarningText",
+            "type": 1,
+            "query": "{\"version\":\"AzureDataExplorerQuery/1.0\",\"queryText\":\"sqldb_database_properties\\r\\n| where sample_time_utc between (({timeRange:start} - 2h) .. {timeRange:end})\\r\\n| where logical_server_name =~ @\\\"{serverName}\\\"\\r\\n| where database_name == @\\\"{databaseName}\\\"\\r\\n| where replica_type =='Primary' \\r\\n| where query_store_actual_state_desc != \\\"READ_WRITE\\\"\\r\\n| extend query_store_actual_state_desc = iif(isempty(query_store_actual_state_desc), \\\"<missing>\\\", query_store_actual_state_desc)\\r\\n| distinct query_store_actual_state_desc\\r\\n| sort by query_store_actual_state_desc asc\\r\\n| extend warning_row = strcat(\\\"| `\\\", query_store_actual_state_desc, \\\"` | \\\")\\r\\n| summarize warning = strcat_array(make_list(warning_row), \\\"\\\\r\\\\n\\\")\\r\\n| where isnotempty(warning)\\r\\n\",\"clusterName\":\"{adxClusterUri}\",\"databaseName\":\"{adxDatabase}\"}",
+            "isHiddenWhenLocked": true,
+            "queryType": 9
           }
         ],
         "style": "above",
@@ -63,6 +72,41 @@
         }
       ],
       "name": "qds_help"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "Top query data in the selected time range might be missing or incomplete because the [Query Store](https://go.microsoft.com/fwlink/?linkid=2213253) state is other than `READ_WRITE`:\r\n\r\n| Query Store state |\r\n|:--|\r\n{qdsMissingDataWarningText}\r\n\r\nFor more information, see [Best practices for managing Query Store](https://go.microsoft.com/fwlink/?linkid=2198632).",
+        "style": "info"
+      },
+      "conditionalVisibilities": [
+        {
+          "parameterName": "qdsStartTime",
+          "comparison": "isNotEqualTo"
+        },
+        {
+          "parameterName": "qdsEndTime",
+          "comparison": "isNotEqualTo"
+        },
+        {
+          "parameterName": "qdsMissingDataWarningText",
+          "comparison": "isNotEqualTo"
+        }
+      ],
+      "name": "qds_warning_missing_data"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "Top query data is not available for secondary replicas.",
+        "style": "info"
+      },
+      "conditionalVisibility": {
+        "parameterName": "replicaType",
+        "comparison": "isNotEqualTo",
+        "value": "Primary"
+      },
+      "name": "qds_warning_secondary"
     },
     {
       "type": 9,

--- a/Workbooks/Database watcher/Azure SQL Database/estate/estate.workbook
+++ b/Workbooks/Database watcher/Azure SQL Database/estate/estate.workbook
@@ -6030,6 +6030,11 @@
           "value": "1"
         },
         {
+          "parameterName": "sqldb_database_properties",
+          "comparison": "isEqualTo",
+          "value": "1"
+        },
+        {
           "parameterName": "matchPattern",
           "comparison": "isNotEqualTo"
         }

--- a/Workbooks/Database watcher/Azure SQL Database/estate/top queries/top queries.workbook
+++ b/Workbooks/Database watcher/Azure SQL Database/estate/top queries/top queries.workbook
@@ -25,6 +25,15 @@
             "query": "{\"version\":\"AzureDataExplorerQuery/1.0\",\"queryText\":\"union\\r\\n(\\r\\n// The most recent interval that is earlier than the end of time range.\\r\\n// This may be earlier than the start of time range by at most 2h.\\r\\nsqldb_database_query_runtime_stats\\r\\n| where interval_end_time between (({timeRange:start} - 2h) .. {timeRange:end})\\r\\n{subscriptionFilter}\\r\\n{resourceGroupFilter}\\r\\n{serverNameFilter}\\r\\n{databaseNameFilter}\\r\\n{elasticPoolNameFilter}\\r\\n| summarize interval_end_time = max(interval_end_time)\\r\\n),\\r\\n(\\r\\n// latest interval end within time range\\r\\nsqldb_database_query_runtime_stats\\r\\n| where interval_end_time >= {timeRange:start} and interval_start_time <= {timeRange:end}\\r\\n{subscriptionFilter}\\r\\n{resourceGroupFilter}\\r\\n{serverNameFilter}\\r\\n{databaseNameFilter}\\r\\n{elasticPoolNameFilter}\\r\\n| summarize interval_end_time = max(interval_end_time)\\r\\n)\\r\\n// return the latest of these times as end of QDS range\\r\\n// if there isn't a complete QDS interval within time range, this will show the latest available interval\\r\\n| summarize qds_end_time = datetime_add(\\\"second\\\", 1, max(interval_end_time)) // make-series treats the end of interval as not inclusive, fudge by 1 second\\r\\n\",\"clusterName\":\"{adxClusterUri}\",\"databaseName\":\"{adxDatabase}\"}",
             "isHiddenWhenLocked": true,
             "queryType": 9
+          },
+          {
+            "id": "621902c6-c42c-4102-bd83-08f58a7c4a3a",
+            "version": "KqlParameterItem/1.0",
+            "name": "qdsMissingDataWarningText",
+            "type": 1,
+            "query": "{\"version\":\"AzureDataExplorerQuery/1.0\",\"queryText\":\"sqldb_database_properties\\r\\n| where sample_time_utc between (({timeRange:start} - 2h) .. {timeRange:end})\\r\\n{subscriptionFilter}\\r\\n{resourceGroupFilter}\\r\\n{serverNameFilter}\\r\\n{databaseNameFilter}\\r\\n{elasticPoolNameFilter}\\r\\n| where replica_type == \\\"Primary\\\"\\r\\n| where query_store_actual_state_desc != \\\"READ_WRITE\\\"\\r\\n| extend query_store_actual_state_desc = iif(isempty(query_store_actual_state_desc), \\\"<missing>\\\", query_store_actual_state_desc)\\r\\n| distinct logical_server_name, database_name, logical_database_id, query_store_actual_state_desc\\r\\n| sort by database_name asc, logical_server_name asc\\r\\n| summarize databases = strcat(\\r\\n                              strcat_array(\\r\\n                                          make_list(\\r\\n                                                   strcat(database_name, \\\" (\\\", logical_server_name, \\\")\\\"),\\r\\n                                                   5\\r\\n                                                   ),\\r\\n                                          \\\", \\\"\\r\\n                                          ),\\r\\n                              iif(\\r\\n                                 dcount(logical_database_id) > 5,\\r\\n                                 strcat(\\\" and \\\", tostring(dcount(logical_database_id) - 5), \\\" more\\\"),\\r\\n                                 \\\"\\\")\\r\\n                              )\\r\\n            by query_store_actual_state_desc\\r\\n| sort by query_store_actual_state_desc asc\\r\\n| extend warning_row = strcat(\\\"| `\\\", query_store_actual_state_desc, \\\"` | \\\", databases, \\\" |\\\")\\r\\n| summarize warning = strcat_array(make_list(warning_row), \\\"\\\\r\\\\n\\\")\\r\\n| where isnotempty(warning)\\r\\n\",\"clusterName\":\"{adxClusterUri}\",\"databaseName\":\"{adxDatabase}\"}",
+            "isHiddenWhenLocked": true,
+            "queryType": 9
           }
         ],
         "style": "above",
@@ -53,6 +62,28 @@
         }
       ],
       "name": "qds_help"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "Top query data in the selected time range might be missing or incomplete for some databases because their [Query Store](https://go.microsoft.com/fwlink/?linkid=2213253) state is other than `READ_WRITE`:\r\n\r\n| Query Store state | Database(s) (logical server) |\r\n|:--|:--|\r\n{qdsMissingDataWarningText}\r\n\r\nFor more information, see [Best practices for managing Query Store](https://go.microsoft.com/fwlink/?linkid=2198632).",
+        "style": "info"
+      },
+      "conditionalVisibilities": [
+        {
+          "parameterName": "qdsStartTime",
+          "comparison": "isNotEqualTo"
+        },
+        {
+          "parameterName": "qdsEndTime",
+          "comparison": "isNotEqualTo"
+        },
+        {
+          "parameterName": "qdsMissingDataWarningText",
+          "comparison": "isNotEqualTo"
+        }
+      ],
+      "name": "qds_warning_missing_data"
     },
     {
       "type": 9,

--- a/Workbooks/Database watcher/Azure SQL Database/estate/top queries/top queries.workbook
+++ b/Workbooks/Database watcher/Azure SQL Database/estate/top queries/top queries.workbook
@@ -66,7 +66,7 @@
     {
       "type": 1,
       "content": {
-        "json": "Top query data in the selected time range might be missing or incomplete for some databases because their [Query Store](https://go.microsoft.com/fwlink/?linkid=2213253) state is other than `READ_WRITE`:\r\n\r\n| Query Store state | Database(s) (logical server) |\r\n|:--|:--|\r\n{qdsMissingDataWarningText}\r\n\r\nFor more information, see [Best practices for managing Query Store](https://go.microsoft.com/fwlink/?linkid=2198632).",
+        "json": "Top query data in the selected time range might be missing or incomplete for some databases because their [Query Store](https://go.microsoft.com/fwlink/?linkid=2213253) state is other than `READ_WRITE`. For more information, see [Best practices for managing Query Store](https://go.microsoft.com/fwlink/?linkid=2198632).\r\n\r\n| Query Store state | Database(s) (logical server) |\r\n|:--|:--|\r\n{qdsMissingDataWarningText}",
         "style": "info"
       },
       "conditionalVisibilities": [

--- a/Workbooks/Database watcher/Azure SQL Managed Instance/estate/estate.workbook
+++ b/Workbooks/Database watcher/Azure SQL Managed Instance/estate/estate.workbook
@@ -3058,6 +3058,11 @@
           "value": "1"
         },
         {
+          "parameterName": "sqlmi_database_properties",
+          "comparison": "isEqualTo",
+          "value": "1"
+        },
+        {
           "parameterName": "matchPattern",
           "comparison": "isNotEqualTo"
         }

--- a/Workbooks/Database watcher/Azure SQL Managed Instance/estate/top queries/top queries.workbook
+++ b/Workbooks/Database watcher/Azure SQL Managed Instance/estate/top queries/top queries.workbook
@@ -66,7 +66,7 @@
     {
       "type": 1,
       "content": {
-        "json": "Top query data in the selected time range might be missing or incomplete for some databases because their [Query Store](https://go.microsoft.com/fwlink/?linkid=2213253) state is other than `READ_WRITE`:\r\n\r\n| Query Store state | Database(s) (managed instance) |\r\n|:--|:--|\r\n{qdsMissingDataWarningText}\r\n\r\nFor more information, see [Best practices for managing Query Store](https://go.microsoft.com/fwlink/?linkid=2198632).",
+        "json": "Top query data in the selected time range might be missing or incomplete for some databases because their [Query Store](https://go.microsoft.com/fwlink/?linkid=2213253) state is other than `READ_WRITE`. For more information, see [Best practices for managing Query Store](https://go.microsoft.com/fwlink/?linkid=2198632).\r\n\r\n| Query Store state | Database(s) (managed instance) |\r\n|:--|:--|\r\n{qdsMissingDataWarningText}",
         "style": "info"
       },
       "conditionalVisibilities": [

--- a/Workbooks/Database watcher/Azure SQL Managed Instance/estate/top queries/top queries.workbook
+++ b/Workbooks/Database watcher/Azure SQL Managed Instance/estate/top queries/top queries.workbook
@@ -25,6 +25,15 @@
             "query": "{\"version\":\"AzureDataExplorerQuery/1.0\",\"queryText\":\"union\\r\\n(\\r\\n// The most recent interval that is earlier than the end of time range.\\r\\n// This may be earlier than the start of time range by at most 2h.\\r\\nsqlmi_query_runtime_stats\\r\\n| where interval_end_time between (({timeRange:start} - 2h) .. {timeRange:end})\\r\\n{subscriptionFilter}\\r\\n{resourceGroupFilter}\\r\\n{managedInstanceNameFilter}\\r\\n| summarize interval_end_time = max(interval_end_time)\\r\\n),\\r\\n(\\r\\n// latest interval end within time range\\r\\nsqlmi_query_runtime_stats\\r\\n| where interval_end_time >= {timeRange:start} and interval_start_time <= {timeRange:end}\\r\\n{subscriptionFilter}\\r\\n{resourceGroupFilter}\\r\\n{managedInstanceNameFilter}\\r\\n| summarize interval_end_time = max(interval_end_time)\\r\\n)\\r\\n// return the latest of these times as end of QDS range\\r\\n// if there isn't a complete QDS interval within time range, this will show the latest available interval\\r\\n| summarize qds_end_time = datetime_add(\\\"second\\\", 1, max(interval_end_time)) // make-series treats the end of interval as not inclusive, fudge by 1 second\\r\\n\",\"clusterName\":\"{adxClusterUri}\",\"databaseName\":\"{adxDatabase}\"}",
             "isHiddenWhenLocked": true,
             "queryType": 9
+          },
+          {
+            "id": "621902c6-c42c-4102-bd83-08f58a7c4a3a",
+            "version": "KqlParameterItem/1.0",
+            "name": "qdsMissingDataWarningText",
+            "type": 1,
+            "query": "{\"version\":\"AzureDataExplorerQuery/1.0\",\"queryText\":\"sqlmi_database_properties\\r\\n| where sample_time_utc between (({timeRange:start} - 2h) .. {timeRange:end})\\r\\n{subscriptionFilter}\\r\\n{resourceGroupFilter}\\r\\n{managedInstanceNameFilter}\\r\\n| where database_id > 4\\r\\n| where replica_type == \\\"Primary\\\"\\r\\n| where query_store_actual_state_desc != \\\"READ_WRITE\\\"\\r\\n| extend query_store_actual_state_desc = iif(isempty(query_store_actual_state_desc), \\\"<missing>\\\", query_store_actual_state_desc)\\r\\n| distinct managed_instance_name = tostring(split(managed_instance_name, \\\".\\\")[0]), database_name, logical_database_id, query_store_actual_state_desc\\r\\n| sort by database_name asc, managed_instance_name asc\\r\\n| summarize databases = strcat(\\r\\n                              strcat_array(\\r\\n                                          make_list(\\r\\n                                                   strcat(database_name, \\\" (\\\", managed_instance_name, \\\")\\\"),\\r\\n                                                   5\\r\\n                                                   ),\\r\\n                                          \\\", \\\"\\r\\n                                          ),\\r\\n                              iif(\\r\\n                                 dcount(logical_database_id) > 5,\\r\\n                                 strcat(\\\" and \\\", tostring(dcount(logical_database_id) - 5), \\\" more\\\"),\\r\\n                                 \\\"\\\")\\r\\n                              )\\r\\n            by query_store_actual_state_desc\\r\\n| sort by query_store_actual_state_desc asc\\r\\n| extend warning_row = strcat(\\\"| `\\\", query_store_actual_state_desc, \\\"` | \\\", databases, \\\" |\\\")\\r\\n| summarize warning = strcat_array(make_list(warning_row), \\\"\\\\r\\\\n\\\")\\r\\n| where isnotempty(warning)\\r\\n\",\"clusterName\":\"{adxClusterUri}\",\"databaseName\":\"{adxDatabase}\"}",
+            "isHiddenWhenLocked": true,
+            "queryType": 9
           }
         ],
         "style": "above",
@@ -53,6 +62,28 @@
         }
       ],
       "name": "qds_help"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "Top query data in the selected time range might be missing or incomplete for some databases because their [Query Store](https://go.microsoft.com/fwlink/?linkid=2213253) state is other than `READ_WRITE`:\r\n\r\n| Query Store state | Database(s) (managed instance) |\r\n|:--|:--|\r\n{qdsMissingDataWarningText}\r\n\r\nFor more information, see [Best practices for managing Query Store](https://go.microsoft.com/fwlink/?linkid=2198632).",
+        "style": "info"
+      },
+      "conditionalVisibilities": [
+        {
+          "parameterName": "qdsStartTime",
+          "comparison": "isNotEqualTo"
+        },
+        {
+          "parameterName": "qdsEndTime",
+          "comparison": "isNotEqualTo"
+        },
+        {
+          "parameterName": "qdsMissingDataWarningText",
+          "comparison": "isNotEqualTo"
+        }
+      ],
+      "name": "qds_warning_missing_data"
     },
     {
       "type": 9,

--- a/Workbooks/Database watcher/Azure SQL Managed Instance/instance/instance.workbook
+++ b/Workbooks/Database watcher/Azure SQL Managed Instance/instance/instance.workbook
@@ -887,6 +887,19 @@
             "isHiddenWhenLocked": true,
             "queryType": 8,
             "id": "64b3e4a0-b802-49bb-8d68-53662b58d0cd"
+          },
+          {
+            "id": "bf9f3984-1df1-480a-9881-d755c4c43ce9",
+            "version": "KqlParameterItem/1.0",
+            "name": "replicaType",
+            "type": 1,
+            "isRequired": true,
+            "query": "{\"version\":\"AzureDataExplorerQuery/1.0\",\"queryText\":\"sqlmi_instance_properties\\r\\n| where sample_time_utc between (\\r\\n                                iif(({timeRange:end} - {timeRange:start}) <= 1h, ({timeRange:start} - 1h), {timeRange:start})\\r\\n                                ..\\r\\n                                iif(({timeRange:end} - {timeRange:start}) <= 1h, ({timeRange:end} + 1h), {timeRange:end})\\r\\n                                ) // Expand the range if selected range is shorter than the least frequent collection interval (1h)\\r\\n| where managed_instance_name =~ @\\\"{managedInstanceName}\\\"\\r\\n| where ({haReplica} and replica_type == \\\"HA secondary\\\") or (not ({haReplica}) and replica_type != \\\"HA secondary\\\")\\r\\n| top 1 by sample_time_utc\\r\\n| project replica_type\",\"clusterName\":\"{adxClusterUri}\",\"databaseName\":\"{adxDatabase}\"}",
+            "isHiddenWhenLocked": true,
+            "timeContext": {
+              "durationMs": 86400000
+            },
+            "queryType": 9
           }
         ],
         "style": "pills",
@@ -5212,13 +5225,13 @@
           "value": "1"
         },
         {
-          "parameterName": "managedInstanceName",
-          "comparison": "isNotEqualTo"
+          "parameterName": "sqlmi_database_properties",
+          "comparison": "isEqualTo",
+          "value": "1"
         },
         {
-          "parameterName": "haReplica",
-          "comparison": "isEqualTo",
-          "value": "false"
+          "parameterName": "managedInstanceName",
+          "comparison": "isNotEqualTo"
         }
       ],
       "name": "top_queries_group"

--- a/Workbooks/Database watcher/Azure SQL Managed Instance/instance/top queries/top queries.workbook
+++ b/Workbooks/Database watcher/Azure SQL Managed Instance/instance/top queries/top queries.workbook
@@ -76,7 +76,7 @@
     {
       "type": 1,
       "content": {
-        "json": "Top query data in the selected time range might be missing or incomplete for some databases because their [Query Store](https://go.microsoft.com/fwlink/?linkid=2213253) state is other than `READ_WRITE`:\r\n\r\n| Query Store state | Database(s) |\r\n|:--|:--|\r\n{qdsMissingDataWarningText}\r\n\r\nFor more information, see [Best practices for managing Query Store](https://go.microsoft.com/fwlink/?linkid=2198632).",
+        "json": "Top query data in the selected time range might be missing or incomplete for some databases because their [Query Store](https://go.microsoft.com/fwlink/?linkid=2213253) state is other than `READ_WRITE`. For more information, see [Best practices for managing Query Store](https://go.microsoft.com/fwlink/?linkid=2198632).\r\n\r\n| Query Store state | Database(s) |\r\n|:--|:--|\r\n{qdsMissingDataWarningText}",
         "style": "info"
       },
       "conditionalVisibilities": [

--- a/Workbooks/Database watcher/Azure SQL Managed Instance/instance/top queries/top queries.workbook
+++ b/Workbooks/Database watcher/Azure SQL Managed Instance/instance/top queries/top queries.workbook
@@ -12,7 +12,7 @@
             "name": "qdsStartTime",
             "type": 1,
             "isRequired": true,
-            "query": "{\"version\":\"AzureDataExplorerQuery/1.0\",\"queryText\":\"union\\r\\n(\\r\\n// The most recent interval that is earlier than the end of time range.\\r\\n// This may be earlier than the start of time range by at most 2h.\\r\\nsqlmi_query_runtime_stats\\r\\n| where interval_start_time between (({timeRange:start} - 2h) .. {timeRange:end})\\r\\n| where managed_instance_name =~ @\\\"{managedInstanceName}\\\"\\r\\n| summarize interval_start_time = max(interval_start_time)\\r\\n),\\r\\n(\\r\\n// earliest interval start within time range\\r\\nsqlmi_query_runtime_stats\\r\\n| where interval_end_time >= {timeRange:start} and interval_start_time <= {timeRange:end}\\r\\n| where managed_instance_name =~ @\\\"{managedInstanceName}\\\"\\r\\n| summarize interval_start_time = min(interval_start_time)\\r\\n)\\r\\n// return the earliest of these times as start of QDS range\\r\\n// if there isn't a complete QDS interval within time range, this will show the most recent available interval outside of the range\\r\\n| summarize qds_start_time = min(interval_start_time)\",\"clusterName\":\"{adxClusterUri}\",\"databaseName\":\"{adxDatabase}\"}",
+            "query": "{\"version\":\"AzureDataExplorerQuery/1.0\",\"queryText\":\"union\\r\\n(\\r\\n// The most recent interval that is earlier than the end of time range.\\r\\n// This may be earlier than the start of time range by at most 2h.\\r\\nsqlmi_query_runtime_stats\\r\\n| where interval_start_time between (({timeRange:start} - 2h) .. {timeRange:end})\\r\\n| where managed_instance_name =~ @\\\"{managedInstanceName}\\\"\\r\\n| where \\\"{replicaType}\\\" == \\\"Primary\\\"\\r\\n| summarize interval_start_time = max(interval_start_time)\\r\\n),\\r\\n(\\r\\n// earliest interval start within time range\\r\\nsqlmi_query_runtime_stats\\r\\n| where interval_end_time >= {timeRange:start} and interval_start_time <= {timeRange:end}\\r\\n| where managed_instance_name =~ @\\\"{managedInstanceName}\\\"\\r\\n| where \\\"{replicaType}\\\" == \\\"Primary\\\"\\r\\n| summarize interval_start_time = min(interval_start_time)\\r\\n)\\r\\n// return the earliest of these times as start of QDS range\\r\\n// if there isn't a complete QDS interval within time range, this will show the most recent available interval outside of the range\\r\\n| summarize qds_start_time = min(interval_start_time)\",\"clusterName\":\"{adxClusterUri}\",\"databaseName\":\"{adxDatabase}\"}",
             "isHiddenWhenLocked": true,
             "queryType": 9
           },
@@ -22,7 +22,7 @@
             "name": "qdsEndTime",
             "type": 1,
             "isRequired": true,
-            "query": "{\"version\":\"AzureDataExplorerQuery/1.0\",\"queryText\":\"union\\r\\n(\\r\\n// The most recent interval that is earlier than the end of time range.\\r\\n// This may be earlier than the start of time range by at most 2h.\\r\\nsqlmi_query_runtime_stats\\r\\n| where interval_end_time between (({timeRange:start} - 2h) .. {timeRange:end})\\r\\n| where managed_instance_name =~ @\\\"{managedInstanceName}\\\"\\r\\n| summarize interval_end_time = max(interval_end_time)\\r\\n),\\r\\n(\\r\\n// latest interval end within time range\\r\\nsqlmi_query_runtime_stats\\r\\n| where interval_end_time >= {timeRange:start} and interval_start_time <= {timeRange:end}\\r\\n| where managed_instance_name =~ @\\\"{managedInstanceName}\\\"\\r\\n| summarize interval_end_time = max(interval_end_time)\\r\\n)\\r\\n// return the latest of these times as end of QDS range\\r\\n// if there isn't a complete QDS interval within time range, this will show the latest available interval\\r\\n| summarize qds_end_time = datetime_add(\\\"second\\\", 1, max(interval_end_time)) // make-series treats the end of interval as not inclusive, fudge by 1 second\\r\\n\",\"clusterName\":\"{adxClusterUri}\",\"databaseName\":\"{adxDatabase}\"}",
+            "query": "{\"version\":\"AzureDataExplorerQuery/1.0\",\"queryText\":\"union\\r\\n(\\r\\n// The most recent interval that is earlier than the end of time range.\\r\\n// This may be earlier than the start of time range by at most 2h.\\r\\nsqlmi_query_runtime_stats\\r\\n| where interval_end_time between (({timeRange:start} - 2h) .. {timeRange:end})\\r\\n| where managed_instance_name =~ @\\\"{managedInstanceName}\\\"\\r\\n| where \\\"{replicaType}\\\" == \\\"Primary\\\"\\r\\n| summarize interval_end_time = max(interval_end_time)\\r\\n),\\r\\n(\\r\\n// latest interval end within time range\\r\\nsqlmi_query_runtime_stats\\r\\n| where interval_end_time >= {timeRange:start} and interval_start_time <= {timeRange:end}\\r\\n| where managed_instance_name =~ @\\\"{managedInstanceName}\\\"\\r\\n| where \\\"{replicaType}\\\" == \\\"Primary\\\"\\r\\n| summarize interval_end_time = max(interval_end_time)\\r\\n)\\r\\n// return the latest of these times as end of QDS range\\r\\n// if there isn't a complete QDS interval within time range, this will show the latest available interval\\r\\n| summarize qds_end_time = datetime_add(\\\"second\\\", 1, max(interval_end_time)) // make-series treats the end of interval as not inclusive, fudge by 1 second\\r\\n\",\"clusterName\":\"{adxClusterUri}\",\"databaseName\":\"{adxDatabase}\"}",
             "isHiddenWhenLocked": true,
             "queryType": 9
           },
@@ -33,6 +33,15 @@
             "type": 1,
             "isRequired": true,
             "query": "{\"version\":\"AzureDataExplorerQuery/1.0\",\"queryText\":\"// QDS data may be collected on the primary or on its secondary HA replica.\\r\\n// QDS data collection from geo replicas is blocked to avoid associating query workload from the primary with the server/database name of a geo secondary.\\r\\n// If QDS data is collected from both primary and HA secondary, KQL queries must be restricted to data from either primary or HA secondary to avoid wrong results from querying duplicate data.\\r\\n// This parameter determines the replica type to use in that filter.\\r\\n// HA secondary is used only if all data from all databases on the instance within the interval is from HA secondary. Otherwise, primary is used.\\r\\nsqlmi_query_runtime_stats\\r\\n| where interval_start_time >= todatetime(\\\"{qdsStartTime}\\\") and interval_end_time <= todatetime(\\\"{qdsEndTime}\\\")\\r\\n| where managed_instance_name =~ @\\\"{managedInstanceName}\\\"\\r\\n| summarize count_from_ha_secondary = countif(replica_type == \\\"HA secondary\\\"),\\r\\n            count_from_primary = countif(replica_type == \\\"Primary\\\")\\r\\n| project replica_type = iif(count_from_ha_secondary > 0 and count_from_primary == 0, \\\"HA secondary\\\", \\\"Primary\\\")\\r\\n\",\"clusterName\":\"{adxClusterUri}\",\"databaseName\":\"{adxDatabase}\"}",
+            "isHiddenWhenLocked": true,
+            "queryType": 9
+          },
+          {
+            "id": "621902c6-c42c-4102-bd83-08f58a7c4a3a",
+            "version": "KqlParameterItem/1.0",
+            "name": "qdsMissingDataWarningText",
+            "type": 1,
+            "query": "{\"version\":\"AzureDataExplorerQuery/1.0\",\"queryText\":\"sqlmi_database_properties\\r\\n| where sample_time_utc between (({timeRange:start} - 2h) .. {timeRange:end})\\r\\n| where managed_instance_name =~ @\\\"{managedInstanceName}\\\"\\r\\n| where database_id > 4\\r\\n| where replica_type =='Primary' \\r\\n| where query_store_actual_state_desc != \\\"READ_WRITE\\\"\\r\\n| extend query_store_actual_state_desc = iif(isempty(query_store_actual_state_desc), \\\"<missing>\\\", query_store_actual_state_desc)\\r\\n| distinct database_name, query_store_actual_state_desc\\r\\n| sort by database_name asc\\r\\n| summarize databases = strcat(\\r\\n                              strcat_array(\\r\\n                                          make_list(\\r\\n                                                   database_name,\\r\\n                                                   5\\r\\n                                                   ),\\r\\n                                          \\\", \\\"\\r\\n                                          ),\\r\\n                              iif(\\r\\n                                 dcount(database_name) > 5,\\r\\n                                 strcat(\\\" and \\\", tostring(dcount(database_name) - 5), \\\" more\\\"),\\r\\n                                 \\\"\\\")\\r\\n                              )\\r\\n            by query_store_actual_state_desc\\r\\n| sort by query_store_actual_state_desc asc\\r\\n| extend warning_row = strcat(\\\"| `\\\", query_store_actual_state_desc, \\\"` | \\\", databases, \\\" |\\\")\\r\\n| summarize warning = strcat_array(make_list(warning_row), \\\"\\\\r\\\\n\\\")\\r\\n| where isnotempty(warning)\\r\\n\",\"clusterName\":\"{adxClusterUri}\",\"databaseName\":\"{adxDatabase}\"}",
             "isHiddenWhenLocked": true,
             "queryType": 9
           }
@@ -63,6 +72,41 @@
         }
       ],
       "name": "qds_help"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "Top query data in the selected time range might be missing or incomplete for some databases because their [Query Store](https://go.microsoft.com/fwlink/?linkid=2213253) state is other than `READ_WRITE`:\r\n\r\n| Query Store state | Database(s) |\r\n|:--|:--|\r\n{qdsMissingDataWarningText}\r\n\r\nFor more information, see [Best practices for managing Query Store](https://go.microsoft.com/fwlink/?linkid=2198632).",
+        "style": "info"
+      },
+      "conditionalVisibilities": [
+        {
+          "parameterName": "qdsStartTime",
+          "comparison": "isNotEqualTo"
+        },
+        {
+          "parameterName": "qdsEndTime",
+          "comparison": "isNotEqualTo"
+        },
+        {
+          "parameterName": "qdsMissingDataWarningText",
+          "comparison": "isNotEqualTo"
+        }
+      ],
+      "name": "qds_warning_missing_data"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "Top query data is not available for secondary replicas.",
+        "style": "info"
+      },
+      "conditionalVisibility": {
+        "parameterName": "replicaType",
+        "comparison": "isNotEqualTo",
+        "value": "Primary"
+      },
+      "name": "qds_warning_secondary"
     },
     {
       "type": 9,

--- a/Workbooks/Database watcher/SQL Server/estate/estate.workbook
+++ b/Workbooks/Database watcher/SQL Server/estate/estate.workbook
@@ -2949,6 +2949,11 @@
           "value": "1"
         },
         {
+          "parameterName": "sqlserver_database_properties",
+          "comparison": "isEqualTo",
+          "value": "1"
+        },
+        {
           "parameterName": "matchPattern",
           "comparison": "isNotEqualTo"
         }

--- a/Workbooks/Database watcher/SQL Server/estate/top queries/top queries.workbook
+++ b/Workbooks/Database watcher/SQL Server/estate/top queries/top queries.workbook
@@ -25,11 +25,19 @@
             "query": "{\"version\":\"AzureDataExplorerQuery/1.0\",\"queryText\":\"union\\r\\n(\\r\\n// The most recent interval that is earlier than the end of time range.\\r\\n// This may be earlier than the start of time range by at most 2h.\\r\\nsqlserver_query_runtime_stats\\r\\n| where interval_end_time between (({timeRange:start} - 2h) .. {timeRange:end})\\r\\n{subscriptionFilter}\\r\\n{resourceGroupFilter}\\r\\n{machineNameFilter}\\r\\n{serverNameFilter}\\r\\n| summarize interval_end_time = max(interval_end_time)\\r\\n),\\r\\n(\\r\\n// latest interval end within time range\\r\\nsqlserver_query_runtime_stats\\r\\n| where interval_end_time >= {timeRange:start} and interval_start_time <= {timeRange:end}\\r\\n{subscriptionFilter}\\r\\n{resourceGroupFilter}\\r\\n{machineNameFilter}\\r\\n{serverNameFilter}\\r\\n| summarize interval_end_time = max(interval_end_time)\\r\\n)\\r\\n// return the latest of these times as end of QDS range\\r\\n// if there isn't a complete QDS interval within time range, this will show the latest available interval\\r\\n| summarize qds_end_time = datetime_add(\\\"second\\\", 1, max(interval_end_time)) // make-series treats the end of interval as not inclusive, fudge by 1 second\\r\\n\",\"clusterName\":\"{adxClusterUri}\",\"databaseName\":\"{adxDatabase}\"}",
             "isHiddenWhenLocked": true,
             "queryType": 9
+          },
+          {
+            "id": "621902c6-c42c-4102-bd83-08f58a7c4a3a",
+            "version": "KqlParameterItem/1.0",
+            "name": "qdsMissingDataWarningText",
+            "type": 1,
+            "query": "{\"version\":\"AzureDataExplorerQuery/1.0\",\"queryText\":\"sqlserver_database_properties\\r\\n| where sample_time_utc between (({timeRange:start} - 2h) .. {timeRange:end})\\r\\n{subscriptionFilter}\\r\\n{resourceGroupFilter}\\r\\n{machineNameFilter}\\r\\n{serverNameFilter}\\r\\n| where database_id > 4\\r\\n| where is_primary_replica or isnull(is_primary_replica)\\r\\n| where query_store_actual_state_desc != \\\"READ_WRITE\\\"\\r\\n| extend query_store_actual_state_desc = iif(isempty(query_store_actual_state_desc), \\\"<missing>\\\", query_store_actual_state_desc)\\r\\n| distinct machine_name, server_name, database_name, query_store_actual_state_desc\\r\\n| sort by database_name asc, machine_name asc, server_name asc\\r\\n| summarize databases = strcat(\\r\\n                              strcat_array(\\r\\n                                          make_list(\\r\\n                                                   strcat(database_name, \\\" (\\\", iif(machine_name == server_name, server_name, strcat(machine_name, \\\" | \\\", server_name)), \\\")\\\"),\\r\\n                                                   5\\r\\n                                                   ),\\r\\n                                          \\\", \\\"\\r\\n                                          ),\\r\\n                              iif(\\r\\n                                 dcount(strcat(machine_name, \\\"|\\\", server_name, \\\"|\\\", database_name)) > 5,\\r\\n                                 strcat(\\\" and \\\", tostring(dcount(strcat(machine_name, \\\"|\\\", server_name, \\\"|\\\", database_name)) - 5), \\\" more\\\"),\\r\\n                                 \\\"\\\")\\r\\n                              )\\r\\n            by query_store_actual_state_desc\\r\\n| sort by query_store_actual_state_desc asc\\r\\n| extend warning_row = strcat(\\\"| `\\\", query_store_actual_state_desc, \\\"` | \\\", databases, \\\" |\\\")\\r\\n| summarize warning = strcat_array(make_list(warning_row), \\\"\\\\r\\\\n\\\")\\r\\n| where isnotempty(warning)\\r\\n\",\"clusterName\":\"{adxClusterUri}\",\"databaseName\":\"{adxDatabase}\"}",
+            "isHiddenWhenLocked": true,
+            "queryType": 9
           }
         ],
         "style": "above",
-        "queryType": 0,
-        "resourceType": "microsoft.operationalinsights/workspaces"
+        "queryType": 9
       },
       "name": "top_query_qds_time_parameters"
     },
@@ -54,6 +62,28 @@
         }
       ],
       "name": "qds_help"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "Top query data in the selected time range might be missing or incomplete for some databases because their [Query Store](https://go.microsoft.com/fwlink/?linkid=2213253) state is other than `READ_WRITE`:\r\n\r\n| Query Store state | Database(s) (server) |\r\n|:--|:--|\r\n{qdsMissingDataWarningText}\r\n\r\nFor more information, see [Best practices for managing Query Store](https://go.microsoft.com/fwlink/?linkid=2198632).",
+        "style": "info"
+      },
+      "conditionalVisibilities": [
+        {
+          "parameterName": "qdsStartTime",
+          "comparison": "isNotEqualTo"
+        },
+        {
+          "parameterName": "qdsEndTime",
+          "comparison": "isNotEqualTo"
+        },
+        {
+          "parameterName": "qdsMissingDataWarningText",
+          "comparison": "isNotEqualTo"
+        }
+      ],
+      "name": "qds_warning_missing_data"
     },
     {
       "type": 9,

--- a/Workbooks/Database watcher/SQL Server/estate/top queries/top queries.workbook
+++ b/Workbooks/Database watcher/SQL Server/estate/top queries/top queries.workbook
@@ -66,7 +66,7 @@
     {
       "type": 1,
       "content": {
-        "json": "Top query data in the selected time range might be missing or incomplete for some databases because their [Query Store](https://go.microsoft.com/fwlink/?linkid=2213253) state is other than `READ_WRITE`:\r\n\r\n| Query Store state | Database(s) (server) |\r\n|:--|:--|\r\n{qdsMissingDataWarningText}\r\n\r\nFor more information, see [Best practices for managing Query Store](https://go.microsoft.com/fwlink/?linkid=2198632).",
+        "json": "Top query data in the selected time range might be missing or incomplete for some databases because their [Query Store](https://go.microsoft.com/fwlink/?linkid=2213253) state is other than `READ_WRITE`. For more information, see [Best practices for managing Query Store](https://go.microsoft.com/fwlink/?linkid=2198632).\r\n\r\n| Query Store state | Database(s) (server) |\r\n|:--|:--|\r\n{qdsMissingDataWarningText}",
         "style": "info"
       },
       "conditionalVisibilities": [

--- a/Workbooks/Database watcher/SQL Server/instance/instance.workbook
+++ b/Workbooks/Database watcher/SQL Server/instance/instance.workbook
@@ -5181,6 +5181,11 @@
           "value": "1"
         },
         {
+          "parameterName": "sqlserver_database_properties",
+          "comparison": "isEqualTo",
+          "value": "1"
+        },
+        {
           "parameterName": "serverName",
           "comparison": "isNotEqualTo"
         },

--- a/Workbooks/Database watcher/SQL Server/instance/top queries/top queries.workbook
+++ b/Workbooks/Database watcher/SQL Server/instance/top queries/top queries.workbook
@@ -25,6 +25,15 @@
             "query": "{\"version\":\"AzureDataExplorerQuery/1.0\",\"queryText\":\"union\\r\\n(\\r\\n// The most recent interval that is earlier than the end of time range.\\r\\n// This may be earlier than the start of time range by at most 2h.\\r\\nsqlserver_query_runtime_stats\\r\\n| where interval_end_time between (({timeRange:start} - 2h) .. {timeRange:end})\\r\\n| where server_name =~ @\\\"{serverName}\\\"\\r\\n| where machine_name =~ @\\\"{machineName}\\\"\\r\\n| summarize interval_end_time = max(interval_end_time)\\r\\n),\\r\\n(\\r\\n// latest interval end within time range\\r\\nsqlserver_query_runtime_stats\\r\\n| where interval_end_time >= {timeRange:start} and interval_start_time <= {timeRange:end}\\r\\n| where server_name =~ @\\\"{serverName}\\\"\\r\\n| where machine_name =~ @\\\"{machineName}\\\"\\r\\n| summarize interval_end_time = max(interval_end_time)\\r\\n)\\r\\n// return the latest of these times as end of QDS range\\r\\n// if there isn't a complete QDS interval within time range, this will show the latest available interval\\r\\n| summarize qds_end_time = datetime_add(\\\"second\\\", 1, max(interval_end_time)) // make-series treats the end of interval as not inclusive, fudge by 1 second\\r\\n\",\"clusterName\":\"{adxClusterUri}\",\"databaseName\":\"{adxDatabase}\"}",
             "isHiddenWhenLocked": true,
             "queryType": 9
+          },
+          {
+            "id": "621902c6-c42c-4102-bd83-08f58a7c4a3a",
+            "version": "KqlParameterItem/1.0",
+            "name": "qdsMissingDataWarningText",
+            "type": 1,
+            "query": "{\"version\":\"AzureDataExplorerQuery/1.0\",\"queryText\":\"sqlserver_database_properties\\r\\n| where sample_time_utc between (({timeRange:start} - 2h) .. {timeRange:end})\\r\\n| where server_name =~ @\\\"{serverName}\\\"\\r\\n| where machine_name =~ @\\\"{machineName}\\\"\\r\\n| where database_id > 4\\r\\n| where is_primary_replica or isnull(is_primary_replica)\\r\\n| where query_store_actual_state_desc != \\\"READ_WRITE\\\"\\r\\n| extend query_store_actual_state_desc = iif(isempty(query_store_actual_state_desc), \\\"<missing>\\\", query_store_actual_state_desc)\\r\\n| distinct database_name, query_store_actual_state_desc\\r\\n| sort by database_name asc\\r\\n| summarize databases = strcat(\\r\\n                              strcat_array(\\r\\n                                          make_list(\\r\\n                                                   database_name,\\r\\n                                                   5\\r\\n                                                   ),\\r\\n                                          \\\", \\\"\\r\\n                                          ),\\r\\n                              iif(\\r\\n                                 dcount(database_name) > 5,\\r\\n                                 strcat(\\\" and \\\", tostring(dcount(database_name) - 5), \\\" more\\\"),\\r\\n                                 \\\"\\\")\\r\\n                              )\\r\\n            by query_store_actual_state_desc\\r\\n| sort by query_store_actual_state_desc asc\\r\\n| extend warning_row = strcat(\\\"| `\\\", query_store_actual_state_desc, \\\"` | \\\", databases, \\\" |\\\")\\r\\n| summarize warning = strcat_array(make_list(warning_row), \\\"\\\\r\\\\n\\\")\\r\\n| where isnotempty(warning)\\r\\n\",\"clusterName\":\"{adxClusterUri}\",\"databaseName\":\"{adxDatabase}\"}",
+            "isHiddenWhenLocked": true,
+            "queryType": 9
           }
         ],
         "style": "above",
@@ -53,6 +62,28 @@
         }
       ],
       "name": "qds_help"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "Top query data in the selected time range might be missing or incomplete for some databases because their [Query Store](https://go.microsoft.com/fwlink/?linkid=2213253) state is other than `READ_WRITE`:\r\n\r\n| Query Store state | Database(s) |\r\n|:--|:--|\r\n{qdsMissingDataWarningText}\r\n\r\nFor more information, see [Best practices for managing Query Store](https://go.microsoft.com/fwlink/?linkid=2198632).",
+        "style": "info"
+      },
+      "conditionalVisibilities": [
+        {
+          "parameterName": "qdsStartTime",
+          "comparison": "isNotEqualTo"
+        },
+        {
+          "parameterName": "qdsEndTime",
+          "comparison": "isNotEqualTo"
+        },
+        {
+          "parameterName": "qdsMissingDataWarningText",
+          "comparison": "isNotEqualTo"
+        }
+      ],
+      "name": "qds_warning_missing_data"
     },
     {
       "type": 9,

--- a/Workbooks/Database watcher/SQL Server/instance/top queries/top queries.workbook
+++ b/Workbooks/Database watcher/SQL Server/instance/top queries/top queries.workbook
@@ -66,7 +66,7 @@
     {
       "type": 1,
       "content": {
-        "json": "Top query data in the selected time range might be missing or incomplete for some databases because their [Query Store](https://go.microsoft.com/fwlink/?linkid=2213253) state is other than `READ_WRITE`:\r\n\r\n| Query Store state | Database(s) |\r\n|:--|:--|\r\n{qdsMissingDataWarningText}\r\n\r\nFor more information, see [Best practices for managing Query Store](https://go.microsoft.com/fwlink/?linkid=2198632).",
+        "json": "Top query data in the selected time range might be missing or incomplete for some databases because their [Query Store](https://go.microsoft.com/fwlink/?linkid=2213253) state is other than `READ_WRITE`. For more information, see [Best practices for managing Query Store](https://go.microsoft.com/fwlink/?linkid=2198632).\r\n\r\n| Query Store state | Database(s) |\r\n|:--|:--|\r\n{qdsMissingDataWarningText}",
         "style": "info"
       },
       "conditionalVisibilities": [


### PR DESCRIPTION
## Summary

When there is no data on the `Top queries` dashboards, show info messages if Query Store isn't collecting or when the replica type isn't supported.

## Screenshots

![image](https://github.com/user-attachments/assets/6220f70b-f76c-42e5-aa40-f7c68cb8f176)
![image](https://github.com/user-attachments/assets/a65b7399-0b78-48af-8264-805cf9e3684c)

## Validation

- [x] Validate your changes using one or more of the [testing](https://github.com/microsoft/Application-Insights-Workbooks/blob/master/Documentation/Testing.md) methods.
  
## Checklist

- [x] If you are adding a new template, gallery, or folder, add your team and folder/file(s) to the CODEOWNERS file at the root of the repo. CODEOWNERS entries should be teams, not individuals.
      When done correctly, this means that from then on *your* team does reviews of *your* things, not the workbooks team.
- [x] Ensure all steps in your template have meaningful names.
- [x] Ensure all parameters and grid columns have display names set so they can be localized.
