### PR TITLE
Updated Metrics Usage Insights Workbook

### DIFF
--- a/Workbooks/Azure Monitor - Workspaces/Metrics Usage Insights/Metrics Usage Insights.workbook
+++ b/Workbooks/Azure Monitor - Workspaces/Metrics Usage Insights/Metrics Usage Insights.workbook
@@ -1,3 +1,4 @@
+
 {
   "version": "Notebook/1.0",
   "items": [
@@ -1386,9 +1387,9 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "let startDate = startofday({start_end_date:start});\nlet table_endDate = toscalar(AMWMetricsUsageDetails\n| where StartTime >= ago(5d)\n| summarize max(StartTime));\nlet endDate = startofday(min_of({start_end_date:end}, table_endDate));\nAMWMetricsUsageDetails\n| extend comp_start_date = startDate, comp_end_date = endDate\n| summarize c=count(), max(comp_start_date), max(comp_end_date)\n| project label=iff(c>0,\"Final comparison dates taken into account of the data:\",\"\"),max_comp_start_date, max_comp_end_date\n| where isnotempty(label) ",
+              "query": "let startDate = startofday({start_end_date:start});\nlet table_endDate = toscalar(AMWMetricsUsageDetails\n| where StartTime >= ago(5d)\n| summarize max(StartTime));\nlet endDate = startofday(min_of({start_end_date:end}, table_endDate));\nAMWMetricsUsageDetails\n| extend comp_start_date = startDate, comp_end_date = endDate\n| summarize c=count(), max(comp_start_date), max(comp_end_date)\n| project label=iff(c>0,\"Final start and end comparison dates taken into account of the data:\",\"\"),max_comp_start_date, max_comp_end_date\n| where isnotempty(label) ",
               "size": 4,
-              "title": "Final comparison dates taken into account of the data:",
+              "title": "Initial and final dates of time period used for comparison",
               "noDataMessage": "Please verify that the metrics usage insights is available in the region where your AMW was created.",
               "noDataMessageStyle": 4,
               "timeContext": {
@@ -1419,6 +1420,9 @@
                   "dateFormat": {
                     "showUtcTime": true,
                     "formatName": null
+                  },
+                  "tooltipFormat": {
+                    "tooltip": "Start Date"
                   }
                 },
                 "rightContent": {
@@ -1427,13 +1431,16 @@
                   "dateFormat": {
                     "showUtcTime": true,
                     "formatName": null
+                  },
+                  "tooltipFormat": {
+                    "tooltip": "End Date"
                   }
                 },
                 "showBorder": false,
                 "size": "auto"
               }
             },
-            "name": "Final comparison dates taken into account of the data:",
+            "name": "Initial and final dates of time period used for comparison",
             "styleSettings": {
               "margin": "0 0 -90px 0"
             }
