### PR TITLE
Patch 2

### DIFF
--- a/Workbooks/Usage/Analysis of Page Views/Analysis of Page Views.workbook
+++ b/Workbooks/Usage/Analysis of Page Views/Analysis of Page Views.workbook
@@ -178,7 +178,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "let pages = dynamic([{Pages}]);\nlet allEvents = pageViews\n| where timestamp {TimeRange};\nlet interestingEvents = allEvents\n| where array_length(pages)==0 or name in (pages) or '*' in (pages) \n{OtherFilters};\ninterestingEvents\n| summarize Users = dcount(user_Id), Sessions = dcount(session_Id), Instances = count() by name\n| extend rank = 2, name = strcat('🔷 ', name)\n| union (interestingEvents\n        | summarize Users = dcount(user_Id), Sessions = dcount(session_Id), Instances = count()\n        | extend name = '🔶 Overall', rank = 1)\n| extend jkey = 1\n| join kind = inner (allEvents \n                    | summarize AllUsers = dcount(user_Id), AllSessions = dcount(session_Id), AllInstances = count()\n                    | extend jkey = 1) on jkey \n| project ['Page Name'] = name, ['Unique Users'] = Users, ['As % of app Users'] = round(100.0 * Users / AllUsers, 2),\n          ['Unique Sessions'] = Sessions, ['As % of app Sessions'] = round(100.0 * Sessions / AllSessions, 2),\n          ['Total Page Views'] = Instances , ['As % of app Page Views'] = round(100.0 * Instances / AllInstances, 2), rank\n| order by rank asc, ['Unique Users'] desc\n| project-away rank",
+              "query": "let pages = dynamic([{Pages}]);\nlet allEvents = pageViews\n| where timestamp {TimeRange};\nlet interestingEvents = allEvents\n| where array_length(pages)==0 or name in (pages) or '*' in (pages) \n{OtherFilters};\ninterestingEvents\n| summarize Users = dcount(user_AuthenticatedId), Sessions = dcount(session_Id), Instances = count() by name\n| extend rank = 2, name = strcat('🔷 ', name)\n| union (interestingEvents\n        | summarize Users = dcount(user_AuthenticatedId), Sessions = dcount(session_Id), Instances = count()\n        | extend name = '🔶 Overall', rank = 1)\n| extend jkey = 1\n| join kind = inner (allEvents \n                    | summarize AllUsers = dcount(user_AuthenticatedId), AllSessions = dcount(session_Id), AllInstances = count()\n                    | extend jkey = 1) on jkey \n| project ['Page Name'] = name, ['Unique Users'] = Users, ['As % of app Users'] = round(100.0 * Users / AllUsers, 2),\n          ['Unique Sessions'] = Sessions, ['As % of app Sessions'] = round(100.0 * Sessions / AllSessions, 2),\n          ['Total Page Views'] = Instances , ['As % of app Page Views'] = round(100.0 * Instances / AllInstances, 2), rank\n| order by rank asc, ['Unique Users'] desc\n| project-away rank",
               "size": 0,
               "showAnalytics": true,
               "title": "Page Views by Page Name",
@@ -406,7 +406,7 @@
                   "type": 2,
                   "description": "For users, the first use is calculated as the first use within the time range. It is possible that the user started using your app before the time range.",
                   "isRequired": true,
-                  "query": "datatable(x:string, y:string)[\n'session_Id', 'Start of the Session',\n'user_Id', 'First use by Anonymous User ⚠️',\n'user_AuthenticatedId', 'First use by Authenticated User ⚠️',\n];",
+                  "query": "datatable(x:string, y:string)[\n'session_Id', 'Start of the Session',\n'user_AuthenticatedId', 'First use by Anonymous User ⚠️',\n'user_AuthenticatedId', 'First use by Authenticated User ⚠️',\n];",
                   "value": "session_Id",
                   "resourceType": "microsoft.insights/components"
                 }

--- a/Workbooks/Usage/Analysis of Page Views/Analysis of Page Views.workbook
+++ b/Workbooks/Usage/Analysis of Page Views/Analysis of Page Views.workbook
@@ -406,7 +406,7 @@
                   "type": 2,
                   "description": "For users, the first use is calculated as the first use within the time range. It is possible that the user started using your app before the time range.",
                   "isRequired": true,
-                  "query": "datatable(x:string, y:string)[\n'session_Id', 'Start of the Session',\n'user_AuthenticatedId', 'First use by Anonymous User ⚠️',\n'user_AuthenticatedId', 'First use by Authenticated User ⚠️',\n];",
+                  "query": "datatable(x:string, y:string)[\n'session_Id', 'Start of the Session',\n'user_Id', 'First use by Anonymous User ⚠️',\n'user_AuthenticatedId', 'First use by Authenticated User ⚠️',\n];",
                   "value": "session_Id",
                   "resourceType": "microsoft.insights/components"
                 }


### PR DESCRIPTION
Unique users was using user_Id which over reports the number of users since each user can have multiple user_Id's I think user_AuthenticatedId should be used which will accurately report the number of users viewing the page.