### PR TITLE
cost tab updates

### DIFF
--- a/Workbooks/UsageMetrics/Agents - Overview/Agents - Overview.workbook
+++ b/Workbooks/UsageMetrics/Agents - Overview/Agents - Overview.workbook
@@ -2161,7 +2161,8 @@
                       "minimumSignificantDigits": 1,
                       "maximumSignificantDigits": 4
                     }
-                  }
+                  },
+                  "min": 0
                 }
               },
               "mapSettings": {

--- a/Workbooks/UsageMetrics/Agents - Overview/Agents - Overview.workbook
+++ b/Workbooks/UsageMetrics/Agents - Overview/Agents - Overview.workbook
@@ -2103,9 +2103,11 @@
                       "style": "currency",
                       "useGrouping": true,
                       "maximumFractionDigits": 4,
-                      "minimumSignificantDigits": 1
+                      "minimumSignificantDigits": 1,
+                      "maximumSignificantDigits": 4
                     }
-                  }
+                  },
+                  "min": 0
                 }
               }
             },
@@ -2156,7 +2158,8 @@
                       "style": "currency",
                       "useGrouping": true,
                       "maximumFractionDigits": 4,
-                      "minimumSignificantDigits": 1
+                      "minimumSignificantDigits": 1,
+                      "maximumSignificantDigits": 4
                     }
                   }
                 }
@@ -2182,9 +2185,9 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "// Trace-Level Cost Table: per-run cost, token, and duration rollup\r\nlet allSpans = dependencies\r\n| extend parsedDimensions = parse_json(customDimensions)\r\n| extend AgentName = tostring(parsedDimensions[\"gen_ai.agent.name\"])\r\n| extend inputCost = todouble(parsedDimensions[\"microsoft.gen_ai.cost.input\"])\r\n| extend outputCost = todouble(parsedDimensions[\"microsoft.gen_ai.cost.output\"])\r\n| extend inputTokens = toint(parsedDimensions[\"gen_ai.usage.input_tokens\"])\r\n| extend outputTokens = toint(parsedDimensions[\"gen_ai.usage.output_tokens\"])\r\n| extend Model = tostring(parsedDimensions[\"gen_ai.request.model\"]);\r\n// Tree edges: child -> parent (excludes top-level self-references)\r\nlet treeEdges = allSpans\r\n| where operation_ParentId != operation_Id\r\n| project source = id, target = operation_ParentId;\r\n// Virtual edges: connect top-level spans to agent spans in the same operation\r\n// This handles flat topologies where spans are siblings sharing operation_Id\r\nlet virtualEdges = allSpans\r\n| where operation_ParentId == operation_Id\r\n| project source = id, sourceOp = operation_Id\r\n| join kind=inner (allSpans | where isnotempty(AgentName) | project target = id, targetOp = operation_Id) on $left.sourceOp == $right.targetOp\r\n| where source != target\r\n| project source, target;\r\nlet edges = treeEdges | union virtualEdges;\r\nlet agentCosts = edges\r\n| make-graph source --> target with allSpans on id\r\n| graph-match (chat)-[e*1..{MaxGraphDepth}]->(agent)\r\n  where isnotempty(agent.AgentName) and (chat.inputCost > 0 or chat.outputCost > 0 or chat.inputTokens > 0 or chat.outputTokens > 0)\r\n  project AgentName = agent.AgentName, WorkflowName = agent.AgentName, inputCost = chat.inputCost, outputCost = chat.outputCost, inputTokens = chat.inputTokens, outputTokens = chat.outputTokens, Model = chat.Model, operation_Id = chat.operation_Id, chatItemId = chat.itemId, timestamp = chat.timestamp, agentDuration = agent.duration;\r\nagentCosts\r\n| where \"{SelectedAgent}\" == \"__ALL__\" or \"{SelectedAgent}\" == AgentName\r\n| summarize [\"Total Cost\"] = round(sum(inputCost + outputCost), 4), [\"Input Tokens\"] = sum(inputTokens), [\"Output Tokens\"] = sum(outputTokens), [\"Total Tokens\"] = sum(inputTokens + outputTokens), Model = any(Model), [\"Duration (ms)\"] = max(agentDuration), timestamp = min(timestamp), chatItemId = take_any(chatItemId) by operation_Id, AgentName, WorkflowName\r\n| project [\"Trace ID\"] = operation_Id, [\"Total Cost\"], [\"Agent\"] = AgentName, [\"Workflow\"] = WorkflowName, Model, [\"Input Tokens\"], [\"Output Tokens\"], [\"Total Tokens\"], [\"Duration (ms)\"], itemId = chatItemId, timestamp\r\n| order by [\"Total Cost\"] desc\r\n| take 100",
+              "query": "// Trace-Level Cost Table: per-run cost, token, and duration rollup\r\nlet allSpans = dependencies\r\n| extend parsedDimensions = parse_json(customDimensions)\r\n| extend AgentName = tostring(parsedDimensions[\"gen_ai.agent.name\"])\r\n| extend inputCost = todouble(parsedDimensions[\"microsoft.gen_ai.cost.input\"])\r\n| extend outputCost = todouble(parsedDimensions[\"microsoft.gen_ai.cost.output\"])\r\n| extend inputTokens = toint(parsedDimensions[\"gen_ai.usage.input_tokens\"])\r\n| extend outputTokens = toint(parsedDimensions[\"gen_ai.usage.output_tokens\"])\r\n| extend Model = tostring(parsedDimensions[\"gen_ai.request.model\"]);\r\n// Tree edges: child -> parent (excludes top-level self-references)\r\nlet treeEdges = allSpans\r\n| where operation_ParentId != operation_Id\r\n| project source = id, target = operation_ParentId;\r\n// Virtual edges: connect top-level spans to agent spans in the same operation\r\n// This handles flat topologies where spans are siblings sharing operation_Id\r\nlet virtualEdges = allSpans\r\n| where operation_ParentId == operation_Id\r\n| project source = id, sourceOp = operation_Id\r\n| join kind=inner (allSpans | where isnotempty(AgentName) | project target = id, targetOp = operation_Id) on $left.sourceOp == $right.targetOp\r\n| where source != target\r\n| project source, target;\r\nlet edges = treeEdges | union virtualEdges;\r\nlet agentCosts = edges\r\n| make-graph source --> target with allSpans on id\r\n| graph-match (chat)-[e*1..{MaxGraphDepth}]->(agent)\r\n  where isnotempty(agent.AgentName) and (chat.inputCost > 0 or chat.outputCost > 0 or chat.inputTokens > 0 or chat.outputTokens > 0)\r\n  project AgentName = agent.AgentName, inputCost = chat.inputCost, outputCost = chat.outputCost, inputTokens = chat.inputTokens, outputTokens = chat.outputTokens, Model = chat.Model, operation_Id = chat.operation_Id, chatItemId = chat.itemId, timestamp = chat.timestamp, agentDuration = agent.duration;\r\nagentCosts\r\n| where \"{SelectedAgent}\" == \"__ALL__\" or \"{SelectedAgent}\" == AgentName\r\n| summarize [\"Total Cost\"] = round(sum(inputCost + outputCost), 4), [\"Input Tokens\"] = sum(inputTokens), [\"Output Tokens\"] = sum(outputTokens), [\"Total Tokens\"] = sum(inputTokens + outputTokens), Models = make_set(Model), [\"Duration (ms)\"] = max(agentDuration), timestamp = min(timestamp), chatItemId = take_any(chatItemId) by operation_Id, AgentName\r\n| extend Model = iff(array_length(Models) > 1, \"Multiple\", tostring(Models[0]))\r\n| project [\"Trace ID\"] = operation_Id, [\"Total Cost\"], [\"Agent\"] = AgentName, Model, [\"Input Tokens\"], [\"Output Tokens\"], [\"Total Tokens\"], [\"Duration (ms)\"], itemId = chatItemId, timestamp\r\n| order by [\"Total Cost\"] desc\r\n| take 100",
               "size": 0,
