### PR TITLE
Add customer statsbeat workbook and add it to the insights-components…

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -67,6 +67,8 @@
 /Workbooks/UsageMetrics/** @microsoft/ApplicationInsights-PortalExperiences @microsoft/applicationinsights-devtools
 /Workbooks/WorkItems/** @microsoft/ApplicationInsights-PortalExperiences @microsoft/applicationinsights-devtools
 
+/Workbooks/Customer*Statsbeat/** @microsoft/TelReach-Devs
+
 /Workbooks/IoTHub/** @microsoft/iotedge-workbooks
 /Workbooks/IoT*Central/** @microsoft/iotedge-workbooks
 

--- a/Workbooks/Customer Statsbeat/Customer Statsbeat Insights.workbook
+++ b/Workbooks/Customer Statsbeat/Customer Statsbeat Insights.workbook
@@ -1,0 +1,28 @@
+{
+  "version": "Notebook/1.0",
+  "items": [
+    {
+      "type": 1,
+      "content": {
+        "json": "## Customer Statsbeat\n---\nThe Customer Statsbeat workbook provides a clear visualization of success and failure metrics for your application. It leverages the Azure Monitor SDK to track and chart two key custom metrics: preview.item.success.count and preview.item.dropped.count. This workbook helps teams monitor operational health, identify trends, and quickly detect anomalies in customer-facing processes by displaying these metrics over time in an intuitive line chart format.\n"
+      },
+      "name": "text - 2"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "customMetrics\n| where name in (\"preview.item.dropped.count\", \"preview.item.success.count\")\n| summarize total_count = sum(value) by name, bin(timestamp, 1m)\n| extend display_name = case(\n    name == \"preview.item.success.count\", \"success count\",\n    name == \"preview.item.dropped.count\", \"dropped count\",\n    name\n)\n| project timestamp, name = display_name, total_count\n| render timechart",
+        "size": 1,
+        "title": "Telemetry Export Success Count",
+        "timeContext": {
+          "durationMs": 2592000000
+        },
+        "queryType": 0,
+        "resourceType": "microsoft.insights/components"
+      },
+      "name": "Success and Failure Count"
+    }
+  ],
+  "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
+}

--- a/gallery/workbook/microsoft.insights-components.json
+++ b/gallery/workbook/microsoft.insights-components.json
@@ -258,6 +258,19 @@
 					"kind": "dashboard"
 				}
 			]
+		},
+		{
+			"id": "Customer Statsbeat Dashboards",
+			"name": "Customer Statsbeat Dashboards (Preview)",
+			"templates": [
+				{
+					"id": "Workbooks/Customer Statsbeat/Customer Statsbeat Insights",
+					"author": "Microsoft",
+					"description": "Customer Statsbeat Insights Dashboard",
+					"name": "Customer Statsbeat Insights",
+					"kind": "dashboard"
+				}
+			]
 		}
 	]
 }


### PR DESCRIPTION
## Summary

This pull request introduces a new workbook for monitoring customer-facing metrics and updates related ownership and gallery configuration files. The most important changes include the addition of a new "Customer Statsbeat Insights" workbook, updates to the `CODEOWNERS` file to assign ownership for the new workbook, and modifications to the gallery configuration to include the new workbook.

### Addition of the new "Customer Statsbeat Insights" workbook:
* Added a new workbook file, `Workbooks/Customer Statsbeat/Customer Statsbeat Insights.workbook`, which provides visualizations for success and failure metrics (`preview.item.success.count` and `preview.item.dropped.count`) using Azure Monitor SDK. The workbook includes a line chart rendering these metrics over time.

### Updates to ownership:
* Updated the `CODEOWNERS` file to assign the `@microsoft/TelReach-Devs` team as the owner of all files under the `Workbooks/Customer*Statsbeat/**` path.

### Updates to gallery configuration:
* Modified the `gallery/workbook/microsoft.insights-components.json` file to include the new "Customer Statsbeat Insights" workbook as a preview dashboard under the name "Customer Statsbeat Dashboards (Preview)."

## Screenshots

- [] If you added a template to a gallery, show a screenshot of it in the gallery view (which verifies its shows up where you expected).

  It is also good to show a screenshot of template content, so people can see what you expect it to look like, compared to what they see when they might run it themselves.

## Validation

- [ ] Validate your changes using one or more of the [testing](https://github.com/microsoft/Application-Insights-Workbooks/blob/master/Documentation/Testing.md) methods.
  
  Make sure you've tested your template content. Fixing things while in PR is trivial. Hotfixing it later is very expensive; at the current time at least 3 teams are involved in a hotfix!

## Checklist

- [ ] If you are adding a new template, gallery, or folder, add your team and folder/file(s) to the CODEOWNERS file at the root of the repo. CODEOWNERS entries should be teams, not individuals.
      When done correctly, this means that from then on *your* team does reviews of *your* things, not the workbooks team.
- [ ] Ensure all steps in your template have meaningful names.
- [ ] Ensure all parameters and grid columns have display names set so they can be localized.
