### PR TITLE
Enhance Metrics Usage Insights workbook - Add new tab

### DIFF
--- a/Workbooks/Azure Monitor - Workspaces/Metrics Usage Insights/Metrics Usage Insights.workbook
+++ b/Workbooks/Azure Monitor - Workspaces/Metrics Usage Insights/Metrics Usage Insights.workbook
@@ -283,7 +283,7 @@
                     "columnMatch": "Last Queried (days ago)",
                     "formatter": 0,
                     "tooltipFormat": {
-                      "tooltip": "The number of days from\u00e2\u20ac\u00af\"Insights as of\" date on the report\u00e2\u20ac\u00afwhen the metric was queried last."
+                      "tooltip": "The number of days fromâ€¯\"Insights as of\" date on the reportâ€¯when the metric was queried last."
                     }
                   },
                   {
@@ -1180,7 +1180,7 @@
                     "columnMatch": "Last Queried (days ago)",
                     "formatter": 0,
                     "tooltipFormat": {
-                      "tooltip": "The number of days from\u00e2\u20ac\u00af\"Insights as of\" date on the report\u00e2\u20ac\u00afwhen the metric was queried last."
+                      "tooltip": "The number of days fromâ€¯\"Insights as of\" date on the reportâ€¯when the metric was queried last."
                     }
                   },
                   {

--- a/Workbooks/Azure Monitor - Workspaces/Metrics Usage Insights/Metrics Usage Insights.workbook
+++ b/Workbooks/Azure Monitor - Workspaces/Metrics Usage Insights/Metrics Usage Insights.workbook
@@ -1470,9 +1470,6 @@
               "title": "Initial and final dates of time period used for comparison",
               "noDataMessage": "Please verify that the metrics usage insights is available in the region where your AMW was created.",
               "noDataMessageStyle": 4,
-              "timeContext": {
-                "durationMs": 259200000
-              },
               "queryType": 0,
               "resourceType": "microsoft.monitor/accounts",
               "visualization": "tiles",
@@ -1516,7 +1513,8 @@
                 },
                 "showBorder": false,
                 "size": "auto"
-              }
+              },
+              "timeContextFromParameter": "start_end_date"
             },
             "name": "Initial and final dates of time period used for comparison",
             "styleSettings": {
@@ -1625,8 +1623,54 @@
                     }
                   }
                 ],
-                "labelSettings": []
-              }
+                "labelSettings": [
+                  {
+                    "columnId": "Namespace",
+                    "label": "Namespace"
+                  },
+                  {
+                    "columnId": "Metric",
+                    "label": "Metric"
+                  },
+                  {
+                    "columnId": "Dimensions",
+                    "label": "Dimensions"
+                  },
+                  {
+                    "columnId": "Initial Event Rate",
+                    "label": "Initial Event Rate"
+                  },
+                  {
+                    "columnId": "Final Event Rate",
+                    "label": "Final Event Rate"
+                  },
+                  {
+                    "columnId": "Event Rate Difference",
+                    "label": "Event Rate Difference"
+                  },
+                  {
+                    "columnId": "Event Rate Change %",
+                    "label": "Event Rate Change %"
+                  },
+                  {
+                    "columnId": "Initial Timeseries",
+                    "label": "Initial Timeseries"
+                  },
+                  {
+                    "columnId": "Final Timeseries",
+                    "label": "Final Timeseries"
+                  },
+                  {
+                    "columnId": "Timeseries Difference",
+                    "label": "Timeseries Difference"
+                  },
+                  {
+                    "columnId": "Timeseries Change %",
+                    "label": "Timeseries Change %"
+                  }
+                ]
+              },
+              "timeContextFromParameter": "start_end_date"
             },
             "name": "Timeseries and Event Rates on Initial and Final Dates of Time Period",
             "conditionalVisibilities": [

--- a/Workbooks/Azure Monitor - Workspaces/Metrics Usage Insights/Metrics Usage Insights.workbook
+++ b/Workbooks/Azure Monitor - Workspaces/Metrics Usage Insights/Metrics Usage Insights.workbook
@@ -68,6 +68,14 @@
             "linkLabel": "Unused Metrics",
             "subTarget": "unusedMetrics",
             "style": "link"
+          },
+          {
+            "id": "9479d0f5-2f17-496a-814d-77cc25877511",
+            "cellValue": "tabName",
+            "linkTarget": "parameter",
+            "linkLabel": "Ingestion Volume Change",
+            "subTarget": "ingestedVolume",
+            "style": "link"
           }
         ]
       },
