### PR TITLE
[database watcher] Use free ADX compressed size limit in data store warning

### DIFF
--- a/Workbooks/Database watcher/watcher.workbook
+++ b/Workbooks/Database watcher/watcher.workbook
@@ -641,7 +641,7 @@
                   "version": "KqlParameterItem/1.0",
                   "name": "dataStoreSizeProperties",
                   "type": 1,
-                  "query": "{\"version\":\"AzureDataExplorerQuery/1.0\",\"queryText\":\".show database extents\\r\\n| summarize uncompressed_size_bytes = sum(OriginalSize),\\r\\n            compressed_size_bytes = sum(CompressedSize)\\r\\n| extend freeKustoWarning = iif(\\\"{watcherDataStoreType}\\\" == \\\"free\\\" and uncompressed_size_bytes > 85899345920, true, false) // Greater than 80 GiB\\r\\n| project uncompressed_size_bytes, compressed_size_bytes, 1formatted_uncompressed_size = format_bytes(uncompressed_size_bytes), 2formatted_compressed_size = format_bytes(compressed_size_bytes), freeKustoWarning\\r\\n| project dynamic_to_json(pack_all())\",\"clusterName\":\"{adxClusterUri}\",\"databaseName\":\"{adxDatabase}\"}",
+                  "query": "{\"version\":\"AzureDataExplorerQuery/1.0\",\"queryText\":\".show database extents\\r\\n| summarize uncompressed_size_bytes = sum(OriginalSize),\\r\\n            compressed_size_bytes = sum(CompressedSize)\\r\\n| extend freeKustoWarning = iif(\\\"{watcherDataStoreType}\\\" == \\\"free\\\" and compressed_size_bytes > 17179869184, true, false) // Greater than 16 GiB\\r\\n| project uncompressed_size_bytes, compressed_size_bytes, 1formatted_uncompressed_size = format_bytes(uncompressed_size_bytes), 2formatted_compressed_size = format_bytes(compressed_size_bytes), freeKustoWarning, 3compression_ratio = strcat(tostring(iif(isfinite(uncompressed_size_bytes/compressed_size_bytes), round(uncompressed_size_bytes/compressed_size_bytes, 1), real(null))), \\\" times\\\")\\r\\n| project dynamic_to_json(pack_all())\",\"clusterName\":\"{adxClusterUri}\",\"databaseName\":\"{adxDatabase}\"}",
                   "isHiddenWhenLocked": true,
                   "queryType": 9
                 }
@@ -976,6 +976,24 @@
                       "thresholdsOptions": "icons",
                       "thresholdsGrid": [
                         {
+                          "operator": "Default",
+                          "thresholdValue": null,
+                          "representation": "Blank",
+                          "text": "{0}{1}"
+                        }
+                      ]
+                    },
+                    "tooltipFormat": {
+                      "tooltip": "Originally ingested data size before compression"
+                    }
+                  },
+                  {
+                    "columnMatch": "2formatted_compressed_size",
+                    "formatter": 18,
+                    "formatOptions": {
+                      "thresholdsOptions": "icons",
+                      "thresholdsGrid": [
+                        {
                           "sourceColumn": "freeKustoWarning",
                           "operator": "==",
                           "thresholdValue": "true",
@@ -994,15 +1012,15 @@
                       ]
                     },
                     "tooltipFormat": {
-                      "tooltip": "Originally ingested data size before compression"
+                      "tooltip": "Stored data size after applying columnstore compression"
                     }
                   },
                   {
-                    "columnMatch": "2formatted_compressed_size",
+                    "columnMatch": "3compression_ratio",
                     "formatter": 22,
                     "formatOptions": {
                       "compositeBarSettings": {
-                        "labelText": "[\"2formatted_compressed_size\"]",
+                        "labelText": "[\"3compression_ratio\"]",
                         "columnSettings": [
                           {
                             "columnName": "compressed_size_bytes",
@@ -1015,9 +1033,6 @@
                         ],
                         "noRowsScaling": true
                       }
-                    },
-                    "tooltipFormat": {
-                      "tooltip": "Stored data size after applying columnstore compression"
                     }
                   },
                   {
@@ -1041,11 +1056,15 @@
                   {
                     "columnId": "2formatted_compressed_size",
                     "label": "Compressed"
+                  },
+                  {
+                    "columnId": "3compression_ratio",
+                    "label": "Compression ratio"
                   }
                 ]
               }
             },
-            "customWidth": "30",
+            "customWidth": "50",
             "conditionalVisibility": {
               "parameterName": "adxClusterPingResult",
               "comparison": "isEqualTo",


### PR DESCRIPTION
## Summary

When the free ADX cluster is close to running out of space quota, show a warning based on the compressed size (which is the enforced limit), instead of a warning based on the approximate and not enforced original data size.

## Screenshots

![image](https://github.com/user-attachments/assets/db54b547-7ac3-4f25-b6ec-94b7710ea10c)

## Validation

- [x] Validate your changes using one or more of the [testing](https://github.com/microsoft/Application-Insights-Workbooks/blob/master/Documentation/Testing.md) methods.

## Checklist

- [x] If you are adding a new template, gallery, or folder, add your team and folder/file(s) to the CODEOWNERS file at the root of the repo. CODEOWNERS entries should be teams, not individuals.
      When done correctly, this means that from then on *your* team does reviews of *your* things, not the workbooks team.
- [x] Ensure all steps in your template have meaningful names.
- [x] Ensure all parameters and grid columns have display names set so they can be localized.
