### PR TITLE
Add label filter to online experimentation workbook

### DIFF
--- a/Workbooks/Online Experimentation/Experiment Analysis/Experiment Analysis.workbook
+++ b/Workbooks/Online Experimentation/Experiment Analysis/Experiment Analysis.workbook
@@ -61,6 +61,19 @@
             },
             "jsonData": "[\"True\", \"False\"]",
             "value": "False"
+          },
+          {
+            "id": "8457ab9c-f249-4f3a-8a65-a0ed296932df",
+            "version": "KqlParameterItem/1.0",
+            "name": "HideLabel",
+            "label": "Hide Label picker",
+            "type": 2,
+            "isHiddenWhenLocked": true,
+            "typeSettings": {
+              "additionalResourceOptions": []
+            },
+            "jsonData": "[\"True\", \"False\"]",
+            "value": "False"
           }
         ],
         "style": "above",
@@ -196,8 +209,7 @@
             },
             "timeContextFromParameter": "TimeRange",
             "queryType": 0,
-            "resourceType": "microsoft.operationalinsights/workspaces",
-            "value": "system_prompt"
+            "resourceType": "microsoft.operationalinsights/workspaces"
           }
         ],
         "style": "above",
@@ -271,6 +283,52 @@
         ],
         "parameters": [
           {
+            "id": "2b2553e9-e276-4a7e-8820-b30b7beca46e",
+            "version": "KqlParameterItem/1.0",
+            "name": "Label",
+            "type": 2,
+            "description": "Select Label to analyze",
+            "isRequired": true,
+            "query": "OEWExperimentScorecards\n| where TimeGenerated between ({TimeRange:start} .. {TimeRange:end})\n| where FeatureName == '{FeatureName}' and AllocationId == '{AllocationId}'\n| summarize LatestScorecard=max(TimeGenerated) by Label\n| order by LatestScorecard desc, Label asc\n| project Label = iff(Label == \"\", \"<empty>\", Label)",
+            "crossComponentResources": [
+              "{Workspace}"
+            ],
+            "typeSettings": {
+              "additionalResourceOptions": [],
+              "showDefault": false
+            },
+            "timeContext": {
+              "durationMs": 2592000000
+            },
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces"
+          }
+        ],
+        "style": "above",
+        "queryType": 0,
+        "resourceType": "microsoft.operationalinsights/workspaces"
+      },
+      "conditionalVisibility": {
+        "parameterName": "HideLabel",
+        "comparison": "isNotEqualTo",
+        "value": "True"
+      },
+      "customWidth": "0",
+      "name": "HideLabel",
+      "styleSettings": {
+        "margin": "5px",
+        "padding": "0"
+      }
+    },
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "crossComponentResources": [
+          "{Workspace}"
+        ],
+        "parameters": [
+          {
             "id": "773a3f34-a30d-4bc8-adae-31a0471b3e34",
             "version": "KqlParameterItem/1.0",
             "name": "ScorecardId",
@@ -278,7 +336,7 @@
             "type": 2,
             "description": "Experiment data accumulates over time. Experiment analysis provides regular snapshots of the metric results.",
             "isRequired": true,
-            "query": "OEWExperimentScorecards\r\n| where FeatureName == '{FeatureName}' and AllocationId == '{AllocationId}'\r\n| project ScorecardId, TimeGenerated, AnalysisStartTime, AnalysisEndTime\r\n| summarize arg_max(TimeGenerated, *) by ScorecardId\r\n| summarize arg_max(TimeGenerated, *) by AnalysisEndTime\r\n| order by AnalysisEndTime desc\r\n| project\r\n    value = ScorecardId,\r\n    label = strcat(\r\n        round((AnalysisEndTime - AnalysisStartTime) / 1d, 1),\r\n        \" days (\",\r\n        format_datetime(AnalysisStartTime, 'MM/dd/yyyy HH:mm'),\r\n        ' - ',\r\n        format_datetime(AnalysisEndTime, 'MM/dd/yyyy HH:mm'),\r\n        ' UTC)'\r\n    ),\r\n    selected = row_number() == 1",
+            "query": "OEWExperimentScorecards\r\n| where FeatureName == '{FeatureName}' and AllocationId == '{AllocationId}' and Label == '{Label}'\r\n| project ScorecardId, TimeGenerated, AnalysisStartTime, AnalysisEndTime\r\n| summarize arg_max(TimeGenerated, *) by ScorecardId\r\n| summarize arg_max(TimeGenerated, *) by AnalysisEndTime\r\n| order by AnalysisEndTime desc\r\n| project\r\n    value = ScorecardId,\r\n    label = strcat(\r\n        round((AnalysisEndTime - AnalysisStartTime) / 1d, 1),\r\n        \" days (\",\r\n        format_datetime(AnalysisStartTime, 'MM/dd/yyyy HH:mm'),\r\n        ' - ',\r\n        format_datetime(AnalysisEndTime, 'MM/dd/yyyy HH:mm'),\r\n        ' UTC)'\r\n    ),\r\n    selected = row_number() == 1",
             "crossComponentResources": [
               "{Workspace}"
             ],

--- a/Workbooks/Online Experimentation/Experiment Status/Experiment Status.workbook
+++ b/Workbooks/Online Experimentation/Experiment Status/Experiment Status.workbook
@@ -26,6 +26,21 @@
             },
             "jsonData": "[\"True\", \"False\"]",
             "value": "False"
+          },
+          {
+            "version": "KqlParameterItem/1.0",
+            "name": "HideLabel",
+            "type": 2,
+            "description": "Hide Label picker",
+            "isHiddenWhenLocked": true,
+            "typeSettings": {
+              "additionalResourceOptions": [],
+              "showDefault": false
+            },
+            "jsonData": "[\"True\", \"False\"]",
+            "value": "False",
+            "label": "Hide Label picker",
+            "id": "90156714-090d-4e69-bb6d-1214c5c3a5e6"
           }
         ],
         "style": "above",
