### PR TITLE
Change missing diagnostic setting message to a warning

### DIFF
--- a/Workbooks/Azure Monitor - Workspaces/Metrics Usage Insights/Metrics Usage Insights.workbook
+++ b/Workbooks/Azure Monitor - Workspaces/Metrics Usage Insights/Metrics Usage Insights.workbook
@@ -109,7 +109,7 @@
             "type": 1,
             "content": {
               "json": "Please ensure this AMW has been successfully onboarded to Diagnostic Settings.",
-              "style": "error"
+              "style": "warning"
             },
             "conditionalVisibility": {
               "parameterName": "DiagnosticSettingsEnabled",
@@ -914,7 +914,7 @@
             "type": 1,
             "content": {
               "json": "Please ensure this AMW has been successfully onboarded to Diagnostic Settings.",
-              "style": "error"
+              "style": "warning"
             },
             "conditionalVisibility": {
               "parameterName": "DiagnosticSettingsEnabled",


### PR DESCRIPTION
## Summary

Based on the feedback from the demo this morning, after checking with the PM, changing the error to a warning for the missing diagnostic setting message in the Metrics Usage Insights workbook is the right approach.
## Screenshots
<img width="680" alt="image" src="https://github.com/user-attachments/assets/80a121c5-f387-45bc-8150-aa6b433f428b" />

## Validation

- [ ] Validate your changes using one or more of the [testing](https://github.com/microsoft/Application-Insights-Workbooks/blob/master/Documentation/Testing.md) methods.
  
  Make sure you've tested your template content. Fixing things while in PR is trivial. Hotfixing it later is very expensive; at the current time at least 3 teams are involved in a hotfix!

## Checklist

- [ ] If you are adding a new template, gallery, or folder, add your team and folder/file(s) to the CODEOWNERS file at the root of the repo. CODEOWNERS entries should be teams, not individuals.
      When done correctly, this means that from then on *your* team does reviews of *your* things, not the workbooks team.
- [ ] Ensure all steps in your template have meaningful names.
- [ ] Ensure all parameters and grid columns have display names set so they can be localized.
