### PR TITLE
🔧 Add inline step toolbar buttons to Foundry Dashboard

### DIFF
--- a/Workbooks/Azure Machine Learning/AI Studio/FoundryDashboard/FoundryDashboard.workbook
+++ b/Workbooks/Azure Machine Learning/AI Studio/FoundryDashboard/FoundryDashboard.workbook
@@ -224,7 +224,7 @@
           ],
           "visualization": "tiles",
           "sortBy": [],
-          "showViewButton": true,
+          "showViewButton": false,
           "showAnalytics": true,
           "tileSettings": {
             "titleContent": {
@@ -319,7 +319,7 @@
             "{ApplicationInsights}"
           ],
           "visualization": "tiles",
-          "showViewButton": true,
+          "showViewButton": false,
           "showAnalytics": true,
           "tileSettings": {
             "titleContent": {
@@ -413,7 +413,7 @@
           "crossComponentResources": [
             "{ApplicationInsights}"
           ],
-          "showViewButton": true,
+          "showViewButton": false,
           "showAnalytics": true,
           "visualization": "tiles",
           "tileSettings": {
@@ -527,7 +527,7 @@
           "crossComponentResources": [
             "{ApplicationInsights}"
           ],
-          "showViewButton": true,
+          "showViewButton": false,
           "showAnalytics": true,
           "visualization": "tiles",
           "tileSettings": {

--- a/Workbooks/Azure Machine Learning/AI Studio/FoundryDashboard/FoundryDashboard.workbook
+++ b/Workbooks/Azure Machine Learning/AI Studio/FoundryDashboard/FoundryDashboard.workbook
@@ -527,7 +527,8 @@
           "crossComponentResources": [
             "{ApplicationInsights}"
           ],
-          "showViewButton": false,
+          "showViewButton": true,
+          "showAnalytics": true,
           "visualization": "tiles",
           "tileSettings": {
             "titleContent": {

--- a/Workbooks/Azure Machine Learning/AI Studio/FoundryDashboard/FoundryDashboard.workbook
+++ b/Workbooks/Azure Machine Learning/AI Studio/FoundryDashboard/FoundryDashboard.workbook
@@ -224,7 +224,8 @@
           ],
           "visualization": "tiles",
           "sortBy": [],
-          "showViewButton": false,
+          "showViewButton": true,
+          "showAnalytics": true,
           "tileSettings": {
             "titleContent": {
               "columnMatch": "metric",
@@ -318,7 +319,8 @@
             "{ApplicationInsights}"
           ],
           "visualization": "tiles",
-          "showViewButton": false,
+          "showViewButton": true,
+          "showAnalytics": true,
           "tileSettings": {
             "titleContent": {
               "columnMatch": "metric",
@@ -411,7 +413,8 @@
           "crossComponentResources": [
             "{ApplicationInsights}"
           ],
-          "showViewButton": false,
+          "showViewButton": true,
+          "showAnalytics": true,
           "visualization": "tiles",
           "tileSettings": {
             "titleContent": {


### PR DESCRIPTION
This PR adds the inline step toolbar buttons to the Foundry dashboard:

![image](https://github.com/user-attachments/assets/001d9a77-1c84-4a4c-a05b-b2454a701af7)