-              "title": "Most expensive conversations/workflows",
+              "title": "Most expensive traces",
               "timeContextFromParameter": "TimeRange",
               "queryType": 0,
               "resourceType": "microsoft.insights/components",
@@ -2199,7 +2202,7 @@
                     "formatter": 7,
                     "formatOptions": {
                       "linkTarget": "DependencyDetails",
-                      "linkIsContextBlade": true,
+                      "linkIsContextBlade": false,
                       "appInsightsContext": {
                         "resourceIdSource": "workbook",
                         "secondaryIdSource": "column",
@@ -2244,7 +2247,7 @@
                 "labelSettings": [
                   {
                     "columnId": "Trace ID",
-                    "label": "Conversation/trace ID"
+                    "label": "Trace ID"
                   },
                   {
                     "columnId": "Total Cost",
@@ -2253,10 +2256,6 @@
                   {
                     "columnId": "Agent",
                     "label": "Agent name"
-                  },
-                  {
-                    "columnId": "Workflow",
-                    "label": "Workflow name"
                   },
                   {
                     "columnId": "Model",

--- a/Workbooks/UsageMetrics/Agents - Overview/Agents - Overview.workbook
+++ b/Workbooks/UsageMetrics/Agents - Overview/Agents - Overview.workbook
@@ -174,7 +174,6 @@
             "resourceType": "microsoft.insights/components",
             "value": "__ALL__"
           },
-
           {
             "id": "71b8c43c-55aa-4c4a-98f9-60a7e9718c21",
             "version": "KqlParameterItem/1.0",
@@ -393,7 +392,6 @@
         "version": "NotebookGroup/1.0",
         "groupType": "editable",
         "items": [
-
           {
             "type": 12,
             "content": {
@@ -1028,7 +1026,7 @@
                               },
                               "timeContextFromParameter": "TimeRange",
                               "queryType": 0,
-                              "resourceType": "microsoft.insights/components"   
+                              "resourceType": "microsoft.insights/components"
                             },
                             {
                               "id": "aaf0d4fb-e443-4def-9577-73bd1df95d2b",
@@ -1939,7 +1937,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "// Agent Cost Summary: cost and token metrics per agent with period-over-period change\r\nlet timeRange = {TimeRange:seconds};\r\nlet currentStart = {TimeRange:start};\r\nlet currentEnd = {TimeRange:end};\r\nlet previousStart = datetime_add(\"second\", -timeRange, currentStart);\r\nlet allSpans = dependencies\r\n| where timestamp between (previousStart .. currentEnd)\r\n| extend parsedDimensions = parse_json(customDimensions)\r\n| extend AgentName = tostring(parsedDimensions[\"gen_ai.agent.name\"])\r\n| extend inputCost = todouble(parsedDimensions[\"microsoft.gen_ai.cost.input\"])\r\n| extend outputCost = todouble(parsedDimensions[\"microsoft.gen_ai.cost.output\"])\r\n| extend inputTokens = toint(parsedDimensions[\"gen_ai.usage.input_tokens\"])\r\n| extend outputTokens = toint(parsedDimensions[\"gen_ai.usage.output_tokens\"]);\r\n// Tree edges: child -> parent (excludes top-level self-references)\r\nlet treeEdges = allSpans\r\n| where operation_ParentId != operation_Id\r\n| project source = id, target = operation_ParentId;\r\n// Virtual edges: connect top-level spans to agent spans in the same operation\r\n// This handles flat topologies where spans are siblings sharing operation_Id\r\nlet virtualEdges = allSpans\r\n| where operation_ParentId == operation_Id\r\n| project source = id, sourceOp = operation_Id\r\n| join kind=inner (allSpans | where isnotempty(AgentName) | project target = id, targetOp = operation_Id) on $left.sourceOp == $right.targetOp\r\n| where source != target\r\n| project source, target;\r\nlet edges = treeEdges | union virtualEdges;\r\nlet agentCosts = edges\r\n| make-graph source --> target with allSpans on id\r\n| graph-match (chat)-[e*1..{MaxGraphDepth}]->(agent)\r\n  where isnotempty(agent.AgentName) and (chat.inputCost > 0 or chat.outputCost > 0 or chat.inputTokens > 0 or chat.outputTokens > 0)\r\n  project AgentName = agent.AgentName, inputCost = chat.inputCost, outputCost = chat.outputCost, inputTokens = chat.inputTokens, outputTokens = chat.outputTokens, timestamp = chat.timestamp;\r\nlet currentPeriod = agentCosts\r\n| where timestamp between (currentStart .. currentEnd)\r\n| summarize CurrentCost = sum(inputCost + outputCost), CurrentTokens = sum(inputTokens + outputTokens) by AgentName;\r\nlet previousPeriod = agentCosts\r\n| where timestamp between (previousStart .. currentStart)\r\n| summarize PreviousCost = sum(inputCost + outputCost), PreviousTokens = sum(inputTokens + outputTokens) by AgentName;\r\ncurrentPeriod\r\n| join kind=leftouter (previousPeriod) on AgentName\r\n| extend CostChange = CurrentCost - coalesce(PreviousCost, 0.0)\r\n| extend CostChangePercent = iff(coalesce(PreviousCost, 0.0) > 0, round((CurrentCost - PreviousCost) / PreviousCost * 100, 1), real(null))\r\n| extend TokenChange = CurrentTokens - coalesce(PreviousTokens, 0)\r\n| extend TokenChangePercent = iff(coalesce(PreviousTokens, 0) > 0, round(todouble(CurrentTokens - PreviousTokens) / todouble(PreviousTokens) * 100, 1), real(null))\r\n| project AgentName, EstimatedCost = CurrentCost, CostChange, CostChangePercent, TotalTokens = CurrentTokens, TokenChange, TokenChangePercent\r\n| order by EstimatedCost desc\r\n| limit 100",
+              "query": "// Agent Cost Summary: cost and token metrics per agent with period-over-period change\r\nlet timeRange = {TimeRange:seconds};\r\nlet currentStart = {TimeRange:start};\r\nlet currentEnd = {TimeRange:end};\r\nlet previousStart = datetime_add(\"second\", -timeRange, currentStart);\r\nlet allSpans = dependencies\r\n| where timestamp between (previousStart .. currentEnd)\r\n| extend parsedDimensions = parse_json(customDimensions)\r\n| extend AgentName = tostring(parsedDimensions[\"gen_ai.agent.name\"])\r\n| extend inputCost = todouble(parsedDimensions[\"microsoft.gen_ai.cost.input\"])\r\n| extend outputCost = todouble(parsedDimensions[\"microsoft.gen_ai.cost.output\"])\r\n| extend inputTokens = toint(parsedDimensions[\"gen_ai.usage.input_tokens\"])\r\n| extend outputTokens = toint(parsedDimensions[\"gen_ai.usage.output_tokens\"]);\r\n// Tree edges: child -> parent (excludes top-level self-references)\r\nlet treeEdges = allSpans\r\n| where operation_ParentId != operation_Id\r\n| project source = id, target = operation_ParentId;\r\n// Virtual edges: connect top-level spans to agent spans in the same operation\r\n// This handles flat topologies where spans are siblings sharing operation_Id\r\nlet virtualEdges = allSpans\r\n| where operation_ParentId == operation_Id\r\n| project source = id, sourceOp = operation_Id\r\n| join kind=inner (allSpans | where isnotempty(AgentName) | project target = id, targetOp = operation_Id) on $left.sourceOp == $right.targetOp\r\n| where source != target\r\n| project source, target;\r\nlet edges = treeEdges | union virtualEdges;\r\nlet agentCosts = edges\r\n| make-graph source --> target with allSpans on id\r\n| graph-match (chat)-[e*1..{MaxGraphDepth}]->(agent)\r\n  where isnotempty(agent.AgentName) and (chat.inputCost > 0 or chat.outputCost > 0 or chat.inputTokens > 0 or chat.outputTokens > 0)\r\n  project AgentName = agent.AgentName, inputCost = chat.inputCost, outputCost = chat.outputCost, inputTokens = chat.inputTokens, outputTokens = chat.outputTokens, timestamp = chat.timestamp;\r\nlet currentPeriod = agentCosts\r\n| where timestamp between (currentStart .. currentEnd)\r\n| summarize CurrentCost = sum(inputCost + outputCost), CurrentTokens = sum(inputTokens + outputTokens) by AgentName;\r\nlet previousPeriod = agentCosts\r\n| where timestamp between (previousStart .. currentStart)\r\n| summarize PreviousCost = sum(inputCost + outputCost), PreviousTokens = sum(inputTokens + outputTokens) by AgentName;\r\ncurrentPeriod\r\n| join kind=leftouter (previousPeriod) on AgentName\r\n| extend CostChange = CurrentCost - coalesce(PreviousCost, 0.0)\r\n| extend CostChangePercent = iff(coalesce(PreviousCost, 0.0) > 0, (CurrentCost - PreviousCost) / PreviousCost * 100, real(null))\r\n| extend TokenChange = CurrentTokens - coalesce(PreviousTokens, 0)\r\n| extend TokenChangePercent = iff(coalesce(PreviousTokens, 0) > 0, todouble(CurrentTokens - PreviousTokens) / todouble(PreviousTokens) * 100, real(null))\r\n| project AgentName, EstimatedCost = CurrentCost, CostChange, CostChangePercent, TotalTokens = CurrentTokens, TokenChange, TokenChangePercent\r\n| order by EstimatedCost desc\r\n| limit 100",
               "size": 1,
               "timeContextFromParameter": "TimeRange",
               "queryType": 0,
@@ -1958,7 +1956,9 @@
                         "currency": "USD",
                         "style": "currency",
                         "useGrouping": true,
-                        "maximumFractionDigits": 4
+                        "maximumFractionDigits": 4,
+                        "minimumSignificantDigits": 1,
+                        "maximumSignificantDigits": 4
                       }
                     }
                   },
@@ -1971,7 +1971,9 @@
                         "currency": "USD",
                         "style": "currency",
                         "useGrouping": true,
-                        "maximumFractionDigits": 4
+                        "maximumFractionDigits": 4,
+                        "minimumSignificantDigits": 1,
+                        "maximumSignificantDigits": 4
                       }
                     }
                   },
@@ -1994,7 +1996,9 @@
                       "options": {
                         "currency": "USD",
                         "style": "currency",
-                        "maximumFractionDigits": 4
+                        "maximumFractionDigits": 4,
+                        "minimumSignificantDigits": 1,
+                        "maximumSignificantDigits": 4
                       }
                     }
                   },
