### PR TITLE
Replace outdated M40 tier gate with Free-tier-only visibility

### DIFF
--- a/Workbooks/CosmosDb Mongo vCore/Overview/Overview.workbook
+++ b/Workbooks/CosmosDb Mongo vCore/Overview/Overview.workbook
@@ -71,10 +71,19 @@
             "timeContext": {
               "durationMs": 86400000
             }
+          },
+          {
+            "id": "9a8cf75e-0cce-49cb-b0fa-b8d15715adcb",
+            "version": "KqlParameterItem/1.0",
+            "name": "sku",
+            "type": 1,
+            "query": "{\"version\":\"ARMEndpoint/1.0\",\"data\":null,\"headers\":[],\"method\":\"GET\",\"path\":\"{Resources}\",\"urlParams\":[{\"key\":\"api-version\",\"value\":\"2024-10-01-preview\"}],\"batchDisabled\":false,\"transformers\":[{\"type\":\"jsonpath\",\"settings\":{\"tablePath\":\"properties.compute\",\"columns\":[]}}]}",
+            "isHiddenWhenLocked": true,
+            "queryType": 12
           }
         ],
         "style": "above",
-        "queryType": 0,
+        "queryType": 12,
         "resourceType": "microsoft.operationalinsights/workspaces"
       },
       "name": "Container",
@@ -258,7 +267,7 @@
                   "columnName": "Average Mongo Request Duration"
                 }
               ],
-              "title": "Query Latency (only available for clusters M40 and up)",
+              "title": "Query Latency",
               "gridSettings": {
                 "rowLimit": 10000
               }
@@ -294,7 +303,7 @@
                   "columnName": "Maximum Mongo Request Duration"
                 }
               ],
-              "title": "Slowest Queries by Server (only available forclusters M40 and up)",
+              "title": "Slowest Queries by Server",
               "gridSettings": {
                 "rowLimit": 10000
               }
@@ -321,8 +330,13 @@
           {
             "type": 1,
             "content": {
-              "json": "**Note:** This feature is only available for clusters tier M40 and up.",
+              "json": "**Note:** This feature is not available for Free Tier clusters.",
               "style": "info"
+            },
+            "conditionalVisibility": {
+              "parameterName": "sku",
+              "comparison": "isEqualTo",
+              "value": "Free"
             },
             "name": "text - 0"
           },
@@ -341,6 +355,11 @@
                   "style": "link"
                 }
               ]
+            },
+            "conditionalVisibility": {
+              "parameterName": "sku",
+              "comparison": "isEqualTo",
+              "value": "Free"
             },
             "name": "links - 4"
           },


### PR DESCRIPTION
## Summary

The "Query Performance" tab in the DocumentDB Insights workbook incorrectly displays a "This feature is only available for clusters tier M40 and up" warning with an "Upgrade now" link for all cluster tiers, including M40+. This causes confusion for customers who upgraded specifically for this feature.

Fixed it which solves an open ICM. 

## Screenshots

<img width="1050" height="548" alt="image" src="https://github.com/user-attachments/assets/259c5133-2687-43ab-8696-2baed8761979" />

<img width="1045" height="415" alt="image" src="https://github.com/user-attachments/assets/0cdf77cb-9e96-44ae-b892-0c2c9c13c507" />


## Validation

Used "Advanced Mode" on a new workbook page using free-tier (top picture) and paid (bottom picture) clusters


## Checklist

- [X] If you are adding a new template, gallery, or folder, add your team and folder/file(s) to the CODEOWNERS file at the root of the repo. CODEOWNERS entries should be teams, not individuals.
      When done correctly, this means that from then on *your* team does reviews of *your* things, not the workbooks team.
- [X] Ensure all steps in your template have meaningful names.
- [X] Ensure all parameters and grid columns have display names set so they can be localized.
