### PR TITLE
Fix 'undefined is not valid JSON' on first View Traces click in Agents workbook

### DIFF
--- a/Workbooks/UsageMetrics/Agents - Overview/Agents - Overview.workbook
+++ b/Workbooks/UsageMetrics/Agents - Overview/Agents - Overview.workbook
@@ -244,6 +244,20 @@
             "resourceType": "microsoft.insights/components"
           },
           {
+            "id": "af7e6104-2692-4cc8-a3f5-25634bd31478",
+            "version": "KqlParameterItem/1.0",
+            "name": "AgentErroredOpIdFilter",
+            "type": 1,
+            "query": "let agents = dependencies\r\n| where customDimensions[\"gen_ai.operation.name\"] == \"invoke_agent\"\r\n| extend AgentName = tostring(customDimensions[\"gen_ai.agent.name\"])\r\n| where \"{SelectedAgent}\" == \"__ALL__\" or \"{SelectedAgent}\" == AgentName;\r\nlet agentCalls = dependencies\r\n| lookup kind=inner (agents) on $left.operation_ParentId == $right.id;\r\nunion agents, agentCalls\r\n| extend ErrorType = tostring(customDimensions[\"error.type\"])\r\n| extend ErrorType = iff(success == false and isempty(ErrorType), \"Other\", ErrorType)\r\n| where isnotempty(ErrorType)\r\n| distinct operation_Id\r\n| take iff(\"{SelectedAgent}\" == \"__ALL__\", 0, 300)\r\n| summarize Num = count(), OpIds=make_list(operation_Id)\r\n| extend FilterText = strcat(```\r\n,\r\n        {\r\n          \"dimension\": {\r\n              \"displayName\": \"Operation Id\",\r\n              \"tables\": [\r\n                  \"dependencies\"\r\n              ],\r\n              \"name\": \"operation/id\",\r\n              \"draftKey\": \"operation/id\"\r\n          },\r\n          \"values\":```, OpIds, \"}\")\r\n| project FilterText = iff(Num > 0, FilterText, \"\")",
+            "isHiddenWhenLocked": true,
+            "timeContext": {
+              "durationMs": 0
+            },
+            "timeContextFromParameter": "TimeRange",
+            "queryType": 0,
+            "resourceType": "microsoft.insights/components"
+          },
+          {
             "id": "74747891-f8e5-4e44-897e-c00836791635",
             "version": "KqlParameterItem/1.0",
             "name": "AgentRunsSearchParameters",
@@ -275,41 +289,25 @@
             "name": "AgentRunsFailuresParameters",
             "type": 1,
             "isHiddenWhenLocked": true,
-            "query": "let agents = dependencies\r\n| where customDimensions[\"gen_ai.operation.name\"] == \"invoke_agent\"\r\n| extend AgentName = tostring(customDimensions[\"gen_ai.agent.name\"])\r\n| where \"{SelectedAgent}\" == \"__ALL__\" or \"{SelectedAgent}\" == AgentName;\r\nlet agentCalls = dependencies\r\n| lookup kind=inner (agents) on $left.operation_ParentId == $right.id;\r\nunion agents, agentCalls\r\n| extend ErrorType = tostring(customDimensions[\"error.type\"])\r\n| extend ErrorType = iff(success == false and isempty(ErrorType), \"Other\", ErrorType)\r\n| where isnotempty(ErrorType)\r\n| distinct operation_Id\r\n| take iff(\"{SelectedAgent}\" == \"__ALL__\", 0, 300)\r\n| summarize Num = count(), OpIds = make_list(operation_Id)\r\n| extend OpFilter = iff(Num > 0, strcat(\r\n        \", {          \\\"dimension\\\": {              \\\"displayName\\\": \\\"Operation Id\\\",              \\\"tables\\\": [                  \\\"dependencies\\\"              ],              \\\"name\\\": \\\"operation/id\\\",              \\\"draftKey\\\": \\\"operation/id\\\"          },          \\\"values\\\":\",\r\n        OpIds,\r\n        \"}\"\r\n), \"\")\r\n| project BladeJson = strcat(\r\n    \"{   \\\"ResourceId\\\": \\\"{ResourceId:id}\\\",   \\\"HideChart\\\": true,   \\\"IsGenAiFlow\\\": true,   \\\"FilterSpec\\\": {     \\\"originalParams\\\": {       \\\"eventTypes\\\": [         {           \\\"value\\\": \\\"dependency\\\",           \\\"tableName\\\": \\\"dependencies\\\",           \\\"label\\\": \\\"Dependency\\\"         }       ],       \\\"timeContext\\\": {         \\\"durationMs\\\": \\\"{TimeRange:seconds}000\\\",         \\\"endTime\\\": \\\"{TimeRange:endISO}\\\",         \\\"createdTime\\\": \\\"{TimeRange:startISO}\\\",         \\\"isInitialTime\\\": false,         \\\"grain\\\": 1,         \\\"useDashboardTimeRange\\\": false       },       \\\"filter\\\": [         {           \\\"dimension\\\": {             \\\"displayName\\\": \\\"Dependency call status\\\",             \\\"tables\\\": [               \\\"dependencies\\\"             ],             \\\"name\\\": \\\"dependency/success\\\",             \\\"draftKey\\\": \\\"dependency/success\\\"           },           \\\"values\\\": [             \\\"False\\\"           ],           \\\"operator\\\": {             \\\"label\\\": \\\"=\\\",             \\\"value\\\": \\\"==\\\",             \\\"isSelected\\\": true           }         },         {           \\\"dimension\\\": {             \\\"name\\\": \\\"customDimensions/gen_ai.operation.name\\\",             \\\"draftKey\\\": \\\"customDimensions/gen_ai.operation.name\\\",             \\\"displayName\\\": \\\"GenAI Operation\\\",             \\\"tables\\\": [               \\\"dependencies\\\"             ]           },           \\\"values\\\": [             \\\"invoke_agent\\\",             \\\"execute_tool\\\",             \\\"chat.completions\\\",             \\\"text_completions\\\",             \\\"generate_content\\\"           ]         }\",\r\n    OpFilter,\r\n    \"       ],       \\\"searchPhrase\\\": {         \\\"originalPhrase\\\": \\\"\\\"       }     }   } }\"\r\n)",
-            "timeContext": {
-              "durationMs": 0
-            },
-            "timeContextFromParameter": "TimeRange",
-            "queryType": 0,
-            "resourceType": "microsoft.insights/components"
-          },
-          {
-            "id": "b1c2d3e4-f5a6-4b7c-8d9e-0f1a2b3c4d5e",
-            "version": "KqlParameterItem/1.0",
-            "name": "AgentRunsHasResults",
-            "type": 1,
-            "query": "dependencies\r\n| where customDimensions[\"gen_ai.operation.name\"] == \"invoke_agent\"\r\n| extend AgentName = tostring(customDimensions[\"gen_ai.agent.name\"])\r\n| where \"{SelectedAgent}\" == \"__ALL__\" or \"{SelectedAgent}\" == AgentName\r\n| summarize Num = count()\r\n| project HasResults = iff(Num > 0, \"true\", \"false\")",
-            "isHiddenWhenLocked": true,
-            "timeContext": {
-              "durationMs": 0
-            },
-            "timeContextFromParameter": "TimeRange",
-            "queryType": 0,
-            "resourceType": "microsoft.insights/components"
-          },
-          {
-            "id": "a9b8c7d6-e5f4-4a3b-2c1d-0e9f8a7b6c5d",
-            "version": "KqlParameterItem/1.0",
-            "name": "GenAIErrorsHasResults",
-            "type": 1,
-            "query": "let agents = dependencies\r\n| where customDimensions[\"gen_ai.operation.name\"] == \"invoke_agent\"\r\n| extend AgentName = tostring(customDimensions[\"gen_ai.agent.name\"])\r\n| where \"{SelectedAgent}\" == \"__ALL__\" or \"{SelectedAgent}\" == AgentName;\r\nlet agentCalls = dependencies\r\n| lookup kind=inner (agents) on $left.operation_ParentId == $right.id;\r\nunion agents, agentCalls\r\n| extend ErrorType = tostring(customDimensions[\"error.type\"])\r\n| extend ErrorType = iff(success == false and isempty(ErrorType), \"Other\", ErrorType)\r\n| where isnotempty(ErrorType)\r\n| summarize Num = count()\r\n| project HasResults = iff(Num > 0, \"true\", \"false\")",
-            "isHiddenWhenLocked": true,
-            "timeContext": {
-              "durationMs": 0
-            },
-            "timeContextFromParameter": "TimeRange",
-            "queryType": 0,
-            "resourceType": "microsoft.insights/components"
+            "criteriaData": [
+              {
+                "criteriaContext": {
+                  "leftOperand": "SelectedAgent",
+                  "operator": "!=",
+                  "rightValType": "static",
+                  "rightVal": "__ALL__",
+                  "resultValType": "static",
+                  "resultVal": "{   \"ResourceId\": \"{ResourceId:id}\",   \"HideChart\": true,   \"IsGenAiFlow\": true,   \"FilterSpec\": {     \"originalParams\": {       \"eventTypes\": [         {           \"value\": \"dependency\",           \"tableName\": \"dependencies\",           \"label\": \"Dependency\"         }       ],       \"timeContext\": {         \"durationMs\": \"{TimeRange:seconds}000\",         \"endTime\": \"{TimeRange:endISO}\",         \"createdTime\": \"{TimeRange:startISO}\",         \"isInitialTime\": false,         \"grain\": 1,         \"useDashboardTimeRange\": false       },       \"filter\": [         {           \"dimension\": {             \"displayName\": \"Dependency call status\",             \"tables\": [               \"dependencies\"             ],             \"name\": \"dependency/success\",             \"draftKey\": \"dependency/success\"           },           \"values\": [             \"False\"           ],           \"operator\": {             \"label\": \"=\",             \"value\": \"==\",             \"isSelected\": true           }         },         {           \"dimension\": {             \"name\": \"customDimensions/gen_ai.operation.name\",             \"draftKey\": \"customDimensions/gen_ai.operation.name\",             \"displayName\": \"GenAI Operation\",             \"tables\": [               \"dependencies\"             ]           },           \"values\": [             \"invoke_agent\",             \"execute_tool\",             \"chat.completions\",             \"text_completions\",             \"generate_content\"           ]         }{AgentErroredOpIdFilter}       ],       \"searchPhrase\": {         \"originalPhrase\": \"\"       }     }   } }"
+                }
+              },
+              {
+                "criteriaContext": {
+                  "operator": "Default",
+                  "resultValType": "static",
+                  "resultVal": "{   \"ResourceId\": \"{ResourceId:id}\", \"HideChart\": true,\"IsGenAiFlow\": true,\r\n   \"FilterSpec\": {     \"originalParams\": {       \"eventTypes\": [         {           \"value\": \"dependency\",           \"tableName\": \"dependencies\",           \"label\": \"Dependency\"         }       ],       \"timeContext\": {         \"durationMs\": \"{TimeRange:seconds}000\",         \"endTime\": \"{TimeRange:endISO}\",         \"createdTime\": \"{TimeRange:startISO}\",         \"isInitialTime\": false,         \"grain\": 1,         \"useDashboardTimeRange\": false       },       \"filter\": [          {             \"dimension\": {                 \"displayName\": \"Dependency call status\",                 \"tables\": [                     \"dependencies\"                 ],                 \"name\": \"dependency/success\",                 \"draftKey\": \"dependency/success\"             },             \"values\": [                 \"False\"             ],             \"operator\": {                 \"label\": \"=\",                 \"value\": \"==\",                 \"isSelected\": true             }         },         {           \"dimension\": {             \"name\": \"customDimensions/gen_ai.operation.name\",             \"draftKey\": \"customDimensions/gen_ai.operation.name\",             \"displayName\": \"GenAI Operation\",             \"tables\": [               \"dependencies\"             ]           },           \"values\": [             \"invoke_agent\",             \"execute_tool\",             \"chat.completions\",             \"text_completions\",             \"generate_content\"           ]         }       ],       \"searchPhrase\": {         \"originalPhrase\": \"\"       }     }   } }"
+                }
+              }
+            ]
           },
           {
             "id": "c4d5e6f7-a8b9-0c1d-2e3f-4a5b6c7d8e9f",
@@ -586,9 +584,8 @@
                         },
                         "customWidth": "0",
                         "conditionalVisibility": {
-                          "parameterName": "AgentRunsHasResults",
-                          "comparison": "isEqualTo",
-                          "value": "true"
+                          "parameterName": "AgentRunsSearchParameters",
+                          "comparison": "isNotEqualTo"
                         },
                         "name": "AgentRunsOpenBlade",
                         "styleSettings": {
@@ -658,9 +655,8 @@
                         },
                         "customWidth": "0",
                         "conditionalVisibility": {
-                          "parameterName": "GenAIErrorsHasResults",
-                          "comparison": "isEqualTo",
-                          "value": "true"
+                          "parameterName": "AgentRunsFailuresParameters",
+                          "comparison": "isNotEqualTo"
                         },
                         "name": "GenAIErrorsOpenBlade",
                         "styleSettings": {

--- a/Workbooks/UsageMetrics/Agents - Overview/Agents - Overview.workbook
+++ b/Workbooks/UsageMetrics/Agents - Overview/Agents - Overview.workbook
@@ -583,6 +583,11 @@
                           ]
                         },
                         "customWidth": "0",