@@ -2007,7 +2011,9 @@
                         "currency": "USD",
                         "style": "currency",
                         "useGrouping": true,
-                        "maximumFractionDigits": 4
+                        "maximumFractionDigits": 4,
+                        "minimumSignificantDigits": 1,
+                        "maximumSignificantDigits": 4
                       }
                     }
                   },
@@ -2083,9 +2089,9 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "// Cost per Agent Execution: average cost per run over time\r\nlet allSpans = dependencies\r\n| extend parsedDimensions = parse_json(customDimensions)\r\n| extend AgentName = tostring(parsedDimensions[\"gen_ai.agent.name\"])\r\n| extend inputCost = todouble(parsedDimensions[\"microsoft.gen_ai.cost.input\"])\r\n| extend outputCost = todouble(parsedDimensions[\"microsoft.gen_ai.cost.output\"])\r\n| extend inputTokens = toint(parsedDimensions[\"gen_ai.usage.input_tokens\"])\r\n| extend outputTokens = toint(parsedDimensions[\"gen_ai.usage.output_tokens\"]);\r\n// Tree edges: child -> parent (excludes top-level self-references)\r\nlet treeEdges = allSpans\r\n| where operation_ParentId != operation_Id\r\n| project source = id, target = operation_ParentId;\r\n// Virtual edges: connect top-level spans to agent spans in the same operation\r\n// This handles flat topologies where spans are siblings sharing operation_Id\r\nlet virtualEdges = allSpans\r\n| where operation_ParentId == operation_Id\r\n| project source = id, sourceOp = operation_Id\r\n| join kind=inner (allSpans | where isnotempty(AgentName) | project target = id, targetOp = operation_Id) on $left.sourceOp == $right.targetOp\r\n| where source != target\r\n| project source, target;\r\nlet edges = treeEdges | union virtualEdges;\r\nlet agentCosts = edges\r\n| make-graph source --> target with allSpans on id\r\n| graph-match (chat)-[e*1..{MaxGraphDepth}]->(agent)\r\n  where isnotempty(agent.AgentName) and (chat.inputCost > 0 or chat.outputCost > 0 or chat.inputTokens > 0 or chat.outputTokens > 0)\r\n  project AgentName = agent.AgentName, inputCost = chat.inputCost, outputCost = chat.outputCost, operation_Id = chat.operation_Id, EventTime = todatetime(agent.timestamp);\r\nagentCosts\r\n| where \"{SelectedAgent}\" == \"__ALL__\" or \"{SelectedAgent}\" == AgentName\r\n| summarize ExecutionCost = sum(inputCost + outputCost) by operation_Id, AgentName, EventTime\r\n| summarize CostPerExecution = round(avg(ExecutionCost),8) by AgentName, bin(EventTime, {TimeRange:grain})\r\n| project EventTime=todatetime(EventTime), AgentName, CostPerExecution",
+              "query": "// Cost per Agent Execution: average cost per run over time\r\nlet allSpans = dependencies\r\n| extend parsedDimensions = parse_json(customDimensions)\r\n| extend AgentName = tostring(parsedDimensions[\"gen_ai.agent.name\"])\r\n| extend inputCost = todouble(parsedDimensions[\"microsoft.gen_ai.cost.input\"])\r\n| extend outputCost = todouble(parsedDimensions[\"microsoft.gen_ai.cost.output\"])\r\n| extend inputTokens = toint(parsedDimensions[\"gen_ai.usage.input_tokens\"])\r\n| extend outputTokens = toint(parsedDimensions[\"gen_ai.usage.output_tokens\"]);\r\n// Tree edges: child -> parent (excludes top-level self-references)\r\nlet treeEdges = allSpans\r\n| where operation_ParentId != operation_Id\r\n| project source = id, target = operation_ParentId;\r\n// Virtual edges: connect top-level spans to agent spans in the same operation\r\n// This handles flat topologies where spans are siblings sharing operation_Id\r\nlet virtualEdges = allSpans\r\n| where operation_ParentId == operation_Id\r\n| project source = id, sourceOp = operation_Id\r\n| join kind=inner (allSpans | where isnotempty(AgentName) | project target = id, targetOp = operation_Id) on $left.sourceOp == $right.targetOp\r\n| where source != target\r\n| project source, target;\r\nlet edges = treeEdges | union virtualEdges;\r\nlet agentCosts = edges\r\n| make-graph source --> target with allSpans on id\r\n| graph-match (chat)-[e*1..{MaxGraphDepth}]->(agent)\r\n  where isnotempty(agent.AgentName) and (chat.inputCost > 0 or chat.outputCost > 0 or chat.inputTokens > 0 or chat.outputTokens > 0)\r\n  project AgentName = agent.AgentName, inputCost = chat.inputCost, outputCost = chat.outputCost, operation_Id = chat.operation_Id, EventTime = todatetime(agent.timestamp);\r\nagentCosts\r\n| where \"{SelectedAgent}\" == \"__ALL__\" or \"{SelectedAgent}\" == AgentName\r\n| summarize ExecutionCost = sum(inputCost + outputCost) by operation_Id, AgentName, EventTime\r\n| summarize CostPerExecution = avg(ExecutionCost) by AgentName, bin(EventTime, {TimeRange:grain})\r\n| project EventTime=todatetime(EventTime), AgentName, CostPerExecution",
               "size": 0,
