### PR TITLE
SQL VM BPA Workbook: Add h3 tag for section headers

### DIFF
--- a/Workbooks/Azure SQL VM/SQL Assessment/SQL Assessment.workbook
+++ b/Workbooks/Azure SQL VM/SQL Assessment/SQL Assessment.workbook
@@ -1324,7 +1324,7 @@
                       {
                         "type": 1,
                         "content": {
-                          "json": "<span style=\"font-size: 14px\">**Total Issues**</span>\r\n\r\n"
+                          "json": "<h3 style=\"font-size: 14px\">**Total Issues**</h3>\r\n\r\n"
                         },
                         "name": "textTotalIssues"
                       },
@@ -1447,7 +1447,7 @@
                       {
                         "type": 1,
                         "content": {
-                          "json": "<span style=\"font-size: 14px\">**New Issues**</span>\r\n\r\n"
+                          "json": "<h3 style=\"font-size: 14px\">**New Issues**</h3>\r\n\r\n"
                         },
                         "name": "textNewIssues"
                       },
@@ -1491,7 +1491,7 @@
                       {
                         "type": 1,
                         "content": {
-                          "json": "<span style=\"font-size: 14px\">**Resolved Issues**</span>\r\n\r\n"
+                          "json": "<h3 style=\"font-size: 14px\">**Resolved Issues**</h3>\r\n\r\n"
                         },
                         "name": "textResolved"
                       },


### PR DESCRIPTION
# Summary

Resolving accessibility bug: Text visually appearing as heading is not defined as heading programmatically under "Trends" tab.

SQL VM BPA Workbook: Add h3 tag for section headers

# Screenshots

## before

Section headers like "Total issues" are not programmatically defined as heading: 

![image](https://github.com/user-attachments/assets/92b02bbc-eaf3-4049-838e-eac8ec97bf05)

## after 

Section headers now have proper h3 tag applied:

![image](https://github.com/user-attachments/assets/2de34b22-9d1a-43f8-a823-111957e6473b)

