### PR TITLE
Fix incorrect DS warning message in workbooks- account exploration, unused metrics

### DIFF
--- a/Workbooks/Azure Monitor - Workspaces/Metrics Usage Insights/Metrics Usage Insights.workbook
+++ b/Workbooks/Azure Monitor - Workspaces/Metrics Usage Insights/Metrics Usage Insights.workbook
@@ -22,6 +22,15 @@
             "timeContext": {
               "durationMs": 86400000
             }
+          },
+          {
+            "id": "403cdddd-33c0-438f-94d7-336af0f5256d",
+            "version": "KqlParameterItem/1.0",
+            "name": "DiagnosticSettingsEnabled",
+            "isHiddenWhenLocked": true,
+            "type": 1,
+            "query": "{\"version\":\"ARMEndpoint/1.0\",\"data\":null,\"headers\":[],\"method\":\"GET\",\"path\":\"{Amw}/providers/Microsoft.Insights/diagnosticSettings?api-version=2021-05-01-preview\",\"urlParams\":[],\"batchDisabled\":false,\"transformers\":[{\"type\":\"jsonpath\",\"settings\":{\"tablePath\":\"$.value..properties.logs[?(@.category=='MetricsUsageDetails')].enabled\",\"columns\":[]}}]}",
+            "queryType": 12
           }
         ],
         "style": "pills",
@@ -71,12 +80,36 @@
         "groupType": "editable",
         "items": [
           {
+            "type": 11,
+            "content": {
+              "version": "LinkItem/1.0",
+              "style": "paragraph",
+              "links": [
+                {
+                  "id": "6fb23db6-d5e3-4438-9bef-2106869af472",
+                  "cellValue": "https://review.learn.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-usage-insights",
+                  "linkTarget": "Url",
+                  "linkLabel": "Learn More",
+                  "preText": "Please ensure that the diagnostic settings for this AMW are correctly configured and that it has been successfully onboarded to Diagnostic Settings.",
+                  "postText": ".",
+                  "style": "link"
+                }
+              ]
+            },
+            "conditionalVisibility": {
+              "parameterName": "DiagnosticSettingsEnabled",
+              "comparison": "isEqualTo",
+              "value": ""
+            },
+            "name": "DiagnosticSettingsError"
+          },
+          {
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
               "query": "AMWMetricsUsageDetails\n| summarize c=count(),max(EndTime)\n| project label=iff(c>0,\"Insights as of:\",\"\"),max_EndTime\n| where isnotempty(label) ",
               "size": 4,
-              "noDataMessage": "No insights found. Please onboard to Metrics Usage Details from Diagnostic settings.",
+              "noDataMessage": "Please verify that the Metrics Usage Insights is available in the region where your AMW was created.",
               "noDataMessageStyle": 4,
               "timeContext": {
                 "durationMs": 259200000
@@ -117,6 +150,11 @@
                 "showBorder": false,
                 "size": "full"
               }
+            },
+            "conditionalVisibility": {
+              "parameterName": "DiagnosticSettingsEnabled",
+              "comparison": "isEqualTo",
+              "value": "true"
             },
             "name": "freshnessDate",
             "styleSettings": {
@@ -247,6 +285,11 @@
                 ]
               }
             },
+            "conditionalVisibility": {
+              "parameterName": "DiagnosticSettingsEnabled",
+              "comparison": "isEqualTo",
+              "value": "true"
+            },
             "name": "explorationTable"
           },
           {
@@ -283,6 +326,11 @@
               }
             },
             "customWidth": "49",
+            "conditionalVisibility": {
+              "parameterName": "DiagnosticSettingsEnabled",
+              "comparison": "isEqualTo",
+              "value": "true"
+            },
             "name": "TopTimeSeries"
           },
           {
@@ -325,6 +373,11 @@
               }
             },
             "customWidth": "49",
+            "conditionalVisibility": {
+              "parameterName": "DiagnosticSettingsEnabled",
+              "comparison": "isEqualTo",
+              "value": "true"
+            },
             "name": "TsTrend"
           }
         ]