-              "aggregation": 5,
+              "aggregation": 3,
               "title": "Cost per execution",
               "timeContextFromParameter": "TimeRange",
               "queryType": 0,
@@ -2118,7 +2124,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "// Cost by Model: total cost grouped by model\r\nlet allSpans = dependencies\r\n| extend parsedDimensions = parse_json(customDimensions)\r\n| extend AgentName = tostring(parsedDimensions[\"gen_ai.agent.name\"])\r\n| extend inputCost = todouble(parsedDimensions[\"microsoft.gen_ai.cost.input\"])\r\n| extend outputCost = todouble(parsedDimensions[\"microsoft.gen_ai.cost.output\"])\r\n| extend inputTokens = toint(parsedDimensions[\"gen_ai.usage.input_tokens\"])\r\n| extend outputTokens = toint(parsedDimensions[\"gen_ai.usage.output_tokens\"])\r\n| extend Model = tostring(parsedDimensions[\"gen_ai.request.model\"]);\r\n// Tree edges: child -> parent (excludes top-level self-references)\r\nlet treeEdges = allSpans\r\n| where operation_ParentId != operation_Id\r\n| project source = id, target = operation_ParentId;\r\n// Virtual edges: connect top-level spans to agent spans in the same operation\r\n// This handles flat topologies where spans are siblings sharing operation_Id\r\nlet virtualEdges = allSpans\r\n| where operation_ParentId == operation_Id\r\n| project source = id, sourceOp = operation_Id\r\n| join kind=inner (allSpans | where isnotempty(AgentName) | project target = id, targetOp = operation_Id) on $left.sourceOp == $right.targetOp\r\n| where source != target\r\n| project source, target;\r\nlet edges = treeEdges | union virtualEdges;\r\nlet agentCosts = edges\r\n| make-graph source --> target with allSpans on id\r\n| graph-match (chat)-[e*1..{MaxGraphDepth}]->(agent)\r\n  where isnotempty(agent.AgentName) and (chat.inputCost > 0 or chat.outputCost > 0 or chat.inputTokens > 0 or chat.outputTokens > 0)\r\n  project AgentName = agent.AgentName, inputCost = chat.inputCost, outputCost = chat.outputCost, Model = chat.Model;\r\nagentCosts\r\n| where \"{SelectedAgent}\" == \"__ALL__\" or \"{SelectedAgent}\" == AgentName\r\n| where isnotempty(Model)\r\n| summarize TotalCost = round(sum(inputCost + outputCost), 4) by Model\r\n| where TotalCost > 0\r\n| order by TotalCost desc",
+              "query": "// Cost by Model: total cost grouped by model\r\nlet allSpans = dependencies\r\n| extend parsedDimensions = parse_json(customDimensions)\r\n| extend AgentName = tostring(parsedDimensions[\"gen_ai.agent.name\"])\r\n| extend inputCost = todouble(parsedDimensions[\"microsoft.gen_ai.cost.input\"])\r\n| extend outputCost = todouble(parsedDimensions[\"microsoft.gen_ai.cost.output\"])\r\n| extend inputTokens = toint(parsedDimensions[\"gen_ai.usage.input_tokens\"])\r\n| extend outputTokens = toint(parsedDimensions[\"gen_ai.usage.output_tokens\"])\r\n| extend Model = tostring(parsedDimensions[\"gen_ai.request.model\"]);\r\n// Tree edges: child -> parent (excludes top-level self-references)\r\nlet treeEdges = allSpans\r\n| where operation_ParentId != operation_Id\r\n| project source = id, target = operation_ParentId;\r\n// Virtual edges: connect top-level spans to agent spans in the same operation\r\n// This handles flat topologies where spans are siblings sharing operation_Id\r\nlet virtualEdges = allSpans\r\n| where operation_ParentId == operation_Id\r\n| project source = id, sourceOp = operation_Id\r\n| join kind=inner (allSpans | where isnotempty(AgentName) | project target = id, targetOp = operation_Id) on $left.sourceOp == $right.targetOp\r\n| where source != target\r\n| project source, target;\r\nlet edges = treeEdges | union virtualEdges;\r\nlet agentCosts = edges\r\n| make-graph source --> target with allSpans on id\r\n| graph-match (chat)-[e*1..{MaxGraphDepth}]->(agent)\r\n  where isnotempty(agent.AgentName) and (chat.inputCost > 0 or chat.outputCost > 0 or chat.inputTokens > 0 or chat.outputTokens > 0)\r\n  project AgentName = agent.AgentName, inputCost = chat.inputCost, outputCost = chat.outputCost, Model = chat.Model;\r\nagentCosts\r\n| where \"{SelectedAgent}\" == \"__ALL__\" or \"{SelectedAgent}\" == AgentName\r\n| where isnotempty(Model)\r\n| summarize TotalCost = sum(inputCost + outputCost) by Model\r\n| where TotalCost > 0\r\n| order by TotalCost desc",
               "size": 0,
               "title": "Cost by models",
               "timeContextFromParameter": "TimeRange",
