### PR TITLE
Remove sql insights from workbook gallery

### DIFF
--- a/gallery/workbook/Azure Monitor.json
+++ b/gallery/workbook/Azure Monitor.json
@@ -300,12 +300,6 @@
 					"name": "Azure Data Explorer Overview"
 				},
 				{
-					"id": "Workbooks/Workloads/SQL/SQL Server Insights",
-					"author": "Microsoft",
-					"description": "Performance, usage, and health of your SQL workloads",
-					"name": "SQL Insights"
-				},
-				{
 					"id": "Workbooks/Workloads/SAP/Inventory Checks for SAP",
 					"author": "Microsoft",
                     "description": "Inventory, Configuration, usage, and health of your SAP workloads",

--- a/gallery/workload-insights/Azure Monitor.json
+++ b/gallery/workload-insights/Azure Monitor.json
@@ -15,12 +15,6 @@
 			]
 		},
 		{
-			"id": "SQL",
-			"name": "SQL (preview)",
-			"templates": [
-			]
-		},
-		{
 			"id": "azureMonitorInsights",
 			"name": "Insights",
 			"templates": [

--- a/gallery/workload-insights/Azure Monitor.json
+++ b/gallery/workload-insights/Azure Monitor.json
@@ -18,42 +18,12 @@
 			"id": "SQL",
 			"name": "SQL (preview)",
 			"templates": [
-				{
-					"id": "Workbooks/Workloads/SQL/SQL Servers",
-					"author": "Microsoft",
-					"name": "SQL Servers",
-					"isPreview": true
-				},
-				{
-					"id": "Workbooks/Workloads/SQL/Azure SQL Managed Instances",
-					"author": "Microsoft",
-					"name": "Azure SQL Managed Instances",
-					"isPreview": true
-				},
-				{
-					"id": "Workbooks/Workloads/SQL/Azure SQL Databases",
-					"author": "Microsoft",
-					"name": "Azure SQL Databases",
-					"isPreview": true
-				},
-				{
-					"id": "Workbooks/Workloads/SQL/Availability groups",
-					"author": "Microsoft",
-					"name": "Availability groups",
-					"isPreview": true
-				}
 			]
 		},
 		{
 			"id": "azureMonitorInsights",
 			"name": "Insights",
 			"templates": [
-				{
-					"id": "Workbooks/Workloads/SQL/SQL Server Insights",
-					"author": "Microsoft",
-					"description": "Performance, usage, and health of your SQL workloads",
-					"name": "SQL Insights"
-				}
 			]
 		}
 	]


### PR DESCRIPTION
## Summary

SQL Insights officially got retired on 31 December 2024. Removing its reference from workbook insights gallery

## Screenshots

- [x] If you added a template to a gallery, show a screenshot of it in the gallery view (which verifies its shows up where you expected).
![image](https://github.com/user-attachments/assets/f2fe2d5a-dc4c-493d-9d3d-9419a703a973)


  It is also good to show a screenshot of template content, so people can see what you expect it to look like, compared to what they see when they might run it themselves.

## Validation

- [x] Validate your changes using one or more of the [testing](https://github.com/microsoft/Application-Insights-Workbooks/blob/master/Documentation/Testing.md) methods.
Validated, no SQL Insights under "Insights" gallery
  
  Make sure you've tested your template content. Fixing things while in PR is trivial. Hotfixing it later is very expensive; at the current time at least 3 teams are involved in a hotfix!

## Checklist

- [ ] If you are adding a new template, gallery, or folder, add your team and folder/file(s) to the CODEOWNERS file at the root of the repo. CODEOWNERS entries should be teams, not individuals.
      When done correctly, this means that from then on *your* team does reviews of *your* things, not the workbooks team.
- [ ] Ensure all steps in your template have meaningful names.
- [ ] Ensure all parameters and grid columns have display names set so they can be localized.
