### PR TITLE
updating in context pane to false

### DIFF
--- a/Workbooks/CosmosDb Fleet/Overview.workbook
+++ b/Workbooks/CosmosDb Fleet/Overview.workbook
@@ -460,7 +460,7 @@
                 "linkTarget": "Resource",
                 "subTarget": "advisorRecommendations",
                 "linkLabel": "➡️",
-                "linkIsContextBlade": true,
+                "linkIsContextBlade": false,
                 "customColumnWidthSetting": "8.9996ch"
               }
             },
@@ -471,7 +471,7 @@
                 "linkTarget": "Resource",
                 "subTarget": "advisorRecommendations",
                 "linkLabel": "",
-                "linkIsContextBlade": true
+                "linkIsContextBlade": false
               }
             },
             {

--- a/Workbooks/CosmosDb/Overview/Overview.workbook
+++ b/Workbooks/CosmosDb/Overview/Overview.workbook
@@ -526,7 +526,7 @@
                 "linkTarget": "Resource",
                 "subTarget": "advisorRecommendations",
                 "linkLabel": "➡️",
-                "linkIsContextBlade": true,
+                "linkIsContextBlade": false,
                 "customColumnWidthSetting": "8.9996ch"
               }
             },
@@ -548,7 +548,7 @@
                 "linkTarget": "Resource",
                 "subTarget": "advisorRecommendations",
                 "linkLabel": "➡️",
-                "linkIsContextBlade": true
+                "linkIsContextBlade": false
               }
             },
             {


### PR DESCRIPTION
## Summary

https://msazure.visualstudio.com/One/_workitems/edit/33409794
Right now you have the links inside the Azure Advisor Recommendations  opening up a menu blade in a side context pane. This causes  alot of weird portal issues as the portal doesn't expect menu items to be opened in a context pane. Making change for link to open in a full window instead.

## Screenshots

- [ ] If you added a template to a gallery, show a screenshot of it in the gallery view (which verifies its shows up where you expected).

  It is also good to show a screenshot of template content, so people can see what you expect it to look like, compared to what they see when they might run it themselves.

## Validation

- [ ] Validate your changes using one or more of the [testing](https://github.com/microsoft/Application-Insights-Workbooks/blob/master/Documentation/Testing.md) methods.
  
  Make sure you've tested your template content. Fixing things while in PR is trivial. Hotfixing it later is very expensive; at the current time at least 3 teams are involved in a hotfix!

## Checklist

- [ ] If you are adding a new template, gallery, or folder, add your team and folder/file(s) to the CODEOWNERS file at the root of the repo. CODEOWNERS entries should be teams, not individuals.
      When done correctly, this means that from then on *your* team does reviews of *your* things, not the workbooks team.
- [ ] Ensure all steps in your template have meaningful names.
- [ ] Ensure all parameters and grid columns have display names set so they can be localized.
