### PR TITLE
🔧 Remove view button for now from Foundry dashboard

### DIFF
--- a/Workbooks/Azure Machine Learning/AI Studio/FoundryDashboard/FoundryDashboard.workbook
+++ b/Workbooks/Azure Machine Learning/AI Studio/FoundryDashboard/FoundryDashboard.workbook
@@ -591,6 +591,7 @@
           "size": 4,
           "noDataMessage": "The query returned no results. Note that you must instrument client application with distributed tracing to enable filtering by Application and Model. To learn more about monitoring, go to aka.ms/AzureAIFoundry/Observability/Monitoring",
           "queryType": 0,
+          "showAnalytics": true,
           "showViewButton": false,
           "resourceType": "microsoft.insights/components",
           "crossComponentResources": [
@@ -659,8 +660,7 @@
               "layout": "grid"
             }
           },
-          "title": "Evaluation Metrics ({$rowCount})",
-          "showAnalytics": true
+          "title": "Evaluation Metrics ({$rowCount})"
         },
         "name": "evaluation metrics query tiles",
         "styleSettings": {
@@ -741,7 +741,8 @@
               "label": "Token usage"
             }
           },
-          "showAnalytics": true
+          "showAnalytics": true,
+          "showViewButton": false
         },
         "id": "5dd92ecb-030a-496d-bd61-c8dedff06913",
         "styleSettings": {
@@ -796,7 +797,8 @@
               "label": "Total inference calls"
             }
           },
-          "showAnalytics": true
+          "showAnalytics": true,
+          "showViewButton": false
         },
         "customWidth": "33.3",
         "name": "query - 1",
@@ -864,7 +866,8 @@
               "label": "Time"
             }
           },
-          "showAnalytics": true
+          "showAnalytics": true,
+          "showViewButton": false
         },
         "customWidth": "33.3",
         "name": "query - 2",
@@ -914,7 +917,8 @@
               "position": "bottom"
             }
           },
-          "showAnalytics": true
+          "showAnalytics": true,
+          "showViewButton": false
         },
         "customWidth": "33.3",
         "name": "query - 3",
@@ -958,7 +962,8 @@
               "label": "Average score"
             }
           },
-          "showAnalytics": true
+          "showAnalytics": true,
+          "showViewButton": false
         },
         "name": "query - 4",
         "styleSettings": {
@@ -1001,7 +1006,8 @@
               "label": "Average score"
             }
           },
-          "showAnalytics": true
+          "showAnalytics": true,
+          "showViewButton": false
         },
         "customWidth": "66.67",
         "name": "Daily safety average score",
@@ -1051,7 +1057,8 @@
               "position": "bottom"
             }
           },
-          "showAnalytics": true
+          "showAnalytics": true,
+          "showViewButton": false
         },
         "customWidth": "33.3",
         "name": "query - 6",


### PR DESCRIPTION
This PR modifies the Foundry Dashboard to remove view buttons, in response to a focus trapping bug.