### PR TITLE
Use time legend for x axes in QPI workbooks

### DIFF
--- a/Workbooks/PostgreSQL Flexible Server/Performance/Query Performance Insights/Query Performance Insights.workbook
+++ b/Workbooks/PostgreSQL Flexible Server/Performance/Query Performance Insights/Query Performance Insights.workbook
@@ -1037,7 +1037,11 @@
         ],
         "visualization": "areachart",
         "chartSettings": {
+          "xAxis": "EVENT_TIME_GRAPHGRAIN",
           "showLegend": true,
+          "xSettings": {
+            "scale": "time"
+          },
           "ySettings": {
             "numberFormatSettings": {
               "unit": 23,
@@ -1650,7 +1654,11 @@
         ],
         "visualization": "areachart",
         "chartSettings": {
+          "xAxis": "EVENT_TIME_GRAPHGRAIN",
           "showLegend": true,
+          "xSettings": {
+            "scale": "time"
+          },
           "ySettings": {
             "numberFormatSettings": {
               "unit": 3,
@@ -2344,7 +2352,11 @@
         ],
         "visualization": "areachart",
         "chartSettings": {
+          "xAxis": "EVENT_TIME_GRAPHGRAIN",
           "showLegend": true,
+          "xSettings": {
+            "scale": "time"
+          },
           "ySettings": {
             "numberFormatSettings": {
               "unit": 37,
@@ -3059,7 +3071,11 @@
           "showBorder": false
         },
         "chartSettings": {
-          "showLegend": true
+          "xAxis": "EVENT_TIME_GRAPHGRAIN",
+          "showLegend": true,
+          "xSettings": {
+            "scale": "time"
+          }
         }
       },
       "conditionalVisibilities": [
@@ -3597,7 +3613,11 @@
         ],
         "visualization": "areachart",
         "chartSettings": {
+          "xAxis": "EVENT_TIME_GRAPHGRAIN",
           "showLegend": true,
+          "xSettings": {
+            "scale": "time"
+          },
           "ySettings": {
             "numberFormatSettings": {
               "unit": 23,
@@ -4235,7 +4255,11 @@
           }
         ],
         "chartSettings": {
-          "showLegend": true
+          "xAxis": "EVENT_TIME_GRAPHGRAIN",
+          "showLegend": true,
+          "xSettings": {
+            "scale": "time"
+          }
         }
       },
       "conditionalVisibilities": [


### PR DESCRIPTION
## Summary

Use time legend for x axes in QPI workbooks

## Screenshots
<img width="3351" height="970" alt="image" src="https://github.com/user-attachments/assets/ec49031e-860b-4d26-9008-9a311eb2908b" />


## Validation

- [x] Validate your changes using one or more of the [testing](https://github.com/microsoft/Application-Insights-Workbooks/blob/master/Documentation/Testing.md) methods.
  
  Make sure you've tested your template content. Fixing things while in PR is trivial. Hotfixing it later is very expensive; at the current time at least 3 teams are involved in a hotfix!

## Checklist

- [x] If you are adding a new template, gallery, or folder, add your team and folder/file(s) to the CODEOWNERS file at the root of the repo. CODEOWNERS entries should be teams, not individuals.
      When done correctly, this means that from then on *your* team does reviews of *your* things, not the workbooks team.
- [x] Ensure all steps in your template have meaningful names.
- [x] Ensure all parameters and grid columns have display names set so they can be localized.
