### PR TITLE
Add Customer Statsbeat Basic Success/Failure Report

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -136,6 +136,8 @@
 
 /Workbooks/Online*Experimentation/** @microsoft/exp-devs
 
+/Workbooks/Azure*Monitor*-*Workspaces/Customer*Statsbeat*Insights/** @microsoft/telreachsdk
+
 # Section for gallery files
 /gallery/workbook/WaaSUpdateInsights.json @microsoft/update-compliance-workbooks
 /gallery/workbook/Azure*Monitor.json @microsoft/applicationinsights-devtools

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -136,7 +136,7 @@
 
 /Workbooks/Online*Experimentation/** @microsoft/exp-devs
 
-/Workbooks/Azure*Monitor*-*Workspaces/Customer*Statsbeat*Insights/** @microsoft/telreachsdk
+/Workbooks/Azure*Monitor*-*Workspaces/Customer*Statsbeat*Insights/** @microsoft/TelReach-Devs
 
 # Section for gallery files
 /gallery/workbook/WaaSUpdateInsights.json @microsoft/update-compliance-workbooks

--- a/Workbooks/Azure Monitor - Workspaces/Customer Statsbeat Insights/Customer Statsbeat Insights.workbook
+++ b/Workbooks/Azure Monitor - Workspaces/Customer Statsbeat Insights/Customer Statsbeat Insights.workbook
@@ -1,0 +1,31 @@
+{
+  "version": "Notebook/1.0",
+  "items": [
+    {
+      "type": 1,
+      "content": {
+        "json": "## Customer Statsbeat\n---\nThe Customer Statsbeat workbook provides a clear visualization of success and failure metrics for your application. It leverages the Azure Monitor SDK to track and chart two key custom metrics: preview.item.success.count and preview.item.dropped.count. This workbook helps teams monitor operational health, identify trends, and quickly detect anomalies in customer-facing processes by displaying these metrics over time in an intuitive line chart format.\n"
+      },
+      "name": "text - 2"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "customMetrics\n| where name in (\"preview.item.dropped.count\", \"preview.item.success.count\")\n| summarize total_count = sum(value) by name, bin(timestamp, 1m)\n| project timestamp, name, total_count\n| render timechart",
+        "size": 1,
+        "title": "Telemetry Export Success Count",
+        "timeContext": {
+          "durationMs": 2592000000
+        },
+        "queryType": 0,
+        "resourceType": "microsoft.insights/components"
+      },
+      "name": "Success and Failure Count"
+    }
+  ],
+  "fallbackResourceIds": [
+    "/subscriptions/65b2f83e-7bf1-4be3-bafc-3a4163265a52/resourceGroups/jacksonweber/providers/microsoft.insights/components/jackson-test-application-insights"
+  ],
+  "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
+}

--- a/Workbooks/Azure Monitor - Workspaces/Customer Statsbeat Insights/Customer Statsbeat Insights.workbook
+++ b/Workbooks/Azure Monitor - Workspaces/Customer Statsbeat Insights/Customer Statsbeat Insights.workbook
@@ -12,7 +12,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "customMetrics\n| where name in (\"preview.item.dropped.count\", \"preview.item.success.count\")\n| summarize total_count = sum(value) by name, bin(timestamp, 1m)\n| project timestamp, name, total_count\n| render timechart",
+        "query": "customMetrics\n| where name in (\"preview.item.dropped.count\", \"preview.item.success.count\")\n| summarize total_count = sum(value) by name, bin(timestamp, 1m)\n| extend display_name = case(\n    name == \"preview.item.success.count\", \"success count\",\n    name == \"preview.item.dropped.count\", \"dropped count\",\n    name\n)\n| project timestamp, name = display_name, total_count\n| render timechart",
         "size": 1,
         "title": "Telemetry Export Success Count",
         "timeContext": {

--- a/Workbooks/Azure Monitor - Workspaces/Customer Statsbeat Insights/Customer Statsbeat Insights.workbook
+++ b/Workbooks/Azure Monitor - Workspaces/Customer Statsbeat Insights/Customer Statsbeat Insights.workbook
@@ -24,8 +24,5 @@
       "name": "Success and Failure Count"
     }
   ],
-  "fallbackResourceIds": [
-    "/subscriptions/65b2f83e-7bf1-4be3-bafc-3a4163265a52/resourceGroups/jacksonweber/providers/microsoft.insights/components/jackson-test-application-insights"
-  ],
   "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
 }


### PR DESCRIPTION
## Summary

This pull request introduces a new workbook for Azure Monitor called "Customer Statsbeat Insights." The workbook provides a visualization of success and failure metrics for applications using Azure Monitor SDK, helping teams monitor operational health and detect anomalies.

### Addition of a new workbook:

* [`Workbooks/Azure Monitor - Workspaces/Customer Statsbeat Insights/Customer Statsbeat Insights.workbook`](diffhunk://#diff-1285dca1f06c0b0596db15d4d98f97a4102cec43506091d9c99d6d9700e89005R1-R28): Added a new workbook that tracks two custom metrics (`preview.item.success.count` and `preview.item.dropped.count`) and visualizes them in a time-series chart. The workbook includes a description, a KQL query to fetch and summarize the metrics, and a time range of 30 days for analysis.

## Screenshots
<img width="1156" height="537" alt="image" src="https://github.com/user-attachments/assets/6c8acd77-10d5-4ad6-8503-917bd1960e61" />

- [x] If you added a template to a gallery, show a screenshot of it in the gallery view (which verifies its shows up where you expected).

## Validation

- [x] Validate your changes using one or more of the [testing](https://github.com/microsoft/Application-Insights-Workbooks/blob/master/Documentation/Testing.md) methods.
  
## Checklist

- [x] If you are adding a new template, gallery, or folder, add your team and folder/file(s) to the CODEOWNERS file at the root of the repo. CODEOWNERS entries should be teams, not individuals.
      When done correctly, this means that from then on *your* team does reviews of *your* things, not the workbooks team.
- [x] Ensure all steps in your template have meaningful names.
- [x] Ensure all parameters and grid columns have display names set so they can be localized.
