### PR TITLE
Fix user filter in 'Enriched Microsoft 365 logs' workbook 

### DIFF
--- a/Workbooks/Global Secure Access/Microsoft Entra Internet Access/Enriched Microsoft 365 logs/Enriched Microsoft 365 logs.workbook
+++ b/Workbooks/Global Secure Access/Microsoft Entra Internet Access/Enriched Microsoft 365 logs/Enriched Microsoft 365 logs.workbook
@@ -24,7 +24,7 @@
       "content": {
         "version": "KqlParameterItem/1.0",
         "crossComponentResources": [
-          "value::all"
+          "{LogAnalyticWorkspace}"
         ],
         "parameters": [
           {
@@ -126,7 +126,7 @@
             "multiSelect": true,
             "quote": "'",
             "delimiter": ",",
-            "query": "EnrichedMicrosoft365AuditLogs\r\n| summarize Count = count() by UserId\r\n| order by Count desc, UserId asc\r\n| project Value = UserId, Label = strcat(UserId, ' - ', Count, ' Logs'), Selected = false",
+            "query": "NetworkAccessTraffic | where TrafficType == 'microsoft365' | where UniqueTokenId != \"\"\r\n| project UniqueTokenId, UserId, UserPrincipalName\r\n| join kind=inner (OfficeActivity | extend UniqueTokenId = tostring(AppAccessContext.UniqueTokenId) | where UniqueTokenId != \"\") on UniqueTokenId\r\n| summarize Count = count() by UserId, UserPrincipalName\r\n| order by Count desc, UserId asc\r\n| project Value = UserId, Label = strcat(UserPrincipalName, ' - ', Count, ' Logs'), Selected = false",
             "crossComponentResources": [
               "{LogAnalyticWorkspace}"
             ],
@@ -142,16 +142,14 @@
               "durationMs": 0
             },
             "timeContextFromParameter": "TimeRange",
+            "defaultValue": "value::all",
             "queryType": 0,
-            "resourceType": "microsoft.operationalinsights/workspaces",
-            "value": [
-              "value::all"
-            ]
+            "resourceType": "microsoft.operationalinsights/workspaces"
           }
         ],
         "style": "pills",
-        "queryType": 1,
-        "resourceType": "microsoft.resourcegraph/resources"
+        "queryType": 0,
+        "resourceType": "microsoft.operationalinsights/workspaces"
       },
       "name": "parameters - 15"
     },


### PR DESCRIPTION
## Summary

Correct the user filter in one of the workbook queries.

## Screenshots

- [ ] If you added a template to a gallery, show a screenshot of it in the gallery view (which verifies its shows up where you expected).

  It is also good to show a screenshot of template content, so people can see what you expect it to look like, compared to what they see when they might run it themselves.

## Validation

- [ ] Validate your changes using one or more of the [testing](https://github.com/microsoft/Application-Insights-Workbooks/blob/master/Documentation/Testing.md) methods.
  
  Make sure you've tested your template content. Fixing things while in PR is trivial. Hotfixing it later is very expensive; at the current time at least 3 teams are involved in a hotfix!

## Checklist

- [ ] If you are adding a new template, gallery, or folder, add your team and folder/file(s) to the CODEOWNERS file at the root of the repo. CODEOWNERS entries should be teams, not individuals.
      When done correctly, this means that from then on *your* team does reviews of *your* things, not the workbooks team.
- [ ] Ensure all steps in your template have meaningful names.
- [ ] Ensure all parameters and grid columns have display names set so they can be localized.
