### PR TITLE
[database watcher] Improve storage utilization charts to show maximum storage size

### DIFF
--- a/Workbooks/Database watcher/Azure SQL Database/database/georeplicas/georeplicas.workbook
+++ b/Workbooks/Database watcher/Azure SQL Database/database/georeplicas/georeplicas.workbook
@@ -481,7 +481,7 @@
                 ]
               },
               "tooltipFormat": {
-                "tooltip": "It is recommended that compute size of a geo-replication secondary replica matches the compute size of its primary replica. This instance has [\"local_logical_cpu_count\"] logical CPUs; its partner instance has [\"partner_logical_cpu_count\"] logical CPUs."
+                "tooltip": "It is recommended that compute size of a geo-replication secondary replica matches the compute size of its primary replica. This database or its elastic pool has [\"local_logical_cpu_count\"] logical CPUs; its partner database or elastic pool has [\"partner_logical_cpu_count\"] logical CPUs."
               }
             },
             {

--- a/Workbooks/Database watcher/Azure SQL Database/database/storage/storage.workbook
+++ b/Workbooks/Database watcher/Azure SQL Database/database/storage/storage.workbook
@@ -75,6 +75,7 @@
         "groupType": "editable",
         "title": "Storage consumption details",
         "expandable": true,
+        "expanded": true,
         "items": [
           {
             "type": 1,
@@ -92,7 +93,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "{\"version\":\"AzureDataExplorerQuery/1.0\",\"queryText\":\"datatable(key:int, metric_name:string) [\\r\\n1, \\\"Used data\\\",\\r\\n1, \\\"Allocated data\\\"\\r\\n]\\r\\n| join kind=inner\\r\\n(\\r\\nsqldb_database_storage_utilization\\r\\n| where sample_time_utc between ({timeRange:start} .. {timeRange:end})\\r\\n| where logical_server_name =~ @\\\"{serverName}\\\"\\r\\n| where database_name == @\\\"{databaseName}\\\"\\r\\n| where ({haReplica} and replica_type == \\\"HA secondary\\\") or (not ({haReplica}) and replica_type != \\\"HA secondary\\\")\\r\\n| extend key = int(1)\\r\\n) on key\\r\\n| project metric_name, sample_time_utc, data_size_used_mb, data_size_allocated_mb\\r\\n| extend metric = case(\\r\\n                      metric_name == \\\"Used data\\\", data_size_used_mb,\\r\\n                      metric_name == \\\"Allocated data\\\", data_size_allocated_mb,\\r\\n                      decimal(null)\\r\\n                      )\\r\\n| make-series metric = max(metric) default = long(null) on sample_time_utc from {timeRange:start} to {timeRange:end} step {timeRange:grain} by metric_name\\r\\n| project metric_name, metric = series_fill_forward(series_fill_linear(metric, int(null), false)), sample_time_utc\",\"clusterName\":\"{adxClusterUri}\",\"databaseName\":\"{adxDatabase}\"}",
+              "query": "{\"version\":\"AzureDataExplorerQuery/1.0\",\"queryText\":\"datatable(key:int, metric_name:string) [\\r\\n1, \\\"Used data\\\",\\r\\n1, \\\"Allocated data\\\",\\r\\n1, \\\"Max data\\\"\\r\\n]\\r\\n| join kind=inner\\r\\n(\\r\\nsqldb_database_storage_utilization\\r\\n| where sample_time_utc between ({timeRange:start} .. {timeRange:end})\\r\\n| where logical_server_name =~ @\\\"{serverName}\\\"\\r\\n| where database_name == @\\\"{databaseName}\\\"\\r\\n| where ({haReplica} and replica_type == \\\"HA secondary\\\") or (not ({haReplica}) and replica_type != \\\"HA secondary\\\")\\r\\n| extend key = int(1)\\r\\n) on key\\r\\n| project metric_name, sample_time_utc, data_size_used_mb, data_size_allocated_mb, data_max_size_mb\\r\\n| extend metric = case(\\r\\n                      metric_name == \\\"Used data\\\", data_size_used_mb,\\r\\n                      metric_name == \\\"Allocated data\\\", data_size_allocated_mb,\\r\\n                      metric_name == \\\"Max data\\\", data_max_size_mb,\\r\\n                      decimal(null)\\r\\n                      )\\r\\n| where (data_max_size_mb == -1 and metric_name != \\\"Max data\\\") or data_max_size_mb != -1\\r\\n| make-series metric = max(metric) default = long(null) on sample_time_utc from {timeRange:start} to {timeRange:end} step {timeRange:grain} by metric_name\\r\\n| project metric_name, metric = series_fill_forward(series_fill_linear(metric, int(null), false)), sample_time_utc\",\"clusterName\":\"{adxClusterUri}\",\"databaseName\":\"{adxDatabase}\"}",
               "size": 1,
               "aggregation": 5,
               "showAnalytics": true,
@@ -124,6 +125,10 @@
                   {
                     "seriesName": "Used data",
                     "color": "green"
+                  },
+                  {
+                    "seriesName": "Max data",
+                    "color": "red"
                   }
                 ],
                 "ySettings": {
@@ -145,7 +150,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "{\"version\":\"AzureDataExplorerQuery/1.0\",\"queryText\":\"datatable(key:int, metric_name:string) [\\r\\n1, \\\"Used log\\\",\\r\\n1, \\\"Allocated log\\\"\\r\\n]\\r\\n| join kind=inner\\r\\n(\\r\\nsqldb_database_storage_utilization\\r\\n| where sample_time_utc between ({timeRange:start} .. {timeRange:end})\\r\\n| where logical_server_name =~ @\\\"{serverName}\\\"\\r\\n| where database_name == @\\\"{databaseName}\\\"\\r\\n| where ({haReplica} and replica_type == \\\"HA secondary\\\") or (not ({haReplica}) and replica_type != \\\"HA secondary\\\")\\r\\n| extend key = int(1)\\r\\n) on key\\r\\n| project metric_name, sample_time_utc, log_size_used_mb, log_size_allocated_mb\\r\\n| extend metric = case(\\r\\n                      metric_name == \\\"Used log\\\", log_size_used_mb,\\r\\n                      metric_name == \\\"Allocated log\\\", log_size_allocated_mb,\\r\\n                      decimal(null)\\r\\n                      )\\r\\n| make-series metric = max(metric) default = long(null) on sample_time_utc from {timeRange:start} to {timeRange:end} step {timeRange:grain} by metric_name\\r\\n| project metric_name, metric = series_fill_forward(series_fill_linear(metric, int(null), false)), sample_time_utc\",\"clusterName\":\"{adxClusterUri}\",\"databaseName\":\"{adxDatabase}\"}",
+              "query": "{\"version\":\"AzureDataExplorerQuery/1.0\",\"queryText\":\"datatable(key:int, metric_name:string) [\\r\\n1, \\\"Used log\\\",\\r\\n1, \\\"Allocated log\\\",\\r\\n1, \\\"Max log\\\"\\r\\n]\\r\\n| join kind=inner\\r\\n(\\r\\nsqldb_database_storage_utilization\\r\\n| where sample_time_utc between ({timeRange:start} .. {timeRange:end})\\r\\n| where logical_server_name =~ @\\\"{serverName}\\\"\\r\\n| where database_name == @\\\"{databaseName}\\\"\\r\\n| where ({haReplica} and replica_type == \\\"HA secondary\\\") or (not ({haReplica}) and replica_type != \\\"HA secondary\\\")\\r\\n| extend key = int(1)\\r\\n) on key\\r\\n| project metric_name, sample_time_utc, log_size_used_mb, log_size_allocated_mb, log_max_size_mb\\r\\n| extend metric = case(\\r\\n                      metric_name == \\\"Used log\\\", log_size_used_mb,\\r\\n                      metric_name == \\\"Allocated log\\\", log_size_allocated_mb,\\r\\n                      metric_name == \\\"Max log\\\", log_max_size_mb,\\r\\n                      decimal(null)\\r\\n                      )\\r\\n| make-series metric = max(metric) default = long(null) on sample_time_utc from {timeRange:start} to {timeRange:end} step {timeRange:grain} by metric_name\\r\\n| project metric_name, metric = series_fill_forward(series_fill_linear(metric, int(null), false)), sample_time_utc\",\"clusterName\":\"{adxClusterUri}\",\"databaseName\":\"{adxDatabase}\"}",
               "size": 1,
               "aggregation": 5,
               "showAnalytics": true,
@@ -177,6 +182,10 @@
                   {
                     "seriesName": "Used log",
                     "color": "green"
+                  },
+                  {
+                    "seriesName": "Max log",
+                    "color": "red"
                   }
                 ],
                 "ySettings": {
@@ -198,7 +207,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "{\"version\":\"AzureDataExplorerQuery/1.0\",\"queryText\":\"datatable(key:int, metric_name:string) [\\r\\n1, \\\"Used tempdb data\\\",\\r\\n1, \\\"Allocated tempdb data\\\"\\r\\n]\\r\\n| join kind=inner\\r\\n(\\r\\nsqldb_database_storage_utilization\\r\\n| where sample_time_utc between ({timeRange:start} .. {timeRange:end})\\r\\n| where logical_server_name =~ @\\\"{serverName}\\\"\\r\\n| where database_name == @\\\"{databaseName}\\\"\\r\\n| where ({haReplica} and replica_type == \\\"HA secondary\\\") or (not ({haReplica}) and replica_type != \\\"HA secondary\\\")\\r\\n| extend key = int(1)\\r\\n) on key\\r\\n| project metric_name, sample_time_utc, tempdb_data_size_used_mb, tempdb_data_size_allocated_mb\\r\\n| extend metric = case(\\r\\n                      metric_name == \\\"Used tempdb data\\\", tempdb_data_size_used_mb,\\r\\n                      metric_name == \\\"Allocated tempdb data\\\", tempdb_data_size_allocated_mb,\\r\\n                      decimal(null)\\r\\n                      )\\r\\n| make-series metric = max(metric) default = long(null) on sample_time_utc from {timeRange:start} to {timeRange:end} step {timeRange:grain} by metric_name\\r\\n| project metric_name, metric = series_fill_forward(series_fill_linear(metric, int(null), false)), sample_time_utc\",\"clusterName\":\"{adxClusterUri}\",\"databaseName\":\"{adxDatabase}\"}",
+              "query": "{\"version\":\"AzureDataExplorerQuery/1.0\",\"queryText\":\"datatable(key:int, metric_name:string) [\\r\\n1, \\\"Used tempdb data\\\",\\r\\n1, \\\"Allocated tempdb data\\\",\\r\\n1, \\\"Max tempdb data\\\"\\r\\n]\\r\\n| join kind=inner\\r\\n(\\r\\nsqldb_database_storage_utilization\\r\\n| where sample_time_utc between ({timeRange:start} .. {timeRange:end})\\r\\n| where logical_server_name =~ @\\\"{serverName}\\\"\\r\\n| where database_name == @\\\"{databaseName}\\\"\\r\\n| where ({haReplica} and replica_type == \\\"HA secondary\\\") or (not ({haReplica}) and replica_type != \\\"HA secondary\\\")\\r\\n| extend key = int(1)\\r\\n) on key\\r\\n| project metric_name, sample_time_utc, tempdb_data_size_used_mb, tempdb_data_size_allocated_mb, tempdb_data_max_size_mb\\r\\n| extend metric = case(\\r\\n                      metric_name == \\\"Used tempdb data\\\", tempdb_data_size_used_mb,\\r\\n                      metric_name == \\\"Allocated tempdb data\\\", tempdb_data_size_allocated_mb,\\r\\n                      metric_name == \\\"Max tempdb data\\\", tempdb_data_max_size_mb,\\r\\n                      decimal(null)\\r\\n                      )\\r\\n| make-series metric = max(metric) default = long(null) on sample_time_utc from {timeRange:start} to {timeRange:end} step {timeRange:grain} by metric_name\\r\\n| project metric_name, metric = series_fill_forward(series_fill_linear(metric, int(null), false)), sample_time_utc\",\"clusterName\":\"{adxClusterUri}\",\"databaseName\":\"{adxDatabase}\"}",
               "size": 1,
               "aggregation": 5,
               "showAnalytics": true,
@@ -230,6 +239,10 @@
                   {
                     "seriesName": "Used tempdb data",
                     "color": "green"
+                  },
+                  {
+                    "seriesName": "Max tempdb data",
+                    "color": "red"
                   }
                 ],
                 "ySettings": {
@@ -251,7 +264,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "{\"version\":\"AzureDataExplorerQuery/1.0\",\"queryText\":\"datatable(key:int, metric_name:string) [\\r\\n1, \\\"Used tempdb log\\\",\\r\\n1, \\\"Allocated tempdb log\\\"\\r\\n]\\r\\n| join kind=inner\\r\\n(\\r\\nsqldb_database_storage_utilization\\r\\n| where sample_time_utc between ({timeRange:start} .. {timeRange:end})\\r\\n| where logical_server_name =~ @\\\"{serverName}\\\"\\r\\n| where database_name == @\\\"{databaseName}\\\"\\r\\n| where ({haReplica} and replica_type == \\\"HA secondary\\\") or (not ({haReplica}) and replica_type != \\\"HA secondary\\\")\\r\\n| extend key = int(1)\\r\\n) on key\\r\\n| project metric_name, sample_time_utc, tempdb_log_size_used_mb, tempdb_log_size_allocated_mb\\r\\n| extend metric = case(\\r\\n                      metric_name == \\\"Used tempdb log\\\", tempdb_log_size_used_mb,\\r\\n                      metric_name == \\\"Allocated tempdb log\\\", tempdb_log_size_allocated_mb,\\r\\n                      decimal(null)\\r\\n                      )\\r\\n| make-series metric = max(metric) default = long(null) on sample_time_utc from {timeRange:start} to {timeRange:end} step {timeRange:grain} by metric_name\\r\\n| project metric_name, metric = series_fill_forward(series_fill_linear(metric, int(null), false)), sample_time_utc\",\"clusterName\":\"{adxClusterUri}\",\"databaseName\":\"{adxDatabase}\"}",
+              "query": "{\"version\":\"AzureDataExplorerQuery/1.0\",\"queryText\":\"datatable(key:int, metric_name:string) [\\r\\n1, \\\"Used tempdb log\\\",\\r\\n1, \\\"Allocated tempdb log\\\",\\r\\n1, \\\"Max tempdb log\\\"\\r\\n]\\r\\n| join kind=inner\\r\\n(\\r\\nsqldb_database_storage_utilization\\r\\n| where sample_time_utc between ({timeRange:start} .. {timeRange:end})\\r\\n| where logical_server_name =~ @\\\"{serverName}\\\"\\r\\n| where database_name == @\\\"{databaseName}\\\"\\r\\n| where ({haReplica} and replica_type == \\\"HA secondary\\\") or (not ({haReplica}) and replica_type != \\\"HA secondary\\\")\\r\\n| extend key = int(1)\\r\\n) on key\\r\\n| project metric_name, sample_time_utc, tempdb_log_size_used_mb, tempdb_log_size_allocated_mb, tempdb_log_max_size_mb\\r\\n| extend metric = case(\\r\\n                      metric_name == \\\"Used tempdb log\\\", tempdb_log_size_used_mb,\\r\\n                      metric_name == \\\"Allocated tempdb log\\\", tempdb_log_size_allocated_mb,\\r\\n                      metric_name == \\\"Max tempdb log\\\", tempdb_log_max_size_mb,\\r\\n                      decimal(null)\\r\\n                      )\\r\\n| make-series metric = max(metric) default = long(null) on sample_time_utc from {timeRange:start} to {timeRange:end} step {timeRange:grain} by metric_name\\r\\n| project metric_name, metric = series_fill_forward(series_fill_linear(metric, int(null), false)), sample_time_utc\",\"clusterName\":\"{adxClusterUri}\",\"databaseName\":\"{adxDatabase}\"}",
               "size": 1,
               "aggregation": 5,
               "showAnalytics": true,
@@ -283,6 +296,10 @@
                   {
                     "seriesName": "Used tempdb log",
                     "color": "green"
+                  },
+                  {
+                    "seriesName": "Max tempdb log",
+                    "color": "red"
                   }
                 ],
                 "ySettings": {
@@ -371,7 +388,6 @@
         "groupType": "editable",
         "title": "Storage IO statistics",
         "expandable": true,
-        "expanded": true,
         "items": [
           {
             "type": 1,

--- a/Workbooks/Database watcher/Azure SQL Database/elastic pool/storage/storage.workbook
+++ b/Workbooks/Database watcher/Azure SQL Database/elastic pool/storage/storage.workbook
@@ -63,6 +63,7 @@
         "groupType": "editable",
         "title": "Storage consumption details",
         "expandable": true,
+        "expanded": true,
         "items": [
           {
             "type": 1,
@@ -80,7 +81,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "{\"version\":\"AzureDataExplorerQuery/1.0\",\"queryText\":\"datatable(key:int, metric_name:string) [\\r\\n1, \\\"Used data\\\",\\r\\n1, \\\"Allocated data\\\"\\r\\n]\\r\\n| join kind=inner\\r\\n(\\r\\nsqldb_elastic_pool_storage_utilization\\r\\n| where sample_time_utc between ({timeRange:start} .. {timeRange:end})\\r\\n| where logical_server_name =~ @\\\"{serverName}\\\"\\r\\n| where elastic_pool_name == @\\\"{elasticPoolName}\\\"\\r\\n| where ({haReplica} and replica_type == \\\"HA secondary\\\") or (not ({haReplica}) and replica_type != \\\"HA secondary\\\")\\r\\n| extend key = int(1)\\r\\n) on key\\r\\n| project metric_name, sample_time_utc, elastic_pool_data_size_used_mb, elastic_pool_allocated_storage_size_mb\\r\\n| extend metric = case(\\r\\n                      metric_name == \\\"Used data\\\", elastic_pool_data_size_used_mb,\\r\\n                      metric_name == \\\"Allocated data\\\", elastic_pool_allocated_storage_size_mb,\\r\\n                      long(null)\\r\\n                      )\\r\\n| make-series metric = max(metric) default = long(null) on sample_time_utc from {timeRange:start} to {timeRange:end} step {timeRange:grain} by metric_name\\r\\n| project metric_name, metric = series_fill_forward(series_fill_linear(metric, int(null), false)), sample_time_utc\",\"clusterName\":\"{adxClusterUri}\",\"databaseName\":\"{adxDatabase}\"}",
+              "query": "{\"version\":\"AzureDataExplorerQuery/1.0\",\"queryText\":\"datatable(key:int, metric_name:string) [\\r\\n1, \\\"Used data\\\",\\r\\n1, \\\"Allocated data\\\",\\r\\n1, \\\"Max data\\\"\\r\\n]\\r\\n| join kind=inner\\r\\n(\\r\\nsqldb_elastic_pool_storage_utilization\\r\\n| where sample_time_utc between ({timeRange:start} .. {timeRange:end})\\r\\n| where logical_server_name =~ @\\\"{serverName}\\\"\\r\\n| where elastic_pool_name == @\\\"{elasticPoolName}\\\"\\r\\n| where ({haReplica} and replica_type == \\\"HA secondary\\\") or (not ({haReplica}) and replica_type != \\\"HA secondary\\\")\\r\\n| extend key = int(1)\\r\\n) on key\\r\\n| project metric_name, sample_time_utc, elastic_pool_data_size_used_mb, elastic_pool_allocated_storage_size_mb, elastic_pool_data_max_size_mb\\r\\n| extend metric = case(\\r\\n                      metric_name == \\\"Used data\\\", elastic_pool_data_size_used_mb,\\r\\n                      metric_name == \\\"Allocated data\\\", elastic_pool_allocated_storage_size_mb,\\r\\n                      metric_name == \\\"Max data\\\", elastic_pool_data_max_size_mb,\\r\\n                      long(null)\\r\\n                      )\\r\\n| make-series metric = max(metric) default = long(null) on sample_time_utc from {timeRange:start} to {timeRange:end} step {timeRange:grain} by metric_name\\r\\n| project metric_name, metric = series_fill_forward(series_fill_linear(metric, int(null), false)), sample_time_utc\",\"clusterName\":\"{adxClusterUri}\",\"databaseName\":\"{adxDatabase}\"}",
               "size": 1,
               "aggregation": 5,
               "showAnalytics": true,
@@ -112,6 +113,10 @@
                   {
                     "seriesName": "Used data",
                     "color": "green"
+                  },
+                  {
+                    "seriesName": "Max data",
+                    "color": "red"
                   }
                 ],
                 "ySettings": {
@@ -133,7 +138,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "{\"version\":\"AzureDataExplorerQuery/1.0\",\"queryText\":\"datatable(key:int, metric_name:string) [\\r\\n1, \\\"Used tempdb data\\\",\\r\\n1, \\\"Allocated tempdb data\\\"\\r\\n]\\r\\n| join kind=inner\\r\\n(\\r\\nsqldb_elastic_pool_storage_utilization\\r\\n| where sample_time_utc between ({timeRange:start} .. {timeRange:end})\\r\\n| where logical_server_name =~ @\\\"{serverName}\\\"\\r\\n| where elastic_pool_name == @\\\"{elasticPoolName}\\\"\\r\\n| where ({haReplica} and replica_type == \\\"HA secondary\\\") or (not ({haReplica}) and replica_type != \\\"HA secondary\\\")\\r\\n| extend key = int(1)\\r\\n) on key\\r\\n| project metric_name, sample_time_utc, tempdb_data_size_used_mb, tempdb_data_size_allocated_mb\\r\\n| extend metric = case(\\r\\n                      metric_name == \\\"Used tempdb data\\\", tempdb_data_size_used_mb,\\r\\n                      metric_name == \\\"Allocated tempdb data\\\", tempdb_data_size_allocated_mb,\\r\\n                      decimal(null)\\r\\n                      )\\r\\n| make-series metric = max(metric) default = long(null) on sample_time_utc from {timeRange:start} to {timeRange:end} step {timeRange:grain} by metric_name\\r\\n| project metric_name, metric = series_fill_forward(series_fill_linear(metric, int(null), false)), sample_time_utc\",\"clusterName\":\"{adxClusterUri}\",\"databaseName\":\"{adxDatabase}\"}",
+              "query": "{\"version\":\"AzureDataExplorerQuery/1.0\",\"queryText\":\"datatable(key:int, metric_name:string) [\\r\\n1, \\\"Used tempdb data\\\",\\r\\n1, \\\"Allocated tempdb data\\\",\\r\\n1, \\\"Max tempdb data\\\"\\r\\n]\\r\\n| join kind=inner\\r\\n(\\r\\nsqldb_elastic_pool_storage_utilization\\r\\n| where sample_time_utc between ({timeRange:start} .. {timeRange:end})\\r\\n| where logical_server_name =~ @\\\"{serverName}\\\"\\r\\n| where elastic_pool_name == @\\\"{elasticPoolName}\\\"\\r\\n| where ({haReplica} and replica_type == \\\"HA secondary\\\") or (not ({haReplica}) and replica_type != \\\"HA secondary\\\")\\r\\n| extend key = int(1)\\r\\n) on key\\r\\n| project metric_name, sample_time_utc, tempdb_data_size_used_mb, tempdb_data_size_allocated_mb, tempdb_data_max_size_mb\\r\\n| extend metric = case(\\r\\n                      metric_name == \\\"Used tempdb data\\\", tempdb_data_size_used_mb,\\r\\n                      metric_name == \\\"Allocated tempdb data\\\", tempdb_data_size_allocated_mb,\\r\\n                      metric_name == \\\"Max tempdb data\\\", tempdb_data_max_size_mb,\\r\\n                      decimal(null)\\r\\n                      )\\r\\n| make-series metric = max(metric) default = long(null) on sample_time_utc from {timeRange:start} to {timeRange:end} step {timeRange:grain} by metric_name\\r\\n| project metric_name, metric = series_fill_forward(series_fill_linear(metric, int(null), false)), sample_time_utc\",\"clusterName\":\"{adxClusterUri}\",\"databaseName\":\"{adxDatabase}\"}",
               "size": 1,
               "aggregation": 5,
               "showAnalytics": true,
@@ -165,6 +170,10 @@
                   {
                     "seriesName": "Used tempdb data",
                     "color": "green"
+                  },
+                  {
+                    "seriesName": "Max tempdb data",
+                    "color": "red"
                   }
                 ],
                 "ySettings": {
@@ -186,7 +195,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "{\"version\":\"AzureDataExplorerQuery/1.0\",\"queryText\":\"datatable(key:int, metric_name:string) [\\r\\n1, \\\"Used tempdb log\\\",\\r\\n1, \\\"Allocated tempdb log\\\"\\r\\n]\\r\\n| join kind=inner\\r\\n(\\r\\nsqldb_elastic_pool_storage_utilization\\r\\n| where sample_time_utc between ({timeRange:start} .. {timeRange:end})\\r\\n| where logical_server_name =~ @\\\"{serverName}\\\"\\r\\n| where elastic_pool_name == @\\\"{elasticPoolName}\\\"\\r\\n| where ({haReplica} and replica_type == \\\"HA secondary\\\") or (not ({haReplica}) and replica_type != \\\"HA secondary\\\")\\r\\n| extend key = int(1)\\r\\n) on key\\r\\n| project metric_name, sample_time_utc, tempdb_log_size_used_mb, tempdb_log_size_allocated_mb\\r\\n| extend metric = case(\\r\\n                      metric_name == \\\"Used tempdb log\\\", tempdb_log_size_used_mb,\\r\\n                      metric_name == \\\"Allocated tempdb log\\\", tempdb_log_size_allocated_mb,\\r\\n                      decimal(null)\\r\\n                      )\\r\\n| make-series metric = max(metric) default = long(null) on sample_time_utc from {timeRange:start} to {timeRange:end} step {timeRange:grain} by metric_name\\r\\n| project metric_name, metric = series_fill_forward(series_fill_linear(metric, int(null), false)), sample_time_utc\",\"clusterName\":\"{adxClusterUri}\",\"databaseName\":\"{adxDatabase}\"}",
+              "query": "{\"version\":\"AzureDataExplorerQuery/1.0\",\"queryText\":\"datatable(key:int, metric_name:string) [\\r\\n1, \\\"Used tempdb log\\\",\\r\\n1, \\\"Allocated tempdb log\\\",\\r\\n1, \\\"Max tempdb log\\\"\\r\\n]\\r\\n| join kind=inner\\r\\n(\\r\\nsqldb_elastic_pool_storage_utilization\\r\\n| where sample_time_utc between ({timeRange:start} .. {timeRange:end})\\r\\n| where logical_server_name =~ @\\\"{serverName}\\\"\\r\\n| where elastic_pool_name == @\\\"{elasticPoolName}\\\"\\r\\n| where ({haReplica} and replica_type == \\\"HA secondary\\\") or (not ({haReplica}) and replica_type != \\\"HA secondary\\\")\\r\\n| extend key = int(1)\\r\\n) on key\\r\\n| project metric_name, sample_time_utc, tempdb_log_size_used_mb, tempdb_log_size_allocated_mb, tempdb_log_max_size_mb\\r\\n| extend metric = case(\\r\\n                      metric_name == \\\"Used tempdb log\\\", tempdb_log_size_used_mb,\\r\\n                      metric_name == \\\"Allocated tempdb log\\\", tempdb_log_size_allocated_mb,\\r\\n                      metric_name == \\\"Max tempdb log\\\", tempdb_log_max_size_mb,\\r\\n                      decimal(null)\\r\\n                      )\\r\\n| make-series metric = max(metric) default = long(null) on sample_time_utc from {timeRange:start} to {timeRange:end} step {timeRange:grain} by metric_name\\r\\n| project metric_name, metric = series_fill_forward(series_fill_linear(metric, int(null), false)), sample_time_utc\",\"clusterName\":\"{adxClusterUri}\",\"databaseName\":\"{adxDatabase}\"}",
               "size": 1,
               "aggregation": 5,
               "showAnalytics": true,
@@ -218,6 +227,10 @@
                   {
                     "seriesName": "Used tempdb log",
                     "color": "green"
+                  },
+                  {
+                    "seriesName": "Max tempdb log",
+                    "color": "red"
                   }
                 ],
                 "ySettings": {
@@ -246,7 +259,6 @@
         "groupType": "editable",
         "title": "Storage IO statistics",
         "expandable": true,
-        "expanded": true,
         "items": [
           {
             "type": 1,

--- a/Workbooks/Database watcher/Azure SQL Managed Instance/instance/databases/databases.workbook
+++ b/Workbooks/Database watcher/Azure SQL Managed Instance/instance/databases/databases.workbook
@@ -1050,7 +1050,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "{\"version\":\"AzureDataExplorerQuery/1.0\",\"queryText\":\"datatable(key:int, metric_name:string) [\\r\\n1, \\\"Used data\\\",\\r\\n1, \\\"Allocated data\\\"\\r\\n]\\r\\n| join kind=inner\\r\\n(\\r\\nsqlmi_database_storage_utilization\\r\\n| where collection_time_utc between ({timeRange:start} .. {timeRange:end})\\r\\n| where managed_instance_name =~ @\\\"{managedInstanceName}\\\"\\r\\n| where ({haReplica} and replica_type == \\\"HA secondary\\\") or (not ({haReplica}) and replica_type != \\\"HA secondary\\\")\\r\\n| where database_id == {selectedDatabase:$.database_id}\\r\\n| extend key = int(1)\\r\\n) on key\\r\\n| project metric_name, collection_time_utc, data_size_used_mb, data_size_allocated_mb\\r\\n| extend metric = case(\\r\\n                      metric_name == \\\"Used data\\\", data_size_used_mb,\\r\\n                      metric_name == \\\"Allocated data\\\", data_size_allocated_mb,\\r\\n                      decimal(null)\\r\\n                      )\\r\\n| make-series metric = max(metric) default = long(null) on collection_time_utc from {timeRange:start} to {timeRange:end} step {timeRange:grain} by metric_name\\r\\n| project metric_name, metric = series_fill_forward(series_fill_linear(metric, int(null), false)), collection_time_utc\",\"clusterName\":\"{adxClusterUri}\",\"databaseName\":\"{adxDatabase}\"}",
+              "query": "{\"version\":\"AzureDataExplorerQuery/1.0\",\"queryText\":\"datatable(key:int, metric_name:string) [\\r\\n1, \\\"Used data\\\",\\r\\n1, \\\"Allocated data\\\",\\r\\n1, \\\"Max data\\\"\\r\\n]\\r\\n| join kind=inner\\r\\n(\\r\\nsqlmi_database_storage_utilization\\r\\n| where collection_time_utc between ({timeRange:start} .. {timeRange:end})\\r\\n| where managed_instance_name =~ @\\\"{managedInstanceName}\\\"\\r\\n| where ({haReplica} and replica_type == \\\"HA secondary\\\") or (not ({haReplica}) and replica_type != \\\"HA secondary\\\")\\r\\n| where database_id == {selectedDatabase:$.database_id}\\r\\n| extend key = int(1)\\r\\n) on key\\r\\n| project metric_name, collection_time_utc, data_size_used_mb, data_size_allocated_mb, data_max_size_mb\\r\\n| extend metric = case(\\r\\n                      metric_name == \\\"Used data\\\", data_size_used_mb,\\r\\n                      metric_name == \\\"Allocated data\\\", data_size_allocated_mb,\\r\\n                      metric_name == \\\"Max data\\\", data_max_size_mb,\\r\\n                      decimal(null)\\r\\n                      )\\r\\n| where (metric_name == \\\"Max data\\\" and isnotempty(data_max_size_mb)) or metric_name != \\\"Max data\\\"\\r\\n| make-series metric = max(metric) default = long(null) on collection_time_utc from {timeRange:start} to {timeRange:end} step {timeRange:grain} by metric_name\\r\\n| project metric_name, metric = series_fill_forward(series_fill_linear(metric, int(null), false)), collection_time_utc\",\"clusterName\":\"{adxClusterUri}\",\"databaseName\":\"{adxDatabase}\"}",
               "size": 1,
               "aggregation": 5,
               "showAnalytics": true,
@@ -1082,6 +1082,10 @@
                   {
                     "seriesName": "Used data",
                     "color": "green"
+                  },
+                  {
+                    "seriesName": "Max data",
+                    "color": "red"
                   }
                 ],
                 "ySettings": {
@@ -1103,7 +1107,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "{\"version\":\"AzureDataExplorerQuery/1.0\",\"queryText\":\"datatable(key:int, metric_name:string) [\\r\\n1, \\\"Used log\\\",\\r\\n1, \\\"Allocated log\\\"\\r\\n]\\r\\n| join kind=inner\\r\\n(\\r\\nsqlmi_database_storage_utilization\\r\\n| where collection_time_utc between ({timeRange:start} .. {timeRange:end})\\r\\n| where managed_instance_name =~ @\\\"{managedInstanceName}\\\"\\r\\n| where ({haReplica} and replica_type == \\\"HA secondary\\\") or (not ({haReplica}) and replica_type != \\\"HA secondary\\\")\\r\\n| where database_id == {selectedDatabase:$.database_id}\\r\\n| extend key = int(1)\\r\\n) on key\\r\\n| project metric_name, collection_time_utc, log_size_used_mb, log_size_allocated_mb\\r\\n| extend metric = case(\\r\\n                      metric_name == \\\"Used log\\\", log_size_used_mb,\\r\\n                      metric_name == \\\"Allocated log\\\", log_size_allocated_mb,\\r\\n                      decimal(null)\\r\\n                      )\\r\\n| make-series metric = max(metric) default = long(null) on collection_time_utc from {timeRange:start} to {timeRange:end} step {timeRange:grain} by metric_name\\r\\n| project metric_name, metric = series_fill_forward(series_fill_linear(metric, int(null), false)), collection_time_utc\",\"clusterName\":\"{adxClusterUri}\",\"databaseName\":\"{adxDatabase}\"}",
+              "query": "{\"version\":\"AzureDataExplorerQuery/1.0\",\"queryText\":\"datatable(key:int, metric_name:string) [\\r\\n1, \\\"Used log\\\",\\r\\n1, \\\"Allocated log\\\",\\r\\n1, \\\"Max log\\\"\\r\\n]\\r\\n| join kind=inner\\r\\n(\\r\\nsqlmi_database_storage_utilization\\r\\n| where collection_time_utc between ({timeRange:start} .. {timeRange:end})\\r\\n| where managed_instance_name =~ @\\\"{managedInstanceName}\\\"\\r\\n| where ({haReplica} and replica_type == \\\"HA secondary\\\") or (not ({haReplica}) and replica_type != \\\"HA secondary\\\")\\r\\n| where database_id == {selectedDatabase:$.database_id}\\r\\n| extend key = int(1)\\r\\n) on key\\r\\n| project metric_name, collection_time_utc, log_size_used_mb, log_size_allocated_mb, log_max_size_mb\\r\\n| extend metric = case(\\r\\n                      metric_name == \\\"Used log\\\", log_size_used_mb,\\r\\n                      metric_name == \\\"Allocated log\\\", log_size_allocated_mb,\\r\\n                      metric_name == \\\"Max log\\\", log_max_size_mb,\\r\\n                      decimal(null)\\r\\n                      )\\r\\n| where (metric_name == \\\"Max log\\\" and isnotempty(log_max_size_mb)) or metric_name != \\\"Max log\\\"\\r\\n| make-series metric = max(metric) default = long(null) on collection_time_utc from {timeRange:start} to {timeRange:end} step {timeRange:grain} by metric_name\\r\\n| project metric_name, metric = series_fill_forward(series_fill_linear(metric, int(null), false)), collection_time_utc\",\"clusterName\":\"{adxClusterUri}\",\"databaseName\":\"{adxDatabase}\"}",
               "size": 1,
               "aggregation": 5,
               "showAnalytics": true,
@@ -1135,6 +1139,10 @@
                   {
                     "seriesName": "Used log",
                     "color": "green"
+                  },
+                  {
+                    "seriesName": "Max log",
+                    "color": "red"
                   }
                 ],
                 "ySettings": {
@@ -3206,7 +3214,7 @@
                       ]
                     },
                     "tooltipFormat": {
-                      "tooltip": "It is recommended that compute size of a geo-replication secondary replica matches the compute size of its primary replica. This database or its elastic pool has [\"local_logical_cpu_count\"] logical CPUs; its partner database or elastic pool has [\"partner_logical_cpu_count\"] logical CPUs."
+                      "tooltip": "It is recommended that compute size of a geo-replication secondary replica matches the compute size of its primary replica. This instance has [\"local_logical_cpu_count\"] logical CPUs; its partner instance has [\"partner_logical_cpu_count\"] logical CPUs."
                     }
                   },
                   {

--- a/Workbooks/Database watcher/Azure SQL Managed Instance/instance/databases/databases.workbook
+++ b/Workbooks/Database watcher/Azure SQL Managed Instance/instance/databases/databases.workbook
@@ -3214,7 +3214,7 @@
                       ]
                     },
                     "tooltipFormat": {
-                      "tooltip": "It is recommended that compute size of a geo-replication secondary replica matches the compute size of its primary replica. This database or its elastic pool has [\"local_logical_cpu_count\"] logical CPUs; its partner database or elastic pool has [\"partner_logical_cpu_count\"] logical CPUs."
+                      "tooltip": "It is recommended that compute size of a geo-replication secondary replica matches the compute size of its primary replica. This instance has [\"local_logical_cpu_count\"] logical CPUs; its partner instance has [\"partner_logical_cpu_count\"] logical CPUs."
                     }
                   },
                   {

--- a/Workbooks/Database watcher/Azure SQL Managed Instance/instance/databases/databases.workbook
+++ b/Workbooks/Database watcher/Azure SQL Managed Instance/instance/databases/databases.workbook
@@ -3206,7 +3206,7 @@
                       ]
                     },
                     "tooltipFormat": {
-                      "tooltip": "It is recommended that compute size of a geo-replication secondary replica matches the compute size of its primary replica. This instance has [\"local_logical_cpu_count\"] logical CPUs; its partner instance has [\"partner_logical_cpu_count\"] logical CPUs."
+                      "tooltip": "It is recommended that compute size of a geo-replication secondary replica matches the compute size of its primary replica. This database or its elastic pool has [\"local_logical_cpu_count\"] logical CPUs; its partner database or elastic pool has [\"partner_logical_cpu_count\"] logical CPUs."
                     }
                   },
                   {


### PR DESCRIPTION
## Summary

Add a `Max data`/`Max log` series to storage consumption charts.

## Screenshots

![image](https://github.com/user-attachments/assets/0ceea7b4-13f4-4737-8e06-01d57af699a2)

## Validation

- [x] Validate your changes using one or more of the [testing](https://github.com/microsoft/Application-Insights-Workbooks/blob/master/Documentation/Testing.md) methods.

## Checklist

- [x] If you are adding a new template, gallery, or folder, add your team and folder/file(s) to the CODEOWNERS file at the root of the repo. CODEOWNERS entries should be teams, not individuals.
      When done correctly, this means that from then on *your* team does reviews of *your* things, not the workbooks team.
- [x] Ensure all steps in your template have meaningful names.
- [x] Ensure all parameters and grid columns have display names set so they can be localized.
