### PR TITLE
Fixing TimeRange in Insights Blade

### DIFF
--- a/Workbooks/CosmosDb Mongo vCore/Overview/Overview.workbook
+++ b/Workbooks/CosmosDb Mongo vCore/Overview/Overview.workbook
@@ -13,7 +13,6 @@
             "label": "Azure Cosmos DB",
             "type": 5,
             "isRequired": true,
-            "isGlobal": true,
             "isHiddenWhenLocked": true,
             "typeSettings": {
               "additionalResourceOptions": [

--- a/Workbooks/CosmosDb Mongo vCore/Overview/Overview.workbook
+++ b/Workbooks/CosmosDb Mongo vCore/Overview/Overview.workbook
@@ -13,13 +13,15 @@
             "label": "Azure Cosmos DB",
             "type": 5,
             "isRequired": true,
-            "value": "value::1",
+            "isGlobal": true,
             "isHiddenWhenLocked": true,
             "typeSettings": {
               "additionalResourceOptions": [
                 "value::1"
-              ]
-            }
+              ],
+              "showDefault": false
+            },
+            "value": "value::1"
           },
           {
             "id": "f5e823d5-9ac2-4aa2-9553-46f0529f9f2f",
@@ -73,35 +75,13 @@
           }
         ],
         "style": "above",
-        "queryType": 12
+        "queryType": 0,
+        "resourceType": "microsoft.operationalinsights/workspaces"
       },
       "name": "Container",
       "styleSettings": {
         "margin": "0px"
       }
