### PR TITLE
Fix allowedTenantsForQuery to correctly serialize as JSON array

### DIFF
--- a/Workbooks/Azure Monitor - Workspaces/Enable MSFT tenant access/Enable MSFT tenant access.workbook
+++ b/Workbooks/Azure Monitor - Workspaces/Enable MSFT tenant access/Enable MSFT tenant access.workbook
@@ -66,7 +66,7 @@
             "description": "Tenants available for cross-tenant query access, auto-detected from workspace cloud. AME workspaces → CORP. Fairfax/Mooncake workspaces → AME and/or Torus.",
             "isRequired": true,
             "multiSelect": true,
-            "quote": "'",
+            "quote": "\"",
             "delimiter": ",",
             "query": "resources | where id =~ \"{Workspace}\" | extend endpoint = tostring(properties.metrics.prometheusQueryEndpoint) | extend cloud = case(endpoint endswith \"prometheus.monitor.azure.us\", \"FF\", endpoint endswith \"prometheus.monitor.azure.cn\", \"MC\", \"AME\") | extend corp = pack(\"label\", \"CORP (72f988bf-86f1-41af-91ab-2d7cd011db47)\", \"value\", \"72f988bf-86f1-41af-91ab-2d7cd011db47\") | extend ame = pack(\"label\", \"AME (33e01921-4d64-4f8c-a055-5bdaffd5e33d)\", \"value\", \"33e01921-4d64-4f8c-a055-5bdaffd5e33d\") | extend torus = pack(\"label\", \"Torus (cdc5aeea-15c5-4db6-b079-fcadd2505dc2)\", \"value\", \"cdc5aeea-15c5-4db6-b079-fcadd2505dc2\") | project tenants = iff(cloud == \"AME\", pack_array(corp), pack_array(ame, torus)) | mv-expand tenants | project value = tostring(tenants.value), label = tostring(tenants.label)",
             "crossComponentResources": [
@@ -175,7 +175,7 @@
                         "value": "{apiVersion}"
                       }
                     ],
-                    "body": "{                              \r\n  \"id\": \"{Workspace:id}\",\r\n  \"location\": \"{location}\",\r\n  \"name\": \"{Workspace:name}\",\r\n  \"type\": \"microsoft.monitor/accounts\",\r\n  \"properties\": {\r\n      \"allowedTenantsForQuery\": [\"{selectedTenant}\"]\r\n  }\r\n}\r\n ",
+                    "body": "{                              \r\n  \"id\": \"{Workspace:id}\",\r\n  \"location\": \"{location}\",\r\n  \"name\": \"{Workspace:name}\",\r\n  \"type\": \"microsoft.monitor/accounts\",\r\n  \"properties\": {\r\n      \"allowedTenantsForQuery\": [{selectedTenant}]\r\n  }\r\n}\r\n ",
                     "httpMethod": "PUT",
                     "title": "Allow tenant access",
                     "description": "{Workspace:grid}\n\nTenant(s) to allow access: **{selectedTenant:label}**\n\nClick `Allow` to confirm updating allowed tenants on `{Workspace:name}`.",


### PR DESCRIPTION
Change selectedTenant parameter quote from single-quote to double-quote and remove explicit quotes from the ARM action body so multi-select tenant values expand as a proper JSON string array: ["tenant1","tenant2"] instead of ["'tenant1','tenant2'"].

## Summary

Fixing a bug in allowed tenants query arm action, where the tenant has extra single quotes:

<img width="551" height="102" alt="image" src="https://github.com/user-attachments/assets/ad673c19-91fa-4107-851f-604f79a1ecfe" />

## Screenshots

- [ ] If you added a template to a gallery, show a screenshot of it in the gallery view (which verifies its shows up where you expected).

  It is also good to show a screenshot of template content, so people can see what you expect it to look like, compared to what they see when they might run it themselves.

## Validation

- [x] Validate your changes using one or more of the [testing](https://github.com/microsoft/Application-Insights-Workbooks/blob/master/Documentation/Testing.md) methods.
  
  Make sure you've tested your template content. Fixing things while in PR is trivial. Hotfixing it later is very expensive; at the current time at least 3 teams are involved in a hotfix!

## Checklist

- [x] If you are adding a new template, gallery, or folder, add your team and folder/file(s) to the CODEOWNERS file at the root of the repo. CODEOWNERS entries should be teams, not individuals.
      When done correctly, this means that from then on *your* team does reviews of *your* things, not the workbooks team.
- [x] Ensure all steps in your template have meaningful names.
- [x] Ensure all parameters and grid columns have display names set so they can be localized.