@@ -2140,8 +2146,9 @@
                   "numberFormat": {
                     "unit": 17,
                     "options": {
-                      "maximumSignificantDigits": 3,
-                      "maximumFractionDigits": 2
+                      "maximumFractionDigits": 4,
+                      "minimumSignificantDigits": 1,
+                      "maximumSignificantDigits": 4
                     }
                   }
                 }
@@ -2186,7 +2193,7 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "// Trace-Level Cost Table: per-run cost, token, and duration rollup\r\nlet allSpans = dependencies\r\n| extend parsedDimensions = parse_json(customDimensions)\r\n| extend AgentName = tostring(parsedDimensions[\"gen_ai.agent.name\"])\r\n| extend inputCost = todouble(parsedDimensions[\"microsoft.gen_ai.cost.input\"])\r\n| extend outputCost = todouble(parsedDimensions[\"microsoft.gen_ai.cost.output\"])\r\n| extend inputTokens = toint(parsedDimensions[\"gen_ai.usage.input_tokens\"])\r\n| extend outputTokens = toint(parsedDimensions[\"gen_ai.usage.output_tokens\"])\r\n| extend Model = tostring(parsedDimensions[\"gen_ai.request.model\"]);\r\n// Tree edges: child -> parent (excludes top-level self-references)\r\nlet treeEdges = allSpans\r\n| where operation_ParentId != operation_Id\r\n| project source = id, target = operation_ParentId;\r\n// Virtual edges: connect top-level spans to agent spans in the same operation\r\n// This handles flat topologies where spans are siblings sharing operation_Id\r\nlet virtualEdges = allSpans\r\n| where operation_ParentId == operation_Id\r\n| project source = id, sourceOp = operation_Id\r\n| join kind=inner (allSpans | where isnotempty(AgentName) | project target = id, targetOp = operation_Id) on $left.sourceOp == $right.targetOp\r\n| where source != target\r\n| project source, target;\r\nlet edges = treeEdges | union virtualEdges;\r\nlet agentCosts = edges\r\n| make-graph source --> target with allSpans on id\r\n| graph-match (chat)-[e*1..{MaxGraphDepth}]->(agent)\r\n  where isnotempty(agent.AgentName) and (chat.inputCost > 0 or chat.outputCost > 0 or chat.inputTokens > 0 or chat.outputTokens > 0)\r\n  project AgentName = agent.AgentName, inputCost = chat.inputCost, outputCost = chat.outputCost, inputTokens = chat.inputTokens, outputTokens = chat.outputTokens, Model = chat.Model, operation_Id = chat.operation_Id, chatItemId = chat.itemId, timestamp = chat.timestamp, agentDuration = agent.duration;\r\nagentCosts\r\n| where \"{SelectedAgent}\" == \"__ALL__\" or \"{SelectedAgent}\" == AgentName\r\n| summarize [\"Total Cost\"] = round(sum(inputCost + outputCost), 4), [\"Input Tokens\"] = sum(inputTokens), [\"Output Tokens\"] = sum(outputTokens), [\"Total Tokens\"] = sum(inputTokens + outputTokens), Models = make_set(Model), [\"Duration (ms)\"] = max(agentDuration), timestamp = min(timestamp), chatItemId = take_any(chatItemId) by operation_Id, AgentName\r\n| extend Model = iff(array_length(Models) > 1, \"Multiple\", tostring(Models[0]))\r\n| project [\"Trace ID\"] = operation_Id, [\"Total Cost\"], [\"Agent\"] = AgentName, Model, [\"Input Tokens\"], [\"Output Tokens\"], [\"Total Tokens\"], [\"Duration (ms)\"], itemId = chatItemId, timestamp\r\n| order by [\"Total Cost\"] desc\r\n| take 100",
+              "query": "// Trace-Level Cost Table: per-run cost, token, and duration rollup\r\nlet allSpans = dependencies\r\n| extend parsedDimensions = parse_json(customDimensions)\r\n| extend AgentName = tostring(parsedDimensions[\"gen_ai.agent.name\"])\r\n| extend inputCost = todouble(parsedDimensions[\"microsoft.gen_ai.cost.input\"])\r\n| extend outputCost = todouble(parsedDimensions[\"microsoft.gen_ai.cost.output\"])\r\n| extend inputTokens = toint(parsedDimensions[\"gen_ai.usage.input_tokens\"])\r\n| extend outputTokens = toint(parsedDimensions[\"gen_ai.usage.output_tokens\"])\r\n| extend Model = tostring(parsedDimensions[\"gen_ai.request.model\"]);\r\n// Tree edges: child -> parent (excludes top-level self-references)\r\nlet treeEdges = allSpans\r\n| where operation_ParentId != operation_Id\r\n| project source = id, target = operation_ParentId;\r\n// Virtual edges: connect top-level spans to agent spans in the same operation\r\n// This handles flat topologies where spans are siblings sharing operation_Id\r\nlet virtualEdges = allSpans\r\n| where operation_ParentId == operation_Id\r\n| project source = id, sourceOp = operation_Id\r\n| join kind=inner (allSpans | where isnotempty(AgentName) | project target = id, targetOp = operation_Id) on $left.sourceOp == $right.targetOp\r\n| where source != target\r\n| project source, target;\r\nlet edges = treeEdges | union virtualEdges;\r\nlet agentCosts = edges\r\n| make-graph source --> target with allSpans on id\r\n| graph-match (chat)-[e*1..{MaxGraphDepth}]->(agent)\r\n  where isnotempty(agent.AgentName) and (chat.inputCost > 0 or chat.outputCost > 0 or chat.inputTokens > 0 or chat.outputTokens > 0)\r\n  project AgentName = agent.AgentName, inputCost = chat.inputCost, outputCost = chat.outputCost, inputTokens = chat.inputTokens, outputTokens = chat.outputTokens, Model = chat.Model, operation_Id = chat.operation_Id, chatItemId = chat.itemId, timestamp = chat.timestamp, agentDuration = agent.duration;\r\nagentCosts\r\n| where \"{SelectedAgent}\" == \"__ALL__\" or \"{SelectedAgent}\" == AgentName\r\n| summarize [\"Total Cost\"] = sum(inputCost + outputCost), [\"Input Tokens\"] = sum(inputTokens), [\"Output Tokens\"] = sum(outputTokens), [\"Total Tokens\"] = sum(inputTokens + outputTokens), Models = make_set(Model), [\"Duration (ms)\"] = max(agentDuration), timestamp = min(timestamp), chatItemId = take_any(chatItemId) by operation_Id, AgentName\r\n| extend Model = iff(array_length(Models) > 1, \"Multiple\", tostring(Models[0]))\r\n| project [\"Trace ID\"] = operation_Id, [\"Total Cost\"], [\"Agent\"] = AgentName, Model, [\"Input Tokens\"], [\"Output Tokens\"], [\"Total Tokens\"], [\"Duration (ms)\"], itemId = chatItemId, timestamp\r\n| order by [\"Total Cost\"] desc\r\n| take 100",
               "size": 0,
               "title": "Most expensive traces",
               "timeContextFromParameter": "TimeRange",
