### PR TITLE
Add Arc Benefits workbook template and Arc machines gallery

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -104,6 +104,7 @@
 
 /Workbooks/Azure*SQL*VM/** @microsoft/azuresqlvm-workbook
 /Workbooks/Azure*Arc/** @microsoft/arcee-hybrid-data
+/Workbooks/Azure*Arc*Experiences/** @microsoft/arc-user-experiences
 
 /Workbooks/Communication*Services/** @microsoft/acs-data
 
@@ -201,6 +202,7 @@
 /gallery/workbook/microsoft.machinelearningservices-workspaces.json @microsoft/gen-ai-insights
 /gallery/aistudio-insights/microsoft.machinelearningservices-workspaces.json @microsoft/gen-ai-insights
 /gallery/workbook/microsoft.copilot-studio.json @microsoft/gen-ai-insights @microsoft/copilot-studio-insights
+/gallery/workbook/microsoft.hybridcompute-machines.json @microsoft/arc-user-experiences
 
 
 

--- a/Workbooks/Azure Arc Experiences/Arc Benefits/Arc Benefits.workbook
+++ b/Workbooks/Azure Arc Experiences/Arc Benefits/Arc Benefits.workbook
@@ -2455,13 +2455,6 @@
         "json": "---\n\n### 📝 Notes\n\n**Export to Excel:** Click the \"↓\" (Export) button at the top of any table to download data to Excel."
       },
       "name": "notes"
-    },
-    {
-      "type": 1,
-      "content": {
-        "json": "\n\n---\n\n<small>[GitHub Repository](https://github.com/wjpigott/ArcBenefitsDashboard/blob/main/README.md)</small>"
-      },
-      "name": "github-link"
     }
   ],
   "fallbackResourceIds": [

--- a/Workbooks/Azure Arc Experiences/Arc Benefits/Arc Benefits.workbook
+++ b/Workbooks/Azure Arc Experiences/Arc Benefits/Arc Benefits.workbook
@@ -1,0 +1,2471 @@
+{
+  "version": "Notebook/1.0",
+  "items": [
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "parameters": [
+          {
+            "id": "showcosts-param",
+            "version": "KqlParameterItem/1.0",
+            "name": "ShowCosts",
+            "label": "💰 Show Cost Analysis",
+            "type": 10,
+            "isRequired": true,
+            "typeSettings": {
+              "showAsRadioButton": true
+            },
+            "jsonData": "[\r\n  { \"value\": \"true\", \"label\": \"Enabled\" },\r\n  { \"value\": \"false\", \"label\": \"Disabled\" }\r\n]",
+            "value": "false"
+          },
+          {
+            "id": "resourcetype-param",
+            "version": "KqlParameterItem/1.0",
+            "name": "ResourceType",
+            "label": "📊 Dashboard View",
+            "type": 10,
+            "isRequired": true,
+            "typeSettings": {
+              "showAsRadioButton": true
+            },
+            "jsonData": "[\r\n  { \"value\": \"arc\", \"label\": \"Windows Arc Benefits\" },\r\n  { \"value\": \"sql\", \"label\": \"SQL Arc Benefits\" }\r\n]",
+            "value": "arc"
+          },
+          {
+            "id": "subscription-filter",
+            "version": "KqlParameterItem/1.0",
+            "name": "Subscriptions",
+            "label": "🔍 Subscriptions",
+            "type": 6,
+            "isRequired": true,
+            "multiSelect": true,
+            "quote": "'",
+            "delimiter": ",",
+            "query": "Resources\r\n| where type =~ 'microsoft.hybridcompute/machines'\r\n| summarize Count = count() by subscriptionId\r\n| order by Count desc\r\n| extend Rank = row_number()\r\n| project value = subscriptionId, label = subscriptionId, selected = true",
+            "crossComponentResources": [
+              "value::all"
+            ],
+            "typeSettings": {
+              "additionalResourceOptions": [
+                "value::all"
+              ],
+              "showDefault": false
+            },
+            "queryType": 1,
+            "resourceType": "microsoft.resourcegraph/resources",
+            "value": [
+              "value::all"
+            ]
+          }
+        ],
+        "style": "above",
+        "queryType": 1,
+        "resourceType": "microsoft.resourcegraph/resources"
+      },
+      "name": "top-parameters"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "## 🎯 Azure Arc Benefits Dashboard v2.1"
+      },
+      "name": "title"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "### 💰 Labor Costs\n\nEnter the estimated labor cost per server for managing each Arc capability:"
+      },
+      "conditionalVisibility": {
+        "parameterName": "ShowCosts",
+        "comparison": "isEqualTo",
+        "value": "true"
+      },
+      "name": "labor-costs-header"
+    },
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "parameters": [
+          {
+            "id": "defender-cost",
+            "version": "KqlParameterItem/1.0",
+            "name": "DefenderCost",
+            "label": "Defender for Cloud",
+            "type": 1,
+            "value": "25"
+          },
+          {
+            "id": "updatemanager-cost",
+            "version": "KqlParameterItem/1.0",
+            "name": "UpdateManagerCost",
+            "label": "Update Manager",
+            "type": 1,
+            "value": "40"
+          },
+          {
+            "id": "guestconfig-cost",
+            "version": "KqlParameterItem/1.0",
+            "name": "GuestConfigCost",
+            "label": "Guest Configuration",
+            "type": 1,
+            "value": "30"
+          },
+          {
+            "id": "inventory-cost",
+            "version": "KqlParameterItem/1.0",
+            "name": "InventoryCost",
+            "label": "Inventory & Tracking",
+            "type": 1,
+            "value": "30"
+          },
+          {
+            "id": "bestpractice-cost",
+            "version": "KqlParameterItem/1.0",
+            "name": "BestPracticeCost",
+            "label": "Best Practice Assessment",
+            "type": 1,
+            "value": "100"
+          },
+          {
+            "id": "hotpatching-cost",
+            "version": "KqlParameterItem/1.0",
+            "name": "HotpatchingCost",
+            "label": "Hotpatching",
+            "type": 1,
+            "value": "220"
+          }
+        ],
+        "style": "above",
+        "queryType": 1,
+        "resourceType": "microsoft.resourcegraph/resources"
+      },
+      "conditionalVisibility": {
+        "parameterName": "ShowCosts",
+        "comparison": "isEqualTo",
+        "value": "true"
+      },
+      "name": "cost-parameters-row1"
+    },
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "parameters": [
+          {
+            "id": "monitoring-cost",
+            "version": "KqlParameterItem/1.0",
+            "name": "MonitoringCost",
+            "label": "Monitoring & Insights",
+            "type": 1,
+            "value": "100"
+          },
+          {
+            "id": "tagging-cost",
+            "version": "KqlParameterItem/1.0",
+            "name": "TaggingCost",
+            "label": "Resource Tagging",
+            "type": 1,
+            "value": "150"
+          },
+          {
+            "id": "admincenter-cost",
+            "version": "KqlParameterItem/1.0",
+            "name": "AdminCenterCost",
+            "label": "Windows Admin Center",
+            "type": 1,
+            "value": "25"
+          },
+          {
+            "id": "sqlbpa-cost",
+            "version": "KqlParameterItem/1.0",
+            "name": "SqlBpaCost",
+            "label": "SQL Server BPA",
+            "type": 1,
+            "value": "75"
+          },
+          {
+            "id": "sqlperformance-cost",
+            "version": "KqlParameterItem/1.0",
+            "name": "SqlPerformanceCost",
+            "label": "SQL Performance Dashboard",
+            "type": 1,
+            "value": "50"
+          },
+          {
+            "id": "sqldefender-cost",
+            "version": "KqlParameterItem/1.0",
+            "name": "SqlDefenderCost",
+            "label": "SQL Defender for Cloud",
+            "type": 1,
+            "value": "150"
+          }
+        ],
+        "style": "above",
+        "queryType": 1,
+        "resourceType": "microsoft.resourcegraph/resources"
+      },
+      "conditionalVisibility": {
+        "parameterName": "ShowCosts",
+        "comparison": "isEqualTo",
+        "value": "true"
+      },
+      "name": "cost-parameters-row2"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "💡 **Cost Parameters:** The values above represent estimated annual labor/operational costs per server for managing each Arc capability. These are customizable estimates used to calculate potential savings from unconfigured servers. Edit these values to match your organization's costs.\n\n📚 [Learn more about Windows Server software assurance benefits and pricing](https://learn.microsoft.com/en-us/azure/azure-arc/servers/windows-server-management-overview)"
+      },
+      "conditionalVisibility": {
+        "parameterName": "ShowCosts",
+        "comparison": "isEqualTo",
+        "value": "true"
+      },
+      "name": "cost-note"
+    },
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "parameters": [
+          {
+            "id": "arc-tab-param",
+            "name": "ArcTab",
+            "type": 1,
+            "value": "overview"
+          },
+          {
+            "id": "sql-tab-param",
+            "name": "SqlTab",
+            "type": 1,
+            "value": "overview"
+          },
+          {
+            "id": "sqlbpa-cost-hidden",
+            "name": "SqlBpaCost",
+            "type": 1,
+            "value": "75"
+          },
+          {
+            "id": "sqlperformance-cost-hidden",
+            "name": "SqlPerformanceCost",
+            "type": 1,
+            "value": "50"
+          },
+          {
+            "id": "sqldefender-cost-hidden",
+            "name": "SqlDefenderCost",
+            "type": 1,
+            "value": "150"
+          }
+        ],
+        "style": "pills",
+        "queryType": 0,
+        "resourceType": "microsoft.resourcegraph/resources"
+      },
+      "conditionalVisibility": {
+        "parameterName": "alwaysHide",
+        "comparison": "isEqualTo",
+        "value": "true"
+      },
+      "name": "tab-parameter"
+    },
+    {
+      "type": 11,
+      "content": {
+        "version": "LinkItem/1.0",
+        "style": "tabs",
+        "links": [
+          {
+            "id": "overview-tab",
+            "cellValue": "ArcTab",
+            "linkTarget": "parameter",
+            "linkLabel": "📊 Overview",
+            "subTarget": "overview",
+            "preText": "",
+            "style": "link"
+          },
+          {
+            "id": "updatemanager-tab",
+            "cellValue": "ArcTab",
+            "linkTarget": "parameter",
+            "linkLabel": "Update Manager",
+            "subTarget": "updatemanager",
+            "style": "link"
+          },
+          {
+            "id": "defender-tab",
+            "cellValue": "ArcTab",
+            "linkTarget": "parameter",
+            "linkLabel": "Defender",
+            "subTarget": "defender",
+            "style": "link"
+          },
+          {
+            "id": "inventory-tab",
+            "cellValue": "ArcTab",
+            "linkTarget": "parameter",
+            "linkLabel": "Inventory",
+            "subTarget": "inventory",
+            "style": "link"
+          },
+          {
+            "id": "guestconfig-tab",
+            "cellValue": "ArcTab",
+            "linkTarget": "parameter",
+            "linkLabel": "Guest Config",
+            "subTarget": "guestconfig",
+            "style": "link"
+          },
+          {
+            "id": "bestpractice-tab",
+            "cellValue": "ArcTab",
+            "linkTarget": "parameter",
+            "linkLabel": "Best Practice",
+            "subTarget": "bestpractice",
+            "style": "link"
+          },
+          {
+            "id": "tagging-tab",
+            "cellValue": "ArcTab",
+            "linkTarget": "parameter",
+            "linkLabel": "Tagging",
+            "subTarget": "tagging",
+            "style": "link"
+          },
+          {
+            "id": "monitoring-tab",
+            "cellValue": "ArcTab",
+            "linkTarget": "parameter",
+            "linkLabel": "Monitoring",
+            "subTarget": "monitoring",
+            "style": "link"
+          },
+          {
+            "id": "admincenter-tab",
+            "cellValue": "ArcTab",
+            "linkTarget": "parameter",
+            "linkLabel": "Admin Center",
+            "subTarget": "admincenter",
+            "style": "link"
+          },
+          {
+            "id": "hotpatching-tab",
+            "cellValue": "ArcTab",
+            "linkTarget": "parameter",
+            "linkLabel": "Hotpatching",
+            "subTarget": "hotpatching",
+            "style": "link"
+          }
+        ]
+      },
+      "conditionalVisibility": {
+        "parameterName": "ResourceType",
+        "comparison": "isEqualTo",
+        "value": "arc"
+      },
+      "name": "arc-service-tabs"
+    },
+    {
+      "type": 11,
+      "content": {
+        "version": "LinkItem/1.0",
+        "style": "tabs",
+        "links": [
+          {
+            "id": "sql-overview-tab",
+            "cellValue": "SqlTab",
+            "linkTarget": "parameter",
+            "linkLabel": "📊 Overview",
+            "subTarget": "overview",
+            "style": "link"
+          },
+          {
+            "id": "sqldefender-tab",
+            "cellValue": "SqlTab",
+            "linkTarget": "parameter",
+            "linkLabel": "Defender for Cloud",
+            "subTarget": "sqldefender",
+            "style": "link"
+          },
+          {
+            "id": "sqlbpa-tab",
+            "cellValue": "SqlTab",
+            "linkTarget": "parameter",
+            "linkLabel": "Best Practices Assessment",
+            "subTarget": "sqlbpa",
+            "style": "link"
+          },
+          {
+            "id": "sqlperformance-tab",
+            "cellValue": "SqlTab",
+            "linkTarget": "parameter",
+            "linkLabel": "Performance Dashboard",
+            "subTarget": "sqlperformance",
+            "style": "link"
+          },
+          {
+            "id": "sqlinventory-tab",
+            "cellValue": "SqlTab",
+            "linkTarget": "parameter",
+            "linkLabel": "Inventory & Configuration",
+            "subTarget": "sqlinventory",
+            "style": "link"
+          }
+        ]
+      },
+      "conditionalVisibility": {
+        "parameterName": "ResourceType",
+        "comparison": "isEqualTo",
+        "value": "sql"
+      },
+      "name": "sql-service-tabs"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "resources\r\n| where type == \"microsoft.hybridcompute/machines\"\r\n| extend machineId = tolower(id)\r\n| join kind=leftouter (\r\n    resources\r\n    | where type == \"microsoft.hybridcompute/machines/extensions\"\r\n    | extend \r\n        machineId = tolower(substring(id, 0, indexof(id, \"/extensions/\"))),\r\n        extType = tolower(tostring(properties.type)),\r\n        extPublisher = tolower(tostring(properties.publisher)),\r\n        extName = tolower(name)\r\n    | summarize extensions = make_set(strcat(extType, \"|\", extPublisher, \"|\", extName)) by machineId\r\n) on machineId\r\n| join kind=leftouter (\r\n    guestconfigurationresources\r\n    | where type =~ 'microsoft.guestconfiguration/guestconfigurationassignments'\r\n    | parse id with machineId '/providers/Microsoft.GuestConfiguration/guestConfigurationAssignments/' assignmentName\r\n    | project machineId = tolower(machineId)\r\n    | distinct machineId\r\n    | extend hasGuestConfigAssignment = true\r\n) on machineId\r\n| extend \r\n    hasUpdateManager = isnotnull(properties.osProfile.windowsConfiguration.patchSettings.assessmentMode) or isnotnull(properties.osProfile.linuxConfiguration.patchSettings.assessmentMode),\r\n    hasTags = isnotnull(tags) and tostring(tags) != \"{}\",\r\n    isWS2025 = properties.osVersion contains \"2025\" or properties.osVersion contains \"10.0.26100\",\r\n    hasHotpatch = tobool(properties.osProfile.windowsConfiguration.patchSettings.enableHotpatching),\r\n    hasDefender = isnotnull(extensions) and (extensions has \"mde\" or extensions has \"microsoft.azure.security\"),\r\n    hasInventory = isnotnull(extensions) and (extensions has \"changetracking\" or extensions has \"microsoftmonitoringagent\"),\r\n    hasMonitoring = isnotnull(extensions) and (extensions has \"azuremonitorwindowsagent\" or extensions has \"azuremonitorlinuxagent\" or extensions has \"loganalytics\" or extensions has \"omsagent\"),\r\n    hasGuestConfig = hasGuestConfigAssignment == true,\r\n    hasBestPractice = isnotnull(extensions) and (extensions has \"windowsserverassessment\" or extensions has \"assessmentplatform\"),\r\n    hasAdminCenter = isnotnull(extensions) and extensions has \"admincenter\"\r\n| summarize \r\n    TotalServers = count(),\r\n    UpdateManagerConfigured = countif(hasUpdateManager),\r\n    UpdateManagerUnconfigured = countif(not(hasUpdateManager)),\r\n    TaggingConfigured = countif(hasTags),\r\n    TaggingUnconfigured = countif(not(hasTags)),\r\n    HotpatchConfigured = countif(isWS2025 and hasHotpatch),\r\n    HotpatchTotal = countif(isWS2025),\r\n    DefenderConfigured = countif(hasDefender),\r\n    DefenderUnconfigured = countif(not(hasDefender)),\r\n    InventoryConfigured = countif(hasInventory),\r\n    InventoryUnconfigured = countif(not(hasInventory)),\r\n    MonitoringConfigured = countif(hasMonitoring),\r\n    MonitoringUnconfigured = countif(not(hasMonitoring)),\r\n    GuestConfigConfigured = countif(hasGuestConfig),\r\n    GuestConfigUnconfigured = countif(not(hasGuestConfig)),\r\n    BestPracticeConfigured = countif(hasBestPractice),\r\n    BestPracticeUnconfigured = countif(not(hasBestPractice)),\r\n    AdminCenterConfigured = countif(hasAdminCenter),\r\n    AdminCenterUnconfigured = countif(not(hasAdminCenter))\r\n| extend HotpatchUnconfigured = HotpatchTotal - HotpatchConfigured\r\n| extend TotalSavings = todouble(\r\n    (UpdateManagerUnconfigured * {UpdateManagerCost}) +\r\n    (TaggingUnconfigured * {TaggingCost}) +\r\n    (HotpatchUnconfigured * {HotpatchingCost}) +\r\n    (DefenderUnconfigured * {DefenderCost}) +\r\n    (InventoryUnconfigured * {InventoryCost}) +\r\n    (MonitoringUnconfigured * {MonitoringCost}) +\r\n    (GuestConfigUnconfigured * {GuestConfigCost}) +\r\n    (BestPracticeUnconfigured * {BestPracticeCost}) +\r\n    (AdminCenterUnconfigured * {AdminCenterCost}))\r\n| project \r\n    TotalServers,\r\n    TotalSavings,\r\n    services = pack_array(\r\n        pack(\"name\", \"Azure Arc-enabled Servers - Update Manager\", \"category\", \"Security & Compliance\", \"cost\", {UpdateManagerCost}, \"configured\", UpdateManagerConfigured, \"total\", TotalServers),\r\n        pack(\"name\", \"Arc-enabled Servers - Resource Tagging\", \"category\", \"Deployment & Management\", \"cost\", {TaggingCost}, \"configured\", TaggingConfigured, \"total\", TotalServers),\r\n        pack(\"name\", \"Arc-enabled Servers - Hotpatching (WS2025)\", \"category\", \"Security & Compliance\", \"cost\", {HotpatchingCost}, \"configured\", HotpatchConfigured, \"total\", HotpatchTotal),\r\n        pack(\"name\", \"Arc-enabled Servers - Microsoft Defender for Cloud\", \"category\", \"Security & Compliance\", \"cost\", {DefenderCost}, \"configured\", DefenderConfigured, \"total\", TotalServers),\r\n        pack(\"name\", \"Azure Arc-enabled Servers - Inventory & Tracking\", \"category\", \"Security & Compliance\", \"cost\", {InventoryCost}, \"configured\", InventoryConfigured, \"total\", TotalServers),\r\n        pack(\"name\", \"Arc-enabled Servers - Monitoring & Insights\", \"category\", \"Deployment & Management\", \"cost\", {MonitoringCost}, \"configured\", MonitoringConfigured, \"total\", TotalServers),\r\n        pack(\"name\", \"Azure Arc-enabled Servers - Guest Configuration\", \"category\", \"Security & Compliance\", \"cost\", {GuestConfigCost}, \"configured\", GuestConfigConfigured, \"total\", TotalServers),\r\n        pack(\"name\", \"Arc-enabled Servers - Best Practice Assessment\", \"category\", \"Security & Compliance\", \"cost\", {BestPracticeCost}, \"configured\", BestPracticeConfigured, \"total\", TotalServers),\r\n        pack(\"name\", \"Arc-enabled Servers - Windows Admin Center\", \"category\", \"Deployment & Management\", \"cost\", {AdminCenterCost}, \"configured\", AdminCenterConfigured, \"total\", TotalServers),\r\n        pack(\"name\", \"💰 TOTAL ESTIMATED LABOR SAVINGS\", \"category\", \"Totals\", \"cost\", 0, \"configured\", 0, \"total\", 0)\r\n    )\r\n| mv-expand service = services\r\n| extend \r\n    ServiceName = tostring(service.name),\r\n    Category = tostring(service.category),\r\n    Cost = toint(service.cost),\r\n    Configured = tolong(service.configured),\r\n    Total = tolong(service.total)\r\n| extend \r\n    Unconfigured = Total - Configured,\r\n    Percent = iff(Total > 0, round(todouble(Configured) * 100.0 / todouble(Total), 1), 0.0)\r\n| extend Savings = iff(ServiceName startswith \"💰\", TotalSavings, todouble(Unconfigured * Cost))\r\n| extend Status = iff(ServiceName startswith \"💰\", \"\", case(Percent >= 100.0, \"🟢 Fully Configured\", Percent > 0.0, \"🟡 Partially Configured\", \"🔴 Not Configured\"))\r\n| extend SortOrder = iff(ServiceName startswith \"💰\", 1, 0)\r\n| project ServiceName, Category, ConfiguredServers = iff(ServiceName startswith \"💰\", tolong(-1), Configured), UnconfiguredServers = iff(ServiceName startswith \"💰\", tolong(-1), Unconfigured), PercentConfigured = iff(ServiceName startswith \"💰\", todouble(-1), Percent), PotentialSavings = Savings, Status, SortOrder\r\n| order by SortOrder asc, PotentialSavings desc\r\n| project-away SortOrder",
+        "size": 3,
+        "title": "📊 Windows Arc Capabilities Summary - All Services",
+        "queryType": 1,
+        "resourceType": "microsoft.resourcegraph/resources",
+        "crossComponentResources": [
+          "{Subscriptions}"
+        ],
+        "gridSettings": {
+          "formatters": [
+            {
+              "columnMatch": "ConfiguredServers",
+              "formatter": 18,
+              "formatOptions": {
+                "palette": "green",
+                "thresholdsOptions": "icons",
+                "thresholdsGrid": [
+                  {
+                    "operator": "==",
+                    "thresholdValue": "-1",
+                    "representation": "",
+                    "text": ""
+                  },
+                  {
+                    "operator": "Default",
+                    "thresholdValue": null,
+                    "representation": "success",
+                    "text": "{0}{1}"
+                  }
+                ]
+              }
+            },
+            {
+              "columnMatch": "UnconfiguredServers",
+              "formatter": 18,
+              "formatOptions": {
+                "palette": "red",
+                "thresholdsOptions": "icons",
+                "thresholdsGrid": [
+                  {
+                    "operator": "==",
+                    "thresholdValue": "-1",
+                    "representation": "",
+                    "text": ""
+                  },
+                  {
+                    "operator": "Default",
+                    "thresholdValue": null,
+                    "representation": "2",
+                    "text": "{0}{1}"
+                  }
+                ]
+              }
+            },
+            {
+              "columnMatch": "PercentConfigured",
+              "formatter": 18,
+              "formatOptions": {
+                "palette": "greenRed",
+                "thresholdsOptions": "icons",
+                "thresholdsGrid": [
+                  {
+                    "operator": "==",
+                    "thresholdValue": "-1",
+                    "representation": "",
+                    "text": ""
+                  },
+                  {
+                    "operator": "Default",
+                    "thresholdValue": null,
+                    "representation": null,
+                    "text": "{0}{1}"
+                  }
+                ]
+              },
+              "numberFormat": {
+                "unit": 1,
+                "options": {
+                  "style": "decimal",
+                  "maximumFractionDigits": 0
+                }
+              }
+            },
+            {
+              "columnMatch": "PotentialSavings",
+              "formatter": 18,
+              "formatOptions": {
+                "palette": "green",
+                "thresholdsOptions": "icons",
+                "thresholdsGrid": [
+                  {
+                    "operator": "Default",
+                    "representation": "success",
+                    "text": "{0}{1}"
+                  }
+                ]
+              },
+              "numberFormat": {
+                "unit": 0,
+                "options": {
+                  "style": "currency",
+                  "currency": "USD",
+                  "maximumFractionDigits": 0
+                }
+              }
+            }
+          ],
+          "hierarchySettings": {
+            "treeType": 1,
+            "groupBy": [
+              "Category"
+            ],
+            "expandTopLevel": true
+          },
+          "labelSettings": [
+            {
+              "columnId": "ServiceName",
+              "label": "Service Name"
+            },
+            {
+              "columnId": "PotentialSavings",
+              "label": "Potential Savings"
+            }
+          ]
+        },
+        "sortBy": [],
+        "exportToExcelOptions": "all",
+        "showExportToExcel": true
+      },
+      "conditionalVisibility": {
+        "parameterName": "ArcTab",
+        "comparison": "isEqualTo",
+        "value": "overview"
+      },
+      "conditionalVisibilities": [
+        {
+          "parameterName": "ResourceType",
+          "comparison": "isEqualTo",
+          "value": "arc"
+        },
+        {
+          "parameterName": "ArcTab",
+          "comparison": "isEqualTo",
+          "value": "overview"
+        },
+        {
+          "parameterName": "ShowCosts",
+          "comparison": "isEqualTo",
+          "value": "true"
+        }
+      ],
+      "name": "benefits-summary"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "resources\r\n| where type == \"microsoft.hybridcompute/machines\"\r\n| extend machineId = tolower(id)\r\n| join kind=leftouter (\r\n    resources\r\n    | where type == \"microsoft.hybridcompute/machines/extensions\"\r\n    | extend \r\n        machineId = tolower(substring(id, 0, indexof(id, \"/extensions/\"))),\r\n        extType = tolower(tostring(properties.type)),\r\n        extPublisher = tolower(tostring(properties.publisher)),\r\n        extName = tolower(name)\r\n    | summarize extensions = make_set(strcat(extType, \"|\", extPublisher, \"|\", extName)) by machineId\r\n) on machineId\r\n| join kind=leftouter (\r\n    guestconfigurationresources\r\n    | where type =~ 'microsoft.guestconfiguration/guestconfigurationassignments'\r\n    | parse id with machineId '/providers/Microsoft.GuestConfiguration/guestConfigurationAssignments/' assignmentName\r\n    | project machineId = tolower(machineId)\r\n    | distinct machineId\r\n    | extend hasGuestConfigAssignment = true\r\n) on machineId\r\n| extend \r\n    hasUpdateManager = isnotnull(properties.osProfile.windowsConfiguration.patchSettings.assessmentMode) or isnotnull(properties.osProfile.linuxConfiguration.patchSettings.assessmentMode),\r\n    hasTags = isnotnull(tags) and tostring(tags) != \"{}\",\r\n    isWS2025 = properties.osVersion contains \"2025\" or properties.osVersion contains \"10.0.26100\",\r\n    hasHotpatch = tobool(properties.osProfile.windowsConfiguration.patchSettings.enableHotpatching),\r\n    hasDefender = isnotnull(extensions) and (extensions has \"mde\" or extensions has \"microsoft.azure.security\"),\r\n    hasInventory = isnotnull(extensions) and (extensions has \"changetracking\" or extensions has \"microsoftmonitoringagent\"),\r\n    hasMonitoring = isnotnull(extensions) and (extensions has \"azuremonitorwindowsagent\" or extensions has \"azuremonitorlinuxagent\" or extensions has \"loganalytics\" or extensions has \"omsagent\"),\r\n    hasGuestConfig = hasGuestConfigAssignment == true,\r\n    hasBestPractice = isnotnull(extensions) and (extensions has \"windowsserverassessment\" or extensions has \"assessmentplatform\"),\r\n    hasAdminCenter = isnotnull(extensions) and extensions has \"admincenter\"\r\n| summarize \r\n    TotalServers = count(),\r\n    UpdateManagerConfigured = countif(hasUpdateManager),\r\n    UpdateManagerUnconfigured = countif(not(hasUpdateManager)),\r\n    TaggingConfigured = countif(hasTags),\r\n    TaggingUnconfigured = countif(not(hasTags)),\r\n    HotpatchConfigured = countif(isWS2025 and hasHotpatch),\r\n    HotpatchTotal = countif(isWS2025),\r\n    DefenderConfigured = countif(hasDefender),\r\n    DefenderUnconfigured = countif(not(hasDefender)),\r\n    InventoryConfigured = countif(hasInventory),\r\n    InventoryUnconfigured = countif(not(hasInventory)),\r\n    MonitoringConfigured = countif(hasMonitoring),\r\n    MonitoringUnconfigured = countif(not(hasMonitoring)),\r\n    GuestConfigConfigured = countif(hasGuestConfig),\r\n    GuestConfigUnconfigured = countif(not(hasGuestConfig)),\r\n    BestPracticeConfigured = countif(hasBestPractice),\r\n    BestPracticeUnconfigured = countif(not(hasBestPractice)),\r\n    AdminCenterConfigured = countif(hasAdminCenter),\r\n    AdminCenterUnconfigured = countif(not(hasAdminCenter))\r\n| extend HotpatchUnconfigured = HotpatchTotal - HotpatchConfigured\r\n| project \r\n    TotalServers,\r\n    services = pack_array(\r\n        pack(\"name\", \"Azure Arc-enabled Servers - Update Manager\", \"category\", \"Security & Compliance\", \"configured\", UpdateManagerConfigured, \"total\", TotalServers),\r\n        pack(\"name\", \"Arc-enabled Servers - Resource Tagging\", \"category\", \"Deployment & Management\", \"configured\", TaggingConfigured, \"total\", TotalServers),\r\n        pack(\"name\", \"Arc-enabled Servers - Hotpatching (WS2025)\", \"category\", \"Security & Compliance\", \"configured\", HotpatchConfigured, \"total\", HotpatchTotal),\r\n        pack(\"name\", \"Arc-enabled Servers - Microsoft Defender for Cloud\", \"category\", \"Security & Compliance\", \"configured\", DefenderConfigured, \"total\", TotalServers),\r\n        pack(\"name\", \"Azure Arc-enabled Servers - Inventory & Tracking\", \"category\", \"Security & Compliance\", \"configured\", InventoryConfigured, \"total\", TotalServers),\r\n        pack(\"name\", \"Arc-enabled Servers - Monitoring & Insights\", \"category\", \"Deployment & Management\", \"configured\", MonitoringConfigured, \"total\", TotalServers),\r\n        pack(\"name\", \"Azure Arc-enabled Servers - Guest Configuration\", \"category\", \"Security & Compliance\", \"configured\", GuestConfigConfigured, \"total\", TotalServers),\r\n        pack(\"name\", \"Arc-enabled Servers - Best Practice Assessment\", \"category\", \"Security & Compliance\", \"configured\", BestPracticeConfigured, \"total\", TotalServers),\r\n        pack(\"name\", \"Arc-enabled Servers - Windows Admin Center\", \"category\", \"Deployment & Management\", \"configured\", AdminCenterConfigured, \"total\", TotalServers)\r\n    )\r\n| mv-expand service = services\r\n| extend \r\n    ServiceName = tostring(service.name),\r\n    Category = tostring(service.category),\r\n    Configured = tolong(service.configured),\r\n    Total = tolong(service.total)\r\n| extend \r\n    Unconfigured = Total - Configured,\r\n    Percent = iff(Total > 0, round(todouble(Configured) * 100.0 / todouble(Total), 1), 0.0)\r\n| extend Status = case(Percent >= 100.0, \"🟢 Fully Configured\", Percent > 0.0, \"🟡 Partially Configured\", \"🔴 Not Configured\")\r\n| project ServiceName, Category, ConfiguredServers = Configured, UnconfiguredServers = Unconfigured, PercentConfigured = Percent, Status\r\n| order by UnconfiguredServers desc",
+        "size": 3,
+        "title": "📊 Windows Arc Capabilities Summary - All Services",
+        "queryType": 1,
+        "resourceType": "microsoft.resourcegraph/resources",
+        "crossComponentResources": [
+          "{Subscriptions}"
+        ],
+        "gridSettings": {
+          "formatters": [
+            {
+              "columnMatch": "ConfiguredServers",
+              "formatter": 18,
+              "formatOptions": {
+                "palette": "green",
+                "thresholdsOptions": "icons",
+                "thresholdsGrid": [
+                  {
+                    "operator": "Default",
+                    "thresholdValue": null,
+                    "representation": "success",
+                    "text": "{0}{1}"
+                  }
+                ]
+              }
+            },
+            {
+              "columnMatch": "UnconfiguredServers",
+              "formatter": 18,
+              "formatOptions": {
+                "palette": "red",
+                "thresholdsOptions": "icons",
+                "thresholdsGrid": [
+                  {
+                    "operator": "Default",
+                    "thresholdValue": null,
+                    "representation": "2",
+                    "text": "{0}{1}"
+                  }
+                ]
+              }
+            },
+            {
+              "columnMatch": "PercentConfigured",
+              "formatter": 18,
+              "formatOptions": {
+                "palette": "greenRed",
+                "thresholdsOptions": "icons",
+                "thresholdsGrid": [
+                  {
+                    "operator": "Default",
+                    "thresholdValue": null,
+                    "representation": null,
+                    "text": "{0}{1}"
+                  }
+                ]
+              },
+              "numberFormat": {
+                "unit": 1,
+                "options": {
+                  "style": "decimal",
+                  "maximumFractionDigits": 0
+                }
+              }
+            }
+          ],
+          "hierarchySettings": {
+            "treeType": 1,
+            "groupBy": [
+              "Category"
+            ],
+            "expandTopLevel": true
+          },
+          "labelSettings": [
+            {
+              "columnId": "ServiceName",
+              "label": "Service Name"
+            }
+          ]
+        },
+        "sortBy": [],
+        "exportToExcelOptions": "all",
+        "showExportToExcel": true
+      },
+      "conditionalVisibility": {
+        "parameterName": "ArcTab",
+        "comparison": "isEqualTo",
+        "value": "overview"
+      },
+      "conditionalVisibilities": [
+        {
+          "parameterName": "ResourceType",
+          "comparison": "isEqualTo",
+          "value": "arc"
+        },
+        {
+          "parameterName": "ArcTab",
+          "comparison": "isEqualTo",
+          "value": "overview"
+        },
+        {
+          "parameterName": "ShowCosts",
+          "comparison": "isEqualTo",
+          "value": "false"
+        }
+      ],
+      "name": "benefits-summary-no-costs"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "resources\r\n| where type == \"microsoft.azurearcdata/sqlserverinstances\"\r\n| extend machineId = tolower(tostring(properties.containerResourceId))\r\n| join kind=leftouter (\r\n    resources\r\n    | where type == \"microsoft.hybridcompute/machines/extensions\"\r\n    | where properties.type contains \"AzureMonitorWindowsAgent\" or properties.type contains \"AzureMonitorLinuxAgent\"\r\n    | extend machineId = tolower(substring(id, 0, indexof(id, '/extensions/')))\r\n    | summarize hasMonitoring = any(true) by machineId\r\n) on machineId\r\n| extend \r\n    hasBPA = tobool(properties.migration.assessment.enabled) == true,\r\n    hasPerformance = hasMonitoring == true\r\n| summarize \r\n    TotalServers = count(),\r\n    BpaConfigured = countif(hasBPA),\r\n    BpaUnconfigured = countif(not(hasBPA)),\r\n    PerformanceConfigured = countif(hasPerformance),\r\n    PerformanceUnconfigured = countif(not(hasPerformance)),\r\n    InventoryConfigured = count(),\r\n    InventoryUnconfigured = 0\r\n| extend TotalSavings = todouble(\r\n    (BpaUnconfigured * {SqlBpaCost}) +\r\n    (PerformanceUnconfigured * {SqlPerformanceCost}))\r\n| project \r\n    TotalServers,\r\n    TotalSavings,\r\n    services = pack_array(\r\n        pack(\"name\", \"SQL Server Arc - Best Practices Assessment\", \"category\", \"Security & Compliance\", \"cost\", {SqlBpaCost}, \"configured\", BpaConfigured, \"total\", TotalServers),\r\n        pack(\"name\", \"SQL Server Arc - Performance Dashboard\", \"category\", \"Monitoring & Performance\", \"cost\", {SqlPerformanceCost}, \"configured\", PerformanceConfigured, \"total\", TotalServers),\r\n        pack(\"name\", \"SQL Server Arc - Inventory & Configuration\", \"category\", \"Inventory & Tracking\", \"cost\", 0, \"configured\", InventoryConfigured, \"total\", TotalServers),\r\n        pack(\"name\", \"💰 TOTAL ESTIMATED LABOR SAVINGS\", \"category\", \"Totals\", \"cost\", 0, \"configured\", 0, \"total\", 0)\r\n    )\r\n| mv-expand service = services\r\n| extend \r\n    ServiceName = tostring(service.name),\r\n    Category = tostring(service.category),\r\n    Cost = toint(service.cost),\r\n    Configured = tolong(service.configured),\r\n    Total = tolong(service.total)\r\n| extend \r\n    Unconfigured = Total - Configured,\r\n    Percent = iff(Total > 0, round(todouble(Configured) * 100.0 / todouble(Total), 1), 0.0)\r\n| extend Savings = iff(ServiceName startswith \"💰\", TotalSavings, todouble(Unconfigured * Cost))\r\n| extend Status = iff(ServiceName startswith \"💰\", \"\", case(Percent >= 100.0, \"🔵 Fully Configured\", Percent > 0.0, \"🟡 Partially Configured\", \"🔴 Not Configured\"))\r\n| extend SortOrder = iff(ServiceName startswith \"💰\", 1, 0)\r\n| project ServiceName, Category, ConfiguredServers = iff(ServiceName startswith \"💰\", tolong(-1), Configured), UnconfiguredServers = iff(ServiceName startswith \"💰\", tolong(-1), Unconfigured), PercentConfigured = iff(ServiceName startswith \"💰\", todouble(-1), Percent), PotentialSavings = Savings, Status, SortOrder\r\n| order by SortOrder asc, PotentialSavings desc\r\n| project-away SortOrder",
+        "size": 3,
+        "title": "📊 SQL Server Arc Capabilities Summary",
+        "queryType": 1,
+        "resourceType": "microsoft.resourcegraph/resources",
+        "crossComponentResources": [
+          "{Subscriptions}"
+        ],
+        "gridSettings": {
+          "formatters": [
+            {
+              "columnMatch": "ConfiguredServers",
+              "formatter": 18,
+              "formatOptions": {
+                "palette": "green",
+                "thresholdsOptions": "icons",
+                "thresholdsGrid": [
+                  {
+                    "operator": "==",
+                    "thresholdValue": "-1",
+                    "representation": "",
+                    "text": ""
+                  },
+                  {
+                    "operator": "Default",
+                    "thresholdValue": null,
+                    "representation": "success",
+                    "text": "{0}{1}"
+                  }
+                ]
+              }
+            },
+            {
+              "columnMatch": "UnconfiguredServers",
+              "formatter": 18,
+              "formatOptions": {
+                "palette": "red",
+                "thresholdsOptions": "icons",
+                "thresholdsGrid": [
+                  {
+                    "operator": "==",
+                    "thresholdValue": "-1",
+                    "representation": "",
+                    "text": ""
+                  },
+                  {
+                    "operator": "Default",
+                    "thresholdValue": null,
+                    "representation": "2",
+                    "text": "{0}{1}"
+                  }
+                ]
+              }
+            },
+            {
+              "columnMatch": "PercentConfigured",
+              "formatter": 18,
+              "formatOptions": {
+                "palette": "greenRed",
+                "thresholdsOptions": "icons",
+                "thresholdsGrid": [
+                  {
+                    "operator": "==",
+                    "thresholdValue": "-1",
+                    "representation": "",
+                    "text": ""
+                  },
+                  {
+                    "operator": "Default",
+                    "thresholdValue": null,
+                    "representation": null,
+                    "text": "{0}{1}"
+                  }
+                ]
+              },
+              "numberFormat": {
+                "unit": 1,
+                "options": {
+                  "style": "decimal",
+                  "maximumFractionDigits": 0
+                }
+              }
+            },
+            {
+              "columnMatch": "PotentialSavings",
+              "formatter": 18,
+              "formatOptions": {
+                "palette": "green",
+                "customColumnWidthSetting": "20ch",
+                "compositeBarSettings": {
+                  "labelText": "",
+                  "columnSettings": []
+                },
+                "thresholdsOptions": "icons",
+                "thresholdsGrid": [
+                  {
+                    "operator": "Default",
+                    "thresholdValue": null,
+                    "representation": "success",
+                    "text": "{0}{1}"
+                  }
+                ]
+              },
+              "numberFormat": {
+                "unit": 0,
+                "options": {
+                  "style": "currency",
+                  "currency": "USD",
+                  "maximumFractionDigits": 0
+                }
+              },
+              "tooltipFormat": {
+                "tooltip": "Estimated annual labor savings from configuring unconfigured servers"
+              },
+              "conditionalFormatting": {
+                "conditionalFormats": [
+                  {
+                    "condition": "{ShowCosts} == 'false'",
+                    "format": {
+                      "isHidden": true
+                    }
+                  }
+                ]
+              }
+            }
+          ],
+          "hierarchySettings": {
+            "treeType": 1,
+            "groupBy": [
+              "Category"
+            ],
+            "expandTopLevel": true
+          },
+          "labelSettings": [
+            {
+              "columnId": "ServiceName",
+              "label": "Service Name"
+            },
+            {
+              "columnId": "PotentialSavings",
+              "label": "Potential Savings"
+            }
+          ]
+        },
+        "sortBy": [],
+        "exportToExcelOptions": "all",
+        "showExportToExcel": true
+      },
+      "conditionalVisibility": {
+        "parameterName": "SqlTab",
+        "comparison": "isEqualTo",
+        "value": "overview"
+      },
+      "conditionalVisibilities": [
+        {
+          "parameterName": "ResourceType",
+          "comparison": "isEqualTo",
+          "value": "sql"
+        },
+        {
+          "parameterName": "SqlTab",
+          "comparison": "isEqualTo",
+          "value": "overview"
+        },
+        {
+          "parameterName": "ShowCosts",
+          "comparison": "isEqualTo",
+          "value": "true"
+        }
+      ],
+      "name": "sql-benefits-summary"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "resources\r\n| where type == \"microsoft.azurearcdata/sqlserverinstances\"\r\n| extend machineId = tolower(tostring(properties.containerResourceId))\r\n| join kind=leftouter (\r\n    resources\r\n    | where type == \"microsoft.hybridcompute/machines/extensions\"\r\n    | where properties.type contains \"AzureMonitorWindowsAgent\" or properties.type contains \"AzureMonitorLinuxAgent\"\r\n    | extend machineId = tolower(substring(id, 0, indexof(id, '/extensions/')))\r\n    | summarize hasMonitoring = any(true) by machineId\r\n) on machineId\r\n| extend \r\n    hasBPA = tobool(properties.migration.assessment.enabled) == true,\r\n    hasPerformance = hasMonitoring == true\r\n| summarize \r\n    TotalServers = count(),\r\n    BpaConfigured = countif(hasBPA),\r\n    BpaUnconfigured = countif(not(hasBPA)),\r\n    PerformanceConfigured = countif(hasPerformance),\r\n    PerformanceUnconfigured = countif(not(hasPerformance)),\r\n    InventoryConfigured = count(),\r\n    InventoryUnconfigured = 0\r\n| project \r\n    TotalServers,\r\n    services = pack_array(\r\n        pack(\"name\", \"SQL Server Arc - Best Practices Assessment\", \"category\", \"Security & Compliance\", \"configured\", BpaConfigured, \"total\", TotalServers),\r\n        pack(\"name\", \"SQL Server Arc - Performance Dashboard\", \"category\", \"Monitoring & Performance\", \"configured\", PerformanceConfigured, \"total\", TotalServers),\r\n        pack(\"name\", \"SQL Server Arc - Inventory & Configuration\", \"category\", \"Inventory & Tracking\", \"configured\", InventoryConfigured, \"total\", TotalServers)\r\n    )\r\n| mv-expand service = services\r\n| extend \r\n    ServiceName = tostring(service.name),\r\n    Category = tostring(service.category),\r\n    Configured = tolong(service.configured),\r\n    Total = tolong(service.total)\r\n| extend \r\n    Unconfigured = Total - Configured,\r\n    Percent = iff(Total > 0, round(todouble(Configured) * 100.0 / todouble(Total), 1), 0.0)\r\n| extend Status = case(Percent >= 100.0, \"🔵 Fully Configured\", Percent > 0.0, \"🟡 Partially Configured\", \"🔴 Not Configured\")\r\n| project ServiceName, Category, ConfiguredServers = Configured, UnconfiguredServers = Unconfigured, PercentConfigured = Percent, Status\r\n| order by UnconfiguredServers desc",
+        "size": 3,
+        "title": "📊 SQL Server Arc Capabilities Summary",
+        "queryType": 1,
+        "resourceType": "microsoft.resourcegraph/resources",
+        "crossComponentResources": [
+          "{Subscriptions}"
+        ],
+        "gridSettings": {
+          "formatters": [
+            {
+              "columnMatch": "ConfiguredServers",
+              "formatter": 18,
+              "formatOptions": {
+                "palette": "green",
+                "thresholdsOptions": "icons",
+                "thresholdsGrid": [
+                  {
+                    "operator": "Default",
+                    "thresholdValue": null,
+                    "representation": "success",
+                    "text": "{0}{1}"
+                  }
+                ]
+              }
+            },
+            {
+              "columnMatch": "UnconfiguredServers",
+              "formatter": 18,
+              "formatOptions": {
+                "palette": "red",
+                "thresholdsOptions": "icons",
+                "thresholdsGrid": [
+                  {
+                    "operator": "Default",
+                    "thresholdValue": null,
+                    "representation": "2",
+                    "text": "{0}{1}"
+                  }
+                ]
+              }
+            },
+            {
+              "columnMatch": "PercentConfigured",
+              "formatter": 18,
+              "formatOptions": {
+                "palette": "greenRed",
+                "thresholdsOptions": "icons",
+                "thresholdsGrid": [
+                  {
+                    "operator": "Default",
+                    "thresholdValue": null,
+                    "representation": null,
+                    "text": "{0}{1}"
+                  }
+                ]
+              },
+              "numberFormat": {
+                "unit": 1,
+                "options": {
+                  "style": "decimal",
+                  "maximumFractionDigits": 0
+                }
+              }
+            }
+          ],
+          "hierarchySettings": {
+            "treeType": 1,
+            "groupBy": [
+              "Category"
+            ],
+            "expandTopLevel": true
+          },
+          "labelSettings": [
+            {
+              "columnId": "ServiceName",
+              "label": "Service Name"
+            }
+          ]
+        },
+        "sortBy": [],
+        "exportToExcelOptions": "all",
+        "showExportToExcel": true
+      },
+      "conditionalVisibility": {
+        "parameterName": "SqlTab",
+        "comparison": "isEqualTo",
+        "value": "overview"
+      },
+      "conditionalVisibilities": [
+        {
+          "parameterName": "ResourceType",
+          "comparison": "isEqualTo",
+          "value": "sql"
+        },
+        {
+          "parameterName": "SqlTab",
+          "comparison": "isEqualTo",
+          "value": "overview"
+        },
+        {
+          "parameterName": "ShowCosts",
+          "comparison": "isEqualTo",
+          "value": "false"
+        }
+      ],
+      "name": "sql-benefits-summary-no-costs"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "---\n\n### �️ Update Manager - Server Details\n\nServers configured vs. unconfigured for Update Manager (automatic patch management)."
+      },
+      "name": "update-manager-header",
+      "conditionalVisibilities": [
+        {
+          "parameterName": "ResourceType",
+          "comparison": "isEqualTo",
+          "value": "arc"
+        },
+        {
+          "parameterName": "ArcTab",
+          "comparison": "isEqualTo",
+          "value": "updatemanager"
+        }
+      ]
+    },
+    {
+      "type": 12,
+      "content": {
+        "version": "NotebookGroup/1.0",
+        "groupType": "editable",
+        "title": "📋 Notes: Azure Update Manager",
+        "expandable": true,
+        "expanded": false,
+        "items": [
+          {
+            "type": 1,
+            "content": {
+              "json": "**What it provides:**\n- Centralized patch visibility across all servers—Azure, on-premises, VMware, GCP, AWS\n- Automated scheduling, maintenance windows, compliance reporting, and auditability\n- Eliminates multiple tools (WSUS, SCCM, custom scripts, spreadsheets)\n\n**If not used:**\n- Manual patching takes 20–45 minutes per server per cycle\n- Multiple tools = duplicated operational effort\n- Higher likelihood of missed patches and extended vulnerability exposure\n- Significant time spent assembling compliance evidence for audits\n\n** Estimated Labor cost formula:**  \n`Servers × Patch Time/Month × Fully Loaded Labor Rate`\n\n**Example:**  \n500 servers × 0.5 hrs × $80/hr = **$20,000 per month saved**"
+            },
+            "name": "text - 0"
+          }
+        ]
+      },
+      "name": "update-manager-notes",
+      "conditionalVisibilities": [
+        {
+          "parameterName": "ResourceType",
+          "comparison": "isEqualTo",
+          "value": "arc"
+        },
+        {
+          "parameterName": "ArcTab",
+          "comparison": "isEqualTo",
+          "value": "updatemanager"
+        }
+      ]
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "resources\r\n| where type == \"microsoft.hybridcompute/machines\"\r\n| extend \r\n    osVersion = tostring(properties.osVersion),\r\n    hasUpdateManager = isnotnull(properties.osProfile.windowsConfiguration.patchSettings.assessmentMode) or isnotnull(properties.osProfile.linuxConfiguration.patchSettings.assessmentMode)\r\n| extend \r\n    OSName = case(\r\n        osVersion contains \"10.0.26100\", \"Windows Server 2025\",\r\n        osVersion contains \"10.0.20348\", \"Windows Server 2022\",\r\n        osVersion contains \"10.0.17763\", \"Windows Server 2019\",\r\n        osVersion contains \"10.0.14393\", \"Windows Server 2016\",\r\n        osVersion contains \"6.3.9600\", \"Windows Server 2012 R2\",\r\n        osVersion contains \"6.2.9200\", \"Windows Server 2012\",\r\n        osVersion startswith \"5.\", \"Linux (Ubuntu/RHEL)\",\r\n        osVersion startswith \"4.\", \"Linux (Ubuntu/RHEL)\",\r\n        osVersion startswith \"3.\", \"Linux (Ubuntu/RHEL)\",\r\n        \"Unknown OS\"\r\n    ),\r\n    ConfigurationStatus = iff(hasUpdateManager, \"✅ Configured\", \"❌ Not Configured\")\r\n| project \r\n    ServerName = name,\r\n    ResourceGroup = resourceGroup,\r\n    Subscription = subscriptionId,\r\n    OSVersion = OSName,\r\n    Status = ConfigurationStatus,\r\n    Location = location\r\n| order by Status desc, ServerName asc",
+        "size": 0,
+        "title": "All Servers - Update Manager Status",
+        "queryType": 1,
+        "resourceType": "microsoft.resourcegraph/resources",
+        "crossComponentResources": [
+          "{Subscriptions}"
+        ],
+        "gridSettings": {
+          "formatters": [
+            {
+              "columnMatch": "Status",
+              "formatter": 18,
+              "formatOptions": {
+                "thresholdsOptions": "colors",
+                "thresholdsGrid": [
+                  {
+                    "operator": "contains",
+                    "thresholdValue": "Not",
+                    "representation": "yellow",
+                    "text": "{0}"
+                  },
+                  {
+                    "operator": "contains",
+                    "thresholdValue": "Configured",
+                    "representation": "green",
+                    "text": "{0}"
+                  },
+                  {
+                    "operator": "Default",
+                    "thresholdValue": null,
+                    "representation": "gray",
+                    "text": "{0}"
+                  }
+                ]
+              }
+            }
+          ],
+          "filter": true
+        },
+        "exportToExcelOptions": "all",
+        "showExportToExcel": true
+      },
+      "name": "update-manager-details",
+      "conditionalVisibilities": [
+        {
+          "parameterName": "ResourceType",
+          "comparison": "isEqualTo",
+          "value": "arc"
+        },
+        {
+          "parameterName": "ArcTab",
+          "comparison": "isEqualTo",
+          "value": "updatemanager"
+        }
+      ]
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "---\n\n### 🏷️ Resource Tagging - Server Details\n\nServers with proper resource tagging configured."
+      },
+      "name": "tagging-header",
+      "conditionalVisibilities": [
+        {
+          "parameterName": "ResourceType",
+          "comparison": "isEqualTo",
+          "value": "arc"
+        },
+        {
+          "parameterName": "ArcTab",
+          "comparison": "isEqualTo",
+          "value": "tagging"
+        }
+      ]
+    },
+    {
+      "type": 12,
+      "content": {
+        "version": "NotebookGroup/1.0",
+        "groupType": "editable",
+        "title": "📋 Notes: Resource Tagging (with Chargeback/FinOps Benefits)",
+        "expandable": true,
+        "expanded": false,
+        "items": [
+          {
+            "type": 1,
+            "content": {
+              "json": "**What it provides:**\n- Standardized tagging for owner, department, environment, cost center\n- Enables automated reporting for chargeback/showback to departments\n- Supports lifecycle automation (cleanup, patch grouping, compliance)\n- Helps FinOps teams accurately track hybrid costs\n\n**If not used:**\n- Chargeback/showback processes require manual spreadsheet tracking\n- Teams spend 5–10 hours per month reconciling server ownership\n- Higher risk of orphaned assets and unassigned costs\n- Poor visibility slows budget planning and capacity management\n\n** Estimated Labor cost formula:**  \n`FinOps Admin Hours/Month × Labor Rate`"
+            },
+            "name": "text - 0"
+          }
+        ]
+      },
+      "name": "tagging-notes",
+      "conditionalVisibilities": [
+        {
+          "parameterName": "ResourceType",
+          "comparison": "isEqualTo",
+          "value": "arc"
+        },
+        {
+          "parameterName": "ArcTab",
+          "comparison": "isEqualTo",
+          "value": "tagging"
+        }
+      ]
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "resources\r\n| where type == \"microsoft.hybridcompute/machines\"\r\n| extend \r\n    hasTags = isnotnull(tags) and tostring(tags) != \"{}\",\r\n    tagCount = iff(isnotnull(tags), array_length(bag_keys(tags)), 0)\r\n| extend ConfigurationStatus = iff(hasTags, \"✅ Configured\", \"❌ Not Configured\")\r\n| project \r\n    ServerName = name,\r\n    ResourceGroup = resourceGroup,\r\n    Subscription = subscriptionId,\r\n    TagCount = tagCount,\r\n    Status = ConfigurationStatus,\r\n    Location = location\r\n| order by Status desc, ServerName asc",
+        "size": 0,
+        "title": "All Servers - Resource Tagging Status",
+        "queryType": 1,
+        "resourceType": "microsoft.resourcegraph/resources",
+        "crossComponentResources": [
+          "{Subscriptions}"
+        ],
+        "gridSettings": {
+          "formatters": [
+            {
+              "columnMatch": "Status",
+              "formatter": 18,
+              "formatOptions": {
+                "thresholdsOptions": "colors",
+                "thresholdsGrid": [
+                  {
+                    "operator": "contains",
+                    "thresholdValue": "Not",
+                    "representation": "yellow",
+                    "text": "{0}"
+                  },
+                  {
+                    "operator": "contains",
+                    "thresholdValue": "Configured",
+                    "representation": "green",
+                    "text": "{0}"
+                  },
+                  {
+                    "operator": "Default",
+                    "thresholdValue": null,
+                    "representation": "gray",
+                    "text": "{0}"
+                  }
+                ]
+              }
+            }
+          ],
+          "filter": true
+        },
+        "exportToExcelOptions": "all",
+        "showExportToExcel": true
+      },
+      "name": "tagging-details",
+      "conditionalVisibilities": [
+        {
+          "parameterName": "ResourceType",
+          "comparison": "isEqualTo",
+          "value": "arc"
+        },
+        {
+          "parameterName": "ArcTab",
+          "comparison": "isEqualTo",
+          "value": "tagging"
+        }
+      ]
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "---\n\n### 🔥 Hotpatching - Server Details\n\nWindows Server 2025 machines with hotpatching enabled."
+      },
+      "name": "hotpatching-header",
+      "conditionalVisibilities": [
+        {
+          "parameterName": "ResourceType",
+          "comparison": "isEqualTo",
+          "value": "arc"
+        },
+        {
+          "parameterName": "ArcTab",
+          "comparison": "isEqualTo",
+          "value": "hotpatching"
+        }
+      ]
+    },
+    {
+      "type": 12,
+      "content": {
+        "version": "NotebookGroup/1.0",
+        "groupType": "editable",
+        "title": "📋 Notes: Azure Hotpatching (Arc-Enabled Windows Server)",
+        "expandable": true,
+        "expanded": false,
+        "items": [
+          {
+            "type": 1,
+            "content": {
+              "json": "**What it provides:**\n- Zero-reboot patching for supported Core.\n\n**If not used:**\n- Monthly reboots required. Labor and Software downtime costs.\n\n** Estimated Labor cost formula:**  \n`Servers × Reboot Coordination Time × Patch Cycles × Labor Rate`"
+            },
+            "name": "text - 0"
+          }
+        ]
+      },
+      "name": "hotpatching-notes",
+      "conditionalVisibilities": [
+        {
+          "parameterName": "ResourceType",
+          "comparison": "isEqualTo",
+          "value": "arc"
+        },
+        {
+          "parameterName": "ArcTab",
+          "comparison": "isEqualTo",
+          "value": "hotpatching"
+        }
+      ]
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "resources\r\n| where type == \"microsoft.hybridcompute/machines\"\r\n| extend \r\n    osVersion = tostring(properties.osVersion),\r\n    hasHotpatch = tobool(properties.osProfile.windowsConfiguration.patchSettings.enableHotpatching) == true\r\n| extend \r\n    isWS2025 = osVersion contains \"2025\" or osVersion contains \"10.0.26100\",\r\n    OSName = case(\r\n        osVersion contains \"10.0.26100\", \"Windows Server 2025\",\r\n        osVersion contains \"10.0.20348\", \"Windows Server 2022\",\r\n        osVersion contains \"10.0.17763\", \"Windows Server 2019\",\r\n        osVersion contains \"10.0.14393\", \"Windows Server 2016\",\r\n        osVersion contains \"6.3.9600\", \"Windows Server 2012 R2\",\r\n        osVersion contains \"6.2.9200\", \"Windows Server 2012\",\r\n        osVersion startswith \"5.\", \"Linux (Ubuntu/RHEL)\",\r\n        osVersion startswith \"4.\", \"Linux (Ubuntu/RHEL)\",\r\n        osVersion startswith \"3.\", \"Linux (Ubuntu/RHEL)\",\r\n        \"Unknown OS\"\r\n    )\r\n| extend \r\n    ConfigurationStatus = case(\r\n        isWS2025 and hasHotpatch, \"✅ Configured\",\r\n        isWS2025, \"❌ Available but Not Configured\",\r\n        strcat(\"N/A - \", OSName)\r\n    )\r\n| project \r\n    ServerName = name,\r\n    ResourceGroup = resourceGroup,\r\n    Subscription = subscriptionId,\r\n    OSVersion = OSName,\r\n    Status = ConfigurationStatus,\r\n    Location = location\r\n| order by Status desc, ServerName asc",
+        "size": 0,
+        "title": "All Servers - Hotpatching Status",
+        "queryType": 1,
+        "resourceType": "microsoft.resourcegraph/resources",
+        "crossComponentResources": [
+          "{Subscriptions}"
+        ],
+        "gridSettings": {
+          "formatters": [
+            {
+              "columnMatch": "Status",
+              "formatter": 18,
+              "formatOptions": {
+                "thresholdsOptions": "colors",
+                "thresholdsGrid": [
+                  {
+                    "operator": "contains",
+                    "thresholdValue": "Not",
+                    "representation": "yellow",
+                    "text": "{0}"
+                  },
+                  {
+                    "operator": "contains",
+                    "thresholdValue": "Configured",
+                    "representation": "green",
+                    "text": "{0}"
+                  },
+                  {
+                    "operator": "Default",
+                    "thresholdValue": null,
+                    "representation": "gray",
+                    "text": "{0}"
+                  }
+                ]
+              }
+            }
+          ],
+          "filter": true
+        },
+        "exportToExcelOptions": "all",
+        "showExportToExcel": true
+      },
+      "name": "hotpatching-details",
+      "conditionalVisibilities": [
+        {
+          "parameterName": "ResourceType",
+          "comparison": "isEqualTo",
+          "value": "arc"
+        },
+        {
+          "parameterName": "ArcTab",
+          "comparison": "isEqualTo",
+          "value": "hotpatching"
+        }
+      ]
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "---\n\n### 🛡️ Defender for Cloud - Server Details\n\nServers with Microsoft Defender for Endpoint extension installed."
+      },
+      "name": "defender-header",
+      "conditionalVisibilities": [
+        {
+          "parameterName": "ResourceType",
+          "comparison": "isEqualTo",
+          "value": "arc"
+        },
+        {
+          "parameterName": "ArcTab",
+          "comparison": "isEqualTo",
+          "value": "defender"
+        }
+      ]
+    },
+    {
+      "type": 12,
+      "content": {
+        "version": "NotebookGroup/1.0",
+        "groupType": "editable",
+        "title": "📋 Notes: Azure Defender for Cloud (Arc-Enabled Servers)",
+        "expandable": true,
+        "expanded": false,
+        "items": [
+          {
+            "type": 1,
+            "content": {
+              "json": "**What it provides:**\n- Unified security posture mgmt across hybrid.\n\n**If not used:**\n- Manual agent deploy, scans.\n\n** EstimatedLabor cost formula:**  \n`Servers × Security Review Time × Scan Frequency × Labor Rate`"
+            },
+            "name": "text - 0"
+          }
+        ]
+      },
+      "name": "defender-notes",
+      "conditionalVisibilities": [
+        {
+          "parameterName": "ResourceType",
+          "comparison": "isEqualTo",
+          "value": "arc"
+        },
+        {
+          "parameterName": "ArcTab",
+          "comparison": "isEqualTo",
+          "value": "defender"
+        }
+      ]
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "resources\r\n| where type == \"microsoft.hybridcompute/machines\"\r\n| extend \r\n    machineId = tolower(id),\r\n    osVersion = tostring(properties.osVersion)\r\n| join kind=leftouter (\r\n    resources\r\n    | where type == \"microsoft.hybridcompute/machines/extensions\"\r\n    | where properties.type == \"MDE.Windows\" or properties.type == \"MDE.Linux\"\r\n    | extend machineId = tolower(substring(id, 0, indexof(id, '/extensions/')))\r\n    | summarize hasDefender = any(true) by machineId\r\n) on machineId\r\n| extend \r\n    OSName = case(\r\n        osVersion contains \"10.0.26100\", \"Windows Server 2025\",\r\n        osVersion contains \"10.0.20348\", \"Windows Server 2022\",\r\n        osVersion contains \"10.0.17763\", \"Windows Server 2019\",\r\n        osVersion contains \"10.0.14393\", \"Windows Server 2016\",\r\n        osVersion contains \"6.3.9600\", \"Windows Server 2012 R2\",\r\n        osVersion contains \"6.2.9200\", \"Windows Server 2012\",\r\n        osVersion startswith \"5.\", \"Linux (Ubuntu/RHEL)\",\r\n        osVersion startswith \"4.\", \"Linux (Ubuntu/RHEL)\",\r\n        osVersion startswith \"3.\", \"Linux (Ubuntu/RHEL)\",\r\n        \"Unknown OS\"\r\n    ),\r\n    ConfigurationStatus = iff(hasDefender == true, \"✅ Configured\", \"❌ Not Configured\")\r\n| project \r\n    ServerName = name,\r\n    ResourceGroup = resourceGroup,\r\n    Subscription = subscriptionId,\r\n    OSVersion = OSName,\r\n    Status = ConfigurationStatus,\r\n    Location = location\r\n| order by Status desc, ServerName asc",
+        "size": 0,
+        "title": "All Servers - Defender for Cloud Status",
+        "queryType": 1,
+        "resourceType": "microsoft.resourcegraph/resources",
+        "crossComponentResources": [
+          "{Subscriptions}"
+        ],
+        "gridSettings": {
+          "formatters": [
+            {
+              "columnMatch": "Status",
+              "formatter": 18,
+              "formatOptions": {
+                "thresholdsOptions": "colors",
+                "thresholdsGrid": [
+                  {
+                    "operator": "contains",
+                    "thresholdValue": "Not",
+                    "representation": "yellow",
+                    "text": "{0}"
+                  },
+                  {
+                    "operator": "contains",
+                    "thresholdValue": "Configured",
+                    "representation": "green",
+                    "text": "{0}"
+                  },
+                  {
+                    "operator": "Default",
+                    "thresholdValue": null,
+                    "representation": "gray",
+                    "text": "{0}"
+                  }
+                ]
+              }
+            }
+          ],
+          "filter": true
+        },
+        "exportToExcelOptions": "all",
+        "showExportToExcel": true
+      },
+      "name": "defender-details",
+      "conditionalVisibilities": [
+        {
+          "parameterName": "ResourceType",
+          "comparison": "isEqualTo",
+          "value": "arc"
+        },
+        {
+          "parameterName": "ArcTab",
+          "comparison": "isEqualTo",
+          "value": "defender"
+        }
+      ]
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "---\n\n### 📦 Inventory & Tracking - Server Details\n\nServers with Change Tracking extension installed."
+      },
+      "name": "inventory-header",
+      "conditionalVisibilities": [
+        {
+          "parameterName": "ResourceType",
+          "comparison": "isEqualTo",
+          "value": "arc"
+        },
+        {
+          "parameterName": "ArcTab",
+          "comparison": "isEqualTo",
+          "value": "inventory"
+        }
+      ]
+    },
+    {
+      "type": 12,
+      "content": {
+        "version": "NotebookGroup/1.0",
+        "groupType": "editable",
+        "title": "📋 Notes: Azure Change Tracking & Inventory",
+        "expandable": true,
+        "expanded": false,
+        "items": [
+          {
+            "type": 1,
+            "content": {
+              "json": "**What it provides:**\n- Automated tracking of software changes, service state, registry/file modifications\n- Instant visibility when troubleshooting incidents or validating expected changes\n- Historical change timeline for audits or RCA (root cause analysis)\n\n**If not used:**\n- Manual investigation requires RDP/SSH into each server\n- Audit prep requires hand-collected software/service lists\n- Troubleshooting incidents take longer without a timeline of system changes\n\n** Estimated Labor cost formula:**  \n`Investigations/Month × Minutes Saved × Labor Rate`\n\n**Typical savings:**  \n10–20 minutes per troubleshooting event"
+            },
+            "name": "text - 0"
+          }
+        ]
+      },
+      "name": "inventory-notes",
+      "conditionalVisibilities": [
+        {
+          "parameterName": "ResourceType",
+          "comparison": "isEqualTo",
+          "value": "arc"
+        },
+        {
+          "parameterName": "ArcTab",
+          "comparison": "isEqualTo",
+          "value": "inventory"
+        }
+      ]
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "resources\r\n| where type == \"microsoft.hybridcompute/machines\"\r\n| extend \r\n    machineId = tolower(id),\r\n    osVersion = tostring(properties.osVersion)\r\n| join kind=leftouter (\r\n    resources\r\n    | where type == \"microsoft.hybridcompute/machines/extensions\"\r\n    | where properties.type == \"ChangeTracking-Windows\" or properties.type == \"ChangeTracking-Linux\"\r\n    | extend machineId = tolower(substring(id, 0, indexof(id, '/extensions/')))\r\n    | summarize hasInventory = any(true) by machineId\r\n) on machineId\r\n| extend \r\n    OSName = case(\r\n        osVersion contains \"10.0.26100\", \"Windows Server 2025\",\r\n        osVersion contains \"10.0.20348\", \"Windows Server 2022\",\r\n        osVersion contains \"10.0.17763\", \"Windows Server 2019\",\r\n        osVersion contains \"10.0.14393\", \"Windows Server 2016\",\r\n        osVersion contains \"6.3.9600\", \"Windows Server 2012 R2\",\r\n        osVersion contains \"6.2.9200\", \"Windows Server 2012\",\r\n        osVersion startswith \"5.\", \"Linux (Ubuntu/RHEL)\",\r\n        osVersion startswith \"4.\", \"Linux (Ubuntu/RHEL)\",\r\n        osVersion startswith \"3.\", \"Linux (Ubuntu/RHEL)\",\r\n        \"Unknown OS\"\r\n    ),\r\n    ConfigurationStatus = iff(hasInventory == true, \"✅ Configured\", \"❌ Not Configured\")\r\n| project \r\n    ServerName = name,\r\n    ResourceGroup = resourceGroup,\r\n    Subscription = subscriptionId,\r\n    OSVersion = OSName,\r\n    Status = ConfigurationStatus,\r\n    Location = location\r\n| order by Status desc, ServerName asc",
+        "size": 0,
+        "title": "All Servers - Inventory & Tracking Status",
+        "queryType": 1,
+        "resourceType": "microsoft.resourcegraph/resources",
+        "crossComponentResources": [
+          "{Subscriptions}"
+        ],
+        "gridSettings": {
+          "formatters": [
+            {
+              "columnMatch": "Status",
+              "formatter": 18,
+              "formatOptions": {
+                "thresholdsOptions": "colors",
+                "thresholdsGrid": [
+                  {
+                    "operator": "contains",
+                    "thresholdValue": "Not",
+                    "representation": "yellow",
+                    "text": "{0}"
+                  },
+                  {
+                    "operator": "contains",
+                    "thresholdValue": "Configured",
+                    "representation": "green",
+                    "text": "{0}"
+                  },
+                  {
+                    "operator": "Default",
+                    "thresholdValue": null,
+                    "representation": "gray",
+                    "text": "{0}"
+                  }
+                ]
+              }
+            }
+          ],
+          "filter": true
+        },
+        "exportToExcelOptions": "all",
+        "showExportToExcel": true
+      },
+      "name": "inventory-details",
+      "conditionalVisibilities": [
+        {
+          "parameterName": "ResourceType",
+          "comparison": "isEqualTo",
+          "value": "arc"
+        },
+        {
+          "parameterName": "ArcTab",
+          "comparison": "isEqualTo",
+          "value": "inventory"
+        }
+      ]
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "---\n\n### 📊 Monitoring & Insights - Server Details\n\nServers with Azure Monitor Agent extension installed."
+      },
+      "name": "monitoring-header",
+      "conditionalVisibilities": [
+        {
+          "parameterName": "ResourceType",
+          "comparison": "isEqualTo",
+          "value": "arc"
+        },
+        {
+          "parameterName": "ArcTab",
+          "comparison": "isEqualTo",
+          "value": "monitoring"
+        }
+      ]
+    },
+    {
+      "type": 12,
+      "content": {
+        "version": "NotebookGroup/1.0",
+        "groupType": "editable",
+        "title": "📋 Notes: Monitoring & Insights",
+        "expandable": true,
+        "expanded": false,
+        "items": [
+          {
+            "type": 1,
+            "content": {
+              "json": "**What it provides:**\n- Unified metrics, logs, alerts, and dashboards for Arc-enabled servers\n- Reduced MTTR through correlated telemetry across hybrid environments\n- Avoids running multiple monitoring agents/tools per environment\n\n**If not used:**\n- Disparate monitoring tools increase operational complexity\n- Troubleshooting requires manually collecting logs from each system\n- Longer outages increase business impact costs\n\n**Cost formula:**  \n`Reduction in MTTR × Downtime Cost per Hour`\n\n**Impact:**  \nEven small MTTR reductions can save tens of thousands per incident"
+            },
+            "name": "text - 0"
+          }
+        ]
+      },
+      "name": "monitoring-notes",
+      "conditionalVisibilities": [
+        {
+          "parameterName": "ResourceType",
+          "comparison": "isEqualTo",
+          "value": "arc"
+        },
+        {
+          "parameterName": "ArcTab",
+          "comparison": "isEqualTo",
+          "value": "monitoring"
+        }
+      ]
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "resources\r\n| where type == \"microsoft.hybridcompute/machines\"\r\n| extend \r\n    machineId = tolower(id),\r\n    osVersion = tostring(properties.osVersion)\r\n| join kind=leftouter (\r\n    resources\r\n    | where type == \"microsoft.hybridcompute/machines/extensions\"\r\n    | extend \r\n        machineId = tolower(substring(id, 0, indexof(id, '/extensions/'))),\r\n        extType = tolower(tostring(properties.type)),\r\n        extPublisher = tolower(tostring(properties.publisher)),\r\n        extName = tolower(name)\r\n    | where extType contains \"azuremonitor\" or extType contains \"loganalytics\" or extType contains \"omsagent\" or extPublisher contains \"microsoft.azure.monitor\"\r\n    | summarize hasMonitoring = any(true) by machineId\r\n) on machineId\r\n| extend \r\n    OSName = case(\r\n        osVersion contains \"10.0.26100\", \"Windows Server 2025\",\r\n        osVersion contains \"10.0.20348\", \"Windows Server 2022\",\r\n        osVersion contains \"10.0.17763\", \"Windows Server 2019\",\r\n        osVersion contains \"10.0.14393\", \"Windows Server 2016\",\r\n        osVersion contains \"6.3.9600\", \"Windows Server 2012 R2\",\r\n        osVersion contains \"6.2.9200\", \"Windows Server 2012\",\r\n        osVersion startswith \"5.\", \"Linux (Ubuntu/RHEL)\",\r\n        osVersion startswith \"4.\", \"Linux (Ubuntu/RHEL)\",\r\n        osVersion startswith \"3.\", \"Linux (Ubuntu/RHEL)\",\r\n        \"Unknown OS\"\r\n    ),\r\n    ConfigurationStatus = iff(hasMonitoring == true, \"✅ Configured\", \"❌ Not Configured\")\r\n| project \r\n    ServerName = name,\r\n    ResourceGroup = resourceGroup,\r\n    Subscription = subscriptionId,\r\n    OSVersion = OSName,\r\n    Status = ConfigurationStatus,\r\n    Location = location\r\n| order by Status desc, ServerName asc",
+        "size": 0,
+        "title": "All Servers - Monitoring & Insights Status",
+        "queryType": 1,
+        "resourceType": "microsoft.resourcegraph/resources",
+        "crossComponentResources": [
+          "{Subscriptions}"
+        ],
+        "gridSettings": {
+          "formatters": [
+            {
+              "columnMatch": "Status",
+              "formatter": 18,
+              "formatOptions": {
+                "thresholdsOptions": "colors",
+                "thresholdsGrid": [
+                  {
+                    "operator": "contains",
+                    "thresholdValue": "Not",
+                    "representation": "yellow",
+                    "text": "{0}"
+                  },
+                  {
+                    "operator": "contains",
+                    "thresholdValue": "Configured",
+                    "representation": "green",
+                    "text": "{0}"
+                  },
+                  {
+                    "operator": "Default",
+                    "thresholdValue": null,
+                    "representation": "gray",
+                    "text": "{0}"
+                  }
+                ]
+              }
+            }
+          ],
+          "filter": true
+        },
+        "exportToExcelOptions": "all",
+        "showExportToExcel": true
+      },
+      "name": "monitoring-details",
+      "conditionalVisibilities": [
+        {
+          "parameterName": "ResourceType",
+          "comparison": "isEqualTo",
+          "value": "arc"
+        },
+        {
+          "parameterName": "ArcTab",
+          "comparison": "isEqualTo",
+          "value": "monitoring"
+        }
+      ]
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "---\n\n### ⚙️ Guest Configuration - Server Details\n\nServers with Guest Configuration extension installed."
+      },
+      "name": "guestconfig-header",
+      "conditionalVisibilities": [
+        {
+          "parameterName": "ResourceType",
+          "comparison": "isEqualTo",
+          "value": "arc"
+        },
+        {
+          "parameterName": "ArcTab",
+          "comparison": "isEqualTo",
+          "value": "guestconfig"
+        }
+      ]
+    },
+    {
+      "type": 12,
+      "content": {
+        "version": "NotebookGroup/1.0",
+        "groupType": "editable",
+        "title": "📋 Notes: Azure Machine Configuration (Guest Configuration)",
+        "expandable": true,
+        "expanded": false,
+        "items": [
+          {
+            "type": 1,
+            "content": {
+              "json": "**What it provides:**\n- Enforces OS, security, and application baselines at scale\n- Automated continuous compliance auditing with Azure Policy\n- Reduces drift and supports frameworks like CIS, NIST, CMMC\n\n**If not used:**\n- Manual configuration validation takes 15–30 minutes per server per quarter\n- Drift persists longer, increasing security and compliance risk\n- GPO/script-based reviews require coordination across teams\n\n** Estimated Labor cost formula:**  \n`Servers × Config Review Time × Compliance Frequency × Labor Rate`"
+            },
+            "name": "text - 0"
+          }
+        ]
+      },
+      "name": "guestconfig-notes",
+      "conditionalVisibilities": [
+        {
+          "parameterName": "ResourceType",
+          "comparison": "isEqualTo",
+          "value": "arc"
+        },
+        {
+          "parameterName": "ArcTab",
+          "comparison": "isEqualTo",
+          "value": "guestconfig"
+        }
+      ]
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "resources\r\n| where type =~ 'microsoft.hybridcompute/machines'\r\n| extend osVersion = tostring(properties.osVersion)\r\n| extend \r\n    OSName = case(\r\n        osVersion contains \"10.0.26100\", \"Windows Server 2025\",\r\n        osVersion contains \"10.0.20348\", \"Windows Server 2022\",\r\n        osVersion contains \"10.0.17763\", \"Windows Server 2019\",\r\n        osVersion contains \"10.0.14393\", \"Windows Server 2016\",\r\n        osVersion contains \"6.3.9600\", \"Windows Server 2012 R2\",\r\n        osVersion contains \"6.2.9200\", \"Windows Server 2012\",\r\n        osVersion startswith \"5.\", \"Linux (Ubuntu/RHEL)\",\r\n        osVersion startswith \"4.\", \"Linux (Ubuntu/RHEL)\",\r\n        osVersion startswith \"3.\", \"Linux (Ubuntu/RHEL)\",\r\n        \"Unknown OS\"\r\n    )\r\n| project machineId = tolower(id), ServerName = name, ResourceGroup = resourceGroup, Subscription = subscriptionId, OSVersion = OSName, Location = location\r\n| join kind=leftouter (\r\n    guestconfigurationresources\r\n    | where type =~ 'microsoft.guestconfiguration/guestconfigurationassignments'\r\n    | parse id with machineId '/providers/Microsoft.GuestConfiguration/guestConfigurationAssignments/' assignmentName\r\n    | project machineId = tolower(machineId)\r\n    | distinct machineId\r\n    | extend hasGuestConfig = true\r\n) on machineId\r\n| extend Status = iff(hasGuestConfig == true, \"✅ Configured\", \"❌ Not Configured\")\r\n| project ServerName, ResourceGroup, Subscription, OSVersion, Status, Location\r\n| order by Status desc, ServerName asc",
+        "size": 0,
+        "title": "All Servers - Guest Configuration Status",
+        "queryType": 1,
+        "resourceType": "microsoft.resourcegraph/resources",
+        "crossComponentResources": [
+          "{Subscriptions}"
+        ],
+        "gridSettings": {
+          "formatters": [
+            {
+              "columnMatch": "Status",
+              "formatter": 18,
+              "formatOptions": {
+                "thresholdsOptions": "colors",
+                "thresholdsGrid": [
+                  {
+                    "operator": "contains",
+                    "thresholdValue": "Not",
+                    "representation": "yellow",
+                    "text": "{0}"
+                  },
+                  {
+                    "operator": "contains",
+                    "thresholdValue": "Configured",
+                    "representation": "green",
+                    "text": "{0}"
+                  },
+                  {
+                    "operator": "Default",
+                    "thresholdValue": null,
+                    "representation": "gray",
+                    "text": "{0}"
+                  }
+                ]
+              }
+            }
+          ],
+          "filter": true
+        },
+        "exportToExcelOptions": "all",
+        "showExportToExcel": true
+      },
+      "name": "guestconfig-details",
+      "conditionalVisibilities": [
+        {
+          "parameterName": "ResourceType",
+          "comparison": "isEqualTo",
+          "value": "arc"
+        },
+        {
+          "parameterName": "ArcTab",
+          "comparison": "isEqualTo",
+          "value": "guestconfig"
+        }
+      ]
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "---\n\n### ✅ Best Practice Assessment - Server Details\n\nServers with Best Practice Assessment extension installed."
+      },
+      "name": "bestpractice-header",
+      "conditionalVisibilities": [
+        {
+          "parameterName": "ResourceType",
+          "comparison": "isEqualTo",
+          "value": "arc"
+        },
+        {
+          "parameterName": "ArcTab",
+          "comparison": "isEqualTo",
+          "value": "bestpractice"
+        }
+      ]
+    },
+    {
+      "type": 12,
+      "content": {
+        "version": "NotebookGroup/1.0",
+        "groupType": "editable",
+        "title": "📋 Notes: Best Practices Assessment (BPA)",
+        "expandable": true,
+        "expanded": false,
+        "items": [
+          {
+            "type": 1,
+            "content": {
+              "json": "**What it provides:**\n- Automated scanning for security misconfigurations and performance issues\n- Prioritized remediation steps and actionable recommendations\n- Reduces risk of outages and improves standardization\n\n**If not used:**\n- Manual runbooks/checklists take 20 minutes per server monthly\n- Issues often discovered only after incidents occur\n- Higher downtime risk from hidden misconfigurations\n\n** EstimatedLabor cost formula:**  \n`Servers × Monthly Health Check Time × Labor Rate`"
+            },
+            "name": "text - 0"
+          }
+        ]
+      },
+      "name": "bestpractice-notes",
+      "conditionalVisibilities": [
+        {
+          "parameterName": "ResourceType",
+          "comparison": "isEqualTo",
+          "value": "arc"
+        },
+        {
+          "parameterName": "ArcTab",
+          "comparison": "isEqualTo",
+          "value": "bestpractice"
+        }
+      ]
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "resources\r\n| where type == \"microsoft.hybridcompute/machines\"\r\n| extend \r\n    machineId = tolower(id),\r\n    osVersion = tostring(properties.osVersion)\r\n| join kind=leftouter (\r\n    resources\r\n    | where type == \"microsoft.hybridcompute/machines/extensions\"\r\n    | extend \r\n        machineId = tolower(substring(id, 0, indexof(id, '/extensions/'))),\r\n        extType = tolower(tostring(properties.type)),\r\n        extName = tolower(name)\r\n    | where extType contains \"windowsserverassessment\" or extType contains \"assessmentplatform\" or extName contains \"windowsserverassessment\" or extName contains \"assessmentplatform\"\r\n    | summarize hasBestPractice = any(true) by machineId\r\n) on machineId\r\n| extend \r\n    OSName = case(\r\n        osVersion contains \"10.0.26100\", \"Windows Server 2025\",\r\n        osVersion contains \"10.0.20348\", \"Windows Server 2022\",\r\n        osVersion contains \"10.0.17763\", \"Windows Server 2019\",\r\n        osVersion contains \"10.0.14393\", \"Windows Server 2016\",\r\n        osVersion contains \"6.3.9600\", \"Windows Server 2012 R2\",\r\n        osVersion contains \"6.2.9200\", \"Windows Server 2012\",\r\n        osVersion startswith \"5.\", \"Linux (Ubuntu/RHEL)\",\r\n        osVersion startswith \"4.\", \"Linux (Ubuntu/RHEL)\",\r\n        osVersion startswith \"3.\", \"Linux (Ubuntu/RHEL)\",\r\n        \"Unknown OS\"\r\n    ),\r\n    ConfigurationStatus = iff(hasBestPractice == true, \"✅ Configured\", \"❌ Not Configured\")\r\n| project \r\n    ServerName = name,\r\n    ResourceGroup = resourceGroup,\r\n    Subscription = subscriptionId,\r\n    OSVersion = OSName,\r\n    Status = ConfigurationStatus,\r\n    Location = location\r\n| order by Status desc, ServerName asc",
+        "size": 0,
+        "title": "All Servers - Best Practice Assessment Status",
+        "queryType": 1,
+        "resourceType": "microsoft.resourcegraph/resources",
+        "crossComponentResources": [
+          "{Subscriptions}"
+        ],
+        "gridSettings": {
+          "formatters": [
+            {
+              "columnMatch": "Status",
+              "formatter": 18,
+              "formatOptions": {
+                "thresholdsOptions": "colors",
+                "thresholdsGrid": [
+                  {
+                    "operator": "contains",
+                    "thresholdValue": "Not",
+                    "representation": "yellow",
+                    "text": "{0}"
+                  },
+                  {
+                    "operator": "contains",
+                    "thresholdValue": "Configured",
+                    "representation": "green",
+                    "text": "{0}"
+                  },
+                  {
+                    "operator": "Default",
+                    "thresholdValue": null,
+                    "representation": "gray",
+                    "text": "{0}"
+                  }
+                ]
+              }
+            }
+          ],
+          "filter": true
+        },
+        "exportToExcelOptions": "all",
+        "showExportToExcel": true
+      },
+      "name": "bestpractice-details",
+      "conditionalVisibilities": [
+        {
+          "parameterName": "ResourceType",
+          "comparison": "isEqualTo",
+          "value": "arc"
+        },
+        {
+          "parameterName": "ArcTab",
+          "comparison": "isEqualTo",
+          "value": "bestpractice"
+        }
+      ]
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "---\n\n### 💻 Windows Admin Center - Server Details\n\nServers with Windows Admin Center extension installed."
+      },
+      "name": "admincenter-header",
+      "conditionalVisibilities": [
+        {
+          "parameterName": "ResourceType",
+          "comparison": "isEqualTo",
+          "value": "arc"
+        },
+        {
+          "parameterName": "ArcTab",
+          "comparison": "isEqualTo",
+          "value": "admincenter"
+        }
+      ]
+    },
+    {
+      "type": 12,
+      "content": {
+        "version": "NotebookGroup/1.0",
+        "groupType": "editable",
+        "title": "📋 Notes: Windows Admin Center in Azure (WAC in Arc)",
+        "expandable": true,
+        "expanded": false,
+        "items": [
+          {
+            "type": 1,
+            "content": {
+              "json": "**What it provides:**\n- Secure, VPN-less server management via browser\n- Tools include Hyper-V Manager, Event Viewer, Registry Editor, PowerShell console\n- JIT access with no public IPs or inbound ports\n\n**If not used:**\n- Teams spend time configuring VPNs and temporary access\n- Management requires RDP/WinRM exposure (security risk)\n- Troubleshooting requires juggling multiple tools rather than a single pane\n\n** EstimatedLabor cost formula:**  \n`Remote Access Sessions × Minutes Saved per Session × Labor Rate`\n\n**Savings:**  \n5–15 minutes per admin session"
+            },
+            "name": "text - 0"
+          }
+        ]
+      },
+      "name": "admincenter-notes",
+      "conditionalVisibilities": [
+        {
+          "parameterName": "ResourceType",
+          "comparison": "isEqualTo",
+          "value": "arc"
+        },
+        {
+          "parameterName": "ArcTab",
+          "comparison": "isEqualTo",
+          "value": "admincenter"
+        }
+      ]
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "resources\r\n| where type == \"microsoft.hybridcompute/machines\"\r\n| extend \r\n    machineId = tolower(id),\r\n    osVersion = tostring(properties.osVersion)\r\n| join kind=leftouter (\r\n    resources\r\n    | where type == \"microsoft.hybridcompute/machines/extensions\"\r\n    | where properties.type contains \"AdminCenter\"\r\n    | extend machineId = tolower(substring(id, 0, indexof(id, '/extensions/')))\r\n    | summarize hasAdminCenter = any(true) by machineId\r\n) on machineId\r\n| extend \r\n    OSName = case(\r\n        osVersion contains \"10.0.26100\", \"Windows Server 2025\",\r\n        osVersion contains \"10.0.20348\", \"Windows Server 2022\",\r\n        osVersion contains \"10.0.17763\", \"Windows Server 2019\",\r\n        osVersion contains \"10.0.14393\", \"Windows Server 2016\",\r\n        osVersion contains \"6.3.9600\", \"Windows Server 2012 R2\",\r\n        osVersion contains \"6.2.9200\", \"Windows Server 2012\",\r\n        osVersion startswith \"5.\", \"Linux (Ubuntu/RHEL)\",\r\n        osVersion startswith \"4.\", \"Linux (Ubuntu/RHEL)\",\r\n        osVersion startswith \"3.\", \"Linux (Ubuntu/RHEL)\",\r\n        \"Unknown OS\"\r\n    ),\r\n    ConfigurationStatus = iff(hasAdminCenter == true, \"✅ Configured\", \"❌ Not Configured\")\r\n| project \r\n    ServerName = name,\r\n    ResourceGroup = resourceGroup,\r\n    Subscription = subscriptionId,\r\n    OSVersion = OSName,\r\n    Status = ConfigurationStatus,\r\n    Location = location\r\n| order by Status desc, ServerName asc",
+        "size": 0,
+        "title": "All Servers - Windows Admin Center Status",
+        "queryType": 1,
+        "resourceType": "microsoft.resourcegraph/resources",
+        "crossComponentResources": [
+          "{Subscriptions}"
+        ],
+        "gridSettings": {
+          "formatters": [
+            {
+              "columnMatch": "Status",
+              "formatter": 18,
+              "formatOptions": {
+                "thresholdsOptions": "colors",
+                "thresholdsGrid": [
+                  {
+                    "operator": "contains",
+                    "thresholdValue": "Not",
+                    "representation": "yellow",
+                    "text": "{0}"
+                  },
+                  {
+                    "operator": "contains",
+                    "thresholdValue": "Configured",
+                    "representation": "green",
+                    "text": "{0}"
+                  },
+                  {
+                    "operator": "Default",
+                    "thresholdValue": null,
+                    "representation": "gray",
+                    "text": "{0}"
+                  }
+                ]
+              }
+            }
+          ],
+          "filter": true
+        },
+        "exportToExcelOptions": "all",
+        "showExportToExcel": true
+      },
+      "name": "admincenter-details",
+      "conditionalVisibilities": [
+        {
+          "parameterName": "ResourceType",
+          "comparison": "isEqualTo",
+          "value": "arc"
+        },
+        {
+          "parameterName": "ArcTab",
+          "comparison": "isEqualTo",
+          "value": "admincenter"
+        }
+      ]
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "---\n\n### 🛡️ SQL Server Defender for Cloud - Details\n\nSQL Server instances with Microsoft Defender for Cloud protection status."
+      },
+      "conditionalVisibilities": [
+        {
+          "parameterName": "ResourceType",
+          "comparison": "isEqualTo",
+          "value": "sql"
+        },
+        {
+          "parameterName": "SqlTab",
+          "comparison": "isEqualTo",
+          "value": "sqldefender"
+        }
+      ],
+      "name": "sqldefender-header"
+    },
+    {
+      "type": 12,
+      "content": {
+        "version": "NotebookGroup/1.0",
+        "groupType": "editable",
+        "title": "📋 Notes: SQL Server Defender for Cloud",
+        "expandable": true,
+        "expanded": false,
+        "items": [
+          {
+            "type": 1,
+            "content": {
+              "json": "**What it provides:**\n- Advanced threat detection and vulnerability assessments for SQL Server\n- Real-time security alerts for suspicious database activities\n- SQL injection attack detection and prevention guidance\n- Automated vulnerability scanning with remediation recommendations\n- Integration with Azure Security Center for unified security management\n- Compliance reporting for regulatory requirements (PCI DSS, SOC, etc.)\n\n**If not used:**\n- Security teams spend 2-3 hours per server quarterly performing manual vulnerability scans\n- Threat detection relies on reactive log analysis instead of proactive monitoring\n- Compliance audits require extensive manual documentation and evidence gathering\n- Security incidents discovered after breach rather than prevention\n- No centralized view of SQL security posture across hybrid environments\n\n**Estimated Labor cost formula:**  \n`SQL Servers × Manual Security Review Hours × Labor Rate × Quarterly Reviews`\n\n**Savings:**  \n2-3 hours per server per quarter for manual security assessments and compliance reviews\n\n**Note:** To check if Microsoft Defender for SQL is enabled, visit the Azure Security Center and verify the SQL pricing tier is set to 'Standard' for your subscriptions."
+            },
+            "name": "text - 0"
+          }
+        ]
+      },
+      "conditionalVisibilities": [
+        {
+          "parameterName": "ResourceType",
+          "comparison": "isEqualTo",
+          "value": "sql"
+        },
+        {
+          "parameterName": "SqlTab",
+          "comparison": "isEqualTo",
+          "value": "sqldefender"
+        }
+      ],
+      "name": "sqldefender-notes"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "resources\r\n| where type == \"microsoft.azurearcdata/sqlserverinstances\"\r\n| extend \r\n    serverName = tostring(properties.containerResourceId),\r\n    sqlVersion = tostring(properties.version),\r\n    sqlEdition = tostring(properties.edition),\r\n    sqlResourceId = tolower(id)\r\n| join kind=leftouter (\r\n    securityresources\r\n    | where type =~ \"microsoft.security/assessments\"\r\n    | where properties.displayName =~ \"Microsoft Defender for SQL status should be protected for Arc-enabled SQL Servers\"\r\n    | extend status = tostring(properties.status.code)\r\n    | extend resourceId = tolower(tostring(properties.resourceDetails.Id))\r\n    | project resourceId, defenderStatus = status\r\n) on $left.sqlResourceId == $right.resourceId\r\n| extend hasDefender = defenderStatus =~ \"Healthy\"\r\n| extend ConfigurationStatus = iff(hasDefender == true, \"✅ Protected\", \"❌ Not Protected\")\r\n| project \r\n    SQLInstanceName = name,\r\n    ResourceGroup = resourceGroup,\r\n    Subscription = subscriptionId,\r\n    SQLVersion = sqlVersion,\r\n    SQLEdition = sqlEdition,\r\n    DefenderStatus = ConfigurationStatus,\r\n    AssessmentStatus = defenderStatus,\r\n    DefenderEnabled = iff(hasDefender == true, \"Yes\", \"No\"),\r\n    Location = location\r\n| order by DefenderStatus desc, SQLInstanceName asc",
+        "size": 0,
+        "title": "SQL Server Instances - Defender for Cloud Protection Status",
+        "queryType": 1,
+        "resourceType": "microsoft.resourcegraph/resources",
+        "crossComponentResources": [
+          "{Subscriptions}"
+        ],
+        "gridSettings": {
+          "formatters": [
+            {
+              "columnMatch": "DefenderStatus",
+              "formatter": 18,
+              "formatOptions": {
+                "thresholdsOptions": "colors",
+                "thresholdsGrid": [
+                  {
+                    "operator": "contains",
+                    "thresholdValue": "Not",
+                    "representation": "yellow",
+                    "text": "{0}"
+                  },
+                  {
+                    "operator": "contains",
+                    "thresholdValue": "Protected",
+                    "representation": "green",
+                    "text": "{0}"
+                  },
+                  {
+                    "operator": "Default",
+                    "thresholdValue": null,
+                    "representation": "gray",
+                    "text": "{0}"
+                  }
+                ]
+              }
+            }
+          ],
+          "filter": true
+        },
+        "exportToExcelOptions": "all",
+        "showExportToExcel": true
+      },
+      "conditionalVisibilities": [
+        {
+          "parameterName": "ResourceType",
+          "comparison": "isEqualTo",
+          "value": "sql"
+        },
+        {
+          "parameterName": "SqlTab",
+          "comparison": "isEqualTo",
+          "value": "sqldefender"
+        }
+      ],
+      "name": "sqldefender-details"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "---\n\n### �️ SQL Server Best Practices Assessment - Details\n\nSQL Server instances with Best Practices Assessment configured."
+      },
+      "conditionalVisibilities": [
+        {
+          "parameterName": "ResourceType",
+          "comparison": "isEqualTo",
+          "value": "sql"
+        },
+        {
+          "parameterName": "SqlTab",
+          "comparison": "isEqualTo",
+          "value": "sqlbpa"
+        }
+      ],
+      "name": "sqlbpa-header"
+    },
+    {
+      "type": 12,
+      "content": {
+        "version": "NotebookGroup/1.0",
+        "groupType": "editable",
+        "title": "📋 Notes: SQL Server Best Practices Assessment",
+        "expandable": true,
+        "expanded": false,
+        "items": [
+          {
+            "type": 1,
+            "content": {
+              "json": "**What it provides:**\n- Automated scanning of SQL Server configurations against Microsoft best practices\n- Identifies security gaps, performance issues, and configuration problems\n- Generates actionable recommendations with priority levels\n- Tracks compliance over time with historical assessments\n\n**If not used:**\n- Manual configuration reviews consume 2-4 hours per server\n- Security vulnerabilities remain undetected until incidents occur\n- Performance problems discovered reactively, not proactively\n- Compliance audits require extensive manual documentation\n\n**Estimated Labor cost formula:**  \n`SQL Servers × Manual Assessment Hours × Labor Rate × Assessment Frequency`\n\n**Savings:**  \n2-4 hours per server per quarter for manual best practice assessments"
+            },
+            "name": "text - 0"
+          }
+        ]
+      },
+      "conditionalVisibilities": [
+        {
+          "parameterName": "ResourceType",
+          "comparison": "isEqualTo",
+          "value": "sql"
+        },
+        {
+          "parameterName": "SqlTab",
+          "comparison": "isEqualTo",
+          "value": "sqlbpa"
+        }
+      ],
+      "name": "sqlbpa-notes"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "resources\r\n| where type == \"microsoft.azurearcdata/sqlserverinstances\"\r\n| extend \r\n    serverName = tostring(properties.containerResourceId),\r\n    sqlVersion = tostring(properties.version),\r\n    sqlEdition = tostring(properties.edition),\r\n    bpaEnabled = tobool(properties.migration.assessment.enabled),\r\n    bpaLastRun = tostring(properties.migration.assessment.assessmentUploadTime),\r\n    hasBPA = tobool(properties.migration.assessment.enabled) == true\r\n| extend ConfigurationStatus = iff(hasBPA == true, \"✅ Configured\", \"❌ Not Configured\")\r\n| project \r\n    SQLInstanceName = name,\r\n    ResourceGroup = resourceGroup,\r\n    Subscription = subscriptionId,\r\n    SQLVersion = sqlVersion,\r\n    SQLEdition = sqlEdition,\r\n    BPAStatus = ConfigurationStatus,\r\n    BPA_Enabled = iff(bpaEnabled == true, \"Yes\", \"No\"),\r\n    BPA_LastUpload = bpaLastRun,\r\n    Location = location\r\n| order by BPAStatus desc, SQLInstanceName asc",
+        "size": 0,
+        "title": "SQL Server Instances - Best Practices Assessment Status",
+        "queryType": 1,
+        "resourceType": "microsoft.resourcegraph/resources",
+        "crossComponentResources": [
+          "{Subscriptions}"
+        ],
+        "gridSettings": {
+          "formatters": [
+            {
+              "columnMatch": "BPAStatus",
+              "formatter": 18,
+              "formatOptions": {
+                "thresholdsOptions": "colors",
+                "thresholdsGrid": [
+                  {
+                    "operator": "contains",
+                    "thresholdValue": "Not",
+                    "representation": "yellow",
+                    "text": "{0}"
+                  },
+                  {
+                    "operator": "contains",
+                    "thresholdValue": "Configured",
+                    "representation": "green",
+                    "text": "{0}"
+                  },
+                  {
+                    "operator": "Default",
+                    "thresholdValue": null,
+                    "representation": "gray",
+                    "text": "{0}"
+                  }
+                ]
+              }
+            }
+          ],
+          "filter": true
+        },
+        "exportToExcelOptions": "all",
+        "showExportToExcel": true
+      },
+      "conditionalVisibilities": [
+        {
+          "parameterName": "ResourceType",
+          "comparison": "isEqualTo",
+          "value": "sql"
+        },
+        {
+          "parameterName": "SqlTab",
+          "comparison": "isEqualTo",
+          "value": "sqlbpa"
+        }
+      ],
+      "name": "sqlbpa-details"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "---\n\n### 📊 SQL Server Performance Dashboard - Details\n\nSQL Server instances with performance monitoring configured via Azure Monitor."
+      },
+      "conditionalVisibilities": [
+        {
+          "parameterName": "ResourceType",
+          "comparison": "isEqualTo",
+          "value": "sql"
+        },
+        {
+          "parameterName": "SqlTab",
+          "comparison": "isEqualTo",
+          "value": "sqlperformance"
+        }
+      ],
+      "name": "sqlperformance-header"
+    },
+    {
+      "type": 12,
+      "content": {
+        "version": "NotebookGroup/1.0",
+        "groupType": "editable",
+        "title": "📋 Notes: SQL Server Performance Dashboard",
+        "expandable": true,
+        "expanded": false,
+        "items": [
+          {
+            "type": 1,
+            "content": {
+              "json": "**What it provides:**\n- Real-time query performance metrics and wait statistics\n- Database resource utilization tracking (CPU, memory, I/O)\n- Slow query identification and execution plan analysis\n- Historical performance trending for capacity planning\n- Integration with Azure Monitor for alerting and dashboards\n\n**If not used:**\n- DBAs spend 1-2 hours per incident troubleshooting blind without metrics\n- Performance degradation detected only after user complaints\n- No historical data for capacity planning or trend analysis\n- Manual query analysis requires multiple tools and DMV queries\n\n**Estimated Labor cost formula:**  \n`SQL Servers × Performance Investigation Hours × Labor Rate × Monthly Incidents`\n\n**Savings:**  \n1-2 hours per performance investigation per server per month"
+            },
+            "name": "text - 0"
+          }
+        ]
+      },
+      "conditionalVisibilities": [
+        {
+          "parameterName": "ResourceType",
+          "comparison": "isEqualTo",
+          "value": "sql"
+        },
+        {
+          "parameterName": "SqlTab",
+          "comparison": "isEqualTo",
+          "value": "sqlperformance"
+        }
+      ],
+      "name": "sqlperformance-notes"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "resources\r\n| where type == \"microsoft.azurearcdata/sqlserverinstances\"\r\n| extend machineId = tolower(tostring(properties.containerResourceId))\r\n| join kind=leftouter (\r\n    resources\r\n    | where type == \"microsoft.hybridcompute/machines/extensions\"\r\n    | where properties.type contains \"AzureMonitorWindowsAgent\" or properties.type contains \"AzureMonitorLinuxAgent\"\r\n    | extend machineId = tolower(substring(id, 0, indexof(id, '/extensions/')))\r\n    | summarize hasMonitoring = any(true) by machineId\r\n) on machineId\r\n| extend ConfigurationStatus = iff(hasMonitoring == true, \"✅ Configured\", \"❌ Not Configured\")\r\n| project \r\n    SQLInstanceName = name,\r\n    ResourceGroup = resourceGroup,\r\n    Subscription = subscriptionId,\r\n    SQLVersion = tostring(properties.version),\r\n    SQLEdition = tostring(properties.edition),\r\n    MonitoringStatus = ConfigurationStatus,\r\n    Location = location\r\n| order by MonitoringStatus desc, SQLInstanceName asc",
+        "size": 0,
+        "title": "SQL Server Instances - Performance Monitoring Status",
+        "queryType": 1,
+        "resourceType": "microsoft.resourcegraph/resources",
+        "crossComponentResources": [
+          "{Subscriptions}"
+        ],
+        "gridSettings": {
+          "formatters": [
+            {
+              "columnMatch": "MonitoringStatus",
+              "formatter": 18,
+              "formatOptions": {
+                "thresholdsOptions": "colors",
+                "thresholdsGrid": [
+                  {
+                    "operator": "contains",
+                    "thresholdValue": "Not",
+                    "representation": "yellow",
+                    "text": "{0}"
+                  },
+                  {
+                    "operator": "contains",
+                    "thresholdValue": "Configured",
+                    "representation": "green",
+                    "text": "{0}"
+                  },
+                  {
+                    "operator": "Default",
+                    "thresholdValue": null,
+                    "representation": "gray",
+                    "text": "{0}"
+                  }
+                ]
+              }
+            }
+          ],
+          "filter": true
+        },
+        "exportToExcelOptions": "all",
+        "showExportToExcel": true
+      },
+      "conditionalVisibilities": [
+        {
+          "parameterName": "ResourceType",
+          "comparison": "isEqualTo",
+          "value": "sql"
+        },
+        {
+          "parameterName": "SqlTab",
+          "comparison": "isEqualTo",
+          "value": "sqlperformance"
+        }
+      ],
+      "name": "sqlperformance-details"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "---\n\n### 📦 SQL Server Inventory & Configuration - Details\n\nSQL Server instances tracked in Azure Arc for inventory and license management."
+      },
+      "conditionalVisibilities": [
+        {
+          "parameterName": "ResourceType",
+          "comparison": "isEqualTo",
+          "value": "sql"
+        },
+        {
+          "parameterName": "SqlTab",
+          "comparison": "isEqualTo",
+          "value": "sqlinventory"
+        }
+      ],
+      "name": "sqlinventory-header"
+    },
+    {
+      "type": 12,
+      "content": {
+        "version": "NotebookGroup/1.0",
+        "groupType": "editable",
+        "title": "📋 Notes: SQL Server Inventory & Configuration",
+        "expandable": true,
+        "expanded": false,
+        "items": [
+          {
+            "type": 1,
+            "content": {
+              "json": "**What it provides:**\n- Automated discovery and tracking of all SQL Server instances\n- Version, edition, and patch level visibility across the enterprise\n- Database inventory with size and growth trends\n- SQL Agent job tracking and monitoring\n- License compliance reporting (PAYG vs. License Mobility)\n- Configuration drift detection\n\n**If not used:**\n- Manual inventory requires scripts run against each server (30-60 min per server)\n- License audits are time-consuming and error-prone\n- No visibility into shadow SQL instances or version sprawl\n- Patching coordination requires manual tracking spreadsheets\n\n**Estimated Labor cost formula:**  \n`SQL Servers × Manual Inventory Hours × Labor Rate × Quarterly Frequency`\n\n**Savings:**  \n30-60 minutes per server per quarter for manual inventory and compliance tracking"
+            },
+            "name": "text - 0"
+          }
+        ]
+      },
+      "conditionalVisibilities": [
+        {
+          "parameterName": "ResourceType",
+          "comparison": "isEqualTo",
+          "value": "sql"
+        },
+        {
+          "parameterName": "SqlTab",
+          "comparison": "isEqualTo",
+          "value": "sqlinventory"
+        }
+      ],
+      "name": "sqlinventory-notes"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "resources\r\n| where type == \"microsoft.azurearcdata/sqlserverinstances\"\r\n| extend \r\n    sqlVersion = tostring(properties.version),\r\n    sqlEdition = tostring(properties.edition),\r\n    licenseType = tostring(properties.licenseType),\r\n    vCores = toint(properties.vCore),\r\n    patchLevel = tostring(properties.patchLevel),\r\n    instanceName = tostring(properties.instanceName),\r\n    hostType = tostring(properties.hostType),\r\n    machineId = tolower(tostring(properties.containerResourceId))\r\n| join kind=leftouter (\r\n    resources\r\n    | where type == \"microsoft.hybridcompute/machines\"\r\n    | extend \r\n        machineId = tolower(id),\r\n        machineModel = tostring(properties.detectedProperties.model)\r\n    | project machineId, machineModel\r\n) on machineId\r\n| extend \r\n    finalHostType = case(\r\n        isnotempty(hostType), hostType,\r\n        machineModel contains \"Virtual\" or machineModel contains \"virtual\", \"Virtual Machine\",\r\n        isnotempty(machineModel), \"Physical Machine\",\r\n        \"Unknown\"\r\n    )\r\n| project \r\n    SQLInstanceName = name,\r\n    ResourceGroup = resourceGroup,\r\n    Subscription = subscriptionId,\r\n    SQLVersion = sqlVersion,\r\n    SQLEdition = sqlEdition,\r\n    LicenseType = licenseType,\r\n    vCores = vCores,\r\n    PatchLevel = patchLevel,\r\n    HostType = finalHostType,\r\n    Location = location\r\n| order by SQLInstanceName asc",
+        "size": 0,
+        "title": "SQL Server Instances - Inventory & Configuration",
+        "queryType": 1,
+        "resourceType": "microsoft.resourcegraph/resources",
+        "crossComponentResources": [
+          "{Subscriptions}"
+        ],
+        "gridSettings": {
+          "formatters": [
+            {
+              "columnMatch": "LicenseType",
+              "formatter": 18,
+              "formatOptions": {
+                "thresholdsOptions": "colors",
+                "thresholdsGrid": [
+                  {
+                    "operator": "contains",
+                    "thresholdValue": "PAID",
+                    "representation": "green",
+                    "text": "{0}"
+                  },
+                  {
+                    "operator": "contains",
+                    "thresholdValue": "Free",
+                    "representation": "blue",
+                    "text": "{0}"
+                  },
+                  {
+                    "operator": "Default",
+                    "thresholdValue": null,
+                    "representation": "gray",
+                    "text": "{0}"
+                  }
+                ]
+              }
+            }
+          ],
+          "filter": true,
+          "sortBy": [
+            {
+              "itemKey": "SQLInstanceName",
+              "sortOrder": 1
+            }
+          ]
+        },
+        "sortBy": [
+          {
+            "itemKey": "SQLInstanceName",
+            "sortOrder": 1
+          }
+        ],
+        "exportToExcelOptions": "all",
+        "showExportToExcel": true
+      },
+      "conditionalVisibilities": [
+        {
+          "parameterName": "ResourceType",
+          "comparison": "isEqualTo",
+          "value": "sql"
+        },
+        {
+          "parameterName": "SqlTab",
+          "comparison": "isEqualTo",
+          "value": "sqlinventory"
+        }
+      ],
+      "name": "sqlinventory-details"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "---\n\n### �📝 Notes\n\n**Export to Excel:** Click the \"↓\" (Export) button at the top of any table to download data to Excel."
+      },
+      "name": "notes"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "\n\n---\n\n<small>[GitHub Repository](https://github.com/wjpigott/ArcBenefitsDashboard/blob/main/README.md)</small>"
+      },
+      "name": "github-link"
+    }
+  ],
+  "fallbackResourceIds": [
+    "Azure Monitor"
+  ],
+  "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
+}

--- a/Workbooks/Azure Arc Experiences/Arc Benefits/Arc Benefits.workbook
+++ b/Workbooks/Azure Arc Experiences/Arc Benefits/Arc Benefits.workbook
@@ -68,7 +68,7 @@
     {
       "type": 1,
       "content": {
-        "json": "## 🎯 Azure Arc Benefits Dashboard v2.1"
+        "json": "## 🎯 Azure Arc Benefits Dashboard"
       },
       "name": "title"
     },

--- a/Workbooks/Azure Arc Experiences/Arc Benefits/Arc Benefits.workbook
+++ b/Workbooks/Azure Arc Experiences/Arc Benefits/Arc Benefits.workbook
@@ -984,7 +984,7 @@
     {
       "type": 1,
       "content": {
-        "json": "---\n\n### �️ Update Manager - Server Details\n\nServers configured vs. unconfigured for Update Manager (automatic patch management)."
+        "json": "---\n\n### 🖥️ Update Manager - Server Details\n\nServers configured vs. unconfigured for Update Manager (automatic patch management)."
       },
       "name": "update-manager-header",
       "conditionalVisibilities": [
@@ -2104,7 +2104,7 @@
     {
       "type": 1,
       "content": {
-        "json": "---\n\n### �️ SQL Server Best Practices Assessment - Details\n\nSQL Server instances with Best Practices Assessment configured."
+        "json": "---\n\n### ✅ SQL Server Best Practices Assessment - Details\n\nSQL Server instances with Best Practices Assessment configured."
       },
       "conditionalVisibilities": [
         {
@@ -2452,7 +2452,7 @@
     {
       "type": 1,
       "content": {
-        "json": "---\n\n### �📝 Notes\n\n**Export to Excel:** Click the \"↓\" (Export) button at the top of any table to download data to Excel."
+        "json": "---\n\n### 📝 Notes\n\n**Export to Excel:** Click the \"↓\" (Export) button at the top of any table to download data to Excel."
       },
       "name": "notes"
     },

--- a/gallery/workbook/microsoft.hybridcompute-machines.json
+++ b/gallery/workbook/microsoft.hybridcompute-machines.json
@@ -1,0 +1,19 @@
+{
+	"$schema": "https://raw.githubusercontent.com/microsoft/Application-Insights-Workbooks/master/schema/gallery.json",
+	"version": "TemplateGallery/1.0",
+	"categories": [
+		{
+			"id": "Azure Arc Experiences",
+			"name": "Azure Arc",
+			"templates": [
+				{
+					"id": "Workbooks/Azure Arc Experiences/Arc Benefits",
+					"name": "Arc Benefits (preview)",
+					"description": "Summarizes the Azure Arc benefits available to your connected machines, including which benefits are in use and where additional value can be realized.",
+					"author": "Microsoft",
+					"isPreview": true
+				}
+			]
+		}
+	]
+}

--- a/gallery/workbook/microsoft.hybridcompute-machines.json
+++ b/gallery/workbook/microsoft.hybridcompute-machines.json
@@ -8,10 +8,9 @@
 			"templates": [
 				{
 					"id": "Workbooks/Azure Arc Experiences/Arc Benefits",
-					"name": "Arc Benefits (preview)",
+					"name": "Arc Benefits",
 					"description": "Summarizes the Azure Arc benefits available to your connected machines, including which benefits are in use and where additional value can be realized.",
-					"author": "Microsoft",
-					"isPreview": true
+					"author": "Microsoft"
 				}
 			]
 		}


### PR DESCRIPTION
## Summary

Publishes the **Arc Benefits** workbook as a Microsoft-owned template so it can surface in Arc Center, rather than being copied by hand from a personal repo.

Authored by **Jeff Pigott** ([original source](https://github.com/wjpigott/ArcBenefitsDashboard/blob/main/workbook/arc-benefits-workbook.json)). The template JSON is unchanged apart from three corrupted characters in section headings — see *Character repair* below. It is an at-scale workbook — a multi-select subscription picker drives Azure Resource Graph queries over `microsoft.hybridcompute/machines` to summarize which Arc benefits are in use across connected machines.

| File | Notes |
|---|---|
| `Workbooks/Azure Arc Experiences/Arc Benefits/Arc Benefits.workbook` | New template. |
| `gallery/workbook/microsoft.hybridcompute-machines.json` | New gallery file — no `microsoft.hybridcompute-*` gallery existed. |
| `CODEOWNERS` | Two entries assigning `@microsoft/arc-user-experiences`. |

## Gallery placement

Derived from the consuming blade rather than assumed. Arc Center opens `UsageNotebookBlade` with:

```json
"parameters": {
    "ComponentId": "Azure Arc",
    "GalleryResourceType": "microsoft.hybridcompute/machines"
}
```

`GalleryResourceType` gives the filename `microsoft.hybridcompute-machines.json`, and no `Type` is passed so it defaults to `workbook` — resolving to `gallery/workbook/microsoft.hybridcompute-machines.json`. `ComponentId` is the hub-level pseudo-value `"Azure Arc"` rather than a machine resource ID, which matches this workbook's at-scale design.

## Folder and ownership

The template takes a new top-level folder rather than nesting under `Workbooks/Azure Arc/`, which `@microsoft/arcee-hybrid-data` owns. Nesting would work — `CODEOWNERS` is last-match-wins — but it would make ownership depend on line order and fail silently if the file were reordered. `Azure Arc Experiences` does not match the existing `/Workbooks/Azure*Arc/**` glob.

`CODEOWNERS` covers the gallery file as well as the template folder; without the former, `/gallery/**` would keep the workbooks team as a required reviewer on every future gallery edit. `*` stands in for spaces per existing convention (e.g. `/Workbooks/Azure*SQL*VM/**`).

## Character repair

Three section headings contained `U+FFFD` (the Unicode replacement character), rendering as `◆` in the portal. Two are restored from the template's own history; the third is a judgment call.

Recovered from the source repo's earliest revision (`a24198f02`), the last with no `U+FFFD` anywhere:

| Heading | Was | Now |
|---|---|---|
| Update Manager - Server Details | `U+FFFD U+FE0F` | `🖥️` — only the base char was destroyed, leaving an orphaned variation selector |
| Notes | `U+FFFD` + `📝` | `📝` — the `U+FFFD` is a spurious insertion, clean in all earlier revisions |

**Not recoverable:** *SQL Server Best Practices Assessment - Details* was introduced already corrupted and has no clean ancestor. Set to `✅` to match its Windows counterpart, *Best Practice Assessment - Server Details*. This is an editorial choice rather than a recovery, and I'm happy to change it if the author prefers something else.

No other bytes are modified.

## Validation

`npm test` passes 4/4. Template content is clean against the repo's checks: no hardcoded `/subscriptions/{guid}` resource IDs, no `fromTemplateId`, no duplicate step IDs, one `.workbook` per folder.

The template ships generally available (no `isPreview`). It can still be exercised on this branch before merge:

```
https://portal.azure.com/?feature.workbookGalleryBranch=ryperl-microsoft-arc-benefits-workbook
```

## Note for reviewers

<img width="1700" height="654" alt="image" src="https://github.com/user-attachments/assets/8e922e45-e143-4e2c-9463-b46e2738fe2f" />


<img width="2930" height="1628" alt="image" src="https://github.com/user-attachments/assets/4d4ddf19-ce1e-4acd-ad1a-21eb50c3e187" />


<img width="2970" height="1190" alt="image" src="https://github.com/user-attachments/assets/ee2e4b20-1244-4614-8907-9e3c6fec231f" />




