### PR TITLE
[IntegrationLogicApps] Hide IntegrationEnvironmentApplication dropdown and change resourceTypeFilter

### DIFF
--- a/Workbooks/Azure Logic Apps/Integration Environment Application/IntegrationLogicApps/IntegrationLogicApps.workbook
+++ b/Workbooks/Azure Logic Apps/Integration Environment Application/IntegrationLogicApps/IntegrationLogicApps.workbook
@@ -6,15 +6,16 @@
       "content": {
         "version": "KqlParameterItem/1.0",
         "parameters": [
-         {
+          {
             "id": "20410b38-d7fe-4c39-a845-19b7e4be6b49",
             "version": "KqlParameterItem/1.0",
             "name": "IntegrationEnvironmentApplication",
             "type": 5,
             "isRequired": true,
+            "isHiddenWhenLocked": true,
             "typeSettings": {
               "resourceTypeFilter": {
-                "private.integrationservice/spaces/applications": true
+                "microsoft.integrationspaces/spaces/applications": true
               },
               "additionalResourceOptions": [],
               "showDefault": false,


### PR DESCRIPTION
## Summary
- Hiding IntegrationEnvironmentApplication resource picker, as we only use 1 at a time (parent resource)
- Changing resourceTypeFilter to official resource type for integration environment application

## Screenshots
![image](https://github.com/user-attachments/assets/e9f5b1cf-b6b0-4864-aafa-f3a296a62479)

## Validation
- [X] Validate your changes using one or more of the [testing](https://github.com/microsoft/Application-Insights-Workbooks/blob/master/Documentation/Testing.md) methods.
