### PR TITLE
Clarify ConfigMgr cache node aggregation in DO workbook

### DIFF
--- a/Workbooks/UpdateCompliance/DeliveryOptimization/DeliveryOptimization.workbook
+++ b/Workbooks/UpdateCompliance/DeliveryOptimization/DeliveryOptimization.workbook
@@ -1737,7 +1737,7 @@
                       {
                         "type": 1,
                         "content": {
-                          "json": "**Cache Node Summary (Aggregated Past 28 Days)**\n\nAggregated summary per cache node over the last 28 days"
+                          "json": "**Cache Node Summary (Aggregated Past 28 Days)**\n\nAggregated summary per cache node over the last 28 days\n\n\\* *All [ConfigMgr nodes](https://learn.microsoft.com/en-us/intune/configmgr/core/plan-design/hierarchy/microsoft-connected-cache) are aggregated into a single row due to processing limitations.*"
                         },
                         "name": "TableDescription"
                       },


### PR DESCRIPTION
## Summary
- In the **Cache Node Summary (Aggregated Past 28 Days)** table, add a note that ConfigMgr nodes are aggregated into a single row due to processing limitations
- Hyperlink to the [Microsoft Connected Cache documentation](https://learn.microsoft.com/en-us/intune/configmgr/core/plan-design/hierarchy/microsoft-connected-cache)

## Validation
- Verified workbook JSON remains valid after the change
<img width="2293" height="656" alt="image" src="https://github.com/user-attachments/assets/ea436465-3a22-45f2-9ef8-18df91fbcbe6" />

Updated:
<img width="1050" height="287" alt="image" src="https://github.com/user-attachments/assets/761360e2-853a-46e0-a28e-1a692d97bb19" />


Workbook Test - https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/resource/subscriptions/15820d8b-8b26-4182-8db6-7bd2be4491f6/resourceGroups/edptest2/providers/Microsoft.OperationalInsights/workspaces/OMS-UC-Test/workbooks