### PR TITLE
Added support for navigating to Logic Apps run history

### DIFF
--- a/Workbooks/Azure Logic Apps/B2B Tracking/Integration Account Tracking/IntegrationAccountTracking.workbook
+++ b/Workbooks/Azure Logic Apps/B2B Tracking/Integration Account Tracking/IntegrationAccountTracking.workbook
@@ -67,7 +67,7 @@
               "durationMs": 86400000
             },
             "value": {
-              "durationMs": 604800000
+              "durationMs": 86400000
             }
           },
           {
@@ -604,7 +604,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "{\"version\":\"AzureDataExplorerQuery/1.0\",\"queryText\":\"(AS2TrackRecords\\r\\n| where EventTime {TimeRange}\\r\\n| where RecordType == \\\"AS2Message\\\"\\r\\n| where isnotempty(CorrelationMessageId)\\r\\n| project \\r\\n    AgreementName,\\r\\n    MessageId,\\r\\n    CorrelationMessageId,\\r\\n    SenderPartnerName,\\r\\n    ReceiverPartnerName, \\r\\n    MessageTime = EventTime,\\r\\n    MessageClientTrackingId = ClientRequestId,\\r\\n    MessageSubscriptionId = WorkflowRunOperationInfo.Workflow.SubscriptionId,\\r\\n    MessageResourceGroup =  WorkflowRunOperationInfo.Workflow.ResourceGroup,\\r\\n    MessageActionName =  WorkflowRunOperationInfo.Operation.OperationName,\\r\\n    MessageLogicAppName = WorkflowRunOperationInfo.Workflow.Name,\\r\\n    AS2MessageStatus = iff (IsMessageFailed, \\\"Failed\\\", \\\"Successful\\\"),  \\r\\n    MessageDirection = Direction,\\r\\n    IsMdnExpected,\\r\\n    DirectionBasedCorrelationId = iff (Direction == \\\"Receive\\\", strcat_delim(\\\"/\\\", WorkflowRunOperationInfo.RunInstance.OperationName, WorkflowRunOperationInfo.Workflow.Name, IntegrationAccountResourceGroup, IntegrationAccountSubscriptionId), \\\"\\\")\\r\\n| join  kind=leftouter (\\r\\n\\tAS2TrackRecords\\r\\n\\t| where EventTime {TimeRange}\\r\\n\\t| where RecordType == \\\"AS2MDN\\\"\\r\\n\\t| project \\r\\n\\t\\tMdnStatusCode = MessageProperties.StatusCode,\\r\\n\\t\\tCorrelationMessageId, \\r\\n\\t\\tAckDirection = Direction, \\r\\n\\t\\tAckTime = EventTime,\\r\\n\\t\\tAckClientTrackingId = ClientRequestId,\\r\\n\\t\\tAckSubscriptionId = WorkflowRunOperationInfo.Workflow.SubscriptionId,\\r\\n\\t\\tAckResourceGroup =  WorkflowRunOperationInfo.Workflow.ResourceGroup,\\r\\n\\t\\tAckActionName =  WorkflowRunOperationInfo.Operation.OperationName,\\r\\n\\t\\tAckLogicAppName = WorkflowRunOperationInfo.Workflow.Name,\\r\\n\\t\\tDirectionBasedCorrelationId = iff (Direction == \\\"Send\\\", strcat_delim(\\\"/\\\", WorkflowRunOperationInfo.RunInstance.OperationName, WorkflowRunOperationInfo.Workflow.Name, IntegrationAccountResourceGroup, IntegrationAccountSubscriptionId), \\\"\\\")\\r\\n\\t| extend MdnStatus = iff (MdnStatusCode ==\\\"1\\\", \\\"Successful\\\", \\\"Failed\\\")\\r\\n) on CorrelationMessageId, DirectionBasedCorrelationId\\r\\n| extend  IsAckValid = AckTime > MessageTime\\r\\n| extend\\r\\n    MessageStatus = iff(AS2MessageStatus == \\\"Successful\\\" and IsMdnExpected,\\r\\n\\t\\tiff(isnotempty(MdnStatusCode) and IsAckValid, \\r\\n\\t\\t\\tMdnStatus, \\r\\n\\t\\t\\t\\\"Pending\\\"), \\r\\n\\t\\tAS2MessageStatus), \\r\\n    AckStatus = iff(IsMdnExpected,\\r\\n\\t\\tiff(isnotempty(MdnStatusCode) and IsAckValid,  \\r\\n\\t\\t\\tiff (MdnStatusCode ==\\\"1\\\", \\\"Successful\\\", \\\"Failed\\\"), \\\"Pending\\\"),                      \\r\\n\\t\\t\\\"NotRequired\\\")\\r\\n)\\r\\n| union \\r\\n\\t(AS2TrackRecords\\r\\n\\t| where EventTime {TimeRange}\\r\\n\\t| where RecordType == \\\"AS2Message\\\"\\r\\n\\t| where isempty(CorrelationMessageId)\\r\\n\\t| project \\r\\n\\t\\tAgreementName,\\r\\n\\t\\tSenderPartnerName,\\r\\n\\t\\tReceiverPartnerName,\\r\\n\\t\\tMessageTime = EventTime,\\r\\n\\t\\tMessageStatus = iff (IsMessageFailed, \\\"Failed\\\", \\\"Successful\\\"),  \\r\\n\\t\\tMessageId,\\r\\n\\t\\tCorrelationMessageId, \\r\\n\\t\\tMessageClientTrackingId = ClientRequestId,\\r\\n\\t\\tMessageSubscriptionId = WorkflowRunOperationInfo.Workflow.SubscriptionId,\\r\\n\\t\\tMessageResourceGroup =  WorkflowRunOperationInfo.Workflow.ResourceGroup,\\r\\n\\t\\tMessageActionName =  WorkflowRunOperationInfo.Operation.OperationName,\\r\\n\\t\\tMessageLogicAppName = WorkflowRunOperationInfo.Workflow.Name,\\r\\n\\t\\tMessageDirection = Direction,\\r\\n\\t\\tIsMdnExpected,\\r\\n\\t\\tDirectionBasedCorrelationId = iff (Direction == \\\"Receive\\\", strcat_delim(\\\"/\\\", WorkflowRunOperationInfo.RunInstance.OperationName, WorkflowRunOperationInfo.Workflow.Name, IntegrationAccountResourceGroup, IntegrationAccountSubscriptionId), \\\"\\\")   )\\r\\n    |  where '{AS2MessageStatus}' == \\\"All\\\" or MessageStatus == '{AS2MessageStatus}'\\r\\n\\t|  where '{AS2AcknowledgementStatus}' == \\\"All\\\" or AckStatus == '{AS2AcknowledgementStatus}'\\r\\n\\t|  where '{AS2MessageDirection}' == \\\"All\\\" or MessageDirection == '{AS2MessageDirection}'\\r\\n\\t|  where  isempty('{AS2SenderPartnerName}') or SenderPartnerName contains '{AS2SenderPartnerName}'\\r\\n\\t|  where  isempty('{AS2ReceiverPartnerName}') or ReceiverPartnerName contains '{AS2ReceiverPartnerName}'\\r\\n    | project \\r\\n        AgreementName,\\r\\n        SenderPartnerName,\\r\\n        ReceiverPartnerName,\\r\\n        MessageStatus,\\r\\n        MessageDirection,\\r\\n        MessageTime,\\r\\n        MessageClientTrackingId,\\r\\n        MessageId,\\r\\n        IsMdnExpected,\\r\\n        AckStatus,\\r\\n        CorrelationMessageId\\r\\n    | order by MessageTime desc\",\"clusterName\":\"{KustoCluster}\",\"databaseName\":\"{Database}\"}",
+              "query": "{\"version\":\"AzureDataExplorerQuery/1.0\",\"queryText\":\"(AS2TrackRecords\\r\\n| where EventTime {TimeRange}\\r\\n| where RecordType == \\\"AS2Message\\\"\\r\\n| where isnotempty(CorrelationMessageId)\\r\\n| project \\r\\n    AgreementName,\\r\\n    MessageId,\\r\\n    CorrelationMessageId,\\r\\n    SenderPartnerName,\\r\\n    ReceiverPartnerName, \\r\\n    MessageTime = EventTime,\\r\\n    MessageClientTrackingId = ClientRequestId,\\r\\n    MessageSubscriptionId = WorkflowRunOperationInfo.Workflow.SubscriptionId,\\r\\n    MessageResourceGroup =  WorkflowRunOperationInfo.Workflow.ResourceGroup,\\r\\n    MessageLogicAppName = WorkflowRunOperationInfo.Workflow.LogicAppName,\\r\\n    MessageWorkflowName =  WorkflowRunOperationInfo.Workflow.Name,\\r\\n    MessageActionName =  WorkflowRunOperationInfo.Operation.OperationName,\\r\\n    MessageWorkflowRunId = WorkflowRunOperationInfo.RunInstance.RunId,\\r\\n    MessageWorkflowResourceId = strcat('/subscriptions/', WorkflowRunOperationInfo.Workflow.SubscriptionId,'/resourceGroups/', WorkflowRunOperationInfo.Workflow.ResourceGroup, '/providers/Microsoft.Web/sites/',WorkflowRunOperationInfo.Workflow.LogicAppName, '/workflows/',WorkflowRunOperationInfo.Workflow.Name ),\\r\\n    AS2MessageStatus = iff (IsMessageFailed, \\\"Failed\\\", \\\"Successful\\\"),  \\r\\n    MessageDirection = Direction,\\r\\n    IsMdnExpected,\\r\\n    DirectionBasedCorrelationId = iff (Direction == \\\"Receive\\\", strcat_delim(\\\"/\\\", WorkflowRunOperationInfo.RunInstance.OperationName, WorkflowRunOperationInfo.Workflow.Name, IntegrationAccountResourceGroup, IntegrationAccountSubscriptionId), \\\"\\\")\\r\\n| join  kind=leftouter (\\r\\n\\tAS2TrackRecords\\r\\n\\t| where EventTime {TimeRange}\\r\\n\\t| where RecordType == \\\"AS2MDN\\\"\\r\\n\\t| project \\r\\n\\t\\tMdnStatusCode = MessageProperties.StatusCode,\\r\\n\\t\\tCorrelationMessageId, \\r\\n\\t\\tAckDirection = Direction, \\r\\n\\t\\tAckTime = EventTime,\\r\\n\\t\\tAckClientTrackingId = ClientRequestId,\\r\\n\\t\\tAckSubscriptionId = WorkflowRunOperationInfo.Workflow.SubscriptionId,\\r\\n\\t\\tAckResourceGroup =  WorkflowRunOperationInfo.Workflow.ResourceGroup,\\r\\n\\t\\tAckLogicAppName = WorkflowRunOperationInfo.Workflow.LogicAppName,\\r\\n        AckWorkflowName =  WorkflowRunOperationInfo.Workflow.Name,\\r\\n        AckActionName =  WorkflowRunOperationInfo.Operation.OperationName,\\r\\n        AckWorkflowRunId = WorkflowRunOperationInfo.RunInstance.RunId,\\r\\n        AckWorkflowResourceId = strcat('/subscriptions/', WorkflowRunOperationInfo.Workflow.SubscriptionId,'/resourceGroups/', WorkflowRunOperationInfo.Workflow.ResourceGroup, '/providers/Microsoft.Web/sites/',WorkflowRunOperationInfo.Workflow.LogicAppName, '/workflows/',WorkflowRunOperationInfo.Workflow.Name ),\\r\\n\\t\\tDirectionBasedCorrelationId = iff (Direction == \\\"Send\\\", strcat_delim(\\\"/\\\", WorkflowRunOperationInfo.RunInstance.OperationName, WorkflowRunOperationInfo.Workflow.Name, IntegrationAccountResourceGroup, IntegrationAccountSubscriptionId), \\\"\\\")\\r\\n\\t| extend MdnStatus = iff (MdnStatusCode ==\\\"1\\\", \\\"Successful\\\", \\\"Failed\\\")\\r\\n) on CorrelationMessageId, DirectionBasedCorrelationId\\r\\n| extend  IsAckValid = AckTime > MessageTime\\r\\n| extend\\r\\n    MessageStatus = iff(AS2MessageStatus == \\\"Successful\\\" and IsMdnExpected,\\r\\n\\t\\tiff(isnotempty(MdnStatusCode) and IsAckValid, \\r\\n\\t\\t\\tMdnStatus, \\r\\n\\t\\t\\t\\\"Pending\\\"), \\r\\n\\t\\tAS2MessageStatus), \\r\\n    AckStatus = iff(IsMdnExpected,\\r\\n\\t\\tiff(isnotempty(MdnStatusCode) and IsAckValid,  \\r\\n\\t\\t\\tiff (MdnStatusCode ==\\\"1\\\", \\\"Successful\\\", \\\"Failed\\\"), \\\"Pending\\\"),                      \\r\\n\\t\\t\\\"NotRequired\\\")\\r\\n)\\r\\n| union \\r\\n\\t(AS2TrackRecords\\r\\n\\t| where EventTime {TimeRange}\\r\\n\\t| where RecordType == \\\"AS2Message\\\"\\r\\n\\t| where isempty(CorrelationMessageId)\\r\\n\\t| project \\r\\n\\t\\tAgreementName,\\r\\n\\t\\tSenderPartnerName,\\r\\n\\t\\tReceiverPartnerName,\\r\\n\\t\\tMessageTime = EventTime,\\r\\n\\t\\tMessageStatus = iff (IsMessageFailed, \\\"Failed\\\", \\\"Successful\\\"),  \\r\\n\\t\\tMessageId,\\r\\n\\t\\tCorrelationMessageId, \\r\\n\\t\\tMessageClientTrackingId = ClientRequestId,\\r\\n\\t\\tMessageSubscriptionId = WorkflowRunOperationInfo.Workflow.SubscriptionId,\\r\\n        MessageResourceGroup =  WorkflowRunOperationInfo.Workflow.ResourceGroup,\\r\\n        MessageLogicAppName = WorkflowRunOperationInfo.Workflow.LogicAppName,\\r\\n        MessageWorkflowName =  WorkflowRunOperationInfo.Workflow.Name,\\r\\n        MessageActionName =  WorkflowRunOperationInfo.Operation.OperationName,\\r\\n        MessageWorkflowRunId = WorkflowRunOperationInfo.RunInstance.RunId,\\r\\n        MessageWorkflowResourceId = strcat('/subscriptions/', WorkflowRunOperationInfo.Workflow.SubscriptionId,'/resourceGroups/', WorkflowRunOperationInfo.Workflow.ResourceGroup, '/providers/Microsoft.Web/sites/',WorkflowRunOperationInfo.Workflow.LogicAppName, '/workflows/',WorkflowRunOperationInfo.Workflow.Name ),\\r\\n\\t\\tMessageDirection = Direction,\\r\\n\\t\\tIsMdnExpected,\\r\\n\\t\\tDirectionBasedCorrelationId = iff (Direction == \\\"Receive\\\", strcat_delim(\\\"/\\\", WorkflowRunOperationInfo.RunInstance.OperationName, WorkflowRunOperationInfo.Workflow.Name, IntegrationAccountResourceGroup, IntegrationAccountSubscriptionId), \\\"\\\")   )\\r\\n    |  where '{AS2MessageStatus}' == \\\"All\\\" or MessageStatus == '{AS2MessageStatus}'\\r\\n\\t|  where '{AS2AcknowledgementStatus}' == \\\"All\\\" or AckStatus == '{AS2AcknowledgementStatus}'\\r\\n\\t|  where '{AS2MessageDirection}' == \\\"All\\\" or MessageDirection == '{AS2MessageDirection}'\\r\\n\\t|  where  isempty('{AS2SenderPartnerName}') or SenderPartnerName contains '{AS2SenderPartnerName}'\\r\\n\\t|  where  isempty('{AS2ReceiverPartnerName}') or ReceiverPartnerName contains '{AS2ReceiverPartnerName}'\\r\\n    | project \\r\\n        AgreementName,\\r\\n        SenderPartnerName,\\r\\n        ReceiverPartnerName,\\r\\n        MessageStatus,\\r\\n        MessageDirection,\\r\\n        MessageTime,\\r\\n        MessageClientTrackingId,\\r\\n        MessageId,\\r\\n        IsMdnExpected,\\r\\n        AckStatus,\\r\\n        AckClientTrackingId,\\r\\n        CorrelationMessageId,\\r\\n        MessageWorkflowRunId,\\r\\n        AckWorkflowRunId,\\r\\n        MessageWorkflowResourceId,\\r\\n        AckWorkflowResourceId\\r\\n    | order by MessageTime desc\",\"clusterName\":\"{KustoCluster}\",\"databaseName\":\"{Database}\"}",
               "size": 3,
               "showAnalytics": true,
               "title": "AS2 Messages",
@@ -636,6 +636,40 @@
                           "text": "{0}{1}"
                         }
                       ]
