### PR TITLE
Add initial version of App Insights Agents workbook

### DIFF
--- a/Workbooks/UsageMetrics/Agents - Overview/Agents - Overview.workbook
+++ b/Workbooks/UsageMetrics/Agents - Overview/Agents - Overview.workbook
@@ -107,6 +107,10 @@
             "type": 1,
             "query": "let agents = dependencies\r\n| where customDimensions[\"gen_ai.operation.name\"] == \"invoke_agent\"\r\n| extend AgentName = tostring(customDimensions[\"gen_ai.agent.name\"]);\r\nlet tools = dependencies\r\n| extend Operation = tostring(customDimensions[\"gen_ai.operation.name\"])\r\n| where isnotempty(Operation)\r\n| where Operation == \"execute_tool\"\r\n| lookup kind=leftouter (agents) on $left.operation_ParentId == $right.id\r\n| where \"{SelectedAgent}\" == \"__ALL__\" or \"{SelectedAgent}\" == AgentName\r\n| extend Tool = tostring(customDimensions[\"gen_ai.tool.name\"])\r\n| extend Description = tostring(customDimensions[\"gen_ai.tool.description\"]);\r\ntools\r\n| where success == false\r\n| project timestamp, Tool\r\n| evaluate autocluster()\r\n| where Percent > 60\r\n| order by Percent desc\r\n| take 1\r\n| project Detection = strcat(toint(Percent), \"% of tool failures were on calls to '\", Tool, \"'\")",
             "isHiddenWhenLocked": true,
+            "timeContext": {
+              "durationMs": 0
+            },
+            "timeContextFromParameter": "TimeRange",
             "queryType": 0,
             "resourceType": "microsoft.insights/components",
             "value": ""


### PR DESCRIPTION
## Summary

Introduces initial workbook content for App Insights Agents view. This workbook is not added to a gallery.

## Screenshots

- [ ] If you added a template to a gallery, show a screenshot of it in the gallery view (which verifies its shows up where you expected).

  It is also good to show a screenshot of template content, so people can see what you expect it to look like, compared to what they see when they might run it themselves.

## Validation

- [X] Validate your changes using one or more of the [testing](https://github.com/microsoft/Application-Insights-Workbooks/blob/master/Documentation/Testing.md) methods.
  
  Make sure you've tested your template content. Fixing things while in PR is trivial. Hotfixing it later is very expensive; at the current time at least 3 teams are involved in a hotfix!

## Checklist

- [X] If you are adding a new template, gallery, or folder, add your team and folder/file(s) to the CODEOWNERS file at the root of the repo. CODEOWNERS entries should be teams, not individuals.
      When done correctly, this means that from then on *your* team does reviews of *your* things, not the workbooks team.
- [X] Ensure all steps in your template have meaningful names.
- [X] Ensure all parameters and grid columns have display names set so they can be localized.
