### PR TITLE
Users/natahari/contenttypebugfix

### DIFF
--- a/Workbooks/UpdateCompliance/DeliveryOptimization/DeliveryOptimization.workbook
+++ b/Workbooks/UpdateCompliance/DeliveryOptimization/DeliveryOptimization.workbook
@@ -1302,7 +1302,7 @@
                   "type": 3,
                   "content": {
                     "version": "KqlItem/1.0",
-                    "query": "\r\nlet _SnapshotTime = datetime({DOSnapshotTime});\r\n\r\nUCDOAggregatedStatus | where TimeGenerated == _SnapshotTime| summarize BytesFromPeers = sum(BytesFromPeers) , BytesFromGroupPeers = sum(BytesFromGroupPeers) , BytesFromCDN =  sum(BytesFromCDN), BytesFromCache = sum(BytesFromCache) by ContentType \r\n| project ContentType, BytesFromPeers, BytesFromGroupPeers, BytesFromCDN, BytesFromCache\r\n",
+                    "query": "\r\nlet _SnapshotTime = datetime({DOSnapshotTime});\r\n\r\nUCDOAggregatedStatus | where TimeGenerated == _SnapshotTime \r\n| project ContentType, BytesFromPeers, BytesFromGroupPeers, BytesFromCDN, BytesFromCache\r\n",
                     "size": 0,
                     "title": "Volume by content type and source",
                     "queryType": 0,


### PR DESCRIPTION
## Summary

UCDOAggregatedStatus table have data aggregated by ContentType and Tenant per snapshot. We do not need to further summarize the data. 

Removing the unnecessary summarized operation. There wont be any change in visualization
 
## Screenshots and Validation

Content distribution(%) Details

results without extra summarize operation (new)

<img width="1208" height="710" alt="image" src="https://github.com/user-attachments/assets/8e1276a5-8a1e-432d-bece-81eff57c8345" />

result with extra summarize operation (old) 

<img width="800" height="491" alt="image" src="https://github.com/user-attachments/assets/7b2428b9-aa23-4c09-8d42-2fe8ceb3c957" />


Volume by content type and source

results without extra summarize operation (new)

<img width="800" height="521" alt="image" src="https://github.com/user-attachments/assets/b21ae911-060e-4369-99fd-edd86fac42ed" />


result with extra summarize operation (old) 

<img width="1216" height="767" alt="image" src="https://github.com/user-attachments/assets/fbe68954-5d69-4968-9b26-a5f31e90471a" />


