### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/template-validation.yaml
+++ b/.github/workflows/template-validation.yaml
@@ -2,6 +2,8 @@
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
 name: Template Validation
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/microsoft/Application-Insights-Workbooks/security/code-scanning/5](https://github.com/microsoft/Application-Insights-Workbooks/security/code-scanning/5)

In general, the fix is to explicitly declare a `permissions` block for the workflow or for the individual job(s), restricting `GITHUB_TOKEN` to the minimum required access. For a typical test workflow that only checks out code and runs `npm install` / `npm test`, read-only access to repository contents is sufficient, so `permissions: contents: read` is an appropriate baseline.

The best fix here is to add a `permissions` block at the workflow root (top level, alongside `name` and `on`) so that it applies to all jobs, including `build`. This avoids changing job behavior while documenting and constraining token usage. Specifically, in `.github/workflows/template-validation.yaml`, after the `name: Template Validation` line and before the `on:` block, add:

```yaml
permissions:
  contents: read
```

No additional imports or external libraries are needed; this is purely a YAML configuration change within the workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
