### PR TITLE
[database watcher] Hide a not applicable chart for Hyperscale databases

### DIFF
--- a/Workbooks/Database watcher/Azure SQL Database/database/database.workbook
+++ b/Workbooks/Database watcher/Azure SQL Database/database/database.workbook
@@ -5409,6 +5409,11 @@
               }
             },
             "customWidth": "50",
+            "conditionalVisibility": {
+              "parameterName": "isHyperscaleDatabase",
+              "comparison": "isNotEqualTo",
+              "value": "1"
+            },
             "name": "transaction_delay"
           },
           {
@@ -5430,11 +5435,18 @@
               "json": "|Metric|Description|\r\n|:-|:-|\r\n|`Transaction delay`|The average delay encountered by each transaction to guarantee that committed data is hardened in the transaction log of synchronous commit replicas. Applicable to availability group replicas with synchronous commit only.|\r\n\r\nData is collected from [sys.dm_os_performance_counters](https://go.microsoft.com/fwlink/?linkid=2198647)."
             },
             "customWidth": "50",
-            "conditionalVisibility": {
-              "parameterName": "showDescriptions",
-              "comparison": "isEqualTo",
-              "value": "true"
-            },
+            "conditionalVisibilities": [
+              {
+                "parameterName": "showDescriptions",
+                "comparison": "isEqualTo",
+                "value": "true"
+              },
+              {
+                "parameterName": "isHyperscaleDatabase",
+                "comparison": "isNotEqualTo",
+                "value": "1"
+              }
+            ],
             "name": "transactions_and_replicas_help_transaction_delay"
           },
           {


### PR DESCRIPTION
## Summary

The "Transaction delay" chart is populated only for databases that have a sync commit replica because the underlying performance counter isn't populated otherwise. Hyperscale databases can never have a sync commit replica, hence this chart is not applicable and is potentially misleading.

To avoid confusion, the following chart no longer appears for Hyperscale databases.

## Screenshots

<img width="1631" height="432" alt="image" src="https://github.com/user-attachments/assets/d10fee13-2902-463b-a33c-a4aac5f2ddef" />

- [x] If you added a template to a gallery, show a screenshot of it in the gallery view (which verifies its shows up where you expected).

## Validation

- [x] Validate your changes using one or more of the [testing](https://github.com/microsoft/Application-Insights-Workbooks/blob/master/Documentation/Testing.md) methods.
  
## Checklist

- [x] If you are adding a new template, gallery, or folder, add your team and folder/file(s) to the CODEOWNERS file at the root of the repo. CODEOWNERS entries should be teams, not individuals.
      When done correctly, this means that from then on *your* team does reviews of *your* things, not the workbooks team.
- [x] Ensure all steps in your template have meaningful names.
- [x] Ensure all parameters and grid columns have display names set so they can be localized.
