### PR TITLE
Fix container VA tiles: recover CVE severity and correct bucket double-counting

### DIFF
--- a/Workbooks/Azure Security Center/Vulnerabilities/Vulnerabilities.workbook
+++ b/Workbooks/Azure Security Center/Vulnerabilities/Vulnerabilities.workbook
@@ -237,14 +237,14 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "securityresources\n| where type == \"microsoft.security/assessments\"\n| where properties.metadata.recommendationCategory == \"SoftwareUpdate\"\n| where properties.resourceDetails.ResourceType == \".containerimage\"\n| where properties.resourceDetails.Source == \"Azure\"\n| extend status = tostring(properties.status.code)\n| where status == \"Unhealthy\"\n| extend Resource = tolower(extract(@'(?i)(.*?)/securityentitydata/([^/]+)', 1, id))\n| extend ResourceType = \"microsoft.containerregistry/registries\"\n| summarize Count=dcount(Resource) by ResourceType",
+        "query": "securityresources\n| where subscriptionId in~ ({Subscription:subid})\n| where type == \"microsoft.security/assessments\"\n| where properties.metadata.recommendationCategory == \"SoftwareUpdate\"\n| where properties.resourceDetails.ResourceType == \".containerimage\"\n| where properties.resourceDetails.Source == \"Azure\"\n| where tostring(properties.status.code) == \"Unhealthy\"\n| extend Resource = tolower(extract(@'(?i)(.*?)/securityentitydata/([^/]+)', 1, id))\n| extend ResourceType = \"microsoft.containerregistry/registries\"\n| summarize by Resource, ResourceType\n| summarize Count = count() by ResourceType",
         "size": 4,
         "title": "Unhealthy container registries",
         "noDataMessage": "No unhealthy container registries found",
         "queryType": 1,
