### PR TITLE
Updated VWan workbook

### DIFF
--- a/Workbooks/Network Insights/VirtualWANWorkbooks/NetworkInsights-VirtualWANMetrics/NetworkInsights-VirtualWANMetrics.workbook
+++ b/Workbooks/Network Insights/VirtualWANWorkbooks/NetworkInsights-VirtualWANMetrics/NetworkInsights-VirtualWANMetrics.workbook
@@ -1548,6 +1548,5 @@
   "fallbackResourceIds": [
     "Azure Monitor"
   ],
-  "fromTemplateId": "Community-Workbooks/Network Insights/VirtualWANWorkbooks/NetworkInsights-VirtualWANMetrics",
   "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
 }


### PR DESCRIPTION
## Summary

Explain your changes, so people looking at the PR know *what* and *why*, the code changes are the *how*.

Virtual wan workbook is failing to fetch data for virtual hub queries in airgap clouds as armEndpoint is hardcoded. Updated Virtual wan workbook to pick armEndpoint from url params. Verified locally and by redirecting to github branch 

## Screenshots
**Before:-**
<img width="946" height="100" alt="image" src="https://github.com/user-attachments/assets/87a941c7-ebd2-4669-b45a-4aefc0c0cae8" />

**After:-**

<img width="1225" height="79" alt="image" src="https://github.com/user-attachments/assets/64b5bbaa-71a3-4c3d-a749-09871b16c4d1" />

<img width="1242" height="656" alt="image" src="https://github.com/user-attachments/assets/0b967a8d-93eb-4f4e-8355-e483969fb781" />

- [x] If you added a template to a gallery, show a screenshot of it in the gallery view (which verifies its shows up where you expected).

  It is also good to show a screenshot of template content, so people can see what you expect it to look like, compared to what they see when they might run it themselves.

## Validation

- [x] Validate your changes using one or more of the [testing](https://github.com/microsoft/Application-Insights-Workbooks/blob/master/Documentation/Testing.md) methods.
  
  Make sure you've tested your template content. Fixing things while in PR is trivial. Hotfixing it later is very expensive; at the current time at least 3 teams are involved in a hotfix!

## Checklist

- [ ] If you are adding a new template, gallery, or folder, add your team and folder/file(s) to the CODEOWNERS file at the root of the repo. CODEOWNERS entries should be teams, not individuals.
      When done correctly, this means that from then on *your* team does reviews of *your* things, not the workbooks team.
- [ ] Ensure all steps in your template have meaningful names.
- [x] Ensure all parameters and grid columns have display names set so they can be localized.