-    },
-    {
-      "type": 9,
-      "content": {
-        "version": "KqlParameterItem/1.0",
-        "parameters": [
-          {
-            "id": "dcc7e5f0-4795-4311-a9b6-f38f0f7267ff",
-            "version": "KqlParameterItem/1.0",
-            "name": "selectedTab",
-            "type": 1,
-            "isHiddenWhenLocked": true,
-            "timeContext": {
-              "durationMs": 86400000
-            },
-            "value": ""
-          }
-        ],
-        "style": "pills",
-        "queryType": 0,
-        "resourceType": "microsoft.documentdb/databaseaccounts"
-      },
-      "name": "parameters - 13"
     },
     {
       "type": 11,
@@ -168,8 +148,9 @@
               "resourceIds": [
                 "{Resources}"
               ],
+              "timeContextFromParameter": "TimeRange",
               "timeContext": {
-                "durationMs": 3600000
+                "durationMs": 14400000
               },
               "metrics": [
                 {
@@ -199,8 +180,9 @@
               "resourceIds": [
                 "{Resources}"
               ],
+              "timeContextFromParameter": "TimeRange",
               "timeContext": {
-                "durationMs": 3600000
+                "durationMs": 14400000
               },
               "metrics": [
                 {
@@ -230,8 +212,9 @@
               "resourceIds": [
                 "{Resources}"
               ],
+              "timeContextFromParameter": "TimeRange",
               "timeContext": {
-                "durationMs": 3600000
+                "durationMs": 14400000
               },
               "metrics": [
                 {
@@ -261,8 +244,9 @@
               "resourceIds": [
                 "{Resources}"
               ],
+              "timeContextFromParameter": "TimeRange",
               "timeContext": {
-                "durationMs": 3600000
+                "durationMs": 14400000
               },
               "metrics": [
                 {
@@ -296,8 +280,9 @@
               "resourceIds": [
                 "{Resources}"
               ],
+              "timeContextFromParameter": "TimeRange",
               "timeContext": {
-                "durationMs": 3600000
+                "durationMs": 14400000
               },
               "metrics": [
                 {
@@ -373,8 +358,9 @@
               "resourceIds": [
                 "{Resources}"
               ],
+              "timeContextFromParameter": "TimeRange",
               "timeContext": {
-                "durationMs": 3600000
+                "durationMs": 14400000
               },
               "metrics": [
                 {
@@ -407,8 +393,9 @@
               "resourceIds": [
                 "{Resources}"
               ],
+              "timeContextFromParameter": "TimeRange",
               "timeContext": {
-                "durationMs": 3600000
+                "durationMs": 14400000
               },
               "metrics": [
                 {
@@ -440,8 +427,9 @@
               "resourceIds": [
                 "{Resources}"
               ],
+              "timeContextFromParameter": "TimeRange",
               "timeContext": {
-                "durationMs": 3600000
+                "durationMs": 14400000
               },
               "metrics": [
                 {
@@ -489,8 +477,9 @@
               "resourceIds": [
                 "{Resources}"
               ],
+              "timeContextFromParameter": "TimeRange",
               "timeContext": {
-                "durationMs": 3600000
+                "durationMs": 14400000
               },
               "metrics": [
                 {
@@ -523,8 +512,9 @@
               "resourceIds": [
                 "{Resources}"
               ],
+              "timeContextFromParameter": "TimeRange",
               "timeContext": {
-                "durationMs": 3600000
+                "durationMs": 14400000
               },
               "metrics": [
                 {
@@ -554,8 +544,9 @@
               "resourceIds": [
                 "{Resources}"
               ],
+              "timeContextFromParameter": "TimeRange",
               "timeContext": {
-                "durationMs": 3600000
+                "durationMs": 14400000
               },
               "metrics": [
                 {
@@ -585,8 +576,9 @@
               "resourceIds": [
                 "{Resources}"
               ],
+              "timeContextFromParameter": "TimeRange",
               "timeContext": {
-                "durationMs": 3600000
+                "durationMs": 14400000
               },
               "metrics": [
                 {
@@ -637,14 +629,16 @@
               "resourceIds": [
                 "{Resources}"
               ],
+              "timeContextFromParameter": "TimeRange",
               "timeContext": {
-                "durationMs": 3600000
+                "durationMs": 0
               },
               "metrics": [
                 {
                   "namespace": "microsoft.documentdb/mongoclusters",
                   "metric": "microsoft.documentdb/mongoclusters-Saturation-StoragePercent",
-                  "aggregation": 3
+                  "aggregation": 3,
+                  "splitBy": null
                 },
                 {
                   "namespace": "microsoft.documentdb/mongoclusters",
@@ -673,14 +667,16 @@
               "resourceIds": [
                 "{Resources}"
               ],
+              "timeContextFromParameter": "TimeRange",
               "timeContext": {
-                "durationMs": 3600000
+                "durationMs": 0
               },
               "metrics": [
                 {
                   "namespace": "microsoft.documentdb/mongoclusters",
                   "metric": "microsoft.documentdb/mongoclusters-Traffic-IOPS",
-                  "aggregation": 4
+                  "aggregation": 4,
+                  "splitBy": null
                 }
               ],
               "title": "IOPS by Server",
@@ -704,14 +700,16 @@
               "resourceIds": [
                 "{Resources}"
               ],
+              "timeContextFromParameter": "TimeRange",
               "timeContext": {
-                "durationMs": 3600000
+                "durationMs": 0
               },
               "metrics": [
                 {
                   "namespace": "microsoft.documentdb/mongoclusters",
                   "metric": "microsoft.documentdb/mongoclusters-Traffic-IOPS",
-                  "aggregation": 3
+                  "aggregation": 3,
+                  "splitBy": null
                 }
               ],
               "title": "Peak Storage Traffic by Server",
@@ -735,14 +733,16 @@
               "resourceIds": [
                 "{Resources}"
               ],
+              "timeContextFromParameter": "TimeRange",
               "timeContext": {
-                "durationMs": 3600000
+                "durationMs": 0
               },
               "metrics": [
                 {
                   "namespace": "microsoft.documentdb/mongoclusters",
                   "metric": "microsoft.documentdb/mongoclusters-Saturation-StorageUsed",
-                  "aggregation": 3
+                  "aggregation": 3,
+                  "splitBy": null
                 }
               ],
               "title": "Storage Capacity Usage by Server",


### PR DESCRIPTION
Solves customer IcM where they couldn't edit their metrics by time range

## Summary

There was a metrics display issue within the Insights dashboard where, despite metrics data flowing correctly, the dashboard fails to expand the selected time range beyond one hour.

## Screenshots

Before fix (from IcM):
<img width="825" height="723" alt="image" src="https://github.com/user-attachments/assets/705cddaa-6069-4c57-9537-78257e7b67b2" />

After fix (different dataset):
<img width="2242" height="1087" alt="image" src="https://github.com/user-attachments/assets/88083dfd-310b-4cb1-8a98-e7a4d7d65d2d" />


## Validation

Validated using Advanced Editor

## Checklist

- [x] If you are adding a new template, gallery, or folder, add your team and folder/file(s) to the CODEOWNERS file at the root of the repo. CODEOWNERS entries should be teams, not individuals.
      When done correctly, this means that from then on *your* team does reviews of *your* things, not the workbooks team.
- [x] Ensure all steps in your template have meaningful names.
- [x] Ensure all parameters and grid columns have display names set so they can be localized.