-        "resourceType": "microsoft.resourcegraph/resources",
+        "resourceType": "microsoft.resources/tenants",
         "crossComponentResources": [
-          "{Subscription}"
+          "value::tenant"
         ],
         "visualization": "table",
         "gridSettings": {
@@ -437,14 +437,14 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "securityresources\n| where type == \"microsoft.security/assessments\"\n| where properties.metadata.recommendationCategory == \"SoftwareUpdate\"\n| where properties.resourceDetails.ResourceType == \".containerimage\"\n| where properties.resourceDetails.Source == \"Azure\"\n| extend status = tostring(properties.status.code)\n| where status == \"Unhealthy\"\n| extend CvesRaw = parse_json(tostring(properties.additionalData.CvesDetails))\n| project-away properties\n| mv-expand cve = CvesRaw\n| project-away CvesRaw\n| extend CveId = tostring(cve.CveId)\n| extend Severity = tostring(cve.Severity)\n| summarize Count = dcount(CveId) by Severity",
+        "query": "securityresources\n| where subscriptionId in~ ({Subscription:subid})\n| where type == \"microsoft.security/assessments\"\n| where properties.metadata.recommendationCategory == \"SoftwareUpdate\"\n| where properties.resourceDetails.ResourceType == \".containerimage\"\n| where properties.resourceDetails.Source == \"Azure\"\n| where tostring(properties.status.code) == \"Unhealthy\"\n| extend Resource = tolower(extract(@'(?i)(.*?)/securityentitydata/([^/]+)', 1, id))\n| project CvesRaw = parse_json(tostring(properties.additionalData.CvesDetails))\n| mv-expand cve = CvesRaw\n| extend cveId = tolower(tostring(cve.CveId)), inlineSev = tostring(cve.Severity)\n| summarize inlineSev = min(inlineSev) by cveId\n| join kind=leftouter (\n    securityresources\n    | where type =~ \"microsoft.security/cvedetails\"\n    | project cveId = tolower(tostring(properties.cveId)), cveSeverity = tostring(properties.severity)\n) on cveId\n| extend Severity = iff(isempty(cveSeverity), inlineSev, cveSeverity)\n| extend Severity = iff(isempty(Severity), 'Unknown', Severity)\n| summarize Count = count() by Severity",
         "size": 1,
         "title": "Distinct vulnerabilities by severity",
         "noDataMessage": "No unhealthy container registries found",
         "queryType": 1,
-        "resourceType": "microsoft.resourcegraph/resources",
+        "resourceType": "microsoft.resources/tenants",
         "crossComponentResources": [
-          "{Subscription}"
+          "value::tenant"
         ],
         "visualization": "piechart",
         "tileSettings": {
@@ -648,14 +648,14 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "securityresources\n| where type == \"microsoft.security/assessments\"\n| where properties.metadata.recommendationCategory == \"SoftwareUpdate\"\n| where properties.resourceDetails.ResourceType == \".containerimage\"\n| where properties.resourceDetails.Source == \"Azure\"\n| extend status = tostring(properties.status.code)\n| where status == \"Unhealthy\"\n| extend Resource = tolower(extract(@'(?i)(.*?)/securityentitydata/([^/]+)', 1, id))\n| extend CvesRaw = parse_json(tostring(properties.additionalData.CvesDetails))\n| project-away properties\n| mv-expand cve = CvesRaw\n| project-away CvesRaw\n| extend CveId = tostring(cve.CveId)\n| extend Severity = tostring(cve.Severity)\n| summarize Total=dcount(CveId), sevC=dcountif(CveId, Severity==\"Critical\"), sevH=dcountif(CveId, Severity==\"High\"), sevM=dcountif(CveId, Severity==\"Medium\"), sevL=dcountif(CveId, Severity==\"Low\") by Resource\n| order by sevC desc",
+        "query": "securityresources\n| where subscriptionId in~ ({Subscription:subid})\n| where type == \"microsoft.security/assessments\"\n| where properties.metadata.recommendationCategory == \"SoftwareUpdate\"\n| where properties.resourceDetails.ResourceType == \".containerimage\"\n| where properties.resourceDetails.Source == \"Azure\"\n| where tostring(properties.status.code) == \"Unhealthy\"\n| extend Resource = tolower(extract(@'(?i)(.*?)/securityentitydata/([^/]+)', 1, id))\n| project Resource, CvesRaw = parse_json(tostring(properties.additionalData.CvesDetails))\n| mv-expand cve = CvesRaw\n| extend cveId = tolower(tostring(cve.CveId)), inlineSev = tostring(cve.Severity)\n| summarize inlineSev = min(inlineSev) by Resource, cveId\n| join kind=leftouter (\n    securityresources\n    | where type =~ \"microsoft.security/cvedetails\"\n    | project cveId = tolower(tostring(properties.cveId)), cveSeverity = tostring(properties.severity)\n) on cveId\n| extend Severity = iff(isempty(cveSeverity), inlineSev, cveSeverity)\n| extend Severity = iff(isempty(Severity), 'Unknown', Severity)\n| summarize Total = count(), sevC = countif(Severity == 'Critical'), sevH = countif(Severity == 'High'), sevM = countif(Severity == 'Medium'), sevL = countif(Severity == 'Low') by Resource\n| order by sevC desc, sevH desc, sevM desc",
         "size": 0,
         "title": "Vulnerabilities by severity per container registry",
         "noDataMessage": "No unhealthy container registries found",
         "queryType": 1,
-        "resourceType": "microsoft.resourcegraph/resources",
+        "resourceType": "microsoft.resources/tenants",
         "crossComponentResources": [
-          "{Subscription}"
+          "value::tenant"
         ],
         "gridSettings": {
           "formatters": [
@@ -1201,7 +1201,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "securityresources\n| where type == \"microsoft.security/assessments\"\n| where properties.metadata.recommendationCategory == \"SoftwareUpdate\"\n| where properties.resourceDetails.ResourceType == \".containerimage\"\n| where properties.resourceDetails.Source == \"Azure\"\n| extend status = tostring(properties.status.code)\n| where status == \"Unhealthy\"\n| extend Resource = tolower(extract(@'(?i)(.*?)/securityentitydata/([^/]+)', 1, id))\n| extend ResourceGroup = tostring(split(Resource, '/')[4])\n| extend FixedVersion = tostring(properties.additionalData.FixedVersion)\n| extend CvesRaw = parse_json(tostring(properties.additionalData.CvesDetails))\n| project-away properties\n| mv-expand cve = CvesRaw\n| project-away CvesRaw\n| extend CveId = tostring(cve.CveId)\n| extend CveSeverity = tostring(cve.Severity)\n| extend isPatchable = iff(isnotempty(FixedVersion), 1, 0)\n| summarize Total=dcount(CveId), sevC=dcountif(CveId, CveSeverity==\"Critical\"), sevH=dcountif(CveId, CveSeverity==\"High\"), sevM=dcountif(CveId, CveSeverity==\"Medium\"), sevL=dcountif(CveId, CveSeverity==\"Low\"), patchAvailable=dcountif(CveId, isPatchable==1), CVEcount=dcount(CveId) by ResourceGroup, Resource\n| order by sevC desc, sevH desc",
+        "query": "securityresources\n| where subscriptionId in~ ({Subscription:subid})\n| where type == \"microsoft.security/assessments\"\n| where properties.metadata.recommendationCategory == \"SoftwareUpdate\"\n| where properties.resourceDetails.ResourceType == \".containerimage\"\n| where properties.resourceDetails.Source == \"Azure\"\n| where tostring(properties.status.code) == \"Unhealthy\"\n| extend Resource = tolower(extract(@'(?i)(.*?)/securityentitydata/([^/]+)', 1, id))\n| extend ResourceGroup = tostring(split(Resource, '/')[4])\n| extend FixedVersion = tostring(properties.additionalData.FixedVersion)\n| project Resource, ResourceGroup, FixedVersion, CvesRaw = parse_json(tostring(properties.additionalData.CvesDetails))\n| mv-expand cve = CvesRaw\n| extend cveId = tolower(tostring(cve.CveId)), inlineSev = tostring(cve.Severity)\n| extend isPatchable = iff(isnotempty(FixedVersion), 1, 0)\n| summarize inlineSev = min(inlineSev), isPatchable = max(isPatchable) by ResourceGroup, Resource, cveId\n| join kind=leftouter (\n    securityresources\n    | where type =~ \"microsoft.security/cvedetails\"\n    | project cveId = tolower(tostring(properties.cveId)), cveSeverity = tostring(properties.severity)\n) on cveId\n| extend Severity = iff(isempty(cveSeverity), inlineSev, cveSeverity)\n| extend Severity = iff(isempty(Severity), 'Unknown', Severity)\n| summarize Total = count(), sevC = countif(Severity == 'Critical'), sevH = countif(Severity == 'High'), sevM = countif(Severity == 'Medium'), sevL = countif(Severity == 'Low'), patchAvailable = countif(isPatchable == 1), CVEcount = count() by ResourceGroup, Resource\n| order by sevC desc, sevH desc",
         "size": 0,
         "title": "Vulnerable container registries |  Select a container registry to view the list of vulnerabilities",
         "noDataMessage": "No unhealthy registries found",
@@ -1209,9 +1209,9 @@
         "exportParameterName": "selectedACR",
         "exportDefaultValue": "All",
         "queryType": 1,
-        "resourceType": "microsoft.resourcegraph/resources",
+        "resourceType": "microsoft.resources/tenants",
         "crossComponentResources": [
-          "{Subscription}"
+          "value::tenant"
         ],
         "gridSettings": {
           "formatters": [
@@ -1370,14 +1370,14 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "securityresources\n| where type == \"microsoft.security/assessments\"\n| where properties.metadata.recommendationCategory == \"SoftwareUpdate\"\n| where properties.resourceDetails.ResourceType == \".containerimage\"\n| where properties.resourceDetails.Source == \"Azure\"\n| extend status = tostring(properties.status.code)\n| where status == \"Unhealthy\"\n| extend Resource = tolower(extract(@'(?i)(.*?)/securityentitydata/([^/]+)', 1, id))\n| where \"{selectedACR}\" == \"All\" or Resource == \"{selectedACR}\"\n| extend resourceData = parse_json(tostring(properties.resourceAdditionalData))\n| extend registryName = tostring(resourceData.RepositoryDetails.RegistryHost)\n| extend Repo = tostring(resourceData.RepositoryDetails.RepositoryName)\n| extend imageDigest = tostring(resourceData.ImageUri)\n| extend FixedVersion = tostring(properties.additionalData.FixedVersion)\n| extend CvesRaw = parse_json(tostring(properties.additionalData.CvesDetails))\n| project-away properties\n| mv-expand cve = CvesRaw\n| project-away CvesRaw\n| extend CveId = tostring(cve.CveId)\n| extend CveSeverity = tostring(cve.Severity)\n| extend isPatchable = iff(isnotempty(FixedVersion), 1, 0)\n| summarize sevC=dcountif(CveId, CveSeverity==\"Critical\"), sevH=dcountif(CveId, CveSeverity==\"High\"), sevM=dcountif(CveId, CveSeverity==\"Medium\"), sevL=dcountif(CveId, CveSeverity==\"Low\"), patchAvailable=dcountif(CveId, isPatchable==1), CVEcount=dcount(CveId) by Resource, registryName, Repo, imageDigest\n| order by sevC desc, sevH desc\n| project imageDigest, CVEcount, patchAvailable, sevC, sevH, sevM, sevL, Resource, registryName, Repo",
+        "query": "securityresources\n| where subscriptionId in~ ({Subscription:subid})\n| where type == \"microsoft.security/assessments\"\n| where properties.metadata.recommendationCategory == \"SoftwareUpdate\"\n| where properties.resourceDetails.ResourceType == \".containerimage\"\n| where properties.resourceDetails.Source == \"Azure\"\n| where tostring(properties.status.code) == \"Unhealthy\"\n| extend Resource = tolower(extract(@'(?i)(.*?)/securityentitydata/([^/]+)', 1, id))\n| where \"{selectedACR}\" == \"All\" or Resource == \"{selectedACR}\"\n| extend resourceData = parse_json(tostring(properties.resourceAdditionalData))\n| extend registryName = tostring(resourceData.RepositoryDetails.RegistryHost)\n| extend Repo = tostring(resourceData.RepositoryDetails.RepositoryName)\n| extend imageDigest = tostring(resourceData.ImageUri)\n| extend FixedVersion = tostring(properties.additionalData.FixedVersion)\n| project Resource, registryName, Repo, imageDigest, FixedVersion, CvesRaw = parse_json(tostring(properties.additionalData.CvesDetails))\n| mv-expand cve = CvesRaw\n| extend cveId = tolower(tostring(cve.CveId)), inlineSev = tostring(cve.Severity)\n| extend isPatchable = iff(isnotempty(FixedVersion), 1, 0)\n| summarize inlineSev = min(inlineSev), isPatchable = max(isPatchable) by Resource, registryName, Repo, imageDigest, cveId\n| join kind=leftouter (\n    securityresources\n    | where type =~ \"microsoft.security/cvedetails\"\n    | project cveId = tolower(tostring(properties.cveId)), cveSeverity = tostring(properties.severity)\n) on cveId\n| extend Severity = iff(isempty(cveSeverity), inlineSev, cveSeverity)\n| extend Severity = iff(isempty(Severity), 'Unknown', Severity)\n| summarize sevC = countif(Severity == 'Critical'), sevH = countif(Severity == 'High'), sevM = countif(Severity == 'Medium'), sevL = countif(Severity == 'Low'), patchAvailable = countif(isPatchable == 1), CVEcount = count() by Resource, registryName, Repo, imageDigest\n| order by sevC desc, sevH desc\n| project imageDigest, CVEcount, patchAvailable, sevC, sevH, sevM, sevL, Resource, registryName, Repo",
         "size": 0,
         "title": "Vulnerable images",
         "noDataMessage": "No vulnerable images found",
         "queryType": 1,
-        "resourceType": "microsoft.resourcegraph/resources",
+        "resourceType": "microsoft.resources/tenants",
         "crossComponentResources": [
-          "{Subscription}"
+          "value::tenant"
         ],
         "gridSettings": {
           "formatters": [
@@ -1538,15 +1538,15 @@
             "type": 3,
             "content": {
               "version": "KqlItem/1.0",
-              "query": "securityresources\n| where type == \"microsoft.security/assessments\"\n| where properties.metadata.recommendationCategory == \"SoftwareUpdate\"\n| where properties.resourceDetails.ResourceType == \".containerimage\"\n| where properties.resourceDetails.Source == \"Azure\"\n| extend status = tostring(properties.status.code)\n| where status == \"Unhealthy\"\n| extend Resource = tolower(extract(@'(?i)(.*?)/securityentitydata/([^/]+)', 1, id))\n| where \"{selectedACR}\" == \"All\" or Resource == \"{selectedACR}\"\n| extend ResourceGroup = tostring(split(Resource, '/')[4])\n| extend resourceData = parse_json(tostring(properties.resourceAdditionalData))\n| extend RepositoryName = tostring(resourceData.RepositoryDetails.RepositoryName)\n| extend ImageURI = tostring(resourceData.ImageUri)\n| extend FixedVersion = tostring(properties.additionalData.FixedVersion)\n| extend DetectedVersion = replace_string(replace_string(replace_string(tostring(properties.additionalData.DetectedSoftwareVersions), \"[\", \"\"), \"]\", \"\"), '\"',\"\")\n| extend Patchable = iff(isnotempty(FixedVersion), \"Yes\", \"No\")\n| extend CvesRaw = parse_json(tostring(properties.additionalData.CvesDetails))\n| project-away properties\n| mv-expand cve = CvesRaw\n| project-away CvesRaw\n| extend Issue = tostring(cve.CveId)\n| extend Severity = tostring(cve.Severity)\n| extend CvssStr = tostring(cve.Cvss)\n| extend CVSS3Score = extract(@'\"Key\":\"3\",\"Value\":\\{\"Base\":([0-9.]+)', 1, CvssStr)\n| project subscriptionId, Resource, ResourceGroup, ImageURI, RepositoryName, Issue, Severity, Patchable, CVSS3Score, DetectedVersion, FixedVersion\n| order by ResourceGroup asc, Resource asc, Severity asc, Issue asc\n| take 1000",
+              "query": "securityresources\n| where subscriptionId in~ ({Subscription:subid})\n| where type == \"microsoft.security/assessments\"\n| where properties.metadata.recommendationCategory == \"SoftwareUpdate\"\n| where properties.resourceDetails.ResourceType == \".containerimage\"\n| where properties.resourceDetails.Source == \"Azure\"\n| where tostring(properties.status.code) == \"Unhealthy\"\n| extend Resource = tolower(extract(@'(?i)(.*?)/securityentitydata/([^/]+)', 1, id))\n| where \"{selectedACR}\" == \"All\" or Resource == \"{selectedACR}\"\n| extend ResourceGroup = tostring(split(Resource, '/')[4])\n| extend resourceData = parse_json(tostring(properties.resourceAdditionalData))\n| extend RepositoryName = tostring(resourceData.RepositoryDetails.RepositoryName)\n| extend ImageURI = tostring(resourceData.ImageUri)\n| extend FixedVersion = tostring(properties.additionalData.FixedVersion)\n| extend DetectedVersion = replace_string(replace_string(replace_string(tostring(properties.additionalData.DetectedSoftwareVersions), \"[\", \"\"), \"]\", \"\"), '\"',\"\")\n| extend Patchable = iff(isnotempty(FixedVersion), \"Yes\", \"No\")\n| project subscriptionId, Resource, ResourceGroup, ImageURI, RepositoryName, DetectedVersion, FixedVersion, Patchable, CvesRaw = parse_json(tostring(properties.additionalData.CvesDetails))\n| mv-expand cve = CvesRaw\n| extend Issue = tostring(cve.CveId), cveId = tolower(tostring(cve.CveId)), inlineSev = tostring(cve.Severity)\n| extend CvssStr = tostring(cve.Cvss)\n| extend CVSS3Score = extract(@'\"Key\":\"3\",\"Value\":\\{\"Base\":([0-9.]+)', 1, CvssStr)\n| join kind=leftouter (\n    securityresources\n    | where type =~ \"microsoft.security/cvedetails\"\n    | project cveId = tolower(tostring(properties.cveId)), cveSeverity = tostring(properties.severity)\n) on cveId\n| extend Severity = iff(isempty(cveSeverity), inlineSev, cveSeverity)\n| extend Severity = iff(isempty(Severity), 'Unknown', Severity)\n| project subscriptionId, Resource, ResourceGroup, ImageURI, RepositoryName, Issue, Severity, Patchable, CVSS3Score, DetectedVersion, FixedVersion\n| order by ResourceGroup asc, Resource asc, Severity asc, Issue asc\n| take 1000",
               "size": 2,
               "title": "Use the search box to filter vulnerabilities by resource, resource group, CVE, severity, etc.",
               "noDataMessage": "No unhealthy registries and images found",
               "showExportToExcel": true,
               "queryType": 1,
-              "resourceType": "microsoft.resourcegraph/resources",
+              "resourceType": "microsoft.resources/tenants",
               "crossComponentResources": [
-                "{Subscription}"
+                "value::tenant"
               ],
               "gridSettings": {
                 "formatters": [

--- a/Workbooks/Azure Security Center/Vulnerabilities/Vulnerabilities.workbook
+++ b/Workbooks/Azure Security Center/Vulnerabilities/Vulnerabilities.workbook
@@ -237,7 +237,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "securityresources\n| where subscriptionId in~ ({Subscription:subid})\n| where type == \"microsoft.security/assessments\"\n| where properties.metadata.recommendationCategory == \"SoftwareUpdate\"\n| where properties.resourceDetails.ResourceType == \".containerimage\"\n| where properties.resourceDetails.Source == \"Azure\"\n| where tostring(properties.status.code) == \"Unhealthy\"\n| extend Resource = tolower(extract(@'(?i)(.*?)/securityentitydata/([^/]+)', 1, id))\n| extend ResourceType = \"microsoft.containerregistry/registries\"\n| summarize by Resource, ResourceType\n| summarize Count = count() by ResourceType",
+        "query": "securityresources\n| where subscriptionId in~ ({Subscription:subid})\n| where type == \"microsoft.security/assessments\"\n| where properties.metadata.recommendationCategory == \"SoftwareUpdate\"\n| where properties.resourceDetails.ResourceType == \".containerimage\"\n| where properties.resourceDetails.Source == \"Azure\"\n| where tostring(properties.status.code) == \"Unhealthy\"\n| extend Resource = tolower(extract(@'(?i)(.*?)/securityentitydata/([^/]+)', 1, id))\n| extend ResourceType = \"microsoft.containerregistry/registries\"\n| summarize Count = dcount(Resource) by ResourceType",
         "size": 4,
         "title": "Unhealthy container registries",
         "noDataMessage": "No unhealthy container registries found",


### PR DESCRIPTION
## Summary

Fixes the **container registry** vulnerability assessment tiles in the Vulnerabilities workbook.

This is the container half of #3222, which reviewers asked be split so a container regression could be rolled back without reverting the machine fixes. The machine half is #3223 — **the two are independent, have no ordering dependency, and either can be reverted alone.**

## The problems

**1. CVE details are no longer emitted inline** in `properties.additionalData.CvesDetails`. **54.0%** of container rows (4,826,322 of 8,933,263) now carry no usable severity. Rendered tenant-wide across 28 container resources, **27.5%** of findings land outside every severity bucket (5,664 of 20,586).

**2. The existing `dcountif` shape double-counts — this is a pre-existing bug.** A CVE carrying more than one inline severity is counted once per severity, so the buckets do not reconcile against the total:

| | Original |
|---|---|
| Reported total | 4,855 |
| Sum of severity buckets | 220 + 1,874 + 1,705 + 290 + 3,232 = **7,321** |
| | **151% of total** |

## The fixes

| # | Change | Why |
|---|---|---|
| 1 | Join `microsoft.security/cvedetails` to recover CVE severity | Problem 1 |
| 2 | Deduplicate before the join so each CVE contributes once | Problem 2 |
| 3 | Move affected queries to tenant scope | Forced by 1 — `cvedetails` only resolves at tenant scope |
| 4 | Add a KQL subscription guard | Preserves the existing subscription picker |

### Result

Of the 1,959 distinct container CVEs with no usable inline severity, the `cvedetails` join rescues **1,867 (95%)**, lifting overall coverage to **87%** (6,760 of 7,750). Unknown drops from 3,232 to roughly 128.

Buckets now reconcile: Total 4,833 — Critical 280, High 2,200, Medium 1,921, Low 304.

### Tenant scope + subscription filter

`microsoft.security/cvedetails` returns rows only at tenant scope, so the affected queries change to:

```jsonc
"resourceType": "microsoft.resources/tenants",
"crossComponentResources": ["value::tenant"]
```

To keep the subscription picker behaving exactly as before, each rescoped query gets a guard as line 2:

```kql
| where subscriptionId in~ ({Subscription:subid})
```

**The `Subscription` parameter itself is unchanged.** No `selectAllValue`, no sentinel. This was verified in the portal rather than assumed — under **All**, Workbooks expands per format specifier:

- `{Subscription}` → `'/subscriptions/<guid>', …` (feeds `crossComponentResources`)
- `{Subscription:subid}` → `'<guid>', …` (feeds the KQL guard)

Both mechanisms agree: a tenant-scoped count card and a subscription-scoped count card both returned **333** across a 333-subscription tenant.

## Notes on `cvedetails`

- Rows have **no `subscriptionId`** (`id` is `/providers/microsoft.security/cvedetails/cve-2006-1451`), so the guard is deliberately **not** injected into the join subquery.
- The field is `severity` (lowercase-first); capital `Severity` silently returns null.
- 379,122 rows, exactly one per `cveId`. `name` is lowercase and `properties.cveId` uppercase, so the join is on `tolower()` both sides.

## Scope

- **Touched:** container items only — `items[7, 10, 13, 18, 19, 20]`. Query and scope changes only; no `gridSettings` changes.
- **Untouched:** machine items, all SQL items, and the shared `Subscription` parameter
- Zero overlapping JSON leaves with #3223 — verified

## Validation

- All 6 changed queries executed live against a 333-subscription tenant: **6/6 HTTP 200 with real data**
- Two drill-down tiles return 0 rows only because they are gated on an unsubstituted `{selectedACR}`; re-run with `All` they return data correctly
- Structural validation: valid JSON, 25 items, guard on line 2 of all 6, exactly one `subscriptionId in~` per query (none leaked into join subqueries)
- Branches merge cleanly with #3223 in either order

Part of #3222