+                    }
+                  },
+                  {
+                    "columnMatch": "MessageClientTrackingId",
+                    "formatter": 7,
+                    "formatOptions": {
+                      "linkTarget": "OpenBlade",
+                      "linkIsContextBlade": true,
+                      "bladeOpenContext": {
+                        "bladeName": "DesignerEditor.ReactView",
+                        "extensionName": "Microsoft_Azure_EMA",
+                        "bladeParameters": [
+                          {
+                            "name": "id",
+                            "source": "column",
+                            "value": "MessageWorkflowResourceId"
+                          },
+                          {
+                            "name": "runId",
+                            "source": "column",
+                            "value": "MessageWorkflowRunId"
+                          },
+                          {
+                            "name": "isReadOnly",
+                            "source": "static",
+                            "value": "true"
+                          },
+                          {
+                            "name": "isMonitoringView",
+                            "source": "static",
+                            "value": "true"
+                          }
+                        ]
+                      }
                     }
                   },
                   {
@@ -680,6 +714,56 @@
                         }
                       ]
                     }
+                  },
+                  {
+                    "columnMatch": "AckClientTrackingId",
+                    "formatter": 7,
+                    "formatOptions": {
+                      "linkTarget": "OpenBlade",
+                      "linkIsContextBlade": true,
+                      "bladeOpenContext": {
+                        "bladeName": "DesignerEditor.ReactView",
+                        "extensionName": "Microsoft_Azure_EMA",
+                        "bladeParameters": [
+                          {
+                            "name": "id",
+                            "source": "column",
+                            "value": "AckWorkflowResourceId"
+                          },
+                          {
+                            "name": "runId",
+                            "source": "column",
+                            "value": "AckWorkflowRunId"
+                          },
+                          {
+                            "name": "isReadOnly",
+                            "source": "static",
+                            "value": "true"
+                          },
+                          {
+                            "name": "isMonitoringView",
+                            "source": "static",
+                            "value": "true"
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  {
+                    "columnMatch": "MessageWorkflowRunId",
+                    "formatter": 5
+                  },
+                  {
+                    "columnMatch": "AckWorkflowRunId",
+                    "formatter": 5
+                  },
+                  {
+                    "columnMatch": "MessageWorkflowResourceId",
+                    "formatter": 5
+                  },
+                  {
+                    "columnMatch": "AckWorkflowResourceId",
+                    "formatter": 5
                   }
                 ],
                 "rowLimit": 1000,
@@ -791,7 +875,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "{\"version\":\"AzureDataExplorerQuery/1.0\",\"queryText\":\"(EdiTrackRecords\\r\\n| where EventTime {TimeRange}\\r\\n| where RecordType == \\\"X12TransactionSet\\\"\\r\\n| where isnotempty(TransactionSetControlNumber)\\r\\n| where MessageProperties.MessageType !in (\\\"997\\\", \\\"999\\\")\\r\\n| project \\r\\n    AgreementName,\\r\\n    TransactionSetControlNumber,\\r\\n    FunctionalGroupControlNumber,\\r\\n    InterchangeControlNumber,\\r\\n    SenderPartnerName,\\r\\n    ReceiverPartnerName,\\r\\n    MessageTime = EventTime,\\r\\n    MessageClientTrackingId = ClientRequestId,\\r\\n    MessageSubscriptionId = WorkflowRunOperationInfo.Workflow.SubscriptionId,\\r\\n    MessageResourceGroup =  WorkflowRunOperationInfo.Workflow.ResourceGroup,\\r\\n    MessageActionName =  WorkflowRunOperationInfo.Operation.OperationName,\\r\\n    MessageLogicAppName = WorkflowRunOperationInfo.Workflow.Name,\\r\\n    MessageDirection = Direction,\\r\\n    IsFunctionalAckExpected = MessageProperties.IsFunctionalAcknowledgmentExpected,\\r\\n    TransactionSetStatus = iff (IsMessageFailed == \\\"false\\\", \\\"Successful\\\", \\\"Failed\\\")\\r\\n| join kind = leftouter  (\\r\\n    EdiTrackRecords \\r\\n    | where EventTime {TimeRange}\\r\\n    | where RecordType == \\\"X12TransactionSetAcknowledgment\\\"\\r\\n    | where MessageProperties.ProcessingStatus != \\\"2\\\" // 1 - received, 2 generated, 3 sent\\r\\n    | project\\r\\n    AgreementName,\\r\\n    TransactionSetControlNumber = RespondingTransactionSetControlNumber,\\r\\n    FunctionalGroupControlNumber = RespondingFunctionalGroupControlNumber,\\r\\n    TransactionSetAckDirection = iff(MessageProperties.Direction == 0, \\\"Send\\\", \\\"Receive\\\"),   // 0 Send, 1 Receive \\r\\n    TransactionSetAckTime = EventTime,\\r\\n    TransactionSetAckClientTrackingId = ClientRequestId,\\r\\n    TransactionSetAckSubscriptionId = WorkflowRunOperationInfo.Workflow.SubscriptionId,\\r\\n    TransactionSetAckResourceGroup =  WorkflowRunOperationInfo.Workflow.ResourceGroup,\\r\\n    TransactionSetAckActionName =  WorkflowRunOperationInfo.Operation.OperationName,\\r\\n    TransactionSetAckLogicAppName = WorkflowRunOperationInfo.Workflow.Name,\\r\\n    TransactionSetAckStatusCode = iff(MessageProperties.StatusCode == \\\"1\\\", \\\"Accepted\\\", iff(MessageProperties.StatusCode == \\\"2\\\", \\\"AcceptedWithError\\\", \\\"Rejected\\\")) // 1 Accepted, 2 AcceptedWithError, 3 Rejected\\r\\n    | extend TransactionSetAckStatus = iff(isnotempty( TransactionSetAckStatusCode), iff(TransactionSetAckStatusCode == \\\"Accepted\\\", \\\"Successful\\\",\\\"Failed\\\"), \\\"\\\")\\r\\n) on AgreementName, TransactionSetControlNumber, FunctionalGroupControlNumber\\r\\n| project \\r\\n    AgreementName,\\r\\n    SenderPartnerName,\\r\\n    ReceiverPartnerName,\\r\\n    MessageClientTrackingId,\\r\\n    InterchangeControlNumber,\\r\\n    FunctionalGroupControlNumber,\\r\\n    TransactionSetControlNumber,\\r\\n    TransactionSetStatus,\\r\\n    MessageTime,\\r\\n    MessageDirection,\\r\\n    MessageSubscriptionId,\\r\\n    MessageResourceGroup,\\r\\n    MessageActionName,\\r\\n    MessageLogicAppName,\\r\\n    IsFunctionalAckExpected,\\r\\n    TransactionSetAckStatusCode,\\r\\n    TransactionSetAckStatus,\\r\\n    TransactionSetAckDirection,\\r\\n    TransactionSetAckTime,\\r\\n    TransactionSetAckClientTrackingId,\\r\\n    TransactionSetAckSubscriptionId,\\r\\n    TransactionSetAckResourceGroup,\\r\\n    TransactionSetAckActionName,\\r\\n    TransactionSetAckLogicAppName\\r\\n| join kind = leftouter  (\\r\\n    EdiTrackRecords \\r\\n    | where EventTime {TimeRange}\\r\\n    | where RecordType == \\\"X12FunctionalGroupAcknowledgment\\\"\\r\\n    | where MessageProperties.ProcessingStatus != \\\"2\\\" // 1 - received, 2 generated, 3 sent\\r\\n    | project\\r\\n    AgreementName,\\r\\n    FunctionalGroupControlNumber = RespondingFunctionalGroupControlNumber,\\r\\n    FunctionalAckDirection = iff(MessageProperties.Direction == 0, \\\"Send\\\", \\\"Receive\\\"),   // 0 Send, 1 Receive \\r\\n    FunctionalAckTime = EventTime,\\r\\n    FunctionalAckClientTrackingId = ClientRequestId,\\r\\n    FunctionalAckSubscriptionId = WorkflowRunOperationInfo.Workflow.SubscriptionId,\\r\\n    FunctionalAckResourceGroup =  WorkflowRunOperationInfo.Workflow.ResourceGroup,\\r\\n    FunctionalAckActionName =  WorkflowRunOperationInfo.Operation.OperationName,\\r\\n    FunctionalAckLogicAppName = WorkflowRunOperationInfo.Workflow.Name,\\r\\n    FunctionalAckStatusCode = iff(MessageProperties.StatusCode == \\\"1\\\", \\\"Accepted\\\", iff(MessageProperties.StatusCode == \\\"2\\\", \\\"AcceptedWithError\\\", \\\"Rejected\\\")) // 1 Accepted, 2 AcceptedWithError, 3 Rejected\\r\\n    | extend FunctionalAckStatus = iff(isnotempty( FunctionalAckStatusCode), iff(FunctionalAckStatusCode == \\\"Accepted\\\", \\\"Successful\\\",\\\"Failed\\\"), \\\"\\\")\\r\\n) on AgreementName, FunctionalGroupControlNumber\\r\\n| project \\r\\n    AgreementName,\\r\\n    SenderPartnerName,\\r\\n    ReceiverPartnerName,\\r\\n    MessageClientTrackingId,\\r\\n    InterchangeControlNumber,\\r\\n    FunctionalGroupControlNumber,\\r\\n    TransactionSetControlNumber,\\r\\n    TransactionSetStatus,\\r\\n    MessageTime,\\r\\n    MessageDirection,\\r\\n    MessageSubscriptionId,\\r\\n    MessageResourceGroup,\\r\\n    MessageActionName,\\r\\n    MessageLogicAppName,\\r\\n    IsFunctionalAckExpected,\\r\\n    TransactionSetAckStatusCode, // 1 Accepted, 2 AcceptedWithError, 3 Rejected\\r\\n    TransactionSetAckStatus, // Successful, Failed or empty\\r\\n    TransactionSetAckDirection,\\r\\n    TransactionSetAckTime,\\r\\n    TransactionSetAckActionName,\\r\\n    TransactionSetAckSubscriptionId,\\r\\n    TransactionSetAckResourceGroup,\\r\\n    TransactionSetAckLogicAppName,\\r\\n    FunctionalAckStatusCode, // 1 Accepted, 2 AcceptedWithError, 3 Rejected\\r\\n    FunctionalAckStatus, // Successful, Failed or empty\\r\\n    FunctionalAckDirection ,   // 0 Send, 1 Receive \\r\\n    FunctionalAckTime,\\r\\n    FunctionalAckClientTrackingId,\\r\\n    FunctionalAckSubscriptionId,\\r\\n    FunctionalAckResourceGroup,\\r\\n    FunctionalAckActionName,\\r\\n    FunctionalAckLogicAppName,\\r\\n    AckActionName = iff(isnotempty( TransactionSetAckActionName), TransactionSetAckActionName, FunctionalAckActionName),\\r\\n    AckLogicAppName = iff(isnotempty( TransactionSetAckLogicAppName), TransactionSetAckLogicAppName, FunctionalAckLogicAppName),\\r\\n    AckDirection = iff(isnotempty(TransactionSetAckDirection), TransactionSetAckDirection, FunctionalAckDirection),\\r\\n    AckTime = iff(isnotempty(TransactionSetAckTime), TransactionSetAckTime, FunctionalAckTime)\\r\\n    | extend  IsAckValid = AckTime > MessageTime\\r\\n    | extend MessageStatus = iff(TransactionSetStatus == \\\"Successful\\\" and IsFunctionalAckExpected and MessageDirection == \\\"Send\\\" ,\\r\\n        iff(isnotempty(TransactionSetAckStatusCode) and IsAckValid, TransactionSetAckStatus, iff(isnotempty(FunctionalAckStatusCode) and IsAckValid, FunctionalAckStatus, \\\"Pending\\\")),\\r\\n        TransactionSetStatus)\\r\\n    | extend AckStatus = iff(IsFunctionalAckExpected == true and MessageDirection == \\\"Send\\\"  , iff(isnotempty( TransactionSetAckStatusCode) and IsAckValid, TransactionSetAckStatusCode,\\r\\n        iff (isnotempty( FunctionalAckStatusCode) and IsAckValid, FunctionalAckStatusCode, \\\"Pending\\\")), \\\"NotRequired\\\"))\\r\\n| union \\r\\n    (EdiTrackRecords\\r\\n    | where EventTime {TimeRange}\\r\\n    | where RecordType == \\\"X12TransactionSet\\\"\\r\\n    | where isempty(TransactionSetControlNumber)\\r\\n    | where MessageProperties.MessageType !in (\\\"997\\\", \\\"999\\\")\\r\\n    |project \\r\\n        AgreementName,\\r\\n        SenderPartnerName,\\r\\n        ReceiverPartnerName,\\r\\n        MessageClientTrackingId = ClientRequestId,\\r\\n        InterchangeControlNumber,\\r\\n        FunctionalGroupControlNumber,\\r\\n        TransactionSetControlNumber,\\r\\n        MessageTime = EventTime,\\r\\n        MessageSubscriptionId = WorkflowRunOperationInfo.Workflow.SubscriptionId,\\r\\n        MessageResourceGroup =  WorkflowRunOperationInfo.Workflow.ResourceGroup,\\r\\n        MessageActionName =  WorkflowRunOperationInfo.Operation.OperationName,\\r\\n        MssageLogicAppName = WorkflowRunOperationInfo.Workflow.Name,\\r\\n        MessageDirection = Direction,\\r\\n        IsFunctionalAckExpected = MessageProperties.IsFunctionalAcknowledgmentExpected\\r\\n        | extend MessageStatus = \\\"Failed\\\")\\r\\n    | where '{X12MessageStatus}' == \\\"All\\\" or MessageStatus == '{X12MessageStatus}'\\r\\n    | where '{X12AcknowledgementStatus}' == \\\"All\\\" or AckStatus == '{X12AcknowledgementStatus}'\\r\\n    | where '{X12MessageDirection}' == \\\"All\\\" or MessageDirection == '{X12MessageDirection}'\\r\\n    | where  isempty('{X12SenderPartnerName}') or SenderPartnerName contains '{X12SenderPartnerName}'\\r\\n    | where  isempty('{X12ReceiverPartnerName}') or ReceiverPartnerName contains '{X12ReceiverPartnerName}'\\r\\n    | project \\r\\n        AgreementName,\\r\\n        SenderPartnerName,\\r\\n        ReceiverPartnerName,\\r\\n        MessageStatus,\\r\\n        MessageDirection,\\r\\n        MessageTime,\\r\\n        MessageClientTrackingId,\\r\\n        InterchangeControlNumber,\\r\\n        FunctionalGroupControlNumber,\\r\\n        TransactionSetStatus,\\r\\n        TransactionSetControlNumber,\\r\\n        IsFunctionalAckExpected,\\r\\n        AckStatus,\\r\\n        TransactionSetAckStatus,\\r\\n        FunctionalAckStatus\\r\\n    | order by MessageTime desc\",\"clusterName\":\"{KustoCluster}\",\"databaseName\":\"{Database}\"}",
+              "query": "{\"version\":\"AzureDataExplorerQuery/1.0\",\"queryText\":\"(EdiTrackRecords\\r\\n| where EventTime {TimeRange}\\r\\n| where RecordType == \\\"X12TransactionSet\\\"\\r\\n| where isnotempty(TransactionSetControlNumber)\\r\\n| where MessageProperties.MessageType !in (\\\"997\\\", \\\"999\\\")\\r\\n| project \\r\\n    AgreementName,\\r\\n    TransactionSetControlNumber,\\r\\n    FunctionalGroupControlNumber,\\r\\n    InterchangeControlNumber,\\r\\n    SenderPartnerName,\\r\\n    ReceiverPartnerName,\\r\\n    MessageTime = EventTime,\\r\\n    MessageClientTrackingId = ClientRequestId,\\r\\n    MessageSubscriptionId = WorkflowRunOperationInfo.Workflow.SubscriptionId,\\r\\n    MessageResourceGroup =  WorkflowRunOperationInfo.Workflow.ResourceGroup,\\r\\n    MessageLogicAppName = WorkflowRunOperationInfo.Workflow.LogicAppName,\\r\\n    MessageWorkflowName =  WorkflowRunOperationInfo.Workflow.Name,\\r\\n    MessageActionName =  WorkflowRunOperationInfo.Operation.OperationName,\\r\\n    MessageWorkflowRunId = WorkflowRunOperationInfo.RunInstance.RunId,\\r\\n    MessageWorkflowResourceId = strcat('/subscriptions/', WorkflowRunOperationInfo.Workflow.SubscriptionId,'/resourceGroups/', WorkflowRunOperationInfo.Workflow.ResourceGroup, '/providers/Microsoft.Web/sites/',WorkflowRunOperationInfo.Workflow.LogicAppName, '/workflows/',WorkflowRunOperationInfo.Workflow.Name ),\\r\\n    MessageDirection = Direction,\\r\\n    IsFunctionalAckExpected = MessageProperties.IsFunctionalAcknowledgmentExpected,\\r\\n    TransactionSetStatus = iff (IsMessageFailed == \\\"false\\\", \\\"Successful\\\", \\\"Failed\\\")\\r\\n| join kind = leftouter  (\\r\\n    EdiTrackRecords \\r\\n    | where EventTime {TimeRange}\\r\\n    | where RecordType == \\\"X12TransactionSetAcknowledgment\\\"\\r\\n    | where MessageProperties.ProcessingStatus != \\\"2\\\" // 1 - received, 2 generated, 3 sent\\r\\n    | project\\r\\n    AgreementName,\\r\\n    TransactionSetControlNumber = RespondingTransactionSetControlNumber,\\r\\n    FunctionalGroupControlNumber = RespondingFunctionalGroupControlNumber,\\r\\n    TransactionSetAckDirection = iff(MessageProperties.Direction == 0, \\\"Send\\\", \\\"Receive\\\"),   // 0 Send, 1 Receive \\r\\n    TransactionSetAckTime = EventTime,\\r\\n    TransactionSetAckClientTrackingId = ClientRequestId,\\r\\n    TransactionSetAckSubscriptionId = WorkflowRunOperationInfo.Workflow.SubscriptionId,\\r\\n    TransactionSetAckResourceGroup =  WorkflowRunOperationInfo.Workflow.ResourceGroup,\\r\\n    TransactionSetAckLogicAppName = WorkflowRunOperationInfo.Workflow.LogicAppName,\\r\\n    TransactionSetAckWorkflowName =  WorkflowRunOperationInfo.Workflow.Name,\\r\\n    TransactionSetAckActionName =  WorkflowRunOperationInfo.Operation.OperationName,\\r\\n    TransactionSetAckWorkflowRunId = WorkflowRunOperationInfo.RunInstance.RunId,\\r\\n    TransactionSetAckWorkflowResourceId = strcat('/subscriptions/', WorkflowRunOperationInfo.Workflow.SubscriptionId,'/resourceGroups/', WorkflowRunOperationInfo.Workflow.ResourceGroup, '/providers/Microsoft.Web/sites/',WorkflowRunOperationInfo.Workflow.LogicAppName, '/workflows/',WorkflowRunOperationInfo.Workflow.Name ),\\r\\n    TransactionSetAckStatusCode = iff(MessageProperties.StatusCode == \\\"1\\\", \\\"Accepted\\\", iff(MessageProperties.StatusCode == \\\"2\\\", \\\"AcceptedWithError\\\", \\\"Rejected\\\")) // 1 Accepted, 2 AcceptedWithError, 3 Rejected\\r\\n    | extend TransactionSetAckStatus = iff(isnotempty( TransactionSetAckStatusCode), iff(TransactionSetAckStatusCode == \\\"Accepted\\\", \\\"Successful\\\",\\\"Failed\\\"), \\\"\\\")\\r\\n) on AgreementName, TransactionSetControlNumber, FunctionalGroupControlNumber\\r\\n| project \\r\\n    AgreementName,\\r\\n    SenderPartnerName,\\r\\n    ReceiverPartnerName,\\r\\n    MessageClientTrackingId,\\r\\n    InterchangeControlNumber,\\r\\n    FunctionalGroupControlNumber,\\r\\n    TransactionSetControlNumber,\\r\\n    TransactionSetStatus,\\r\\n    MessageTime,\\r\\n    MessageDirection,\\r\\n    MessageSubscriptionId,\\r\\n    MessageResourceGroup,\\r\\n    MessageLogicAppName,\\r\\n    MessageActionName,\\r\\n    MessageWorkflowRunId,\\r\\n    MessageWorkflowResourceId,\\r\\n    IsFunctionalAckExpected,\\r\\n    TransactionSetAckStatusCode,\\r\\n    TransactionSetAckStatus,\\r\\n    TransactionSetAckDirection,\\r\\n    TransactionSetAckTime,\\r\\n    TransactionSetAckClientTrackingId,\\r\\n    TransactionSetAckSubscriptionId,\\r\\n    TransactionSetAckResourceGroup,\\r\\n    TransactionSetAckLogicAppName,\\r\\n    TransactionSetAckActionName,\\r\\n    TransactionSetAckWorkflowRunId,\\r\\n    TransactionSetAckWorkflowResourceId\\r\\n| join kind = leftouter  (\\r\\n    EdiTrackRecords \\r\\n    | where EventTime {TimeRange}\\r\\n    | where RecordType == \\\"X12FunctionalGroupAcknowledgment\\\"\\r\\n    | where MessageProperties.ProcessingStatus != \\\"2\\\" // 1 - received, 2 generated, 3 sent\\r\\n    | project\\r\\n    AgreementName,\\r\\n    FunctionalGroupControlNumber = RespondingFunctionalGroupControlNumber,\\r\\n    FunctionalAckDirection = iff(MessageProperties.Direction == 0, \\\"Send\\\", \\\"Receive\\\"),   // 0 Send, 1 Receive \\r\\n    FunctionalAckTime = EventTime,\\r\\n    FunctionalAckClientTrackingId = ClientRequestId,\\r\\n    FunctionalAckSubscriptionId = WorkflowRunOperationInfo.Workflow.SubscriptionId,\\r\\n    FunctionalAckResourceGroup =  WorkflowRunOperationInfo.Workflow.ResourceGroup,\\r\\n    FunctionalAckActionName =  WorkflowRunOperationInfo.Operation.OperationName,\\r\\n    FunctionalAckLogicAppName = WorkflowRunOperationInfo.Workflow.Name,\\r\\n    FunctionalAckStatusCode = iff(MessageProperties.StatusCode == \\\"1\\\", \\\"Accepted\\\", iff(MessageProperties.StatusCode == \\\"2\\\", \\\"AcceptedWithError\\\", \\\"Rejected\\\")) // 1 Accepted, 2 AcceptedWithError, 3 Rejected\\r\\n    | extend FunctionalAckStatus = iff(isnotempty( FunctionalAckStatusCode), iff(FunctionalAckStatusCode == \\\"Accepted\\\", \\\"Successful\\\",\\\"Failed\\\"), \\\"\\\")\\r\\n) on AgreementName, FunctionalGroupControlNumber\\r\\n| project \\r\\n    AgreementName,\\r\\n    SenderPartnerName,\\r\\n    ReceiverPartnerName,\\r\\n    MessageClientTrackingId,\\r\\n    InterchangeControlNumber,\\r\\n    FunctionalGroupControlNumber,\\r\\n    TransactionSetControlNumber,\\r\\n    TransactionSetStatus,\\r\\n    MessageTime,\\r\\n    MessageDirection,\\r\\n    MessageSubscriptionId,\\r\\n    MessageResourceGroup,\\r\\n    MessageLogicAppName,\\r\\n    MessageActionName,\\r\\n    MessageWorkflowRunId,\\r\\n    MessageWorkflowResourceId,\\r\\n    IsFunctionalAckExpected,\\r\\n    TransactionSetAckStatusCode, // 1 Accepted, 2 AcceptedWithError, 3 Rejected\\r\\n    TransactionSetAckStatus, // Successful, Failed or empty\\r\\n    TransactionSetAckDirection,\\r\\n    TransactionSetAckTime,\\r\\n    TransactionSetAckClientTrackingId,\\r\\n    TransactionSetAckSubscriptionId,\\r\\n    TransactionSetAckResourceGroup,\\r\\n    TransactionSetAckLogicAppName,\\r\\n    TransactionSetAckActionName,\\r\\n    TransactionSetAckWorkflowRunId,\\r\\n    TransactionSetAckWorkflowResourceId,\\r\\n    FunctionalAckStatusCode, // 1 Accepted, 2 AcceptedWithError, 3 Rejected\\r\\n    FunctionalAckStatus, // Successful, Failed or empty\\r\\n    FunctionalAckDirection ,   // 0 Send, 1 Receive \\r\\n    FunctionalAckTime,\\r\\n    FunctionalAckClientTrackingId,\\r\\n    FunctionalAckSubscriptionId,\\r\\n    FunctionalAckResourceGroup,\\r\\n    FunctionalAckActionName,\\r\\n    FunctionalAckLogicAppName,\\r\\n    AckActionName = iff(isnotempty( TransactionSetAckActionName), TransactionSetAckActionName, FunctionalAckActionName),\\r\\n    AckLogicAppName = iff(isnotempty( TransactionSetAckLogicAppName), TransactionSetAckLogicAppName, FunctionalAckLogicAppName),\\r\\n    AckDirection = iff(isnotempty(TransactionSetAckDirection), TransactionSetAckDirection, FunctionalAckDirection),\\r\\n    AckTime = iff(isnotempty(TransactionSetAckTime), TransactionSetAckTime, FunctionalAckTime)\\r\\n    | extend  IsAckValid = AckTime > MessageTime\\r\\n    | extend MessageStatus = iff(TransactionSetStatus == \\\"Successful\\\" and IsFunctionalAckExpected and MessageDirection == \\\"Send\\\" ,\\r\\n        iff(isnotempty(TransactionSetAckStatusCode) and IsAckValid, TransactionSetAckStatus, iff(isnotempty(FunctionalAckStatusCode) and IsAckValid, FunctionalAckStatus, \\\"Pending\\\")),\\r\\n        TransactionSetStatus)\\r\\n    | extend AckStatus = iff(IsFunctionalAckExpected == true and MessageDirection == \\\"Send\\\"  , iff(isnotempty( TransactionSetAckStatusCode) and IsAckValid, TransactionSetAckStatusCode,\\r\\n        iff (isnotempty( FunctionalAckStatusCode) and IsAckValid, FunctionalAckStatusCode, \\\"Pending\\\")), \\\"NotRequired\\\"))\\r\\n| union \\r\\n    (EdiTrackRecords\\r\\n    | where EventTime {TimeRange}\\r\\n    | where RecordType == \\\"X12TransactionSet\\\"\\r\\n    | where isempty(TransactionSetControlNumber)\\r\\n    | where MessageProperties.MessageType !in (\\\"997\\\", \\\"999\\\")\\r\\n    |project \\r\\n        AgreementName,\\r\\n        SenderPartnerName,\\r\\n        ReceiverPartnerName,\\r\\n        MessageClientTrackingId = ClientRequestId,\\r\\n        InterchangeControlNumber,\\r\\n        FunctionalGroupControlNumber,\\r\\n        TransactionSetControlNumber,\\r\\n        MessageTime = EventTime,\\r\\n        MessageSubscriptionId = WorkflowRunOperationInfo.Workflow.SubscriptionId,\\r\\n        MessageResourceGroup =  WorkflowRunOperationInfo.Workflow.ResourceGroup,\\r\\n        MessageLogicAppName = WorkflowRunOperationInfo.Workflow.LogicAppName,\\r\\n        MessageWorkflowName =  WorkflowRunOperationInfo.Workflow.Name,\\r\\n        MessageActionName =  WorkflowRunOperationInfo.Operation.OperationName,\\r\\n        MessageWorkflowRunId = WorkflowRunOperationInfo.RunInstance.RunId,\\r\\n        MessageWorkflowResourceId = strcat('/subscriptions/', WorkflowRunOperationInfo.Workflow.SubscriptionId,'/resourceGroups/', WorkflowRunOperationInfo.Workflow.ResourceGroup, '/providers/Microsoft.Web/sites/',WorkflowRunOperationInfo.Workflow.LogicAppName, '/workflows/',WorkflowRunOperationInfo.Workflow.Name ),    \\r\\n        MessageDirection = Direction,\\r\\n        IsFunctionalAckExpected = MessageProperties.IsFunctionalAcknowledgmentExpected\\r\\n        | extend MessageStatus = \\\"Failed\\\")\\r\\n    | where '{X12MessageStatus}' == \\\"All\\\" or MessageStatus == '{X12MessageStatus}'\\r\\n    | where '{X12AcknowledgementStatus}' == \\\"All\\\" or AckStatus == '{X12AcknowledgementStatus}'\\r\\n    | where '{X12MessageDirection}' == \\\"All\\\" or MessageDirection == '{X12MessageDirection}'\\r\\n    | where  isempty('{X12SenderPartnerName}') or SenderPartnerName contains '{X12SenderPartnerName}'\\r\\n    | where  isempty('{X12ReceiverPartnerName}') or ReceiverPartnerName contains '{X12ReceiverPartnerName}'\\r\\n    | project \\r\\n        AgreementName,\\r\\n        SenderPartnerName,\\r\\n        ReceiverPartnerName,\\r\\n        MessageStatus,\\r\\n        MessageDirection,\\r\\n        MessageTime,\\r\\n        MessageClientTrackingId,\\r\\n        InterchangeControlNumber,\\r\\n        FunctionalGroupControlNumber,\\r\\n        TransactionSetStatus,\\r\\n        TransactionSetControlNumber,\\r\\n        IsFunctionalAckExpected,\\r\\n        AckStatus,\\r\\n        TransactionSetAckStatus,\\r\\n        TransactionSetAckClientTrackingId,\\r\\n        FunctionalAckStatus,\\r\\n        MessageWorkflowRunId,\\r\\n        MessageWorkflowResourceId,\\r\\n        TransactionSetAckWorkflowRunId,\\r\\n        TransactionSetAckWorkflowResourceId\\r\\n    | order by MessageTime desc\",\"clusterName\":\"{KustoCluster}\",\"databaseName\":\"{Database}\"}",
               "size": 3,
               "showAnalytics": true,
               "title": "X12 Messages",
@@ -829,6 +913,40 @@
                           "text": "{0}{1}"
                         }
                       ]
+                    }
+                  },
+                  {
+                    "columnMatch": "MessageClientTrackingId",
+                    "formatter": 7,
+                    "formatOptions": {
+                      "linkTarget": "OpenBlade",
+                      "linkIsContextBlade": true,
+                      "bladeOpenContext": {
+                        "bladeName": "DesignerEditor.ReactView",
+                        "extensionName": "Microsoft_Azure_EMA",
+                        "bladeParameters": [
+                          {
+                            "name": "id",
+                            "source": "column",
+                            "value": "MessageWorkflowResourceId"
+                          },
+                          {
+                            "name": "runId",
+                            "source": "column",
+                            "value": "MessageWorkflowRunId"
+                          },
+                          {
+                            "name": "isReadOnly",
+                            "source": "static",
+                            "value": "true"
+                          },
+                          {
+                            "name": "isMonitoringView",
+                            "source": "static",
+                            "value": "true"
+                          }
+                        ]
+                      }
                     }
                   },
                   {
@@ -925,6 +1043,40 @@
                     }
                   },
                   {
+                    "columnMatch": "TransactionSetAckClientTrackingId",
+                    "formatter": 7,
+                    "formatOptions": {
+                      "linkTarget": "OpenBlade",
+                      "linkIsContextBlade": true,
+                      "bladeOpenContext": {
+                        "bladeName": "DesignerEditor.ReactView",
+                        "extensionName": "Microsoft_Azure_EMA",
+                        "bladeParameters": [
+                          {
+                            "name": "id",
+                            "source": "column",
+                            "value": "TransactionSetAckWorkflowResourceId"
+                          },
+                          {
+                            "name": "runId",
+                            "source": "column",
+                            "value": "TransactionSetAckWorkflowRunId"
+                          },
+                          {
+                            "name": "isReadOnly",
+                            "source": "static",
+                            "value": "true"
+                          },
+                          {
+                            "name": "isMonitoringView",
+                            "source": "static",
+                            "value": "true"
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  {
                     "columnMatch": "FunctionalAckStatus",
                     "formatter": 18,
                     "formatOptions": {
@@ -950,6 +1102,22 @@
                         }
                       ]
                     }
+                  },
+                  {
+                    "columnMatch": "MessageWorkflowRunId",
+                    "formatter": 5
+                  },
+                  {
+                    "columnMatch": "MessageWorkflowResourceId",
+                    "formatter": 5
+                  },
+                  {
+                    "columnMatch": "TransactionSetAckWorkflowRunId",
+                    "formatter": 5
+                  },
+                  {
+                    "columnMatch": "TransactionSetAckWorkflowResourceId",
+                    "formatter": 5
                   }
                 ],
                 "rowLimit": 1000,
@@ -972,6 +1140,9 @@
       },
       "name": "X12Details"
     }
+  ],
+  "fallbackResourceIds": [
+    "Azure Monitor"
   ],
   "styleSettings": {
     "paddingStyle": "none",


### PR DESCRIPTION
## Summary


Navigation is implemented using https://learn.microsoft.com/en-us/azure/azure-monitor/visualize/workbooks-link-actions.



## Screenshots

![image](https://github.com/user-attachments/assets/58d30417-e7ee-443e-a9d2-01106546a02e)

Below screenshot is for acknowledgement message run history. Please note that in order for the link to be visible while the run history is opened, other columns are collapsed manually before taking the screenshot.
![image](https://github.com/user-attachments/assets/fe8198d1-a63a-4d16-96b8-407338197e09)


## Validation

Validated using branch redirection feature flag

## Checklist

- [ ] If you are adding a new template, gallery, or folder, add your team and folder/file(s) to the CODEOWNERS file at the root of the repo. CODEOWNERS entries should be teams, not individuals.
      When done correctly, this means that from then on *your* team does reviews of *your* things, not the workbooks team.
- [ ] Ensure all steps in your template have meaningful names.
- [ ] Ensure all parameters and grid columns have display names set so they can be localized.