@@ -2220,9 +2227,11 @@
                     "numberFormat": {
                       "unit": 0,
                       "options": {
-                        "style": "currency",
                         "currency": "USD",
-                        "minimumFractionDigits": 4
+                        "style": "currency",
+                        "minimumFractionDigits": 4,
+                        "minimumSignificantDigits": 1,
+                        "maximumSignificantDigits": 4
                       }
                     }
                   },


### PR DESCRIPTION
## Summary

- change trace link to full blade instead of context blade
- rename conversation/trace ID -> Trace ID
- rename "Most expensive conversations/workflows" -> most expensive traces
- remove workflow name column
- If multiple models are used in a trace just say "multiple" instead of picking arbitrarily
- show average instead of last for cost per execution
- standardize currency formatting

## Screenshots

<img width="1536" height="701" alt="image" src="https://github.com/user-attachments/assets/3a755a84-81e7-411b-a5b3-7fead3e6fd77" />

## Validation

- [x] Validate your changes using one or more of the [testing](https://github.com/microsoft/Application-Insights-Workbooks/blob/master/Documentation/Testing.md) methods.
  
  Make sure you've tested your template content. Fixing things while in PR is trivial. Hotfixing it later is very expensive; at the current time at least 3 teams are involved in a hotfix!

## Checklist

- [x] If you are adding a new template, gallery, or folder, add your team and folder/file(s) to the CODEOWNERS file at the root of the repo. CODEOWNERS entries should be teams, not individuals.
      When done correctly, this means that from then on *your* team does reviews of *your* things, not the workbooks team.
- [x] Ensure all steps in your template have meaningful names.
- [x] Ensure all parameters and grid columns have display names set so they can be localized.
