### PR TITLE
Migrate machine and container VA queries from sub-assessments to assessments

### DIFF
--- a/Workbooks/Azure Security Center/Vulnerabilities/Vulnerabilities.workbook
+++ b/Workbooks/Azure Security Center/Vulnerabilities/Vulnerabilities.workbook
@@ -27,7 +27,8 @@
                 "value::all"
               ],
               "includeAll": false,
-              "showDefault": false
+              "showDefault": false,
+              "selectAllValue": "*"
             },
             "timeContext": {
               "durationMs": 86400000
@@ -129,14 +130,14 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "securityresources\r\n| where type == \"microsoft.security/assessments/subassessments\"\r\n| extend assessmentKey = extract(\".*assessments/(.+?)/.*\",1,  id)\r\n| where assessmentKey == \"1195afff-c881-495e-9bc5-1486211ae03f\"\r\n| project ResourceType=tostring(split(id,\"/\").[6]), ResourceName=tostring(properties.resourceDetails.id)\r\n| summarize Count=dcount(ResourceName) by ResourceType",
+        "query": "securityresources\r\n| where '*' in ({Subscription}) or subscriptionId in~ ({Subscription:subid})\r\n| where type == \"microsoft.security/assessments\"\r\n| where properties.metadata.recommendationCategory == \"SoftwareUpdate\"\r\n| where tostring(properties.resourceDetails.ResourceType) == \"Microsoft.Compute/virtualMachines\" or tostring(properties.resourceDetails.ResourceType) == \"Microsoft.HybridCompute/machines\"\r\n| where tostring(properties.status.code) == 'Unhealthy'\r\n| project ResourceType = tostring(properties.resourceDetails.ResourceType), ResourceName = tolower(tostring(properties.resourceDetails.Id))\r\n| summarize by ResourceType, ResourceName\r\n| summarize Count = count() by ResourceType",
         "size": 4,
         "title": "Unhealthy machines",
         "noDataMessage": "No unhealthy machines found",
         "queryType": 1,
-        "resourceType": "microsoft.resourcegraph/resources",
+        "resourceType": "microsoft.resources/tenants",
         "crossComponentResources": [
-          "{Subscription}"
+          "value::tenant"
         ],
         "visualization": "table",
         "gridSettings": {
@@ -237,14 +238,14 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "securityresources\n| where type == \"microsoft.security/assessments\"\n| where properties.metadata.recommendationCategory == \"SoftwareUpdate\"\n| where properties.resourceDetails.ResourceType == \".containerimage\"\n| where properties.resourceDetails.Source == \"Azure\"\n| extend status = tostring(properties.status.code)\n| where status == \"Unhealthy\"\n| extend Resource = tolower(extract(@'(?i)(.*?)/securityentitydata/([^/]+)', 1, id))\n| extend ResourceType = \"microsoft.containerregistry/registries\"\n| summarize Count=dcount(Resource) by ResourceType",
+        "query": "securityresources\n| where '*' in ({Subscription}) or subscriptionId in~ ({Subscription:subid})\n| where type == \"microsoft.security/assessments\"\n| where properties.metadata.recommendationCategory == \"SoftwareUpdate\"\n| where properties.resourceDetails.ResourceType == \".containerimage\"\n| where properties.resourceDetails.Source == \"Azure\"\n| where tostring(properties.status.code) == \"Unhealthy\"\n| extend Resource = tolower(extract(@'(?i)(.*?)/securityentitydata/([^/]+)', 1, id))\n| extend ResourceType = \"microsoft.containerregistry/registries\"\n| summarize by Resource, ResourceType\n| summarize Count = count() by ResourceType",
         "size": 4,
         "title": "Unhealthy container registries",
         "noDataMessage": "No unhealthy container registries found",
         "queryType": 1,
-        "resourceType": "microsoft.resourcegraph/resources",
+        "resourceType": "microsoft.resources/tenants",
         "crossComponentResources": [
-          "{Subscription}"
+          "value::tenant"
         ],
         "visualization": "table",
         "gridSettings": {
@@ -307,14 +308,14 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "securityresources\n| where type =~ \"microsoft.security/assessments\"\n| extend scanner = tostring(coalesce(properties.additionalData.Scanner, properties.additionalData.scanner))\n| where scanner =~ \"SQL Vulnerability Assessment\"\n| extend ParentResource = tolower(tostring(coalesce(properties.additionalData.ParentResource, properties.additionalData.parentResource)))\n| where isnotempty(ParentResource)\n| extend ResourceType = tolower(split(ParentResource, \"/\").[6])\n| where tostring(properties.status.code) == \"Unhealthy\"\n| summarize Count=dcount(ParentResource) by ResourceType",
+        "query": "securityresources\n| where '*' in ({Subscription}) or subscriptionId in~ ({Subscription:subid})\n| where type =~ \"microsoft.security/assessments\"\n| extend scanner = tostring(coalesce(properties.additionalData.Scanner, properties.additionalData.scanner))\n| where scanner =~ \"SQL Vulnerability Assessment\"\n| extend ParentResource = tolower(tostring(coalesce(properties.additionalData.ParentResource, properties.additionalData.parentResource)))\n| where isnotempty(ParentResource)\n| extend ResourceType = tolower(split(ParentResource, \"/\").[6])\n| where tostring(properties.status.code) == \"Unhealthy\"\n| summarize Count=dcount(ParentResource) by ResourceType",
         "size": 4,
         "title": "Unhealthy SQL resources by type",
         "noDataMessage": "No unhealthy SQL resources found",
         "queryType": 1,
-        "resourceType": "microsoft.resourcegraph/resources",
+        "resourceType": "microsoft.resources/tenants",
         "crossComponentResources": [
-          "{Subscription}"
+          "value::tenant"
         ],
         "visualization": "table",
         "gridSettings": {
@@ -377,14 +378,14 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "securityresources\r\n| where type == \"microsoft.security/assessments/subassessments\"\r\n| extend assessmentKey = extract(\".*assessments/(.+?)/.*\",1,  id)\r\n| where assessmentKey == \"1195afff-c881-495e-9bc5-1486211ae03f\"\r\n| extend VulId = tostring(properties.id), Severity = tostring(properties.status.severity), Status = tostring(properties.status.code)\r\n| where Status == 'Unhealthy'\r\n| summarize Count = dcount(VulId) by Severity",
+        "query": "securityresources\r\n| where '*' in ({Subscription}) or subscriptionId in~ ({Subscription:subid})\r\n| where type == \"microsoft.security/assessments\"\r\n| where properties.metadata.recommendationCategory == \"SoftwareUpdate\"\r\n| where tostring(properties.resourceDetails.ResourceType) == \"Microsoft.Compute/virtualMachines\" or tostring(properties.resourceDetails.ResourceType) == \"Microsoft.HybridCompute/machines\"\r\n| where tostring(properties.status.code) == 'Unhealthy'\r\n| mv-expand cve = parse_json(tostring(properties.additionalData.CvesDetails))\r\n| extend cveId = tolower(tostring(cve.CveId))\r\n| join kind=leftouter (\r\n    securityresources\r\n    | where type =~ \"microsoft.security/cvedetails\"\r\n    | project cveId = tolower(tostring(properties.cveId)), cveDetails = properties\r\n) on cveId\r\n| extend Severity = tostring(cveDetails.severity)\r\n| extend Severity = iff(isempty(Severity), 'Unknown', Severity)\r\n| summarize by Severity, cveId\r\n| summarize Count = count() by Severity",
         "size": 1,
         "title": "Distinct vulnerabilities by severity",
         "noDataMessage": "No unhealthy machines found",
         "queryType": 1,
-        "resourceType": "microsoft.resourcegraph/resources",
+        "resourceType": "microsoft.resources/tenants",
         "crossComponentResources": [
-          "{Subscription}"
+          "value::tenant"
         ],
         "visualization": "piechart",
         "tileSettings": {
@@ -411,6 +412,10 @@
         "chartSettings": {
           "seriesLabelSettings": [
             {
+              "seriesName": "Critical",
+              "color": "redDark"
+            },
+            {
               "seriesName": "High",
               "color": "redBright"
             },
@@ -421,6 +426,10 @@
             {
               "seriesName": "Low",
               "color": "blueDark"
+            },
+            {
+              "seriesName": "Unknown",
+              "color": "gray"
             }
           ]
         }
@@ -437,14 +446,14 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "securityresources\n| where type == \"microsoft.security/assessments\"\n| where properties.metadata.recommendationCategory == \"SoftwareUpdate\"\n| where properties.resourceDetails.ResourceType == \".containerimage\"\n| where properties.resourceDetails.Source == \"Azure\"\n| extend status = tostring(properties.status.code)\n| where status == \"Unhealthy\"\n| extend CvesRaw = parse_json(tostring(properties.additionalData.CvesDetails))\n| project-away properties\n| mv-expand cve = CvesRaw\n| project-away CvesRaw\n| extend CveId = tostring(cve.CveId)\n| extend Severity = tostring(cve.Severity)\n| summarize Count = dcount(CveId) by Severity",
+        "query": "securityresources\n| where '*' in ({Subscription}) or subscriptionId in~ ({Subscription:subid})\n| where type == \"microsoft.security/assessments\"\n| where properties.metadata.recommendationCategory == \"SoftwareUpdate\"\n| where properties.resourceDetails.ResourceType == \".containerimage\"\n| where properties.resourceDetails.Source == \"Azure\"\n| where tostring(properties.status.code) == \"Unhealthy\"\n| extend Resource = tolower(extract(@'(?i)(.*?)/securityentitydata/([^/]+)', 1, id))\n| project CvesRaw = parse_json(tostring(properties.additionalData.CvesDetails))\n| mv-expand cve = CvesRaw\n| extend cveId = tolower(tostring(cve.CveId)), inlineSev = tostring(cve.Severity)\n| summarize inlineSev = min(inlineSev) by cveId\n| join kind=leftouter (\n    securityresources\n    | where type =~ \"microsoft.security/cvedetails\"\n    | project cveId = tolower(tostring(properties.cveId)), cveSeverity = tostring(properties.severity)\n) on cveId\n| extend Severity = iff(isempty(cveSeverity), inlineSev, cveSeverity)\n| extend Severity = iff(isempty(Severity), 'Unknown', Severity)\n| summarize Count = count() by Severity",
         "size": 1,
         "title": "Distinct vulnerabilities by severity",
         "noDataMessage": "No unhealthy container registries found",
         "queryType": 1,
-        "resourceType": "microsoft.resourcegraph/resources",
+        "resourceType": "microsoft.resources/tenants",
         "crossComponentResources": [
-          "{Subscription}"
+          "value::tenant"
         ],
         "visualization": "piechart",
         "tileSettings": {
@@ -505,14 +514,14 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "securityresources\n| where type =~ \"microsoft.security/assessments\"\n| extend scanner = tostring(coalesce(properties.additionalData.Scanner, properties.additionalData.scanner))\n| where scanner =~ \"SQL Vulnerability Assessment\"\n| extend VulnId = tostring(coalesce(properties.additionalData.RuleId, properties.additionalData.ruleId)), Severity = tostring(coalesce(properties.additionalData.Severity, properties.additionalData.severity)), Status = tostring(properties.status.code)\n| where Status == 'Unhealthy'\n| summarize dcount(VulnId) by Severity",
+        "query": "securityresources\n| where '*' in ({Subscription}) or subscriptionId in~ ({Subscription:subid})\n| where type =~ \"microsoft.security/assessments\"\n| extend scanner = tostring(coalesce(properties.additionalData.Scanner, properties.additionalData.scanner))\n| where scanner =~ \"SQL Vulnerability Assessment\"\n| extend VulnId = tostring(coalesce(properties.additionalData.RuleId, properties.additionalData.ruleId)), Severity = tostring(coalesce(properties.additionalData.Severity, properties.additionalData.severity)), Status = tostring(properties.status.code)\n| where Status == 'Unhealthy'\n| summarize dcount(VulnId) by Severity",
         "size": 1,
         "title": "Distinct SQL vulnerabilities by severity",
         "noDataMessage": "No unhealthy SQL resources found",
         "queryType": 1,
-        "resourceType": "microsoft.resourcegraph/resources",
+        "resourceType": "microsoft.resources/tenants",
         "crossComponentResources": [
-          "{Subscription}"
+          "value::tenant"
         ],
         "visualization": "piechart",
         "tileSettings": {
@@ -565,14 +574,14 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "securityresources\r\n| where type == \"microsoft.security/assessments/subassessments\"\r\n| extend assessmentKey = extract(\".*assessments/(.+?)/.*\",1,  id)\r\n| where assessmentKey == \"1195afff-c881-495e-9bc5-1486211ae03f\"\r\n|extend Status = tostring(properties.status.code)\r\n| where Status == 'Unhealthy'\r\n| project Resource = tostring(properties.resourceDetails.id), subscriptionId, Severity = tostring(properties.status.severity), VulnId = tostring(properties.id)\r\n| summarize Total=dcount(VulnId), sevH=dcountif(VulnId, Severity=='High'), sevM=dcountif(VulnId, Severity=='Medium'), sevL=dcountif(VulnId, Severity=='Low') by Resource\r\n| top 500 by sevH desc",
+        "query": "securityresources\r\n| where '*' in ({Subscription}) or subscriptionId in~ ({Subscription:subid})\r\n| where type == \"microsoft.security/assessments\"\r\n| where properties.metadata.recommendationCategory == \"SoftwareUpdate\"\r\n| where tostring(properties.resourceDetails.ResourceType) == \"Microsoft.Compute/virtualMachines\" or tostring(properties.resourceDetails.ResourceType) == \"Microsoft.HybridCompute/machines\"\r\n| where tostring(properties.status.code) == 'Unhealthy'\r\n| mv-expand cve = parse_json(tostring(properties.additionalData.CvesDetails))\r\n| extend cveId = tolower(tostring(cve.CveId))\r\n| join kind=leftouter (\r\n    securityresources\r\n    | where type =~ \"microsoft.security/cvedetails\"\r\n    | project cveId = tolower(tostring(properties.cveId)), cveDetails = properties\r\n) on cveId\r\n| extend Severity = tostring(cveDetails.severity)\r\n| extend Severity = iff(isempty(Severity), 'Unknown', Severity)\r\n| project Resource = tolower(tostring(properties.resourceDetails.Id)), subscriptionId, Severity, cveId\r\n| summarize by Resource, cveId, Severity\r\n| summarize Total = count(), sevC = countif(Severity == 'Critical'), sevH = countif(Severity == 'High'), sevM = countif(Severity == 'Medium'), sevL = countif(Severity == 'Low') by Resource\r\n| order by sevC desc, sevH desc, sevM desc\r\n| take 500",
         "size": 0,
         "title": "Vulnerabilities by severity per machine",
         "noDataMessage": "No unhealthy machines found",
         "queryType": 1,
-        "resourceType": "microsoft.resourcegraph/resources",
+        "resourceType": "microsoft.resources/tenants",
         "crossComponentResources": [
-          "{Subscription}"
+          "value::tenant"
         ],
         "gridSettings": {
           "formatters": [
@@ -584,6 +593,15 @@
               },
               "tooltipFormat": {
                 "tooltip": "[\"Total\"] fndings in total"
+              }
+            },
+            {
+              "columnMatch": "sevC",
+              "formatter": 4,
+              "formatOptions": {
+                "min": 0,
+                "palette": "redDark",
+                "customColumnWidthSetting": "15ch"
               }
             },
             {
@@ -621,6 +639,10 @@
           "rowLimit": 500,
           "labelSettings": [
             {
+              "columnId": "sevC",
+              "label": "Critical"
+            },
+            {
               "columnId": "sevH",
               "label": "High"
             },
@@ -648,14 +670,14 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "securityresources\n| where type == \"microsoft.security/assessments\"\n| where properties.metadata.recommendationCategory == \"SoftwareUpdate\"\n| where properties.resourceDetails.ResourceType == \".containerimage\"\n| where properties.resourceDetails.Source == \"Azure\"\n| extend status = tostring(properties.status.code)\n| where status == \"Unhealthy\"\n| extend Resource = tolower(extract(@'(?i)(.*?)/securityentitydata/([^/]+)', 1, id))\n| extend CvesRaw = parse_json(tostring(properties.additionalData.CvesDetails))\n| project-away properties\n| mv-expand cve = CvesRaw\n| project-away CvesRaw\n| extend CveId = tostring(cve.CveId)\n| extend Severity = tostring(cve.Severity)\n| summarize Total=dcount(CveId), sevC=dcountif(CveId, Severity==\"Critical\"), sevH=dcountif(CveId, Severity==\"High\"), sevM=dcountif(CveId, Severity==\"Medium\"), sevL=dcountif(CveId, Severity==\"Low\") by Resource\n| order by sevC desc",
+        "query": "securityresources\n| where '*' in ({Subscription}) or subscriptionId in~ ({Subscription:subid})\n| where type == \"microsoft.security/assessments\"\n| where properties.metadata.recommendationCategory == \"SoftwareUpdate\"\n| where properties.resourceDetails.ResourceType == \".containerimage\"\n| where properties.resourceDetails.Source == \"Azure\"\n| where tostring(properties.status.code) == \"Unhealthy\"\n| extend Resource = tolower(extract(@'(?i)(.*?)/securityentitydata/([^/]+)', 1, id))\n| project Resource, CvesRaw = parse_json(tostring(properties.additionalData.CvesDetails))\n| mv-expand cve = CvesRaw\n| extend cveId = tolower(tostring(cve.CveId)), inlineSev = tostring(cve.Severity)\n| summarize inlineSev = min(inlineSev) by Resource, cveId\n| join kind=leftouter (\n    securityresources\n    | where type =~ \"microsoft.security/cvedetails\"\n    | project cveId = tolower(tostring(properties.cveId)), cveSeverity = tostring(properties.severity)\n) on cveId\n| extend Severity = iff(isempty(cveSeverity), inlineSev, cveSeverity)\n| extend Severity = iff(isempty(Severity), 'Unknown', Severity)\n| summarize Total = count(), sevC = countif(Severity == 'Critical'), sevH = countif(Severity == 'High'), sevM = countif(Severity == 'Medium'), sevL = countif(Severity == 'Low') by Resource\n| order by sevC desc, sevH desc, sevM desc",
         "size": 0,
         "title": "Vulnerabilities by severity per container registry",
         "noDataMessage": "No unhealthy container registries found",
         "queryType": 1,
-        "resourceType": "microsoft.resourcegraph/resources",
+        "resourceType": "microsoft.resources/tenants",
         "crossComponentResources": [
-          "{Subscription}"
+          "value::tenant"
         ],
         "gridSettings": {
           "formatters": [
@@ -744,14 +766,14 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "securityresources\n| where type =~ \"microsoft.security/assessments\"\n| extend scanner = tostring(coalesce(properties.additionalData.Scanner, properties.additionalData.scanner))\n| where scanner =~ \"SQL Vulnerability Assessment\"\n| extend Resource = tolower(tostring(coalesce(properties.additionalData.ParentResource, properties.additionalData.parentResource))), subscriptionId, severity = tostring(coalesce(properties.additionalData.Severity, properties.additionalData.severity)), status = tostring(properties.status.code), VulnId = tostring(coalesce(properties.additionalData.RuleId, properties.additionalData.ruleId)), description = tostring(properties.metadata.displayName)\n| where isnotempty(Resource)\n| where status == 'Unhealthy'\n| summarize dcount(VulnId) by Resource, severity, VulnId, description\n| summarize Total = count(dcount_VulnId), sevH=countif(severity=='High'), sevM=countif(severity=='Medium'), sevL=countif(severity=='Low') by Resource\n| order by sevH desc",
+        "query": "securityresources\n| where '*' in ({Subscription}) or subscriptionId in~ ({Subscription:subid})\n| where type =~ \"microsoft.security/assessments\"\n| extend scanner = tostring(coalesce(properties.additionalData.Scanner, properties.additionalData.scanner))\n| where scanner =~ \"SQL Vulnerability Assessment\"\n| extend Resource = tolower(tostring(coalesce(properties.additionalData.ParentResource, properties.additionalData.parentResource))), subscriptionId, severity = tostring(coalesce(properties.additionalData.Severity, properties.additionalData.severity)), status = tostring(properties.status.code), VulnId = tostring(coalesce(properties.additionalData.RuleId, properties.additionalData.ruleId)), description = tostring(properties.metadata.displayName)\n| where isnotempty(Resource)\n| where status == 'Unhealthy'\n| summarize dcount(VulnId) by Resource, severity, VulnId, description\n| summarize Total = count(dcount_VulnId), sevH=countif(severity=='High'), sevM=countif(severity=='Medium'), sevL=countif(severity=='Low') by Resource\n| order by sevH desc",
         "size": 0,
         "title": "Vulnerabilities by severity per SQL resource",
         "noDataMessage": "No unhealthy SQL resources found",
         "queryType": 1,
-        "resourceType": "microsoft.resourcegraph/resources",
+        "resourceType": "microsoft.resources/tenants",
         "crossComponentResources": [
-          "{Subscription}"
+          "value::tenant"
         ],
         "gridSettings": {
           "formatters": [
@@ -823,16 +845,16 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "securityresources\r\n| where type == \"microsoft.security/assessments/subassessments\"\r\n| extend assessmentKey = extract(\".*assessments/(.+?)/.*\",1,  id)\r\n| where assessmentKey == \"1195afff-c881-495e-9bc5-1486211ae03f\"\r\n|extend Status = tostring(properties.status.code)\r\n| where Status == 'Unhealthy'\r\n | project Resource = tolower(extract(\"([\\\\s\\\\S]*?)(/providers/Microsoft.Security.*)\",1,id)), ResourceGroup = trim_end(\"/\",extract(\".*resourceGroups/(.+?)/\",0,id)), ResourceType = tolower(split(id,\"/\").[6]), subscriptionId, severity = tostring(parse_json(properties).status.severity), VulnId = tostring(parse_json(properties).id), description = tostring(parse_json(properties).displayName), patchable = parse_json(properties.additionalData).patchable, cve = parse_json(properties.additionalData).cve\r\n | summarize Total = dcount(VulnId), sevH=countif(severity=='High'), sevM=countif(severity=='Medium'), sevL=countif(severity=='Low'), patchAvailable = countif(patchable=='true'), CVEcount =countif(cve!='[]') by ResourceGroup, Resource\r\n | order by sevH desc\r\n | top 500 by sevH desc",
+        "query": "securityresources\r\n| where '*' in ({Subscription}) or subscriptionId in~ ({Subscription:subid})\r\n| where type == \"microsoft.security/assessments\"\r\n| where properties.metadata.recommendationCategory == \"SoftwareUpdate\"\r\n| where tostring(properties.resourceDetails.ResourceType) == \"Microsoft.Compute/virtualMachines\" or tostring(properties.resourceDetails.ResourceType) == \"Microsoft.HybridCompute/machines\"\r\n| where tostring(properties.status.code) == 'Unhealthy'\r\n| mv-expand cve = parse_json(tostring(properties.additionalData.CvesDetails))\r\n| extend cveId = tolower(tostring(cve.CveId))\r\n| join kind=leftouter (\r\n    securityresources\r\n    | where type =~ \"microsoft.security/cvedetails\"\r\n    | project cveId = tolower(tostring(properties.cveId)), cveDetails = properties\r\n) on cveId\r\n| extend Severity = tostring(cveDetails.severity)\r\n| extend Severity = iff(isempty(Severity), 'Unknown', Severity)\r\n| extend Patchable = (tostring(cve.FixStatus) == 'FixAvailable')\r\n| project Resource = tolower(tostring(properties.resourceDetails.Id)), ResourceGroup = resourceGroup, subscriptionId, Severity, cveId, Patchable\r\n| summarize Patchable = (countif(Patchable) > 0) by ResourceGroup, Resource, cveId, Severity\r\n| summarize Total = count(), sevC = countif(Severity == 'Critical'), sevH = countif(Severity == 'High'), sevM = countif(Severity == 'Medium'), sevL = countif(Severity == 'Low'), patchAvailable = countif(Patchable), CVEcount = count() by ResourceGroup, Resource\r\n| order by sevC desc, sevH desc, sevM desc\r\n| take 500",
         "size": 0,
         "title": "Overview | Select a machine to view the list of vulnerabilities",
         "exportFieldName": "Resource",
         "exportParameterName": "selectedServer",
         "exportDefaultValue": "All",
         "queryType": 1,
-        "resourceType": "microsoft.resourcegraph/resources",
+        "resourceType": "microsoft.resources/tenants",
         "crossComponentResources": [
-          "{Subscription}"
+          "value::tenant"
         ],
         "gridSettings": {
           "formatters": [
@@ -862,6 +884,14 @@
               "formatter": 1,
               "formatOptions": {
                 "customColumnWidthSetting": "10ch"
+              }
+            },
+            {
+              "columnMatch": "sevC",
+              "formatter": 4,
+              "formatOptions": {
+                "palette": "redDark",
+                "customColumnWidthSetting": "12ch"
               }
             },
             {
@@ -941,6 +971,10 @@
               "label": "Resource group"
             },
             {
+              "columnId": "sevC",
+              "label": "Critical"
+            },
+            {
               "columnId": "sevH",
               "label": "High"
             },
@@ -976,13 +1010,13 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "securityresources\r\n| where type == \"microsoft.security/assessments/subassessments\"\r\n| extend assessmentKey = extract(\".*assessments/(.+?)/.*\",1,  id)\r\n| where assessmentKey == \"1195afff-c881-495e-9bc5-1486211ae03f\"\r\n| extend Category = tostring(properties.category), Status = tostring(properties.status.code)\r\n| where Status == 'Unhealthy'\r\n| summarize count() by tostring(Category)",
+        "query": "securityresources\r\n| where '*' in ({Subscription}) or subscriptionId in~ ({Subscription:subid})\r\n| where type == \"microsoft.security/assessments\"\r\n| where properties.metadata.recommendationCategory == \"SoftwareUpdate\"\r\n| where tostring(properties.resourceDetails.ResourceType) == \"Microsoft.Compute/virtualMachines\" or tostring(properties.resourceDetails.ResourceType) == \"Microsoft.HybridCompute/machines\"\r\n| where tostring(properties.status.code) == 'Unhealthy'\r\n| extend Category = tostring(properties.additionalData.PackageType)\r\n| extend Category = iff(isempty(Category), 'Unknown', Category)\r\n| mv-expand cve = parse_json(tostring(properties.additionalData.CvesDetails))\r\n| summarize count() by Category",
         "size": 0,
         "title": "Vulnerabilities by category",
         "queryType": 1,
-        "resourceType": "microsoft.resourcegraph/resources",
+        "resourceType": "microsoft.resources/tenants",
         "crossComponentResources": [
-          "{Subscription}"
+          "value::tenant"
         ],
         "visualization": "tiles",
         "gridSettings": {
@@ -1127,14 +1161,14 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "securityresources\r\n| where type == \"microsoft.security/assessments/subassessments\"\r\n| extend assessmentKey = extract(\".*assessments/(.+?)/.*\",1,  id)\r\n| where assessmentKey == \"1195afff-c881-495e-9bc5-1486211ae03f\"\r\n|extend Status = tostring(properties.status.code)\r\n| where Status == 'Unhealthy'\r\n| project Resource = tolower(extract(\"([\\\\s\\\\S]*?)(/providers/Microsoft.Security.*)\",1,id)), ResourceGroup = trim_end(\"/\",extract(\".*resourceGroups/(.+?)/\",0,id)), ResourceType = tolower(split(id,\"/\").[6]), subscriptionId, Severity = tostring(parse_json(properties).status.severity), VulnId = tostring(parse_json(properties).id), Description = tostring(parse_json(properties).displayName), Patchable = parse_json(properties.additionalData).patchable, CVE = properties.additionalData.cve, Category = tostring(properties.category), TimeGenerated = tostring(properties.timeGenerated), Remediation = tostring(properties.remediation), Impact = tostring(properties.impact), Threat = tostring(properties.additionalData.threat)\r\n| where '{selectedServer}' == 'All' or Resource == '{selectedServer}'\r\n| project Severity, VulnId, Description, tostring(Patchable), Category, Resource, ResourceGroup, CVE, TimeGenerated, Remediation, Impact, Threat\r\n| mv-expand CveExpand = split (CVE, \"},\") to typeof(string)\r\n| parse CveExpand with * '\"title\":\"' singleCve '\"' *\r\n| summarize CVEs = tostring(make_list(singleCve)) by Severity, VulnId, Description, tostring(Patchable), Category, Resource, ResourceGroup, TimeGenerated, Threat, Impact, Remediation",
+              "query": "securityresources\r\n| where '*' in ({Subscription}) or subscriptionId in~ ({Subscription:subid})\r\n| where type == \"microsoft.security/assessments\"\r\n| where properties.metadata.recommendationCategory == \"SoftwareUpdate\"\r\n| where tostring(properties.resourceDetails.ResourceType) == \"Microsoft.Compute/virtualMachines\" or tostring(properties.resourceDetails.ResourceType) == \"Microsoft.HybridCompute/machines\"\r\n| where tostring(properties.status.code) == 'Unhealthy'\r\n| mv-expand cve = parse_json(tostring(properties.additionalData.CvesDetails))\r\n| extend cveId = tolower(tostring(cve.CveId))\r\n| join kind=leftouter (\r\n    securityresources\r\n    | where type =~ \"microsoft.security/cvedetails\"\r\n    | project cveId = tolower(tostring(properties.cveId)), cveDetails = properties\r\n) on cveId\r\n| extend Severity = tostring(cveDetails.severity)\r\n| extend Severity = iff(isempty(Severity), 'Unknown', Severity)\r\n| extend Resource = tolower(tostring(properties.resourceDetails.Id))\r\n| where '{selectedServer}' == 'All' or Resource == '{selectedServer}'\r\n| extend Description = tostring(cveDetails.extendedDescription.Summary)\r\n| extend Description = iff(isempty(Description), tostring(cve.Description), Description)\r\n| extend Remediation = tostring(cveDetails.extendedDescription.Remediation)\r\n| extend Remediation = iff(isempty(Remediation), tostring(properties.metadata.remediationDescription), Remediation)\r\n| extend Impact = tostring(cveDetails.extendedDescription.Impact)\r\n| extend Threat = tostring(cveDetails.exploitabilityDetails)\r\n| summarize Software = tostring(make_set(tostring(properties.additionalData.SoftwareName), 50)), FixedVersion = tostring(make_set(tostring(cve.FixedVersion), 50)), TimeGenerated = min(todatetime(properties.status.firstEvaluationDate)) by Severity, VulnId = toupper(cveId), Description, Patchable = tostring(tostring(cve.FixStatus) == 'FixAvailable'), Category = tostring(properties.additionalData.PackageType), Resource, ResourceGroup = resourceGroup, CVE = toupper(cveId), Remediation, Impact, Threat\r\n| project Severity, VulnId, Description, Patchable, Category, Resource, ResourceGroup, Software, FixedVersion, CVE, TimeGenerated, Remediation, Impact, Threat",
               "size": 2,
               "title": "Use the search box to filter vulnerabilities by resource, resource group, CVE, severity, etc.",
               "showExportToExcel": true,
               "queryType": 1,
-              "resourceType": "microsoft.resourcegraph/resources",
+              "resourceType": "microsoft.resources/tenants",
               "crossComponentResources": [
-                "{Subscription}"
+                "value::tenant"
               ],
               "gridSettings": {
                 "formatters": [
@@ -1201,7 +1235,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "securityresources\n| where type == \"microsoft.security/assessments\"\n| where properties.metadata.recommendationCategory == \"SoftwareUpdate\"\n| where properties.resourceDetails.ResourceType == \".containerimage\"\n| where properties.resourceDetails.Source == \"Azure\"\n| extend status = tostring(properties.status.code)\n| where status == \"Unhealthy\"\n| extend Resource = tolower(extract(@'(?i)(.*?)/securityentitydata/([^/]+)', 1, id))\n| extend ResourceGroup = tostring(split(Resource, '/')[4])\n| extend FixedVersion = tostring(properties.additionalData.FixedVersion)\n| extend CvesRaw = parse_json(tostring(properties.additionalData.CvesDetails))\n| project-away properties\n| mv-expand cve = CvesRaw\n| project-away CvesRaw\n| extend CveId = tostring(cve.CveId)\n| extend CveSeverity = tostring(cve.Severity)\n| extend isPatchable = iff(isnotempty(FixedVersion), 1, 0)\n| summarize Total=dcount(CveId), sevC=dcountif(CveId, CveSeverity==\"Critical\"), sevH=dcountif(CveId, CveSeverity==\"High\"), sevM=dcountif(CveId, CveSeverity==\"Medium\"), sevL=dcountif(CveId, CveSeverity==\"Low\"), patchAvailable=dcountif(CveId, isPatchable==1), CVEcount=dcount(CveId) by ResourceGroup, Resource\n| order by sevC desc, sevH desc",
+        "query": "securityresources\n| where '*' in ({Subscription}) or subscriptionId in~ ({Subscription:subid})\n| where type == \"microsoft.security/assessments\"\n| where properties.metadata.recommendationCategory == \"SoftwareUpdate\"\n| where properties.resourceDetails.ResourceType == \".containerimage\"\n| where properties.resourceDetails.Source == \"Azure\"\n| where tostring(properties.status.code) == \"Unhealthy\"\n| extend Resource = tolower(extract(@'(?i)(.*?)/securityentitydata/([^/]+)', 1, id))\n| extend ResourceGroup = tostring(split(Resource, '/')[4])\n| extend FixedVersion = tostring(properties.additionalData.FixedVersion)\n| project Resource, ResourceGroup, FixedVersion, CvesRaw = parse_json(tostring(properties.additionalData.CvesDetails))\n| mv-expand cve = CvesRaw\n| extend cveId = tolower(tostring(cve.CveId)), inlineSev = tostring(cve.Severity)\n| extend isPatchable = iff(isnotempty(FixedVersion), 1, 0)\n| summarize inlineSev = min(inlineSev), isPatchable = max(isPatchable) by ResourceGroup, Resource, cveId\n| join kind=leftouter (\n    securityresources\n    | where type =~ \"microsoft.security/cvedetails\"\n    | project cveId = tolower(tostring(properties.cveId)), cveSeverity = tostring(properties.severity)\n) on cveId\n| extend Severity = iff(isempty(cveSeverity), inlineSev, cveSeverity)\n| extend Severity = iff(isempty(Severity), 'Unknown', Severity)\n| summarize Total = count(), sevC = countif(Severity == 'Critical'), sevH = countif(Severity == 'High'), sevM = countif(Severity == 'Medium'), sevL = countif(Severity == 'Low'), patchAvailable = countif(isPatchable == 1), CVEcount = count() by ResourceGroup, Resource\n| order by sevC desc, sevH desc",
         "size": 0,
         "title": "Vulnerable container registries |  Select a container registry to view the list of vulnerabilities",
         "noDataMessage": "No unhealthy registries found",
@@ -1209,9 +1243,9 @@
         "exportParameterName": "selectedACR",
         "exportDefaultValue": "All",
         "queryType": 1,
-        "resourceType": "microsoft.resourcegraph/resources",
+        "resourceType": "microsoft.resources/tenants",
         "crossComponentResources": [
-          "{Subscription}"
+          "value::tenant"
         ],
         "gridSettings": {
           "formatters": [
@@ -1370,14 +1404,14 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "securityresources\n| where type == \"microsoft.security/assessments\"\n| where properties.metadata.recommendationCategory == \"SoftwareUpdate\"\n| where properties.resourceDetails.ResourceType == \".containerimage\"\n| where properties.resourceDetails.Source == \"Azure\"\n| extend status = tostring(properties.status.code)\n| where status == \"Unhealthy\"\n| extend Resource = tolower(extract(@'(?i)(.*?)/securityentitydata/([^/]+)', 1, id))\n| where \"{selectedACR}\" == \"All\" or Resource == \"{selectedACR}\"\n| extend resourceData = parse_json(tostring(properties.resourceAdditionalData))\n| extend registryName = tostring(resourceData.RepositoryDetails.RegistryHost)\n| extend Repo = tostring(resourceData.RepositoryDetails.RepositoryName)\n| extend imageDigest = tostring(resourceData.ImageUri)\n| extend FixedVersion = tostring(properties.additionalData.FixedVersion)\n| extend CvesRaw = parse_json(tostring(properties.additionalData.CvesDetails))\n| project-away properties\n| mv-expand cve = CvesRaw\n| project-away CvesRaw\n| extend CveId = tostring(cve.CveId)\n| extend CveSeverity = tostring(cve.Severity)\n| extend isPatchable = iff(isnotempty(FixedVersion), 1, 0)\n| summarize sevC=dcountif(CveId, CveSeverity==\"Critical\"), sevH=dcountif(CveId, CveSeverity==\"High\"), sevM=dcountif(CveId, CveSeverity==\"Medium\"), sevL=dcountif(CveId, CveSeverity==\"Low\"), patchAvailable=dcountif(CveId, isPatchable==1), CVEcount=dcount(CveId) by Resource, registryName, Repo, imageDigest\n| order by sevC desc, sevH desc\n| project imageDigest, CVEcount, patchAvailable, sevC, sevH, sevM, sevL, Resource, registryName, Repo",
+        "query": "securityresources\n| where '*' in ({Subscription}) or subscriptionId in~ ({Subscription:subid})\n| where type == \"microsoft.security/assessments\"\n| where properties.metadata.recommendationCategory == \"SoftwareUpdate\"\n| where properties.resourceDetails.ResourceType == \".containerimage\"\n| where properties.resourceDetails.Source == \"Azure\"\n| where tostring(properties.status.code) == \"Unhealthy\"\n| extend Resource = tolower(extract(@'(?i)(.*?)/securityentitydata/([^/]+)', 1, id))\n| where \"{selectedACR}\" == \"All\" or Resource == \"{selectedACR}\"\n| extend resourceData = parse_json(tostring(properties.resourceAdditionalData))\n| extend registryName = tostring(resourceData.RepositoryDetails.RegistryHost)\n| extend Repo = tostring(resourceData.RepositoryDetails.RepositoryName)\n| extend imageDigest = tostring(resourceData.ImageUri)\n| extend FixedVersion = tostring(properties.additionalData.FixedVersion)\n| project Resource, registryName, Repo, imageDigest, FixedVersion, CvesRaw = parse_json(tostring(properties.additionalData.CvesDetails))\n| mv-expand cve = CvesRaw\n| extend cveId = tolower(tostring(cve.CveId)), inlineSev = tostring(cve.Severity)\n| extend isPatchable = iff(isnotempty(FixedVersion), 1, 0)\n| summarize inlineSev = min(inlineSev), isPatchable = max(isPatchable) by Resource, registryName, Repo, imageDigest, cveId\n| join kind=leftouter (\n    securityresources\n    | where type =~ \"microsoft.security/cvedetails\"\n    | project cveId = tolower(tostring(properties.cveId)), cveSeverity = tostring(properties.severity)\n) on cveId\n| extend Severity = iff(isempty(cveSeverity), inlineSev, cveSeverity)\n| extend Severity = iff(isempty(Severity), 'Unknown', Severity)\n| summarize sevC = countif(Severity == 'Critical'), sevH = countif(Severity == 'High'), sevM = countif(Severity == 'Medium'), sevL = countif(Severity == 'Low'), patchAvailable = countif(isPatchable == 1), CVEcount = count() by Resource, registryName, Repo, imageDigest\n| order by sevC desc, sevH desc\n| project imageDigest, CVEcount, patchAvailable, sevC, sevH, sevM, sevL, Resource, registryName, Repo",
         "size": 0,
         "title": "Vulnerable images",
         "noDataMessage": "No vulnerable images found",
         "queryType": 1,
-        "resourceType": "microsoft.resourcegraph/resources",
+        "resourceType": "microsoft.resources/tenants",
         "crossComponentResources": [
-          "{Subscription}"
+          "value::tenant"
         ],
         "gridSettings": {
           "formatters": [
@@ -1538,15 +1572,15 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "securityresources\n| where type == \"microsoft.security/assessments\"\n| where properties.metadata.recommendationCategory == \"SoftwareUpdate\"\n| where properties.resourceDetails.ResourceType == \".containerimage\"\n| where properties.resourceDetails.Source == \"Azure\"\n| extend status = tostring(properties.status.code)\n| where status == \"Unhealthy\"\n| extend Resource = tolower(extract(@'(?i)(.*?)/securityentitydata/([^/]+)', 1, id))\n| where \"{selectedACR}\" == \"All\" or Resource == \"{selectedACR}\"\n| extend ResourceGroup = tostring(split(Resource, '/')[4])\n| extend resourceData = parse_json(tostring(properties.resourceAdditionalData))\n| extend RepositoryName = tostring(resourceData.RepositoryDetails.RepositoryName)\n| extend ImageURI = tostring(resourceData.ImageUri)\n| extend FixedVersion = tostring(properties.additionalData.FixedVersion)\n| extend DetectedVersion = replace_string(replace_string(replace_string(tostring(properties.additionalData.DetectedSoftwareVersions), \"[\", \"\"), \"]\", \"\"), '\"',\"\")\n| extend Patchable = iff(isnotempty(FixedVersion), \"Yes\", \"No\")\n| extend CvesRaw = parse_json(tostring(properties.additionalData.CvesDetails))\n| project-away properties\n| mv-expand cve = CvesRaw\n| project-away CvesRaw\n| extend Issue = tostring(cve.CveId)\n| extend Severity = tostring(cve.Severity)\n| extend CvssStr = tostring(cve.Cvss)\n| extend CVSS3Score = extract(@'\"Key\":\"3\",\"Value\":\\{\"Base\":([0-9.]+)', 1, CvssStr)\n| project subscriptionId, Resource, ResourceGroup, ImageURI, RepositoryName, Issue, Severity, Patchable, CVSS3Score, DetectedVersion, FixedVersion\n| order by ResourceGroup asc, Resource asc, Severity asc, Issue asc\n| take 1000",
+              "query": "securityresources\n| where '*' in ({Subscription}) or subscriptionId in~ ({Subscription:subid})\n| where type == \"microsoft.security/assessments\"\n| where properties.metadata.recommendationCategory == \"SoftwareUpdate\"\n| where properties.resourceDetails.ResourceType == \".containerimage\"\n| where properties.resourceDetails.Source == \"Azure\"\n| where tostring(properties.status.code) == \"Unhealthy\"\n| extend Resource = tolower(extract(@'(?i)(.*?)/securityentitydata/([^/]+)', 1, id))\n| where \"{selectedACR}\" == \"All\" or Resource == \"{selectedACR}\"\n| extend ResourceGroup = tostring(split(Resource, '/')[4])\n| extend resourceData = parse_json(tostring(properties.resourceAdditionalData))\n| extend RepositoryName = tostring(resourceData.RepositoryDetails.RepositoryName)\n| extend ImageURI = tostring(resourceData.ImageUri)\n| extend FixedVersion = tostring(properties.additionalData.FixedVersion)\n| extend DetectedVersion = replace_string(replace_string(replace_string(tostring(properties.additionalData.DetectedSoftwareVersions), \"[\", \"\"), \"]\", \"\"), '\"',\"\")\n| extend Patchable = iff(isnotempty(FixedVersion), \"Yes\", \"No\")\n| project subscriptionId, Resource, ResourceGroup, ImageURI, RepositoryName, DetectedVersion, FixedVersion, Patchable, CvesRaw = parse_json(tostring(properties.additionalData.CvesDetails))\n| mv-expand cve = CvesRaw\n| extend Issue = tostring(cve.CveId), cveId = tolower(tostring(cve.CveId)), inlineSev = tostring(cve.Severity)\n| extend CvssStr = tostring(cve.Cvss)\n| extend CVSS3Score = extract(@'\"Key\":\"3\",\"Value\":\\{\"Base\":([0-9.]+)', 1, CvssStr)\n| join kind=leftouter (\n    securityresources\n    | where type =~ \"microsoft.security/cvedetails\"\n    | project cveId = tolower(tostring(properties.cveId)), cveSeverity = tostring(properties.severity)\n) on cveId\n| extend Severity = iff(isempty(cveSeverity), inlineSev, cveSeverity)\n| extend Severity = iff(isempty(Severity), 'Unknown', Severity)\n| project subscriptionId, Resource, ResourceGroup, ImageURI, RepositoryName, Issue, Severity, Patchable, CVSS3Score, DetectedVersion, FixedVersion\n| order by ResourceGroup asc, Resource asc, Severity asc, Issue asc\n| take 1000",
               "size": 2,
               "title": "Use the search box to filter vulnerabilities by resource, resource group, CVE, severity, etc.",
               "noDataMessage": "No unhealthy registries and images found",
               "showExportToExcel": true,
               "queryType": 1,
-              "resourceType": "microsoft.resourcegraph/resources",
+              "resourceType": "microsoft.resources/tenants",
               "crossComponentResources": [
-                "{Subscription}"
+                "value::tenant"
               ],
               "gridSettings": {
                 "formatters": [
@@ -1643,16 +1677,16 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "securityresources\n| where type =~ \"microsoft.security/assessments\"\n| extend scanner = tostring(coalesce(properties.additionalData.Scanner, properties.additionalData.scanner))\n| where scanner =~ \"SQL Vulnerability Assessment\"\n| extend Resource = tolower(tostring(coalesce(properties.additionalData.ParentResource, properties.additionalData.parentResource))), ResourceGroup = trim_end(\"/\", extract(\"(?i).*resourceGroups/(.+?)/\", 0, tolower(tostring(coalesce(properties.additionalData.ParentResource, properties.additionalData.parentResource))))), subscriptionId, severity = tostring(coalesce(properties.additionalData.Severity, properties.additionalData.severity)), status = tostring(properties.status.code), VulnId = tostring(coalesce(properties.additionalData.RuleId, properties.additionalData.ruleId))\n| where isnotempty(Resource)\n| where status == 'Unhealthy'\n| summarize Total = count(VulnId), sevH=countif(severity=='High'), sevM=countif(severity=='Medium'), sevL=countif(severity=='Low') by ResourceGroup, Resource\n| order by sevH desc",
+        "query": "securityresources\n| where '*' in ({Subscription}) or subscriptionId in~ ({Subscription:subid})\n| where type =~ \"microsoft.security/assessments\"\n| extend scanner = tostring(coalesce(properties.additionalData.Scanner, properties.additionalData.scanner))\n| where scanner =~ \"SQL Vulnerability Assessment\"\n| extend Resource = tolower(tostring(coalesce(properties.additionalData.ParentResource, properties.additionalData.parentResource))), ResourceGroup = trim_end(\"/\", extract(\"(?i).*resourceGroups/(.+?)/\", 0, tolower(tostring(coalesce(properties.additionalData.ParentResource, properties.additionalData.parentResource))))), subscriptionId, severity = tostring(coalesce(properties.additionalData.Severity, properties.additionalData.severity)), status = tostring(properties.status.code), VulnId = tostring(coalesce(properties.additionalData.RuleId, properties.additionalData.ruleId))\n| where isnotempty(Resource)\n| where status == 'Unhealthy'\n| summarize Total = count(VulnId), sevH=countif(severity=='High'), sevM=countif(severity=='Medium'), sevL=countif(severity=='Low') by ResourceGroup, Resource\n| order by sevH desc",
         "size": 0,
         "title": "Vulnerable SQL resources | Select a resource to view the list of vulnerabilities",
         "exportFieldName": "Resource",
         "exportParameterName": "selectedSQL",
         "exportDefaultValue": "All",
         "queryType": 1,
-        "resourceType": "microsoft.resourcegraph/resources",
+        "resourceType": "microsoft.resources/tenants",
         "crossComponentResources": [
-          "{Subscription}"
+          "value::tenant"
         ],
         "gridSettings": {
           "formatters": [
@@ -1788,13 +1822,13 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "securityresources\n| where type =~ \"microsoft.security/assessments\"\n| extend scanner = tostring(coalesce(properties.additionalData.Scanner, properties.additionalData.scanner))\n| where scanner =~ \"SQL Vulnerability Assessment\"\n| extend Resource = tolower(tostring(coalesce(properties.additionalData.ParentResource, properties.additionalData.parentResource))), Severity = tostring(coalesce(properties.additionalData.Severity, properties.additionalData.severity)), Status = tostring(properties.status.code), VulnId = tostring(coalesce(properties.additionalData.RuleId, properties.additionalData.ruleId)), Database = tolower(tostring(coalesce(properties.resourceDetails.Id, properties.resourceDetails.id)))\n| where isnotempty(Resource)\n| extend Database = iff(Database has \"/securityentitydata/sqlservers:\", strcat(extract(@\"^(.*?)/securityentitydata\", 1, Database), \"/servers/\", extract(@\"sqlservers:([^:]+):\", 1, Database), \"/databases/\", extract(@\"databases:([^/]+)\", 1, Database)), Database)\n| where Status == 'Unhealthy'\n| summarize dcount(VulnId) by Resource, Severity, VulnId, tostring(Database)\n| summarize Total = count(dcount_VulnId), sevH=countif(Severity=='High'), sevM=countif(Severity=='Medium'), sevL=countif(Severity=='Low') by Resource, Database\n| order by sevH desc",
+        "query": "securityresources\n| where '*' in ({Subscription}) or subscriptionId in~ ({Subscription:subid})\n| where type =~ \"microsoft.security/assessments\"\n| extend scanner = tostring(coalesce(properties.additionalData.Scanner, properties.additionalData.scanner))\n| where scanner =~ \"SQL Vulnerability Assessment\"\n| extend Resource = tolower(tostring(coalesce(properties.additionalData.ParentResource, properties.additionalData.parentResource))), Severity = tostring(coalesce(properties.additionalData.Severity, properties.additionalData.severity)), Status = tostring(properties.status.code), VulnId = tostring(coalesce(properties.additionalData.RuleId, properties.additionalData.ruleId)), Database = tolower(tostring(coalesce(properties.resourceDetails.Id, properties.resourceDetails.id)))\n| where isnotempty(Resource)\n| extend Database = iff(Database has \"/securityentitydata/sqlservers:\", strcat(extract(@\"^(.*?)/securityentitydata\", 1, Database), \"/servers/\", extract(@\"sqlservers:([^:]+):\", 1, Database), \"/databases/\", extract(@\"databases:([^/]+)\", 1, Database)), Database)\n| where Status == 'Unhealthy'\n| summarize dcount(VulnId) by Resource, Severity, VulnId, tostring(Database)\n| summarize Total = count(dcount_VulnId), sevH=countif(Severity=='High'), sevM=countif(Severity=='Medium'), sevL=countif(Severity=='Low') by Resource, Database\n| order by sevH desc",
         "size": 0,
         "title": "Vulnerable databases per server",
         "queryType": 1,
-        "resourceType": "microsoft.resourcegraph/resources",
+        "resourceType": "microsoft.resources/tenants",
         "crossComponentResources": [
-          "{Subscription}"
+          "value::tenant"
         ],
         "gridSettings": {
           "formatters": [
@@ -1915,14 +1949,14 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "securityresources\n| where type =~ \"microsoft.security/assessments\"\n| extend scanner = tostring(coalesce(properties.additionalData.Scanner, properties.additionalData.scanner))\n| where scanner =~ \"SQL Vulnerability Assessment\"\n| extend Resource = tolower(tostring(coalesce(properties.additionalData.ParentResource, properties.additionalData.parentResource)))\n| where isnotempty(Resource)\n| extend Database = tolower(tostring(coalesce(properties.resourceDetails.Id, properties.resourceDetails.id)))\n| extend Database = iff(Database has \"/securityentitydata/sqlservers:\", strcat(extract(@\"^(.*?)/securityentitydata\", 1, Database), \"/servers/\", extract(@\"sqlservers:([^:]+):\", 1, Database), \"/databases/\", extract(@\"databases:([^/]+)\", 1, Database)), Database)\n| extend ResourceGroup = trim_end(\"/\", extract(\"(?i).*resourceGroups/(.+?)/\", 0, Resource))\n| extend ResourceType = tolower(split(Resource, \"/\").[6])\n| extend Severity = tostring(coalesce(properties.additionalData.Severity, properties.additionalData.severity))\n| extend status = tostring(properties.status.code)\n| extend VulnId = tostring(coalesce(properties.additionalData.RuleId, properties.additionalData.ruleId))\n| extend Description = tostring(properties.metadata.displayName)\n| extend Category = tostring(coalesce(properties.additionalData.Category, properties.additionalData.category))\n| extend TimeGenerated = tostring(properties.status.statusChangeDate)\n| extend Remediation = tostring(coalesce(properties.additionalData.RemediationDescription, properties.additionalData.remediationDescription))\n| extend Impact = tostring(coalesce(properties.additionalData.Impact, properties.additionalData.impact))\n| extend Query = todynamic(coalesce(properties.additionalData.Query, properties.additionalData.query))\n| extend Benchmarks = parse_json(tostring(coalesce(properties.additionalData.Benchmarks, properties.additionalData.benchmarks)))\n| mvexpand Benchmarks\n| extend Benchmark = parse_json(Benchmarks).benchmark\n| where status == 'Unhealthy'\n| where '{selectedSQL}' == 'All' or Resource == '{selectedSQL}'\n| project Severity, VulnId, Description, Category, Resource, Database, ResourceGroup, TimeGenerated, tostring(Benchmark), Remediation, Impact, Query",
+              "query": "securityresources\n| where '*' in ({Subscription}) or subscriptionId in~ ({Subscription:subid})\n| where type =~ \"microsoft.security/assessments\"\n| extend scanner = tostring(coalesce(properties.additionalData.Scanner, properties.additionalData.scanner))\n| where scanner =~ \"SQL Vulnerability Assessment\"\n| extend Resource = tolower(tostring(coalesce(properties.additionalData.ParentResource, properties.additionalData.parentResource)))\n| where isnotempty(Resource)\n| extend Database = tolower(tostring(coalesce(properties.resourceDetails.Id, properties.resourceDetails.id)))\n| extend Database = iff(Database has \"/securityentitydata/sqlservers:\", strcat(extract(@\"^(.*?)/securityentitydata\", 1, Database), \"/servers/\", extract(@\"sqlservers:([^:]+):\", 1, Database), \"/databases/\", extract(@\"databases:([^/]+)\", 1, Database)), Database)\n| extend ResourceGroup = trim_end(\"/\", extract(\"(?i).*resourceGroups/(.+?)/\", 0, Resource))\n| extend ResourceType = tolower(split(Resource, \"/\").[6])\n| extend Severity = tostring(coalesce(properties.additionalData.Severity, properties.additionalData.severity))\n| extend status = tostring(properties.status.code)\n| extend VulnId = tostring(coalesce(properties.additionalData.RuleId, properties.additionalData.ruleId))\n| extend Description = tostring(properties.metadata.displayName)\n| extend Category = tostring(coalesce(properties.additionalData.Category, properties.additionalData.category))\n| extend TimeGenerated = tostring(properties.status.statusChangeDate)\n| extend Remediation = tostring(coalesce(properties.additionalData.RemediationDescription, properties.additionalData.remediationDescription))\n| extend Impact = tostring(coalesce(properties.additionalData.Impact, properties.additionalData.impact))\n| extend Query = todynamic(coalesce(properties.additionalData.Query, properties.additionalData.query))\n| extend Benchmarks = parse_json(tostring(coalesce(properties.additionalData.Benchmarks, properties.additionalData.benchmarks)))\n| mvexpand Benchmarks\n| extend Benchmark = parse_json(Benchmarks).benchmark\n| where status == 'Unhealthy'\n| where '{selectedSQL}' == 'All' or Resource == '{selectedSQL}'\n| project Severity, VulnId, Description, Category, Resource, Database, ResourceGroup, TimeGenerated, tostring(Benchmark), Remediation, Impact, Query",
               "size": 2,
               "title": "Grouped by benchmark | Use the search box to filter vulnerabilities by resource, resource group, severity, etc.",
               "showExportToExcel": true,
               "queryType": 1,
-              "resourceType": "microsoft.resourcegraph/resources",
+              "resourceType": "microsoft.resources/tenants",
               "crossComponentResources": [
-                "{Subscription}"
+                "value::tenant"
               ],
               "gridSettings": {
                 "formatters": [
@@ -1979,14 +2013,14 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "securityresources\n| where type =~ \"microsoft.security/assessments\"\n| extend scanner = tostring(coalesce(properties.additionalData.Scanner, properties.additionalData.scanner))\n| where scanner =~ \"SQL Vulnerability Assessment\"\n| extend Resource = tolower(tostring(coalesce(properties.additionalData.ParentResource, properties.additionalData.parentResource)))\n| where isnotempty(Resource)\n| extend Database = tolower(tostring(coalesce(properties.resourceDetails.Id, properties.resourceDetails.id)))\n| extend Database = iff(Database has \"/securityentitydata/sqlservers:\", strcat(extract(@\"^(.*?)/securityentitydata\", 1, Database), \"/servers/\", extract(@\"sqlservers:([^:]+):\", 1, Database), \"/databases/\", extract(@\"databases:([^/]+)\", 1, Database)), Database)\n| extend ResourceGroup = trim_end(\"/\", extract(\"(?i).*resourceGroups/(.+?)/\", 0, Resource))\n| extend ResourceType = tolower(split(Resource, \"/\").[6])\n| extend Severity = tostring(coalesce(properties.additionalData.Severity, properties.additionalData.severity))\n| extend status = tostring(properties.status.code)\n| extend VulnId = tostring(coalesce(properties.additionalData.RuleId, properties.additionalData.ruleId))\n| extend Description = tostring(properties.metadata.displayName)\n| extend Category = tostring(coalesce(properties.additionalData.Category, properties.additionalData.category))\n| extend TimeGenerated = tostring(properties.status.statusChangeDate)\n| extend Remediation = tostring(coalesce(properties.additionalData.RemediationDescription, properties.additionalData.remediationDescription))\n| extend Impact = tostring(coalesce(properties.additionalData.Impact, properties.additionalData.impact))\n| extend Query = todynamic(coalesce(properties.additionalData.Query, properties.additionalData.query))\n| where status == 'Unhealthy'\n| where '{selectedSQL}' == 'All' or Resource == '{selectedSQL}'\n| project Severity, VulnId, Description, Category, Resource, Database, ResourceGroup, TimeGenerated, Remediation, Impact, Query",
+              "query": "securityresources\n| where '*' in ({Subscription}) or subscriptionId in~ ({Subscription:subid})\n| where type =~ \"microsoft.security/assessments\"\n| extend scanner = tostring(coalesce(properties.additionalData.Scanner, properties.additionalData.scanner))\n| where scanner =~ \"SQL Vulnerability Assessment\"\n| extend Resource = tolower(tostring(coalesce(properties.additionalData.ParentResource, properties.additionalData.parentResource)))\n| where isnotempty(Resource)\n| extend Database = tolower(tostring(coalesce(properties.resourceDetails.Id, properties.resourceDetails.id)))\n| extend Database = iff(Database has \"/securityentitydata/sqlservers:\", strcat(extract(@\"^(.*?)/securityentitydata\", 1, Database), \"/servers/\", extract(@\"sqlservers:([^:]+):\", 1, Database), \"/databases/\", extract(@\"databases:([^/]+)\", 1, Database)), Database)\n| extend ResourceGroup = trim_end(\"/\", extract(\"(?i).*resourceGroups/(.+?)/\", 0, Resource))\n| extend ResourceType = tolower(split(Resource, \"/\").[6])\n| extend Severity = tostring(coalesce(properties.additionalData.Severity, properties.additionalData.severity))\n| extend status = tostring(properties.status.code)\n| extend VulnId = tostring(coalesce(properties.additionalData.RuleId, properties.additionalData.ruleId))\n| extend Description = tostring(properties.metadata.displayName)\n| extend Category = tostring(coalesce(properties.additionalData.Category, properties.additionalData.category))\n| extend TimeGenerated = tostring(properties.status.statusChangeDate)\n| extend Remediation = tostring(coalesce(properties.additionalData.RemediationDescription, properties.additionalData.remediationDescription))\n| extend Impact = tostring(coalesce(properties.additionalData.Impact, properties.additionalData.impact))\n| extend Query = todynamic(coalesce(properties.additionalData.Query, properties.additionalData.query))\n| where status == 'Unhealthy'\n| where '{selectedSQL}' == 'All' or Resource == '{selectedSQL}'\n| project Severity, VulnId, Description, Category, Resource, Database, ResourceGroup, TimeGenerated, Remediation, Impact, Query",
               "size": 2,
               "title": "Grouped by resource | Use the search box to filter vulnerabilities by resource, resource group, severity, etc.",
               "showExportToExcel": true,
               "queryType": 1,
-              "resourceType": "microsoft.resourcegraph/resources",
+              "resourceType": "microsoft.resources/tenants",
               "crossComponentResources": [
-                "{Subscription}"
+                "value::tenant"
               ],
               "gridSettings": {
                 "formatters": [
@@ -2043,14 +2077,14 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "securityresources\n| where type =~ \"microsoft.security/assessments\"\n| extend scanner = tostring(coalesce(properties.additionalData.Scanner, properties.additionalData.scanner))\n| where scanner =~ \"SQL Vulnerability Assessment\"\n| extend Resource = tolower(tostring(coalesce(properties.additionalData.ParentResource, properties.additionalData.parentResource)))\n| where isnotempty(Resource)\n| extend Database = tolower(tostring(coalesce(properties.resourceDetails.Id, properties.resourceDetails.id)))\n| extend Database = iff(Database has \"/securityentitydata/sqlservers:\", strcat(extract(@\"^(.*?)/securityentitydata\", 1, Database), \"/servers/\", extract(@\"sqlservers:([^:]+):\", 1, Database), \"/databases/\", extract(@\"databases:([^/]+)\", 1, Database)), Database)\n| extend ResourceGroup = trim_end(\"/\", extract(\"(?i).*resourceGroups/(.+?)/\", 0, Resource))\n| extend ResourceType = tolower(split(Resource, \"/\").[6])\n| extend Severity = tostring(coalesce(properties.additionalData.Severity, properties.additionalData.severity))\n| extend status = tostring(properties.status.code)\n| extend VulnId = tostring(coalesce(properties.additionalData.RuleId, properties.additionalData.ruleId))\n| extend Description = tostring(properties.metadata.displayName)\n| extend Category = tostring(coalesce(properties.additionalData.Category, properties.additionalData.category))\n| extend TimeGenerated = tostring(properties.status.statusChangeDate)\n| extend Remediation = tostring(coalesce(properties.additionalData.RemediationDescription, properties.additionalData.remediationDescription))\n| extend Impact = tostring(coalesce(properties.additionalData.Impact, properties.additionalData.impact))\n| extend Query = todynamic(coalesce(properties.additionalData.Query, properties.additionalData.query))\n| where status == 'Unhealthy'\n| where '{selectedSQL}' == 'All' or Resource == '{selectedSQL}'\n| project Severity, VulnId, Description, Category, Resource, Database, ResourceGroup, TimeGenerated, Remediation, Impact, Query",
+              "query": "securityresources\n| where '*' in ({Subscription}) or subscriptionId in~ ({Subscription:subid})\n| where type =~ \"microsoft.security/assessments\"\n| extend scanner = tostring(coalesce(properties.additionalData.Scanner, properties.additionalData.scanner))\n| where scanner =~ \"SQL Vulnerability Assessment\"\n| extend Resource = tolower(tostring(coalesce(properties.additionalData.ParentResource, properties.additionalData.parentResource)))\n| where isnotempty(Resource)\n| extend Database = tolower(tostring(coalesce(properties.resourceDetails.Id, properties.resourceDetails.id)))\n| extend Database = iff(Database has \"/securityentitydata/sqlservers:\", strcat(extract(@\"^(.*?)/securityentitydata\", 1, Database), \"/servers/\", extract(@\"sqlservers:([^:]+):\", 1, Database), \"/databases/\", extract(@\"databases:([^/]+)\", 1, Database)), Database)\n| extend ResourceGroup = trim_end(\"/\", extract(\"(?i).*resourceGroups/(.+?)/\", 0, Resource))\n| extend ResourceType = tolower(split(Resource, \"/\").[6])\n| extend Severity = tostring(coalesce(properties.additionalData.Severity, properties.additionalData.severity))\n| extend status = tostring(properties.status.code)\n| extend VulnId = tostring(coalesce(properties.additionalData.RuleId, properties.additionalData.ruleId))\n| extend Description = tostring(properties.metadata.displayName)\n| extend Category = tostring(coalesce(properties.additionalData.Category, properties.additionalData.category))\n| extend TimeGenerated = tostring(properties.status.statusChangeDate)\n| extend Remediation = tostring(coalesce(properties.additionalData.RemediationDescription, properties.additionalData.remediationDescription))\n| extend Impact = tostring(coalesce(properties.additionalData.Impact, properties.additionalData.impact))\n| extend Query = todynamic(coalesce(properties.additionalData.Query, properties.additionalData.query))\n| where status == 'Unhealthy'\n| where '{selectedSQL}' == 'All' or Resource == '{selectedSQL}'\n| project Severity, VulnId, Description, Category, Resource, Database, ResourceGroup, TimeGenerated, Remediation, Impact, Query",
               "size": 2,
               "title": "Grouped by severity | Use the search box to filter vulnerabilities by resource, resource group, severity, etc.",
               "showExportToExcel": true,
               "queryType": 1,
-              "resourceType": "microsoft.resourcegraph/resources",
+              "resourceType": "microsoft.resources/tenants",
               "crossComponentResources": [
-                "{Subscription}"
+                "value::tenant"
               ],
               "gridSettings": {
                 "formatters": [
@@ -2106,14 +2140,14 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "securityresources\n| where type =~ \"microsoft.security/assessments\"\n| extend scanner = tostring(coalesce(properties.additionalData.Scanner, properties.additionalData.scanner))\n| where scanner =~ \"SQL Vulnerability Assessment\"\n| extend Resource = tolower(tostring(coalesce(properties.additionalData.ParentResource, properties.additionalData.parentResource)))\n| where isnotempty(Resource)\n| extend Database = tolower(tostring(coalesce(properties.resourceDetails.Id, properties.resourceDetails.id)))\n| extend Database = iff(Database has \"/securityentitydata/sqlservers:\", strcat(extract(@\"^(.*?)/securityentitydata\", 1, Database), \"/servers/\", extract(@\"sqlservers:([^:]+):\", 1, Database), \"/databases/\", extract(@\"databases:([^/]+)\", 1, Database)), Database)\n| extend ResourceGroup = trim_end(\"/\", extract(\"(?i).*resourceGroups/(.+?)/\", 0, Resource))\n| extend ResourceType = tolower(split(Resource, \"/\").[6])\n| extend Severity = tostring(coalesce(properties.additionalData.Severity, properties.additionalData.severity))\n| extend status = tostring(properties.status.code)\n| extend VulnId = tostring(coalesce(properties.additionalData.RuleId, properties.additionalData.ruleId))\n| extend Description = tostring(properties.metadata.displayName)\n| extend Category = tostring(coalesce(properties.additionalData.Category, properties.additionalData.category))\n| extend TimeGenerated = tostring(properties.status.statusChangeDate)\n| extend Remediation = tostring(coalesce(properties.additionalData.RemediationDescription, properties.additionalData.remediationDescription))\n| extend Impact = tostring(coalesce(properties.additionalData.Impact, properties.additionalData.impact))\n| extend Query = todynamic(coalesce(properties.additionalData.Query, properties.additionalData.query))\n| extend Benchmarks = parse_json(tostring(coalesce(properties.additionalData.Benchmarks, properties.additionalData.benchmarks)))\n| mvexpand Benchmarks\n| extend Benchmark = parse_json(Benchmarks).benchmark\n| where status == 'Unhealthy'\n| where '{selectedSQL}' == 'All' or Resource == '{selectedSQL}'\n| project Severity, VulnId, Description, Category, Resource, Database, ResourceGroup, TimeGenerated, tostring(Benchmark), Remediation, Impact, Query",
+              "query": "securityresources\n| where '*' in ({Subscription}) or subscriptionId in~ ({Subscription:subid})\n| where type =~ \"microsoft.security/assessments\"\n| extend scanner = tostring(coalesce(properties.additionalData.Scanner, properties.additionalData.scanner))\n| where scanner =~ \"SQL Vulnerability Assessment\"\n| extend Resource = tolower(tostring(coalesce(properties.additionalData.ParentResource, properties.additionalData.parentResource)))\n| where isnotempty(Resource)\n| extend Database = tolower(tostring(coalesce(properties.resourceDetails.Id, properties.resourceDetails.id)))\n| extend Database = iff(Database has \"/securityentitydata/sqlservers:\", strcat(extract(@\"^(.*?)/securityentitydata\", 1, Database), \"/servers/\", extract(@\"sqlservers:([^:]+):\", 1, Database), \"/databases/\", extract(@\"databases:([^/]+)\", 1, Database)), Database)\n| extend ResourceGroup = trim_end(\"/\", extract(\"(?i).*resourceGroups/(.+?)/\", 0, Resource))\n| extend ResourceType = tolower(split(Resource, \"/\").[6])\n| extend Severity = tostring(coalesce(properties.additionalData.Severity, properties.additionalData.severity))\n| extend status = tostring(properties.status.code)\n| extend VulnId = tostring(coalesce(properties.additionalData.RuleId, properties.additionalData.ruleId))\n| extend Description = tostring(properties.metadata.displayName)\n| extend Category = tostring(coalesce(properties.additionalData.Category, properties.additionalData.category))\n| extend TimeGenerated = tostring(properties.status.statusChangeDate)\n| extend Remediation = tostring(coalesce(properties.additionalData.RemediationDescription, properties.additionalData.remediationDescription))\n| extend Impact = tostring(coalesce(properties.additionalData.Impact, properties.additionalData.impact))\n| extend Query = todynamic(coalesce(properties.additionalData.Query, properties.additionalData.query))\n| extend Benchmarks = parse_json(tostring(coalesce(properties.additionalData.Benchmarks, properties.additionalData.benchmarks)))\n| mvexpand Benchmarks\n| extend Benchmark = parse_json(Benchmarks).benchmark\n| where status == 'Unhealthy'\n| where '{selectedSQL}' == 'All' or Resource == '{selectedSQL}'\n| project Severity, VulnId, Description, Category, Resource, Database, ResourceGroup, TimeGenerated, tostring(Benchmark), Remediation, Impact, Query",
               "size": 2,
               "title": "Grouped by category | Use the search box to filter vulnerabilities by resource, resource group, severity, etc.",
               "showExportToExcel": true,
               "queryType": 1,
-              "resourceType": "microsoft.resourcegraph/resources",
+              "resourceType": "microsoft.resources/tenants",
               "crossComponentResources": [
-                "{Subscription}"
+                "value::tenant"
               ],
               "gridSettings": {
                 "formatters": [


### PR DESCRIPTION
Follow-up to #3209, which migrated the SQL VA queries off sub-assessments. This does the same for the **machine (server)** and **container** tiles, which are currently broken for customers.

## Problem

Two independent regressions:

**1. Machine tiles render empty.** The 6 machine queries filtered `securityresources` on a hardcoded Qualys assessment key against `microsoft.security/assessments/subassessments`. That table now returns **0 rows tenant-wide**, so every machine tile is blank.

**2. CVE severity shows as `Unknown`.** CVE metadata is no longer emitted inline on the assessment record. On the tenant I validated against, inline severity is `"Unknown"` for **2064 of 2105** machine CVEs (~98%). Containers are less affected but still lose ~7%.

## Changes

### 1. Machine queries → `microsoft.security/assessments`

Replaced the hardcoded assessment key with a category + resource-type filter:

```kusto
| where type == "microsoft.security/assessments"
| where properties.metadata.recommendationCategory == "SoftwareUpdate"
| where tostring(properties.resourceDetails.ResourceType) == "Microsoft.Compute/virtualMachines"
     or tostring(properties.resourceDetails.ResourceType) == "Microsoft.HybridCompute/machines"
| where tostring(properties.status.code) == 'Unhealthy'
```

The `Unhealthy` filter is required: the old `subassessments` table contained only findings, whereas `assessments` also holds healthy rows, which would otherwise inflate every count.

One related fix: `items[16]` grouped by `properties.category`, which does not exist on the new table. It now groups by `PackageType`.

### 2. CVE metadata → `microsoft.security/cvedetails`

Severity, description, remediation and impact now come from a `leftouter` join, for **both** machines and containers:

```kusto
| join kind=leftouter (
    securityresources
    | where type =~ "microsoft.security/cvedetails"
    | project cveId = tolower(tostring(properties.cveId)), cveSeverity = tostring(properties.severity)
) on cveId
```

For containers the inline value is retained as a fallback (join value wins → inline → `'Unknown'`). This resolves 4,998 of 5,031 previously-`Unknown` container CVEs (99.3%).

> `microsoft.security/cvedetails` is currently undocumented. The schema used here was derived empirically: 379,122 rows, exactly one row per `cveId`, keys are lowercase-first (`properties.cveId`, `properties.severity`). Note `severity`, not `Severity` — KQL dynamic access is case-sensitive and the capitalised form silently returns null.

### 3. Tenant scope (required by #2)

`cvedetails` rows are tenant-level and carry **no `subscriptionId`** (`id` = `/providers/microsoft.security/cvedetails/cve-2006-1451`). A subscription-scoped query returns nothing, so all 21 ARG queries move to:

```json
"resourceType": "microsoft.resources/tenants",
"crossComponentResources": ["value::tenant"]
```

**The UI is unchanged.** The subscription picker is preserved and now applies as a KQL filter, injected as line 2 of every query:

```kusto
| where '*' in ({Subscription}) or subscriptionId in~ ({Subscription:subid})
```

The picker gains `"selectAllValue": "*"` so that **All** emits a single sentinel rather than expanding to every subscription ID. Without this, the longest query rendered at 33,493 characters against ARG's ~16,000 limit and every tile errored on load in large tenants; with it, 2,296 characters.

The guard is deliberately **not** applied inside the `cvedetails` sub-query — those rows have no `subscriptionId` and would all be filtered out.

## Consequences worth reviewing

**Critical severity column.** `cvedetails` emits a `Critical` severity that the workbook never rendered. Without a `sevC` column those CVEs count toward `Total` but land in no bucket. Added to the per-resource grids, pie chart and severity filters. Downstream of this, the container grid's `| top 500 by sevH desc` became `| order by ... | take 500`, because ARG's `top` operator accepts only a single sort key.

**Behavioural note.** "All" now means tenant-wide RBAC-visible scope, which may be broader than the previous subscription-list scope.

## Additional bug fix — happy to split out

The container queries now deduplicate severity before the join:

```kusto
| summarize inlineSev = min(inlineSev) by <keys>, cveId
```

This is **pre-existing and unrelated to the regression**. The same CVE can carry different inline severities across images in a registry, so `dcountif` counted it in multiple buckets. On one registry:

```
Total (dcount)  4855
sevC 220 + sevH 1874 + sevM 1705 + sevL 290 + sevU 3232  =  7321   (151% of Total)
```

After the fix the buckets reconcile (Total 4833; C 280 + H 2200 + M 1921 + L 304). It also keeps the join cheap by collapsing the left side from ~8.4M rows to ~5K distinct CVEs. The machine queries do not have this bug (`cvedetails` is strictly one row per CVE).

If reviewers would rather keep this PR to the regression only, I'm glad to pull it into a separate PR.

## Validation

All 21 queries were executed live against a production tenant via the ARG REST API at tenant scope — **0 failures**. The 6 container queries were additionally smoke-tested for row counts and column shape.

Note that `az graph query --management-groups <root>` does **not** give true tenant scope and returns 0 rows for `cvedetails`; the REST API with no scope specified is required.

## Screenshot

I don't have portal access to this template under a tenant with representative data, so I wasn't able to attach a rendered screenshot per CONTRIBUTING.md. Happy to add one if a reviewer can point me at a suitable tenant, or if a member of @microsoft/defender-for-cloud-workbooks can grab one.