@@ -42,6 +57,9 @@
       "type": 9,
       "content": {
         "version": "KqlParameterItem/1.0",
+        "crossComponentResources": [
+          "value::selected"
+        ],
         "parameters": [
           {
             "id": "f8faca65-a2fb-4809-9403-b7201691c7bd",
@@ -84,6 +102,9 @@
       "type": 9,
       "content": {
         "version": "KqlParameterItem/1.0",
+        "crossComponentResources": [
+          "{Workspace}"
+        ],
         "parameters": [
           {
             "id": "27148a8c-f028-4723-9cc0-735033a53ce7",
@@ -125,7 +146,7 @@
             "type": 2,
             "description": "Select the feature flag to analyze",
             "isRequired": true,
-            "query": "OEWExperimentScorecards\r\n| summarize LatestScorecard=max(TimeGenerated) by FeatureName\r\n| order by LatestScorecard desc, FeatureName asc\r\n| project FeatureName",
+            "query": "AppEvents\r\n| extend FeatureName = tostring(Properties['FeatureName'])\r\n| where FeatureName != \"\"\r\n| summarize LatestScorecard=max(TimeGenerated) by FeatureName\r\n| order by LatestScorecard desc, FeatureName asc\r\n| project FeatureName",
             "crossComponentResources": [
               "{Workspace}"
             ],
@@ -134,8 +155,7 @@
               "showDefault": false
             },
             "queryType": 0,
-            "resourceType": "microsoft.operationalinsights/workspaces",
-            "value": "system_prompt"
+            "resourceType": "microsoft.operationalinsights/workspaces"
           }
         ],
         "style": "above",
@@ -149,10 +169,57 @@
       }
     },
     {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "crossComponentResources": [
+          "{Workspace}"
+        ],
+        "parameters": [
+          {
+            "id": "2b2553e9-e276-4a7e-8820-b30b7beca46e",
+            "version": "KqlParameterItem/1.0",
+            "name": "Label",
+            "type": 2,
+            "description": "Select Label to analyze",
+            "isRequired": true,
+            "query": "AppEvents\n| where TimeGenerated between ({TimeRange:start} .. {TimeRange:end})\n| where Properties['FeatureName'] == '{FeatureName}'\n| extend Label = tostring(parse_url(tostring(Properties.FeatureFlagReference))['Query Parameters']['label'])\n| summarize LatestScorecard=max(TimeGenerated) by Label\n| order by LatestScorecard desc, Label asc\n| project Label = iff(Label == \"\", \"<empty>\", Label)",
+            "crossComponentResources": [
+              "{Workspace}"
+            ],
+            "typeSettings": {
+              "additionalResourceOptions": [],
+              "showDefault": false
+            },
+            "timeContext": {
+              "durationMs": 2592000000
+            },
+            "queryType": 0,
+            "resourceType": "microsoft.operationalinsights/workspaces",
+            "value": "<empty>"
+          }
+        ],
+        "style": "above",
+        "queryType": 0,
+        "resourceType": "microsoft.operationalinsights/workspaces"
+      },
+      "conditionalVisibility": {
+        "parameterName": "HideLabel",
+        "comparison": "isNotEqualTo",
+        "value": "True"
+      },
+      "customWidth": "0",
+      "name": "Parameters - Select label",
+      "styleSettings": {
+        "margin": "5",
+        "padding": "0"
+      }
+    },
+    {
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let LatestSummaryTime = OEWExperimentAssignmentSummary_CL\r\n| where FeatureName == '{FeatureName}'\r\n| summarize _BinStartTime = max(_BinStartTime), _BinSize = take_any(_BinSize)\r\n| project coalesce(_BinStartTime + make_timespan(0, _BinSize), bin(now(), 30m));\r\nlet FinalSummary = AppEvents\r\n| where TimeGenerated between (max_of({TimeRange:start}, toscalar(LatestSummaryTime)) .. {TimeRange:end})\r\n| where Name == 'FeatureEvaluation'\r\n| where Properties has 'Percentile'\r\n| where tostring(Properties.FeatureName) == '{FeatureName}'\r\n| where tostring(Properties.VariantAssignmentReason) == 'Percentile'\r\n| where tostring(Properties.TargetingId) != ''\r\n| where tostring(Properties.Enabled) == 'True'\r\n| where tostring(Properties.AllocationId) != ''\r\n| where toint(Properties.VariantAssignmentPercentage) < 100\r\n| project\r\n    TimeGenerated,\r\n    ItemCount,\r\n    FeatureFlagReference = tostring(Properties.FeatureFlagReference),\r\n    FeatureName = tostring(Properties.FeatureName),\r\n    AllocationId = tostring(Properties.AllocationId),\r\n    Variant = tostring(Properties.Variant),\r\n    VariantAssignmentPercentage = toreal(Properties.VariantAssignmentPercentage),\r\n    IsControlVariant = tostring(Properties.DefaultWhenEnabled) == tostring(Properties.Variant)\r\n| summarize\r\n    TimeGenerated = {TimeRange:end},\r\n    VariantAssignmentPercentage = take_any(VariantAssignmentPercentage),\r\n    IsControlVariant = take_any(IsControlVariant),\r\n    AssignmentEventCount = tolong(sum(ItemCount)),\r\n    FirstAssignmentTimestamp = min(TimeGenerated),\r\n    LastAssignmentTimestamp = max(TimeGenerated)\r\n    by FeatureFlagReference, FeatureName, AllocationId, Variant\r\n;\r\nlet variant_ts = OEWExperimentAssignmentSummary_CL\r\n| where TimeGenerated between ({TimeRange:start} .. {TimeRange:end})\r\n| where FeatureName == '{FeatureName}'\r\n| union FinalSummary\r\n| make-series\r\n    AssignmentCountSeries = sum(AssignmentEventCount) default=0\r\n    on TimeGenerated from {TimeRange:start} to {TimeRange:end} step {TimeRange:grain}\r\n    by FeatureName, AllocationId, Variant\r\n| project-away TimeGenerated\r\n;\r\nlet allocation_ts = variant_ts\r\n| mv-expand with_itemindex=i AssignmentCount = AssignmentCountSeries to typeof(long)\r\n| summarize AssignmentCount = sum(AssignmentCount) by FeatureName, AllocationId, i\r\n| summarize AssignmentCountSeries = make_list(AssignmentCount) by FeatureName, AllocationId\r\n;\r\nlet feature_ts = allocation_ts\r\n| mv-expand with_itemindex=i AssignmentCount = AssignmentCountSeries to typeof(long)\r\n| summarize AssignmentCount = sum(AssignmentCount) by FeatureName, i\r\n| summarize AssignmentCountSeries = make_list(AssignmentCount) by FeatureName\r\n;\r\nlet scorecards = OEWExperimentScorecards\r\n| where TimeGenerated > {TimeRange:start} - 7d\r\n| where FeatureName == '{FeatureName}'\r\n| distinct FeatureName, AllocationId\r\n| project FeatureName, AllocationId\r\n;\r\nlet variants = OEWExperimentAssignmentSummary_CL\r\n| where TimeGenerated between ({TimeRange:start} .. {TimeRange:end})\r\n| where FeatureName == '{FeatureName}'\r\n| union FinalSummary\r\n| summarize\r\n    Kind = strcat(\r\n        iff(take_any(IsControlVariant), 'Control', 'Treatment'),\r\n        ' (', toint(take_any(VariantAssignmentPercentage)), ' %)'\r\n    ),\r\n    EarliestAssignment = min(FirstAssignmentTimestamp),\r\n    LatestAssignment = max(LastAssignmentTimestamp),\r\n    AssignmentEventCount = sum(AssignmentEventCount)\r\n    by FeatureName, AllocationId, Variant\r\n// add hierarchy identifiers\r\n| extend\r\n    ID = strcat(FeatureName, '-', AllocationId, '-', Variant),\r\n    PARENT = strcat(FeatureName, '-', AllocationId),\r\n    Name = strcat('💊 ', Variant)\r\n// join to time series\r\n| join kind=leftouter variant_ts on FeatureName, AllocationId, Variant\r\n| project-away FeatureName1, AllocationId1, Variant1\r\n// join to scorecards\r\n| join kind=leftouter scorecards on FeatureName, AllocationId\r\n| extend Analysis = iff(isnotempty(AllocationId1), 'Available', 'Pending')\r\n| extend FeatureOrder = 9999999\r\n| project-away FeatureName1, AllocationId1\r\n;\r\nlet allocations = variants\r\n| summarize\r\n    Kind = 'Experiment',\r\n    EarliestAssignment = min(EarliestAssignment),\r\n    LatestAssignment = max(LatestAssignment),\r\n    AssignmentEventCount = sum(AssignmentEventCount)\r\n    by FeatureName, AllocationId\r\n// add hierarchy identifiers\r\n| extend\r\n    ID = strcat(FeatureName, '-', AllocationId),\r\n    PARENT = ''\r\n| order by PARENT, EarliestAssignment asc\r\n| extend Name = strcat('🔬 Iteration ', row_number(1, prev(PARENT) != PARENT), ' (', AllocationId, ')')\r\n// join to time series\r\n| join kind=leftouter allocation_ts on FeatureName, AllocationId\r\n| project-away FeatureName1, AllocationId1\r\n// join to scorecards\r\n| join kind=leftouter scorecards on FeatureName, AllocationId\r\n| extend Analysis = iff(isnotempty(AllocationId1), 'Available', 'Pending')\r\n| extend FeatureOrder = 9999999\r\n| project-away FeatureName1, AllocationId1\r\n;\r\nlet features = allocations\r\n| summarize\r\n    Kind = 'Feature Flag',\r\n    EarliestAssignment = min(EarliestAssignment),\r\n    LatestIteration = arg_max(EarliestAssignment, AllocationId),\r\n    LatestAssignment = max(LatestAssignment),\r\n    AssignmentEventCount = sum(AssignmentEventCount)\r\n    by FeatureName\r\n| project-away LatestIteration\r\n// add hierarchy identifiers\r\n| extend\r\n    ID = FeatureName,\r\n    PARENT = '',\r\n    Name = strcat('✨ ', FeatureName)\r\n| order by LatestAssignment desc\r\n| extend FeatureOrder = row_number()\r\n// join to time series\r\n| join kind=leftouter feature_ts on FeatureName\r\n| project-away FeatureName1\r\n// join to scorecards\r\n| join kind=leftouter scorecards on FeatureName, AllocationId\r\n| extend Analysis = iff(isnotempty(FeatureName1), 'Available', 'Pending')\r\n| project-away FeatureName1\r\n;\r\nvariants\r\n| union allocations\r\n| union features\r\n| order by FeatureOrder asc, Kind startswith 'Control' desc, Variant asc\r\n| extend TimeSinceActivity = iff(AssignmentEventCount > 0, now() - LatestAssignment, timespan(null)),\r\n    Duration = LatestAssignment - EarliestAssignment, \r\n    EarliestAssignment = format_datetime(EarliestAssignment, 'MM/dd/yyyy h:mm tt'), \r\n    LatestAssignment = format_datetime(LatestAssignment, 'MM/dd/yyyy h:mm tt')\r\n| project\r\n    ID, PARENT, Name, Kind,\r\n    FeatureName, AllocationId, Variant,\r\n    DaysSinceActivity = TimeSinceActivity / 1d,\r\n    TimeSinceActivityFormatted = case(\r\n        abs(TimeSinceActivity) > 1d, strcat(round(TimeSinceActivity / 1d, 1), ' days'),\r\n        abs(TimeSinceActivity) > 1h, strcat(round(TimeSinceActivity / 1h, 1), ' hours'),\r\n        isnotnull(TimeSinceActivity), strcat(round(TimeSinceActivity / 1m, 1), ' mins'),\r\n        ''\r\n    ),\r\n    DurationFormatted = case(\r\n        abs(Duration) > 1d, strcat(round(Duration / 1d, 1), ' days'),\r\n        abs(Duration) > 1h, strcat(round(Duration / 1h, 1), ' hours'),\r\n        isnotnull(Duration), strcat(round(Duration / 1m, 1), ' mins'),\r\n        ''\r\n    ),\r\n    AssignmentEventCount, AssignmentCountSeries,\r\n    Analysis,\r\n    EarliestAssignment = EarliestAssignment,\r\n    LatestAssignment = LatestAssignment,\r\n    Details = bag_pack(\"AssignmentEventCount\", AssignmentEventCount, \"EarliestAssignment\", EarliestAssignment, \"LatestAssignment\", LatestAssignment)\r\n",
+        "query": "let LatestSummaryTime = OEWExperimentAssignmentSummary_CL\r\n| where FeatureName == '{FeatureName}'\r\n| where Label == iff('{Label}' == '<empty>', '', '{Label}')\r\n| summarize _BinStartTime = max(_BinStartTime), _BinSize = take_any(_BinSize)\r\n| project coalesce(_BinStartTime + make_timespan(0, _BinSize), bin(now(), 30m));\r\nlet FinalSummary = AppEvents\r\n| where TimeGenerated between (max_of({TimeRange:start}, toscalar(LatestSummaryTime)) .. {TimeRange:end})\r\n| where Name == 'FeatureEvaluation'\r\n| where Properties has 'Percentile'\r\n| where tostring(Properties.FeatureName) == '{FeatureName}'\r\n| where parse_url(tostring(Properties.FeatureFlagReference))['Query Parameters']['label'] == iff('{Label}' == '<empty>', '', '{Label}')\r\n| where tostring(Properties.VariantAssignmentReason) == 'Percentile'\r\n| where tostring(Properties.TargetingId) != ''\r\n| where tostring(Properties.Enabled) == 'True'\r\n| where tostring(Properties.AllocationId) != ''\r\n| where toint(Properties.VariantAssignmentPercentage) < 100\r\n| project\r\n    TimeGenerated,\r\n    ItemCount,\r\n    FeatureFlagReference = tostring(Properties.FeatureFlagReference),\r\n    FeatureName = tostring(Properties.FeatureName),\r\n    AllocationId = tostring(Properties.AllocationId),\r\n    Variant = tostring(Properties.Variant),\r\n    VariantAssignmentPercentage = toreal(Properties.VariantAssignmentPercentage),\r\n    IsControlVariant = tostring(Properties.DefaultWhenEnabled) == tostring(Properties.Variant)\r\n| summarize\r\n    TimeGenerated = {TimeRange:end},\r\n    VariantAssignmentPercentage = take_any(VariantAssignmentPercentage),\r\n    IsControlVariant = take_any(IsControlVariant),\r\n    AssignmentEventCount = tolong(sum(ItemCount)),\r\n    FirstAssignmentTimestamp = min(TimeGenerated),\r\n    LastAssignmentTimestamp = max(TimeGenerated)\r\n    by FeatureFlagReference, FeatureName, AllocationId, Variant\r\n;\r\nlet variant_ts = OEWExperimentAssignmentSummary_CL\r\n| where TimeGenerated between ({TimeRange:start} .. {TimeRange:end})\r\n| where FeatureName == '{FeatureName}'\r\n| where Label == iff('{Label}' == '<empty>', '', '{Label}')\r\n| union FinalSummary\r\n| make-series\r\n    AssignmentCountSeries = sum(AssignmentEventCount) default=0\r\n    on TimeGenerated from {TimeRange:start} to {TimeRange:end} step {TimeRange:grain}\r\n    by FeatureName, AllocationId, Variant\r\n| project-away TimeGenerated\r\n;\r\nlet allocation_ts = variant_ts\r\n| mv-expand with_itemindex=i AssignmentCount = AssignmentCountSeries to typeof(long)\r\n| summarize AssignmentCount = sum(AssignmentCount) by FeatureName, AllocationId, i\r\n| summarize AssignmentCountSeries = make_list(AssignmentCount) by FeatureName, AllocationId\r\n;\r\nlet feature_ts = allocation_ts\r\n| mv-expand with_itemindex=i AssignmentCount = AssignmentCountSeries to typeof(long)\r\n| summarize AssignmentCount = sum(AssignmentCount) by FeatureName, i\r\n| summarize AssignmentCountSeries = make_list(AssignmentCount) by FeatureName\r\n;\r\nlet scorecards = OEWExperimentScorecards\r\n| where TimeGenerated > {TimeRange:start} - 7d\r\n| where FeatureName == '{FeatureName}'\r\n| where Label == iff('{Label}' == '<empty>', '', '{Label}')\r\n| distinct FeatureName, AllocationId\r\n| project FeatureName, AllocationId\r\n;\r\nlet variants = OEWExperimentAssignmentSummary_CL\r\n| where TimeGenerated between ({TimeRange:start} .. {TimeRange:end})\r\n| where FeatureName == '{FeatureName}'\r\n| where Label == iff('{Label}' == '<empty>', '', '{Label}')\r\n| union FinalSummary\r\n| summarize\r\n    Kind = strcat(\r\n        iff(take_any(IsControlVariant), 'Control', 'Treatment'),\r\n        ' (', toint(take_any(VariantAssignmentPercentage)), ' %)'\r\n    ),\r\n    EarliestAssignment = min(FirstAssignmentTimestamp),\r\n    LatestAssignment = max(LastAssignmentTimestamp),\r\n    AssignmentEventCount = sum(AssignmentEventCount)\r\n    by FeatureName, AllocationId, Variant\r\n// add hierarchy identifiers\r\n| extend\r\n    ID = strcat(FeatureName, '-', AllocationId, '-', Variant),\r\n    PARENT = strcat(FeatureName, '-', AllocationId),\r\n    Name = strcat('💊 ', Variant)\r\n// join to time series\r\n| join kind=leftouter variant_ts on FeatureName, AllocationId, Variant\r\n| project-away FeatureName1, AllocationId1, Variant1\r\n// join to scorecards\r\n| join kind=leftouter scorecards on FeatureName, AllocationId\r\n| extend Analysis = iff(isnotempty(AllocationId1), 'Available', 'Pending')\r\n| extend FeatureOrder = 9999999\r\n| project-away FeatureName1, AllocationId1\r\n;\r\nlet allocations = variants\r\n| summarize\r\n    Kind = 'Experiment',\r\n    EarliestAssignment = min(EarliestAssignment),\r\n    LatestAssignment = max(LatestAssignment),\r\n    AssignmentEventCount = sum(AssignmentEventCount)\r\n    by FeatureName, AllocationId\r\n// add hierarchy identifiers\r\n| extend\r\n    ID = strcat(FeatureName, '-', AllocationId),\r\n    PARENT = ''\r\n| order by PARENT, EarliestAssignment asc\r\n| extend Name = strcat('🔬 Iteration ', row_number(1, prev(PARENT) != PARENT), ' (', AllocationId, ')')\r\n// join to time series\r\n| join kind=leftouter allocation_ts on FeatureName, AllocationId\r\n| project-away FeatureName1, AllocationId1\r\n// join to scorecards\r\n| join kind=leftouter scorecards on FeatureName, AllocationId\r\n| extend Analysis = iff(isnotempty(AllocationId1), 'Available', 'Pending')\r\n| extend FeatureOrder = 9999999\r\n| project-away FeatureName1, AllocationId1\r\n;\r\nlet features = allocations\r\n| summarize\r\n    Kind = 'Feature Flag',\r\n    EarliestAssignment = min(EarliestAssignment),\r\n    LatestIteration = arg_max(EarliestAssignment, AllocationId),\r\n    LatestAssignment = max(LatestAssignment),\r\n    AssignmentEventCount = sum(AssignmentEventCount)\r\n    by FeatureName\r\n| project-away LatestIteration\r\n// add hierarchy identifiers\r\n| extend\r\n    ID = FeatureName,\r\n    PARENT = '',\r\n    Name = strcat('✨ ', FeatureName)\r\n| order by LatestAssignment desc\r\n| extend FeatureOrder = row_number()\r\n// join to time series\r\n| join kind=leftouter feature_ts on FeatureName\r\n| project-away FeatureName1\r\n// join to scorecards\r\n| join kind=leftouter scorecards on FeatureName, AllocationId\r\n| extend Analysis = iff(isnotempty(FeatureName1), 'Available', 'Pending')\r\n| project-away FeatureName1\r\n;\r\nvariants\r\n| union allocations\r\n| union features\r\n| order by FeatureOrder asc, Kind startswith 'Control' desc, Variant asc\r\n| extend TimeSinceActivity = iff(AssignmentEventCount > 0, now() - LatestAssignment, timespan(null)),\r\n    Duration = LatestAssignment - EarliestAssignment, \r\n    EarliestAssignment = format_datetime(EarliestAssignment, 'MM/dd/yyyy h:mm tt'), \r\n    LatestAssignment = format_datetime(LatestAssignment, 'MM/dd/yyyy h:mm tt')\r\n| project\r\n    ID, PARENT, Name, Kind,\r\n    FeatureName, AllocationId, Variant,\r\n    DaysSinceActivity = TimeSinceActivity / 1d,\r\n    TimeSinceActivityFormatted = case(\r\n        abs(TimeSinceActivity) > 1d, strcat(round(TimeSinceActivity / 1d, 1), ' days'),\r\n        abs(TimeSinceActivity) > 1h, strcat(round(TimeSinceActivity / 1h, 1), ' hours'),\r\n        isnotnull(TimeSinceActivity), strcat(round(TimeSinceActivity / 1m, 1), ' mins'),\r\n        ''\r\n    ),\r\n    DurationFormatted = case(\r\n        abs(Duration) > 1d, strcat(round(Duration / 1d, 1), ' days'),\r\n        abs(Duration) > 1h, strcat(round(Duration / 1h, 1), ' hours'),\r\n        isnotnull(Duration), strcat(round(Duration / 1m, 1), ' mins'),\r\n        ''\r\n    ),\r\n    AssignmentEventCount, AssignmentCountSeries,\r\n    Analysis,\r\n    EarliestAssignment = EarliestAssignment,\r\n    LatestAssignment = LatestAssignment,\r\n    Details = bag_pack(\"AssignmentEventCount\", AssignmentEventCount, \"EarliestAssignment\", EarliestAssignment, \"LatestAssignment\", LatestAssignment)\r\n",
         "size": 2,
         "showAnalytics": true,
         "noDataMessage": "No experiments found",


### PR DESCRIPTION
## Summary

- Add label filter to online experimentation workbook
- Swtich to AppEvent in dropdown to enable system prompt and label be picked up faster when assignment is not summarized.

## Screenshots
![image](https://github.com/user-attachments/assets/66c615ec-a0a2-4682-8404-d54eb6f9bea1)
![image](https://github.com/user-attachments/assets/22f820ac-a76d-4b24-8757-051ca67b2b52)


- [ ] If you added a template to a gallery, show a screenshot of it in the gallery view (which verifies its shows up where you expected).

  It is also good to show a screenshot of template content, so people can see what you expect it to look like, compared to what they see when they might run it themselves.

## Validation

- [ ] Validate your changes using one or more of the [testing](https://github.com/microsoft/Application-Insights-Workbooks/blob/master/Documentation/Testing.md) methods.
  
  Make sure you've tested your template content. Fixing things while in PR is trivial. Hotfixing it later is very expensive; at the current time at least 3 teams are involved in a hotfix!

## Checklist

- [ ] If you are adding a new template, gallery, or folder, add your team and folder/file(s) to the CODEOWNERS file at the root of the repo. CODEOWNERS entries should be teams, not individuals.
      When done correctly, this means that from then on *your* team does reviews of *your* things, not the workbooks team.
- [ ] Ensure all steps in your template have meaningful names.
- [ ] Ensure all parameters and grid columns have display names set so they can be localized.