+                        "conditionalVisibility": {
+                          "parameterName": "GenAIDataCheck",
+                          "comparison": "isEqualTo",
+                          "value": "OK"
+                        },
                         "name": "AgentRunsOpenBlade",
                         "styleSettings": {
                           "margin": "0 0 10px 10px"
@@ -650,6 +655,11 @@
                           ]
                         },
                         "customWidth": "0",
+                        "conditionalVisibility": {
+                          "parameterName": "GenAIDataCheck",
+                          "comparison": "isEqualTo",
+                          "value": "OK"
+                        },
                         "name": "GenAIErrorsOpenBlade",
                         "styleSettings": {
                           "margin": "0 0 10px 0"

--- a/Workbooks/UsageMetrics/Agents - Overview/Agents - Overview.workbook
+++ b/Workbooks/UsageMetrics/Agents - Overview/Agents - Overview.workbook
@@ -310,6 +310,34 @@
             ]
           },
           {
+            "id": "b1c2d3e4-f5a6-4b7c-8d9e-0f1a2b3c4d5e",
+            "version": "KqlParameterItem/1.0",
+            "name": "AgentRunsHasResults",
+            "type": 1,
+            "query": "dependencies\r\n| where customDimensions[\"gen_ai.operation.name\"] == \"invoke_agent\"\r\n| extend AgentName = tostring(customDimensions[\"gen_ai.agent.name\"])\r\n| where \"{SelectedAgent}\" == \"__ALL__\" or \"{SelectedAgent}\" == AgentName\r\n| summarize Num = count()\r\n| project HasResults = iff(Num > 0, \"true\", \"false\")",
+            "isHiddenWhenLocked": true,
+            "timeContext": {
+              "durationMs": 0
+            },
+            "timeContextFromParameter": "TimeRange",
+            "queryType": 0,
+            "resourceType": "microsoft.insights/components"
+          },
+          {
+            "id": "a9b8c7d6-e5f4-4a3b-2c1d-0e9f8a7b6c5d",
+            "version": "KqlParameterItem/1.0",
+            "name": "GenAIErrorsHasResults",
+            "type": 1,
+            "query": "let agents = dependencies\r\n| where customDimensions[\"gen_ai.operation.name\"] == \"invoke_agent\"\r\n| extend AgentName = tostring(customDimensions[\"gen_ai.agent.name\"])\r\n| where \"{SelectedAgent}\" == \"__ALL__\" or \"{SelectedAgent}\" == AgentName;\r\nlet agentCalls = dependencies\r\n| lookup kind=inner (agents) on $left.operation_ParentId == $right.id;\r\nunion agents, agentCalls\r\n| extend ErrorType = tostring(customDimensions[\"error.type\"])\r\n| extend ErrorType = iff(success == false and isempty(ErrorType), \"Other\", ErrorType)\r\n| where isnotempty(ErrorType)\r\n| summarize Num = count()\r\n| project HasResults = iff(Num > 0, \"true\", \"false\")",
+            "isHiddenWhenLocked": true,
+            "timeContext": {
+              "durationMs": 0
+            },
+            "timeContextFromParameter": "TimeRange",
+            "queryType": 0,
+            "resourceType": "microsoft.insights/components"
+          },
+          {
             "id": "c4d5e6f7-a8b9-0c1d-2e3f-4a5b6c7d8e9f",
             "version": "KqlParameterItem/1.0",
             "name": "ObsAgentAdditionalContext",
@@ -584,9 +612,9 @@
                         },
                         "customWidth": "0",
                         "conditionalVisibility": {
-                          "parameterName": "GenAIDataCheck",
+                          "parameterName": "AgentRunsHasResults",
                           "comparison": "isEqualTo",
-                          "value": "OK"
+                          "value": "true"
                         },
                         "name": "AgentRunsOpenBlade",
                         "styleSettings": {
@@ -656,9 +684,9 @@
                         },
                         "customWidth": "0",
                         "conditionalVisibility": {
-                          "parameterName": "GenAIDataCheck",
+                          "parameterName": "GenAIErrorsHasResults",
                           "comparison": "isEqualTo",
-                          "value": "OK"
+                          "value": "true"
                         },
                         "name": "GenAIErrorsOpenBlade",
                         "styleSettings": {

--- a/Workbooks/UsageMetrics/Agents - Overview/Agents - Overview.workbook
+++ b/Workbooks/UsageMetrics/Agents - Overview/Agents - Overview.workbook
@@ -244,20 +244,6 @@
             "resourceType": "microsoft.insights/components"
           },
           {
-            "id": "af7e6104-2692-4cc8-a3f5-25634bd31478",
-            "version": "KqlParameterItem/1.0",
-            "name": "AgentErroredOpIdFilter",
-            "type": 1,
-            "query": "let agents = dependencies\r\n| where customDimensions[\"gen_ai.operation.name\"] == \"invoke_agent\"\r\n| extend AgentName = tostring(customDimensions[\"gen_ai.agent.name\"])\r\n| where \"{SelectedAgent}\" == \"__ALL__\" or \"{SelectedAgent}\" == AgentName;\r\nlet agentCalls = dependencies\r\n| lookup kind=inner (agents) on $left.operation_ParentId == $right.id;\r\nunion agents, agentCalls\r\n| extend ErrorType = tostring(customDimensions[\"error.type\"])\r\n| extend ErrorType = iff(success == false and isempty(ErrorType), \"Other\", ErrorType)\r\n| where isnotempty(ErrorType)\r\n| distinct operation_Id\r\n| take iff(\"{SelectedAgent}\" == \"__ALL__\", 0, 300)\r\n| summarize Num = count(), OpIds=make_list(operation_Id)\r\n| extend FilterText = strcat(```\r\n,\r\n        {\r\n          \"dimension\": {\r\n              \"displayName\": \"Operation Id\",\r\n              \"tables\": [\r\n                  \"dependencies\"\r\n              ],\r\n              \"name\": \"operation/id\",\r\n              \"draftKey\": \"operation/id\"\r\n          },\r\n          \"values\":```, OpIds, \"}\")\r\n| project FilterText = iff(Num > 0, FilterText, \"\")",
-            "isHiddenWhenLocked": true,
-            "timeContext": {
-              "durationMs": 0
-            },
-            "timeContextFromParameter": "TimeRange",
-            "queryType": 0,
-            "resourceType": "microsoft.insights/components"
-          },
-          {
             "id": "74747891-f8e5-4e44-897e-c00836791635",
             "version": "KqlParameterItem/1.0",
             "name": "AgentRunsSearchParameters",
@@ -289,25 +275,13 @@
             "name": "AgentRunsFailuresParameters",
             "type": 1,
             "isHiddenWhenLocked": true,
-            "criteriaData": [
-              {
-                "criteriaContext": {
-                  "leftOperand": "SelectedAgent",
-                  "operator": "!=",
-                  "rightValType": "static",
-                  "rightVal": "__ALL__",
-                  "resultValType": "static",
-                  "resultVal": "{   \"ResourceId\": \"{ResourceId:id}\",   \"HideChart\": true,   \"IsGenAiFlow\": true,   \"FilterSpec\": {     \"originalParams\": {       \"eventTypes\": [         {           \"value\": \"dependency\",           \"tableName\": \"dependencies\",           \"label\": \"Dependency\"         }       ],       \"timeContext\": {         \"durationMs\": \"{TimeRange:seconds}000\",         \"endTime\": \"{TimeRange:endISO}\",         \"createdTime\": \"{TimeRange:startISO}\",         \"isInitialTime\": false,         \"grain\": 1,         \"useDashboardTimeRange\": false       },       \"filter\": [         {           \"dimension\": {             \"displayName\": \"Dependency call status\",             \"tables\": [               \"dependencies\"             ],             \"name\": \"dependency/success\",             \"draftKey\": \"dependency/success\"           },           \"values\": [             \"False\"           ],           \"operator\": {             \"label\": \"=\",             \"value\": \"==\",             \"isSelected\": true           }         },         {           \"dimension\": {             \"name\": \"customDimensions/gen_ai.operation.name\",             \"draftKey\": \"customDimensions/gen_ai.operation.name\",             \"displayName\": \"GenAI Operation\",             \"tables\": [               \"dependencies\"             ]           },           \"values\": [             \"invoke_agent\",             \"execute_tool\",             \"chat.completions\",             \"text_completions\",             \"generate_content\"           ]         }{AgentErroredOpIdFilter}       ],       \"searchPhrase\": {         \"originalPhrase\": \"\"       }     }   } }"
-                }
-              },
-              {
-                "criteriaContext": {
-                  "operator": "Default",
-                  "resultValType": "static",
-                  "resultVal": "{   \"ResourceId\": \"{ResourceId:id}\", \"HideChart\": true,\"IsGenAiFlow\": true,\r\n   \"FilterSpec\": {     \"originalParams\": {       \"eventTypes\": [         {           \"value\": \"dependency\",           \"tableName\": \"dependencies\",           \"label\": \"Dependency\"         }       ],       \"timeContext\": {         \"durationMs\": \"{TimeRange:seconds}000\",         \"endTime\": \"{TimeRange:endISO}\",         \"createdTime\": \"{TimeRange:startISO}\",         \"isInitialTime\": false,         \"grain\": 1,         \"useDashboardTimeRange\": false       },       \"filter\": [          {             \"dimension\": {                 \"displayName\": \"Dependency call status\",                 \"tables\": [                     \"dependencies\"                 ],                 \"name\": \"dependency/success\",                 \"draftKey\": \"dependency/success\"             },             \"values\": [                 \"False\"             ],             \"operator\": {                 \"label\": \"=\",                 \"value\": \"==\",                 \"isSelected\": true             }         },         {           \"dimension\": {             \"name\": \"customDimensions/gen_ai.operation.name\",             \"draftKey\": \"customDimensions/gen_ai.operation.name\",             \"displayName\": \"GenAI Operation\",             \"tables\": [               \"dependencies\"             ]           },           \"values\": [             \"invoke_agent\",             \"execute_tool\",             \"chat.completions\",             \"text_completions\",             \"generate_content\"           ]         }       ],       \"searchPhrase\": {         \"originalPhrase\": \"\"       }     }   } }"
-                }
-              }
-            ]
+            "query": "let agents = dependencies\r\n| where customDimensions[\"gen_ai.operation.name\"] == \"invoke_agent\"\r\n| extend AgentName = tostring(customDimensions[\"gen_ai.agent.name\"])\r\n| where \"{SelectedAgent}\" == \"__ALL__\" or \"{SelectedAgent}\" == AgentName;\r\nlet agentCalls = dependencies\r\n| lookup kind=inner (agents) on $left.operation_ParentId == $right.id;\r\nunion agents, agentCalls\r\n| extend ErrorType = tostring(customDimensions[\"error.type\"])\r\n| extend ErrorType = iff(success == false and isempty(ErrorType), \"Other\", ErrorType)\r\n| where isnotempty(ErrorType)\r\n| distinct operation_Id\r\n| take iff(\"{SelectedAgent}\" == \"__ALL__\", 0, 300)\r\n| summarize Num = count(), OpIds = make_list(operation_Id)\r\n| extend OpFilter = iff(Num > 0, strcat(\r\n        \", {          \\\"dimension\\\": {              \\\"displayName\\\": \\\"Operation Id\\\",              \\\"tables\\\": [                  \\\"dependencies\\\"              ],              \\\"name\\\": \\\"operation/id\\\",              \\\"draftKey\\\": \\\"operation/id\\\"          },          \\\"values\\\":\",\r\n        OpIds,\r\n        \"}\"\r\n), \"\")\r\n| project BladeJson = strcat(\r\n    \"{   \\\"ResourceId\\\": \\\"{ResourceId:id}\\\",   \\\"HideChart\\\": true,   \\\"IsGenAiFlow\\\": true,   \\\"FilterSpec\\\": {     \\\"originalParams\\\": {       \\\"eventTypes\\\": [         {           \\\"value\\\": \\\"dependency\\\",           \\\"tableName\\\": \\\"dependencies\\\",           \\\"label\\\": \\\"Dependency\\\"         }       ],       \\\"timeContext\\\": {         \\\"durationMs\\\": \\\"{TimeRange:seconds}000\\\",         \\\"endTime\\\": \\\"{TimeRange:endISO}\\\",         \\\"createdTime\\\": \\\"{TimeRange:startISO}\\\",         \\\"isInitialTime\\\": false,         \\\"grain\\\": 1,         \\\"useDashboardTimeRange\\\": false       },       \\\"filter\\\": [         {           \\\"dimension\\\": {             \\\"displayName\\\": \\\"Dependency call status\\\",             \\\"tables\\\": [               \\\"dependencies\\\"             ],             \\\"name\\\": \\\"dependency/success\\\",             \\\"draftKey\\\": \\\"dependency/success\\\"           },           \\\"values\\\": [             \\\"False\\\"           ],           \\\"operator\\\": {             \\\"label\\\": \\\"=\\\",             \\\"value\\\": \\\"==\\\",             \\\"isSelected\\\": true           }         },         {           \\\"dimension\\\": {             \\\"name\\\": \\\"customDimensions/gen_ai.operation.name\\\",             \\\"draftKey\\\": \\\"customDimensions/gen_ai.operation.name\\\",             \\\"displayName\\\": \\\"GenAI Operation\\\",             \\\"tables\\\": [               \\\"dependencies\\\"             ]           },           \\\"values\\\": [             \\\"invoke_agent\\\",             \\\"execute_tool\\\",             \\\"chat.completions\\\",             \\\"text_completions\\\",             \\\"generate_content\\\"           ]         }\",\r\n    OpFilter,\r\n    \"       ],       \\\"searchPhrase\\\": {         \\\"originalPhrase\\\": \\\"\\\"       }     }   } }\"\r\n)",
+            "timeContext": {
+              "durationMs": 0
+            },
+            "timeContextFromParameter": "TimeRange",
+            "queryType": 0,
+            "resourceType": "microsoft.insights/components"
           },
           {
             "id": "b1c2d3e4-f5a6-4b7c-8d9e-0f1a2b3c4d5e",


### PR DESCRIPTION
## Problem
On initial load, clicking **View Traces with Agent Runs** (or **View Traces with Gen AI Errors**) in the *Agents - Overview* workbook opens an error Details pane instead of the Search blade:

SyntaxError: "undefined" is not valid JSON (thrown by JSON.parse inside WorkbookLinkOpener).

The error self-heals on a second click.

## Root cause
Each link sets its entire `bladeJsonParameters` to a single derived-parameter reference (`{AgentRunsSearchParameters}` / `{AgentRunsFailuresParameters}`). On the first render frame, before that parameter has finished resolving, the token is `undefined`, so `JSON.parse("undefined")` throws. Unlike the Evaluation-card `View Traces` links, these two had no `conditionalVisibility` gating, so they were clickable before their payload resolved. (The Gen AI Errors payload additionally embeds an async helper parameter, `{AgentErroredOpIdFilter}`, which widens that window — while the helper is still resolving, the whole `AgentRunsFailuresParameters` value is reported as `undefined`.)

## Fix
Gate each link on **the exact parameter its own `bladeJsonParameters` reads**, using the standard workbook idiom `"comparison": "isNotEqualTo"` with no `value` — i.e. *visible only when that parameter is non-empty*:

| Link | Gated on (the param it opens with) |
| --- | --- |
| `AgentRunsOpenBlade` | `AgentRunsSearchParameters` |
| `GenAIErrorsOpenBlade` | `AgentRunsFailuresParameters` |

```json
"conditionalVisibility": {
  "parameterName": "AgentRunsFailuresParameters",
  "comparison": "isNotEqualTo"
}
```

Why this is correct and minimal:
- **The gate and the button read the identical parameter**, so they can never disagree. Whatever value the button would receive, the gate evaluated that same value first: empty/unresolved → the link is hidden (nothing to click, so no `JSON.parse(undefined)`); resolved → the link appears and opens with valid JSON.
- **No extra queries.** `AgentRunsSearchParameters` and `AgentRunsFailuresParameters` are in-memory `criteriaData` parameters, so gating on them directly needs no new probe query.
- **Handles the async helper for free.** A workbook parameter with an unexpanded nested token (`{AgentErroredOpIdFilter}`) is reported as *unresolved/empty* (which is exactly why the original error was literally `undefined`, not a stray-token parse error). So gating on `AgentRunsFailuresParameters` transitively waits for the helper to finish — no payload refactor needed.

Net change vs `master` is the two `conditionalVisibility` blocks (8 lines added); no parameters, queries, or payloads were otherwise modified.

## Validation
- Workbook JSON parses cleanly (11 top-level items intact); repository `mocha` validation suite passes (schema + single-workbook-per-folder checks).
- Net diff vs base `master` is exactly the two added `conditionalVisibility` gates.

## Screenshots
Before
<img width="2543" height="1305" alt="image" src="https://github.com/user-attachments/assets/d9edabfa-fb59-4efa-8ad9-e0e3bb34542f" />

After
"View Traces" button hidden on initial load until parameters resolve
<img width="2544" height="1297" alt="image" src="https://github.com/user-attachments/assets/c8aee162-9cb5-40d0-b7b3-bf38cb8d4681" />