@@ -771,6 +824,11 @@
             "content": {
               "version": "KqlParameterItem/1.0",
               "parameters": [
+{
+            "type": 9,
+            "content": {
+              "version": "KqlParameterItem/1.0",
+              "parameters": [
                 {
                   "id": "05607eff-fcbc-40b8-8eda-e36c4b90a6f7",
                   "version": "KqlParameterItem/1.0",
@@ -791,9 +849,37 @@
                 }
               ],
               "style": "pills",
+              "doNotRunWhenHidden": true,
               "queryType": 8
             },
+            "conditionalVisibility": {
+              "parameterName": "DiagnosticSettingsEnabled",
+              "comparison": "isEqualTo",
+              "value": "true"
+            },
             "name": "parameters - 2"
+          },
+          {
+            "type": 11,
+            "content": {
+              "version": "LinkItem/1.0",
+              "style": "paragraph",
+              "links": [
+                {
+                  "id": "5323d8ab-1306-402f-b31d-5bbc3f12bfd2",
+                  "cellValue": "https://review.learn.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-usage-insights",
+                  "linkTarget": "Url",
+                  "linkLabel": "Learn More",
+                  "preText": "Please ensure that the diagnostic settings for this AMW are correctly configured and that it has been successfully onboarded to Diagnostic Settings.",
+                  "style": "link"
+                }
+              ]
+            },
+            "conditionalVisibility": {
+              "parameterName": "DiagnosticSettingsEnabled",
+              "comparison": "isEqualTo"
+            },
+            "name": "DiagnosticSettingsError"
           },
           {
             "type": 3,
@@ -845,6 +931,11 @@
                 "showBorder": false,
                 "size": "full"
               }
+            },
+            "conditionalVisibility": {
+              "parameterName": "DiagnosticSettingsEnabled",
+              "comparison": "isEqualTo",
+              "value": "true"
             },
             "name": "freshnessDate2",
             "styleSettings": {
@@ -967,6 +1058,11 @@
                   }
                 ]
               }
+            },
+            "conditionalVisibility": {
+              "parameterName": "DiagnosticSettingsEnabled",
+              "comparison": "isEqualTo",
+              "value": "true"
             },
             "name": "paramsUnusedMetrics"
           }

--- a/Workbooks/Azure Monitor - Workspaces/Metrics Usage Insights/Metrics Usage Insights.workbook
+++ b/Workbooks/Azure Monitor - Workspaces/Metrics Usage Insights/Metrics Usage Insights.workbook
@@ -87,7 +87,7 @@
               "links": [
                 {
                   "id": "6fb23db6-d5e3-4438-9bef-2106869af472",
-                  "cellValue": "https://review.learn.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-usage-insights",
+                  "cellValue": "https://review.learn.microsoft.com/azure/azure-monitor/essentials/metrics-usage-insights",
                   "linkTarget": "Url",
                   "linkLabel": "Learn More",
                   "preText": "Please ensure that the diagnostic settings for this AMW are correctly configured and that it has been successfully onboarded to Diagnostic Settings.",
@@ -862,7 +862,7 @@
               "links": [
                 {
                   "id": "5323d8ab-1306-402f-b31d-5bbc3f12bfd2",
-                  "cellValue": "https://review.learn.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-usage-insights",
+                  "cellValue": "https://review.learn.microsoft.com/azure/azure-monitor/essentials/metrics-usage-insights",
                   "linkTarget": "Url",
                   "linkLabel": "Learn More",
                   "preText": "Please ensure that the diagnostic settings for this AMW are correctly configured and that it has been successfully onboarded to Diagnostic Settings.",

--- a/Workbooks/Azure Monitor - Workspaces/Metrics Usage Insights/Metrics Usage Insights.workbook
+++ b/Workbooks/Azure Monitor - Workspaces/Metrics Usage Insights/Metrics Usage Insights.workbook
@@ -824,11 +824,6 @@
             "content": {
               "version": "KqlParameterItem/1.0",
               "parameters": [
-{
-            "type": 9,
-            "content": {
-              "version": "KqlParameterItem/1.0",
-              "parameters": [
                 {
                   "id": "05607eff-fcbc-40b8-8eda-e36c4b90a6f7",
                   "version": "KqlParameterItem/1.0",


### PR DESCRIPTION
## Summary

Explain your changes, so people looking at the PR know *what* and *why*, the code changes are the *how*.

## Screenshots

- [ ] If you added a template to a gallery, show a screenshot of it in the gallery view (which verifies its shows up where you expected).

  It is also good to show a screenshot of template content, so people can see what you expect it to look like, compared to what they see when they might run it themselves.

## Validation

- [ ] Validate your changes using one or more of the [testing](https://github.com/microsoft/Application-Insights-Workbooks/blob/master/Documentation/Testing.md) methods.
  
  Make sure you've tested your template content. Fixing things while in PR is trivial. Hotfixing it later is very expensive; at the current time at least 3 teams are involved in a hotfix!

## Checklist

- [ ] If you are adding a new template, gallery, or folder, add your team and folder/file(s) to the CODEOWNERS file at the root of the repo. CODEOWNERS entries should be teams, not individuals.
      When done correctly, this means that from then on *your* team does reviews of *your* things, not the workbooks team.
- [ ] Ensure all steps in your template have meaningful names.
- [ ] Ensure all parameters and grid columns have display names set so they can be localized.
