### PR TITLE
[Online experimentation analysis] Sort experiment dropdown by analysis's start time (iteration)

### DIFF
--- a/Workbooks/Online Experimentation/Experiment Analysis/Experiment Analysis.workbook
+++ b/Workbooks/Online Experimentation/Experiment Analysis/Experiment Analysis.workbook
@@ -84,7 +84,7 @@
             "type": 2,
             "description": "A new experiment starts when the experiment configuration changes",
             "isRequired": true,
-            "query": "AEWExperimentScorecards\r\n| where FeatureName == '{FeatureName}'\r\n| summarize\r\n    EarliestAnalysisTime = min(AnalysisStartTime),\r\n    LatestAnalysisTime = max(AnalysisEndTime)\r\n    by AllocationId\r\n| order by EarliestAnalysisTime asc\r\n| extend Iteration = row_number()\r\n| order by LatestAnalysisTime desc\r\n| project\r\n    value = AllocationId,\r\n    label = strcat('Iteration ', Iteration, ' (', AllocationId, ')'),\r\n    selected = row_number() == 1",
+            "query": "AEWExperimentScorecards\r\n| where FeatureName == '{FeatureName}'\r\n| summarize\r\n    EarliestAnalysisTime = min(AnalysisStartTime),\r\n    LatestAnalysisTime = max(AnalysisEndTime)\r\n    by AllocationId\r\n| order by EarliestAnalysisTime asc\r\n| extend Iteration = row_number()\r\n| order by AllocationId desc\r\n| project\r\n    value = AllocationId,\r\n    label = strcat('Iteration ', Iteration, ' (', AllocationId, ')'),\r\n    selected = row_number() == 1",
             "crossComponentResources": [
               "{Workspace}"
             ],

--- a/Workbooks/Online Experimentation/Experiment Analysis/Experiment Analysis.workbook
+++ b/Workbooks/Online Experimentation/Experiment Analysis/Experiment Analysis.workbook
@@ -84,7 +84,7 @@
             "type": 2,
             "description": "A new experiment starts when the experiment configuration changes",
             "isRequired": true,
-            "query": "AEWExperimentScorecards\r\n| where FeatureName == '{FeatureName}'\r\n| summarize\r\n    EarliestAnalysisTime = min(AnalysisStartTime),\r\n    LatestAnalysisTime = max(AnalysisEndTime)\r\n    by AllocationId\r\n| order by EarliestAnalysisTime asc\r\n| extend Iteration = row_number()\r\n| order by Iteration desc\r\n| project\r\n    value = AllocationId,\r\n    label = strcat('Iteration ', Iteration, ' (', AllocationId, ')'),\r\n    selected = row_number() == 1",
+            "query": "AEWExperimentScorecards\r\n| where FeatureName == '{FeatureName}'\r\n| summarize EarliestAnalysisTime = min(AnalysisStartTime) by AllocationId\r\n| order by EarliestAnalysisTime asc\r\n| extend Iteration = row_number()\r\n| order by Iteration desc\r\n| project\r\n    value = AllocationId,\r\n    label = strcat('Iteration ', Iteration, ' (', AllocationId, ')'),\r\n    selected = row_number() == 1",
             "crossComponentResources": [
               "{Workspace}"
             ],

--- a/Workbooks/Online Experimentation/Experiment Analysis/Experiment Analysis.workbook
+++ b/Workbooks/Online Experimentation/Experiment Analysis/Experiment Analysis.workbook
@@ -84,7 +84,7 @@
             "type": 2,
             "description": "A new experiment starts when the experiment configuration changes",
             "isRequired": true,
-            "query": "AEWExperimentScorecards\r\n| where FeatureName == '{FeatureName}'\r\n| summarize\r\n    EarliestAnalysisTime = min(AnalysisStartTime),\r\n    LatestAnalysisTime = max(AnalysisEndTime)\r\n    by AllocationId\r\n| order by EarliestAnalysisTime asc\r\n| extend Iteration = row_number()\r\n| order by AllocationId desc\r\n| project\r\n    value = AllocationId,\r\n    label = strcat('Iteration ', Iteration, ' (', AllocationId, ')'),\r\n    selected = row_number() == 1",
+            "query": "AEWExperimentScorecards\r\n| where FeatureName == '{FeatureName}'\r\n| summarize\r\n    EarliestAnalysisTime = min(AnalysisStartTime),\r\n    LatestAnalysisTime = max(AnalysisEndTime)\r\n    by AllocationId\r\n| order by EarliestAnalysisTime asc\r\n| extend Iteration = row_number()\r\n| order by Iteration desc\r\n| project\r\n    value = AllocationId,\r\n    label = strcat('Iteration ', Iteration, ' (', AllocationId, ')'),\r\n    selected = row_number() == 1",
             "crossComponentResources": [
               "{Workspace}"
             ],


### PR DESCRIPTION
## Summary
- Experiment dropout currently sort experiments by end time, which in cases like the second iteration end earlier than the first iteration (due to different duration settings), it will makes iteration 1 comes first in the drop down.
- Fixed by sorting them in analysis start time.

## Screenshots
![image](https://github.com/user-attachments/assets/19a1b52e-0077-4979-8c27-b5a7a66d7dce)

- [x] If you added a template to a gallery, show a screenshot of it in the gallery view (which verifies its shows up where you expected).

  It is also good to show a screenshot of template content, so people can see what you expect it to look like, compared to what they see when they might run it themselves.

## Validation

- [x] Validate your changes using one or more of the [testing](https://github.com/microsoft/Application-Insights-Workbooks/blob/master/Documentation/Testing.md) methods.
  
  Make sure you've tested your template content. Fixing things while in PR is trivial. Hotfixing it later is very expensive; at the current time at least 3 teams are involved in a hotfix!

## Checklist

- [x] If you are adding a new template, gallery, or folder, add your team and folder/file(s) to the CODEOWNERS file at the root of the repo. CODEOWNERS entries should be teams, not individuals.
      When done correctly, this means that from then on *your* team does reviews of *your* things, not the workbooks team.
- [x] Ensure all steps in your template have meaningful names.
- [x] Ensure all parameters and grid columns have display names set so they can be localized.
