### PR TITLE
[database watcher] Use 0-100 Y axis for resource utilization

### DIFF
--- a/Workbooks/Database watcher/Azure SQL Database/database/database.workbook
+++ b/Workbooks/Database watcher/Azure SQL Database/database/database.workbook
@@ -1681,7 +1681,9 @@
                       "useGrouping": true,
                       "maximumFractionDigits": 2
                     }
-                  }
+                  },
+                  "min": 0,
+                  "max": 100
                 }
               },
               "textSettings": {

--- a/Workbooks/Database watcher/Azure SQL Database/elastic pool/elastic pool.workbook
+++ b/Workbooks/Database watcher/Azure SQL Database/elastic pool/elastic pool.workbook
@@ -1334,7 +1334,9 @@
                       "useGrouping": true,
                       "maximumFractionDigits": 2
                     }
-                  }
+                  },
+                  "min": 0,
+                  "max": 100
                 }
               },
               "textSettings": {

--- a/Workbooks/Database watcher/Azure SQL Managed Instance/instance/instance.workbook
+++ b/Workbooks/Database watcher/Azure SQL Managed Instance/instance/instance.workbook
@@ -1598,7 +1598,9 @@
                       "useGrouping": true,
                       "maximumFractionDigits": 2
                     }
-                  }
+                  },
+                  "min": 0,
+                  "max": 100
                 }
               },
               "textSettings": {

--- a/Workbooks/Database watcher/SQL Server/instance/instance.workbook
+++ b/Workbooks/Database watcher/SQL Server/instance/instance.workbook
@@ -1497,7 +1497,9 @@
                       "useGrouping": true,
                       "maximumFractionDigits": 2
                     }
-                  }
+                  },
+                  "min": 0,
+                  "max": 100
                 }
               },
               "textSettings": {


### PR DESCRIPTION
## Summary

Previously, the Y axis of the resource utilization chart would auto-scale according to the maximum data value. Hence, the maximum Y axis value could be less than 100%. Customer feedback indicates that this can be misleading because a small spike could be misinterpreted as a major one.

With this change, the maximum value of the Y axis is always 100%. The side effect of that is that small peaks and valleys in resource utilization can become invisible.

## Screenshots

Before:

<img width="1051" height="477" alt="image" src="https://github.com/user-attachments/assets/8e798953-ce95-4841-878e-535c0f456b67" />

After:

<img width="1011" height="458" alt="image" src="https://github.com/user-attachments/assets/13253307-5208-42be-8145-14e68b947de1" />

## Validation

- [x] Validate your changes using one or more of the [testing](https://github.com/microsoft/Application-Insights-Workbooks/blob/master/Documentation/Testing.md) methods.
  
## Checklist

- [ ] If you are adding a new template, gallery, or folder, add your team and folder/file(s) to the CODEOWNERS file at the root of the repo. CODEOWNERS entries should be teams, not individuals.
      When done correctly, this means that from then on *your* team does reviews of *your* things, not the workbooks team.
- [x] Ensure all steps in your template have meaningful names.
- [x] Ensure all parameters and grid columns have display names set so they can be localized.