@@ -1442,10 +1449,10 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "let startDate = {start_end_date:start};\r\nlet table_endDate = toscalar(AMWMetricsUsageDetails\r\n| where StartTime >= ago(5d)\r\n| summarize max(StartTime));\r\nlet endDate = min_of({start_end_date:end}, table_endDate) ;\r\n// add end date validation\r\n// text widget: desciribe start and end date\r\nlet End_TS = \r\n AMWMetricsUsageDetails \r\n| where startofday(StartTime) == startofday(endDate)\r\n| project-rename ['End Date Time Series'] = DailyTimeseriesCount, [\"End Date Event Rate\"] = IncomingEventsCount ;\r\nlet Start_TS = \r\n AMWMetricsUsageDetails \r\n| where startofday(StartTime) == startofday(startDate)\r\n| project-rename ['Start Date Time Series'] = DailyTimeseriesCount, [\"Start Date Event Rate\"] = IncomingEventsCount;\r\n// join\r\nEnd_TS\r\n| join kind=fullouter Start_TS on MetricNamespace, MetricName, DimensionsList\r\n| extend\r\n    ['End Date Time Series'] = coalesce(['End Date Time Series'], 0),\r\n    ['Start Date Time Series'] = coalesce(['Start Date Time Series'], 0),\r\n    [\"End Date Event Rate\"] = coalesce([\"End Date Event Rate\"], 0),\r\n    [\"Start Date Event Rate\"] = coalesce([\"Start Date Event Rate\"], 0)\r\n| extend [\"Time Series Difference\"] = ['End Date Time Series'] - ['Start Date Time Series']\r\n| extend [\"Event Rate Difference\"] = [\"End Date Event Rate\"] - [\"Start Date Event Rate\"]\r\n| extend [\"Time Series Percent Change\"] = round([\"Time Series Difference\"] * 100.0 / ['Start Date Time Series'] )\r\n| extend [\"Event Rate Percent Change\"] = round([\"Event Rate Difference\"] * 100.0 / ['Start Date Event Rate'] )\r\n| project Namespace = MetricNamespace, Metric = MetricName, Dimensions = DimensionsList, ['Start Date Time Series'], ['End Date Time Series'], [\"Time Series Difference\"], [\"Time Series Percent Change\"], [\"Start Date Event Rate\"], [\"End Date Event Rate\"], [\"Event Rate Difference\"], [\"Event Rate Percent Change\"]\r\n| sort by [\"Event Rate Difference\"] desc\r\n\r\n\r\n",
+              "query": "let startDate = {start_end_date:start};\r\nlet table_endDate = toscalar(AMWMetricsUsageDetails\r\n| where StartTime >= ago(5d)\r\n| summarize max(StartTime));\r\nlet endDate = min_of({start_end_date:end}, table_endDate) ;\r\n// add end date validation\r\n// text widget: desciribe start and end date\r\nlet End_TS = \r\n AMWMetricsUsageDetails \r\n| where startofday(StartTime) == startofday(endDate)\r\n| project-rename ['Final Timeseries'] = DailyTimeseriesCount, [\"Final Event Rate\"] = IncomingEventsCount ;\r\nlet Start_TS = \r\n AMWMetricsUsageDetails \r\n| where startofday(StartTime) == startofday(startDate)\r\n| project-rename ['Initial Timeseries'] = DailyTimeseriesCount, [\"Initial Event Rate\"] = IncomingEventsCount;\r\n// join\r\nEnd_TS\r\n| join kind=fullouter Start_TS on MetricNamespace, MetricName, DimensionsList\r\n| extend\r\n    ['Final Timeseries'] = coalesce(['Final Timeseries'], 0),\r\n    ['Initial Timeseries'] = coalesce(['Initial Timeseries'], 0),\r\n    [\"Final Event Rate\"] = coalesce([\"Final Event Rate\"], 0),\r\n    [\"Initial Event Rate\"] = coalesce([\"Initial Event Rate\"], 0)\r\n| extend [\"Timeseries Difference\"] = ['Final Timeseries'] - ['Initial Timeseries']\r\n| extend [\"Event Rate Difference\"] = [\"Final Event Rate\"] - [\"Initial Event Rate\"]\r\n| extend [\"Timeseries Change %\"] = round([\"Timeseries Difference\"] * 100.0 / ['Initial Timeseries'] )\r\n| extend [\"Event Rate Change %\"] = round([\"Event Rate Difference\"] * 100.0 / ['Initial Event Rate'] )\r\n| project Namespace = MetricNamespace, Metric = MetricName, Dimensions = DimensionsList, [\"Initial Event Rate\"], [\"Final Event Rate\"], [\"Event Rate Difference\"], [\"Event Rate Change %\"], ['Initial Timeseries'], ['Final Timeseries'], [\"Timeseries Difference\"], [\"Timeseries Change %\"]\r\n| sort by [\"Event Rate Difference\"] desc\r\n\r\n\r\n",
               "size": 0,
               "showAnalytics": true,
-              "title": "Time Series and Event Rate Count on Start and End Date",
+              "title": "Timeseries and Event Rates on Initial and Final Dates of Time Period",
               "queryType": 0,
               "resourceType": "microsoft.monitor/accounts",
               "visualization": "table",
@@ -1510,7 +1517,7 @@
                 ]
               }
             },
-            "name": "Time Series and Event Rate Count on Start and End Date"
+            "name": "Timeseries and Event Rates on Initial and Final Dates of Time Period"
           }
         ]
       },


### PR DESCRIPTION
## Summary

Added Ingestion Volume Change page to Metrics Usage Insights Workbook

## Screenshots
<img width="3436" height="1329" alt="image" src="https://github.com/user-attachments/assets/21ef83c5-92e2-4ed0-9bb9-f6dd67333210" />

- [x] If you added a template to a gallery, show a screenshot of it in the gallery view (which verifies its shows up where you expected).

  It is also good to show a screenshot of template content, so people can see what you expect it to look like, compared to what they see when they might run it themselves.

## Validation

- [x] Validate your changes using one or more of the [testing](https://github.com/microsoft/Application-Insights-Workbooks/blob/master/Documentation/Testing.md) methods.
  
  Make sure you've tested your template content. Fixing things while in PR is trivial. Hotfixing it later is very expensive; at the current time at least 3 teams are involved in a hotfix!

**Redirecting the Gallery to a GitHub Branch** worked with screenshot:
<img width="761" height="62" alt="image" src="https://github.com/user-attachments/assets/3e274716-73d3-4af0-8047-b27b6077238f" />

## Checklist

- [x] If you are adding a new template, gallery, or folder, add your team and folder/file(s) to the CODEOWNERS file at the root of the repo. CODEOWNERS entries should be teams, not individuals.
      When done correctly, this means that from then on *your* team does reviews of *your* things, not the workbooks team.
- [x] Ensure all steps in your template have meaningful names.
- [x] Ensure all parameters and grid columns have display names set so they can be localized.