@@ -275,7 +283,7 @@
                     "columnMatch": "Last Queried (days ago)",
                     "formatter": 0,
                     "tooltipFormat": {
-                      "tooltip": "The number of days from \"Insights as of\" date on the report when the metric was queried last."
+                      "tooltip": "The number of days from\u00e2\u20ac\u00af\"Insights as of\" date on the report\u00e2\u20ac\u00afwhen the metric was queried last."
                     }
                   },
                   {
@@ -1099,7 +1107,7 @@
                 "value": "true"
               },
               {
-                "parameterName": "DataPresent",
+                "parameterName": "DataPresent2",
                 "comparison": "isNotEqualTo"
               }
             ],
@@ -1172,7 +1180,7 @@
                     "columnMatch": "Last Queried (days ago)",
                     "formatter": 0,
                     "tooltipFormat": {
-                      "tooltip": "The number of days from \"Insights as of\" date on the report when the metric was queried last."
+                      "tooltip": "The number of days from\u00e2\u20ac\u00af\"Insights as of\" date on the report\u00e2\u20ac\u00afwhen the metric was queried last."
                     }
                   },
                   {
@@ -1243,6 +1251,404 @@
         "value": "unusedMetrics"
       },
       "name": "groupUnusedMetrics"
+    },
+    {
+      "type": 12,
+      "content": {
+        "version": "NotebookGroup/1.0",
+        "groupType": "editable",
+        "loadType": "always",
+        "items": [
+          {
+            "type": 9,
+            "content": {
+              "version": "KqlParameterItem/1.0",
+              "parameters": [
+                {
+                  "id": "4f99d884-78ce-4ee8-958e-61fb1da48425",
+                  "version": "KqlParameterItem/1.0",
+                  "name": "DataPresent2",
+                  "type": 1,
+                  "query": "AMWMetricsUsageDetails\r\n| summarize c=count(),max(EndTime)\r\n| project label=iff(c>0,\"Insights as of:\",\"\"),max_EndTime\r\n| where isnotempty(label) ",
+                  "timeContext": {
+                    "durationMs": 86400000
+                  },
+                  "queryType": 0,
+                  "isHiddenWhenLocked": true,
+                  "resourceType": "microsoft.monitor/accounts"
+                }
+              ],
+              "style": "pills",
+              "queryType": 0,
+              "resourceType": "microsoft.monitor/accounts"
+            },
+            "name": "parameters - 5 - Copy"
+          },
+          {
+            "type": 1,
+            "content": {
+              "json": "Please ensure this AMW has been successfully onboarded to Diagnostic Settings.",
+              "style": "warning"
+            },
+            "conditionalVisibility": {
+              "parameterName": "DiagnosticSettingsEnabled",
+              "comparison": "isEqualTo"
+            },
+            "name": "DiagnosticSettingsErrorTextUnused"
+          },
+          {
+            "type": 1,
+            "content": {
+              "json": "Please verify that your Azure Monitor workspace is actively ingesting data and ensure that metrics usage insights are available in the region where your AMW was created. [Find the list of supported regions here](https://learn.microsoft.com/azure/azure-monitor/metrics/metrics-usage-insights#supported-regions)",
+              "style": "warning"
+            },
+            "conditionalVisibilities": [
+              {
+                "parameterName": "DiagnosticSettingsEnabled",
+                "comparison": "isEqualTo",
+                "value": "true"
+              },
+              {
+                "parameterName": "DataPresent2",
+                "comparison": "isEqualTo"
+              }
+            ],
+            "name": "MissingInsightsUnusedText"
+          },
+          {
+            "type": 11,
+            "content": {
+              "version": "LinkItem/1.0",
+              "style": "paragraph",
+              "links": [
+                {
+                  "id": "66b3bdf2-503b-43db-a299-c8d4b61371fb",
+                  "cellValue": "https://learn.microsoft.com/azure/azure-monitor/metrics/metrics-usage-insights",
+                  "linkTarget": "Url",
+                  "linkLabel": "Learn more about metrics usage insights",
+                  "preText": "",
+                  "style": "link"
+                }
+              ]
+            },
+            "name": "InsightssPresent"
+          },
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "AMWMetricsUsageDetails\n| summarize c=count(),max(EndTime)\n| project label=iff(c>0,\"Insights as of:\",\"\"),max_EndTime\n| where isnotempty(label)",
+              "size": 4,
+              "noDataMessage": "No insights found. Please onboard to Metrics Usage Details from Diagnostic settings.",
+              "noDataMessageStyle": 4,
+              "timeContext": {
+                "durationMs": 259200000
+              },
+              "queryType": 0,
+              "resourceType": "microsoft.monitor/accounts",
+              "visualization": "tiles",
+              "gridSettings": {
+                "formatters": [
+                  {
+                    "columnMatch": "Azure Monitor Workspace",
+                    "formatter": 5
+                  },
+                  {
+                    "columnMatch": "Daily Timeseries",
+                    "formatter": 8,
+                    "formatOptions": {
+                      "palette": "orangeRed"
+                    }
+                  }
+                ]
+              },
+              "tileSettings": {
+                "titleContent": {
+                  "formatter": 5
+                },
+                "leftContent": {
+                  "columnMatch": "label",
+                  "formatter": 1
+                },
+                "rightContent": {
+                  "columnMatch": "max_EndTime",
+                  "formatter": 6,
+                  "dateFormat": {
+                    "formatName": null
+                  }
+                },
+                "showBorder": false,
+                "size": "full"
+              }
+            },
+            "conditionalVisibilities": [
+              {
+                "parameterName": "DiagnosticSettingsEnabled",
+                "comparison": "isEqualTo",
+                "value": "true"
+              },
+              {
+                "parameterName": "DataPresent2",
+                "comparison": "isNotEqualTo"
+              }
+            ],
+            "name": "freshnessDate2",
+            "styleSettings": {
+              "margin": "0 0 -90px 0"
+            }
+          },
+          {
+            "type": 9,
+            "content": {
+              "version": "KqlParameterItem/1.0",
+              "parameters": [
+                {
+                  "id": "497edb7c-a0cf-4592-ab69-ea8b9e52a887",
+                  "version": "KqlParameterItem/1.0",
+                  "name": "start_end_date",
+                  "label": "Comparison dates",
+                  "type": 4,
+                  "description": "start and end date for ingested volume",
+                  "isRequired": true,
+                  "typeSettings": {
+                    "selectableValues": [
+                      {
+                        "durationMs": 259200000
+                      },
+                      {
+                        "durationMs": 604800000
+                      },
+                      {
+                        "durationMs": 1209600000
+                      },
+                      {
+                        "durationMs": 2419200000
+                      },
+                      {
+                        "durationMs": 2592000000
+                      },
+                      {
+                        "durationMs": 5184000000
+                      },
+                      {
+                        "durationMs": 7776000000
+                      }
+                    ],
+                    "allowCustom": true
+                  },
+                  "timeContext": {
+                    "durationMs": 86400000
+                  },
+                  "value": {
+                    "durationMs": 604800000
+                  }
+                }
+              ],
+              "style": "pills",
+              "queryType": 0,
+              "resourceType": "microsoft.monitor/accounts"
+            },
+            "name": "parameters - 10",
+            "conditionalVisibilities": [
+              {
+                "parameterName": "DiagnosticSettingsEnabled",
+                "comparison": "isEqualTo",
+                "value": "true"
+              },
+              {
+                "parameterName": "DataPresent2",
+                "comparison": "isNotEqualTo"
+              }
+            ]
+          },
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "let startDate = startofday({start_end_date:start});\nlet table_endDate = toscalar(AMWMetricsUsageDetails\n| where StartTime >= ago(5d)\n| summarize max(StartTime));\nlet endDate = startofday(min_of({start_end_date:end}, table_endDate));\nAMWMetricsUsageDetails\n| extend comp_start_date = startDate, comp_end_date = endDate\n| summarize c=count(), max(comp_start_date), max(comp_end_date)\n| project label=iff(c>0,\"Final start and end comparison dates taken into account of the data:\",\"\"),max_comp_start_date, max_comp_end_date\n| where isnotempty(label) ",
+              "size": 4,
+              "title": "Initial and final dates of time period used for comparison",
+              "noDataMessage": "Please verify that the metrics usage insights is available in the region where your AMW was created.",
+              "noDataMessageStyle": 4,
+              "timeContext": {
+                "durationMs": 259200000
+              },
+              "queryType": 0,
+              "resourceType": "microsoft.monitor/accounts",
+              "visualization": "tiles",
+              "gridSettings": {
+                "formatters": [
+                  {
+                    "columnMatch": "Azure Monitor Workspace",
+                    "formatter": 5
+                  }
+                ]
+              },
+              "tileSettings": {
+                "titleContent": {
+                  "formatter": 1,
+                  "dateFormat": {
+                    "showUtcTime": true,
+                    "formatName": "weekDayPattern"
+                  }
+                },
+                "leftContent": {
+                  "columnMatch": "max_comp_start_date",
+                  "formatter": 6,
+                  "dateFormat": {
+                    "showUtcTime": true,
+                    "formatName": null
+                  },
+                  "tooltipFormat": {
+                    "tooltip": "Start Date"
+                  }
+                },
+                "rightContent": {
+                  "columnMatch": "max_comp_end_date",
+                  "formatter": 6,
+                  "dateFormat": {
+                    "showUtcTime": true,
+                    "formatName": null
+                  },
+                  "tooltipFormat": {
+                    "tooltip": "End Date"
+                  }
+                },
+                "showBorder": false,
+                "size": "auto"
+              }
+            },
+            "name": "Initial and final dates of time period used for comparison",
+            "styleSettings": {
+              "margin": "0 0 -90px 0"
+            },
+            "conditionalVisibilities": [
+              {
+                "parameterName": "DiagnosticSettingsEnabled",
+                "comparison": "isEqualTo",
+                "value": "true"
+              },
+              {
+                "parameterName": "DataPresent2",
+                "comparison": "isNotEqualTo"
+              }
+            ]
+          },
+          {
+            "type": 3,
+            "content": {
+              "version": "KqlItem/1.0",
+              "query": "let startDate = {start_end_date:start};\r\nlet table_endDate = toscalar(AMWMetricsUsageDetails\r\n| where StartTime >= ago(5d)\r\n| summarize max(StartTime));\r\nlet endDate = min_of({start_end_date:end}, table_endDate) ;\r\n// add end date validation\r\n// text widget: desciribe start and end date\r\nlet End_TS = \r\n AMWMetricsUsageDetails \r\n| where startofday(StartTime) == startofday(endDate)\r\n| project-rename ['Final Timeseries'] = DailyTimeseriesCount, [\"Final Event Rate\"] = IncomingEventsCount ;\r\nlet Start_TS = \r\n AMWMetricsUsageDetails \r\n| where startofday(StartTime) == startofday(startDate)\r\n| project-rename ['Initial Timeseries'] = DailyTimeseriesCount, [\"Initial Event Rate\"] = IncomingEventsCount;\r\n// join\r\nEnd_TS\r\n| join kind=fullouter Start_TS on MetricNamespace, MetricName, DimensionsList\r\n| extend\r\n    ['Final Timeseries'] = coalesce(['Final Timeseries'], 0),\r\n    ['Initial Timeseries'] = coalesce(['Initial Timeseries'], 0),\r\n    [\"Final Event Rate\"] = coalesce([\"Final Event Rate\"], 0),\r\n    [\"Initial Event Rate\"] = coalesce([\"Initial Event Rate\"], 0)\r\n| extend [\"Timeseries Difference\"] = ['Final Timeseries'] - ['Initial Timeseries']\r\n| extend [\"Event Rate Difference\"] = [\"Final Event Rate\"] - [\"Initial Event Rate\"]\r\n| extend [\"Timeseries Change %\"] = iff(['Initial Timeseries'] == 0, real(null), abs(round([\"Timeseries Difference\"] * 100.0 / ['Initial Timeseries'] )))\r\n| extend [\"Event Rate Change %\"] = iff(['Initial Event Rate'] == 0, real(null), abs(round([\"Event Rate Difference\"] * 100.0 / ['Initial Event Rate'] )))\r\n| project Namespace = coalesce(MetricNamespace, MetricNamespace1), Metric = coalesce(MetricName, MetricName1), Dimensions = coalesce(DimensionsList, DimensionsList1), [\"Initial Event Rate\"], [\"Final Event Rate\"], [\"Event Rate Difference\"], [\"Event Rate Change %\"], ['Initial Timeseries'], ['Final Timeseries'], [\"Timeseries Difference\"], [\"Timeseries Change %\"]\r\n| sort by [\"Event Rate Difference\"] desc\r\n\r\n\r\n",
+              "size": 0,
+              "showAnalytics": true,
+              "title": "Timeseries and Event Rates on Initial and Final Dates of Time Period",
+              "queryType": 0,
+              "resourceType": "microsoft.monitor/accounts",
+              "visualization": "table",
+              "gridSettings": {
+                "formatters": [
+                  {
+                    "columnMatch": "Namespace",
+                    "formatter": 0,
+                    "tooltipFormat": {
+                      "tooltip": "Namespace in the Azure Monitor Workspace the metric belongs to. Namespaces are not configurable."
+                    }
+                  },
+                  {
+                    "columnMatch": "Metric",
+                    "formatter": 0,
+                    "tooltipFormat": {
+                      "tooltip": "The name of the metric the insight is generated for"
+                    }
+                  },
+                  {
+                    "columnMatch": "Dimensions",
+                    "formatter": 0,
+                    "tooltipFormat": {
+                      "tooltip": "The set of labels/dimensions being described. \"*\" indicates All Dimensions are included"
+                    }
+                  },
+                  {
+                    "columnMatch": "Start Date Time Series",
+                    "formatter": 0,
+                    "tooltipFormat": {
+                      "tooltip": "Number of time series stored on the start date"
+                    }
+                  },
+                  {
+                    "columnMatch": "End Date Time Series",
+                    "formatter": 0,
+                    "tooltipFormat": {
+                      "tooltip": "Number of time series stored on the end date"
+                    }
+                  },
+                  {
+                    "columnMatch": "Time Series Difference",
+                    "formatter": 0,
+                    "tooltipFormat": {
+                      "tooltip": "Difference in number of time series on the 2 dates"
+                    }
+                  },
+                  {
+                    "columnMatch": "Time Series Percent Change",
+                    "formatter": 0,
+                    "tooltipFormat": {
+                      "tooltip": "Percentage change in number of time series on the 2 dates"
+                    }
+                  },
+                  {
+                    "columnMatch": "Start Date Event Rate",
+                    "formatter": 0,
+                    "tooltipFormat": {
+                      "tooltip": "Rate of events ingested on the start date"
+                    }
+                  },
+                  {
+                    "columnMatch": "End Date Event Rate",
+                    "formatter": 0,
+                    "tooltipFormat": {
+                      "tooltip": "Rate of events ingested on the end date"
+                    }
+                  },
+                  {
+                    "columnMatch": "Event Rate Difference",
+                    "formatter": 0,
+                    "tooltipFormat": {
+                      "tooltip": "Difference in rate of events ingested on the 2 dates"
+                    }
+                  },
+                  {
+                    "columnMatch": "Event Rate Percent Change",
+                    "formatter": 0,
+                    "tooltipFormat": {
+                      "tooltip": "Percentage change in rate of events ingested on the 2 dates"
+                    }
+                  }
+                ],
+                "labelSettings": []
+              }
+            },
+            "name": "Timeseries and Event Rates on Initial and Final Dates of Time Period",
+            "conditionalVisibilities": [
+              {
+                "parameterName": "DiagnosticSettingsEnabled",
+                "comparison": "isEqualTo",
+                "value": "true"
+              },
+              {
+                "parameterName": "DataPresent2",
+                "comparison": "isNotEqualTo"
+              }
+            ]
+          }
+        ]
+      },
+      "conditionalVisibility": {
+        "parameterName": "tabName",
+        "comparison": "isEqualTo",
+        "value": "ingestedVolume"
+      },
+      "name": "groupIngestedVolume"
     }
   ],
   "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"

