### PR TITLE
Update WUfB Reports CODEOWNERS team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -20,7 +20,7 @@
 # anything not specified will default to requiring review by the workbooks team
 # it also appears that spaces in directory names are not well handled or are handled differently on different platforms. so here * is used instead of spaces.
 
-/Workbooks/WaaSUpdateInsights/** @microsoft/update-compliance-workbooks
+/Workbooks/WaaSUpdateInsights/** @microsoft/windows-update-for-business-reports-workbooks
 /Workbooks/Azure*Security*Center/** @microsoft/defender-for-cloud-workbooks
 /Workbooks/Defender*for*IoT/** @microsoft/defender-for-iot-workbooks
 /Workbooks/Global*Secure*Access/** @microsoft/global-secure-access-workbooks
@@ -91,7 +91,7 @@
 
 /Workbooks/Network*Security*Perimeter/** @microsoft/networking-nsp-portal-workbooks
 
-/Workbooks/UpdateCompliance/** @microsoft/update-compliance-workbooks
+/Workbooks/UpdateCompliance/** @microsoft/windows-update-for-business-reports-workbooks
 
 /Workbooks/ServiceBus/** @microsoft/service-bus @microsoft/applicationinsights-devtools
 
@@ -142,7 +142,7 @@
 /Workbooks/Self*Serve*Limiting/UpdateIngestionLimits/** @microsoft/azure-monitor-workspaces
 
 # Section for gallery files
-/gallery/workbook/WaaSUpdateInsights.json @microsoft/update-compliance-workbooks
+/gallery/workbook/WaaSUpdateInsights.json @microsoft/windows-update-for-business-reports-workbooks
 /gallery/workbook/Azure*Monitor.json @microsoft/applicationinsights-devtools
 /gallery/workbook/Azure*Advisor.json @microsoft/advisor-waf-sme-workbooks
 /gallery/workbook/microsoft.monitor-accounts.json @microsoft/azure-monitor-workspaces


### PR DESCRIPTION
## Summary

Replace the removed `@microsoft/update-compliance-workbooks` CODEOWNERS team with `@microsoft/windows-update-for-business-reports-workbooks` for the WUfB Reports workbook paths and gallery entry.

This restores valid ownership and review routing after the previous GitHub team was removed.

## Screenshots

Not applicable; this is a CODEOWNERS-only change.

## Validation

- [x] Confirmed the replacement team exists in the Microsoft GitHub organization.
- [x] Confirmed the replacement team has write access to this repository.
- [x] Confirmed all references to the removed team in CODEOWNERS were replaced.

## Checklist

- [x] CODEOWNERS entries use a team, not individuals.
- [x] No workbook template, gallery content, folder, parameter, or grid content changed.