--- a/Workbooks/Azure Monitor - Workspaces/Metrics Usage Insights/Metrics Usage Insights.workbook
+++ b/Workbooks/Azure Monitor - Workspaces/Metrics Usage Insights/Metrics Usage Insights.workbook
@@ -283,7 +283,7 @@
                     "columnMatch": "Last Queried (days ago)",
                     "formatter": 0,
                     "tooltipFormat": {
-                      "tooltip": "The number of days fromâ€¯\"Insights as of\" date on the reportâ€¯when the metric was queried last."
+                      "tooltip": "The number of days from \"Insights as of\" date on the report when the metric was queried last."
                     }
                   },
                   {
@@ -1180,7 +1180,7 @@
                     "columnMatch": "Last Queried (days ago)",
                     "formatter": 0,
                     "tooltipFormat": {
-                      "tooltip": "The number of days fromâ€¯\"Insights as of\" date on the reportâ€¯when the metric was queried last."
+                      "tooltip": "The number of days from \"Insights as of\" date on the report when the metric was queried last."
                     }
                   },
                   {


### PR DESCRIPTION
 1. Preserved existing tabs

  The new file had broken all 3 original tabs (changed resourceType, altered queries, restructured Limits & Usage).
  Rebuilt from the old file as base, only appending the new "Ingestion Volume Change" tab.

  2. Added tooltips to new tab

  Added 3 common-column tooltips (Namespace, Metric, Dimensions) matching the pattern from other tabs.

  3. Fixed visibility conditions

   - Diagnostic error style: error → warning (matches other tabs)
   - Warning text & learn more URL: matched to other tabs (learn.microsoft.com not review.learn.microsoft.com)
   - Dropdown, date tiles, grid: hidden when no diagnostic settings or no data
   - Learn more link: always visible

  4. Fixed pre-existing bug — "Insights as of" on Unused Metrics

  freshnessDate2 referenced DataPresent instead of DataPresent2, so the tile never displayed.

  5. Fixed infinity symbol (∞)

  Guarded both % Change calculations with iff(divisor == 0, real(null), ...) — empty cell instead of ∞.